### PR TITLE
feat(metrics): per-pool certificate-expiry horizon gauge (#169)

### DIFF
--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -720,6 +720,7 @@ async fn reconcile_profile(
         .await
         .insert(name.clone(), pool_state.clone());
     sync_cluster_instance_statuses(&ctx.client, &ns, &pool_state).await;
+    emit_cert_expiry_metrics(&ctx.client, &ns, &name, &pool_state).await;
 
     // Phase metrics here only need the base state taxonomy — pass
     // `None` for `current_hash` so the drift-aware buckets stay 0.
@@ -1228,6 +1229,59 @@ async fn patch_cluster_instance_status(
         )
         .await?;
     Ok(())
+}
+
+/// Best-effort: emit `kobe_cert_expiry_seconds` for a pool by reading each
+/// instance's `{name}-certs` Secret and tracking the soonest-expiring cert per
+/// component. Never fails a reconcile — a missing secret (k3s/k0s backends,
+/// which manage their own PKI, or an instance not yet provisioned) is simply
+/// skipped, so a pool with no kobe-managed PKI emits nothing. See #169.
+async fn emit_cert_expiry_metrics(
+    client: &Client,
+    namespace: &str,
+    profile: &str,
+    pool_state: &PoolState,
+) {
+    use k8s_openapi::api::core::v1::Secret;
+
+    // Secret data key -> metric `component` label.
+    const COMPONENTS: [(&str, &str); 3] = [
+        ("ca.crt", "ca"),
+        ("apiserver.crt", "apiserver"),
+        ("front-proxy-ca.crt", "front_proxy_ca"),
+    ];
+
+    let secrets: Api<Secret> = Api::namespaced(client.clone(), namespace);
+    let now = chrono::Utc::now().timestamp();
+    let mut worst: HashMap<&str, i64> = HashMap::new();
+
+    for cluster_name in pool_state.clusters.keys() {
+        // 404 (non-PKI backend / not yet created) or a transient error → skip.
+        let secret = match secrets.get_opt(&format!("{cluster_name}-certs")).await {
+            Ok(Some(s)) => s,
+            _ => continue,
+        };
+        let Some(data) = secret.data else { continue };
+        for (key, component) in COMPONENTS {
+            let Some(pem) = data.get(key).and_then(|b| std::str::from_utf8(&b.0).ok()) else {
+                continue;
+            };
+            let Some(not_after) = crate::pki::cert_not_after_unix(pem) else {
+                continue;
+            };
+            let horizon = not_after - now;
+            worst
+                .entry(component)
+                .and_modify(|m| *m = (*m).min(horizon))
+                .or_insert(horizon);
+        }
+    }
+
+    for (component, horizon) in worst {
+        crate::metrics::CERT_EXPIRY_SECONDS
+            .with_label_values(&[profile, component])
+            .set(horizon);
+    }
 }
 
 async fn sync_cluster_instance_statuses(client: &Client, namespace: &str, pool_state: &PoolState) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1075,6 +1075,35 @@ pub static LEASE_HOLD_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
 });
 
 // ─────────────────────────────────────────────────────────────────────
+// PKI: certificate expiry horizon
+// ─────────────────────────────────────────────────────────────────────
+
+/// Worst-case (minimum) seconds until certificate expiry across a pool's
+/// instances, by `component` (`ca` | `apiserver` | `front_proxy_ca`). Sourced
+/// from each instance's `{name}-certs` Secret — the kobe-managed PKI in
+/// `pki.rs` — so it only populates for backends that use it (vcluster / vkobe);
+/// k3s/k0s manage their own in-cluster PKI.
+///
+/// Rolled up per pool, NOT per cluster: cluster identity is high-cardinality and
+/// never a label (module rule). The *minimum* horizon makes "some cluster in
+/// this pool has a cert expiring soon" alertable; the specific cluster lives in
+/// logs/traces. Goes negative once a cert is past `NotAfter`.
+///
+/// Note (#169): the kobe PKI currently sets no explicit validity (rcgen default
+/// → effectively non-expiring), so today this surfaces that state rather than a
+/// tight horizon; bounded validity + recycle-before-expiry is the tracked
+/// follow-up. Emitting the gauge now means the alert/dashboard wiring is ready
+/// the day validity becomes bounded.
+pub static CERT_EXPIRY_SECONDS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "kobe_cert_expiry_seconds",
+        "Worst-case seconds until certificate expiry per pool, by component",
+        &["profile", "component"]
+    )
+    .unwrap()
+});
+
+// ─────────────────────────────────────────────────────────────────────
 // Connect proxy: request latency + per-lease cache effectiveness
 // ─────────────────────────────────────────────────────────────────────
 
@@ -1225,6 +1254,8 @@ pub fn init() {
     // Lease timing
     LazyLock::force(&LEASE_QUEUE_WAIT_SECONDS);
     LazyLock::force(&LEASE_HOLD_SECONDS);
+    // PKI
+    LazyLock::force(&CERT_EXPIRY_SECONDS);
     // P0 observability
     LazyLock::force(&POOL_CONSECUTIVE_FAILURES);
     LazyLock::force(&POOL_FAILURE_REASON_CHANGES_TOTAL);

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -526,7 +526,11 @@ mod tests {
         // Garbage / non-PEM input is best-effort None, never a panic.
         assert_eq!(cert_not_after_unix(""), None);
         assert_eq!(cert_not_after_unix("not a certificate"), None);
-        assert_eq!(cert_not_after_unix(&pki.ca_key), None, "a private key is not a cert");
+        assert_eq!(
+            cert_not_after_unix(&pki.ca_key),
+            None,
+            "a private key is not a cert"
+        );
     }
 
     #[test]

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -369,6 +369,16 @@ pub async fn create_pki_secret(
     Ok(())
 }
 
+/// Parse the `NotAfter` (expiry) of the first certificate in a PEM bundle as a
+/// Unix timestamp in seconds. Returns `None` if the input is empty or not a
+/// parseable X.509 PEM — cert-expiry telemetry is best-effort and must never
+/// break a reconcile.
+pub fn cert_not_after_unix(pem: &str) -> Option<i64> {
+    let (_, block) = x509_parser::pem::parse_x509_pem(pem.as_bytes()).ok()?;
+    let cert = block.parse_x509().ok()?;
+    Some(cert.validity().not_after.timestamp())
+}
+
 // ---------------------------------------------------------------------------
 // Internal helpers
 // ---------------------------------------------------------------------------
@@ -492,6 +502,31 @@ mod tests {
             pki.sa_pub.contains("BEGIN PUBLIC KEY"),
             "sa_pub missing PEM header"
         );
+    }
+
+    #[test]
+    fn test_cert_not_after_unix_parses_generated_cert() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let pki = VirtualClusterPki::generate("expiry-test", &["kubernetes"]).unwrap();
+
+        // A freshly generated CA must parse and expire in the future.
+        let not_after = cert_not_after_unix(&pki.ca_cert).expect("CA cert NotAfter should parse");
+        let now = chrono::Utc::now().timestamp();
+        assert!(
+            not_after > now,
+            "generated CA NotAfter ({not_after}) should be in the future (now {now})"
+        );
+
+        // The apiserver serving cert must parse too.
+        assert!(
+            cert_not_after_unix(&pki.apiserver_cert).is_some(),
+            "apiserver cert NotAfter should parse"
+        );
+
+        // Garbage / non-PEM input is best-effort None, never a panic.
+        assert_eq!(cert_not_after_unix(""), None);
+        assert_eq!(cert_not_after_unix("not a certificate"), None);
+        assert_eq!(cert_not_after_unix(&pki.ca_key), None, "a private key is not a cert");
     }
 
     #[test]


### PR DESCRIPTION
## What

Observability-only first slice of #169. kobe's PKI (`src/pki.rs`) mints per-cluster CA / apiserver / front-proxy certs but **nothing tracks their `NotAfter`**, so a cert aging out is a silent, cluster-wide failure (x509-flood history in closed #92/#42). This adds a metric; it does **not** change cert validity or add rotation.

- **`kobe_cert_expiry_seconds{profile, component=ca|apiserver|front_proxy_ca}`** — the worst-case (minimum) seconds-until-expiry across a pool's instances. Rolled up **per pool, never per cluster**: cluster identity is high-cardinality and never a label (module rule), and the minimum makes "some cluster in this pool has a cert expiring soon" alertable; the specific cluster lives in logs/traces.
- **`pki::cert_not_after_unix()`** — best-effort `NotAfter` parse via `x509-parser` (already a direct dep). `None` on non-PEM input; never panics.
- Emitted best-effort from the profile reconcile (alongside `sync_cluster_instance_statuses`) by reading each instance's `{name}-certs` Secret. A missing secret — k3s/k0s manage their own in-cluster PKI, or the instance isn't provisioned yet — is skipped, so non-PKI pools emit nothing.

## Scope / follow-up

The kobe PKI currently sets **no explicit validity** (rcgen default → effectively non-expiring), so today this gauge surfaces *that state* rather than a tight horizon. Bounded validity + **recycle-before-expiry** (the drift-input half of #169, and the part that touches long-lived pkobe/persistent presets) is deliberately **not** in this PR — doing bounded validity without rotation would make long-lived clusters break at expiry. Wiring the gauge now means alerts/dashboards are ready the day validity becomes bounded.

Also note this covers kobe-managed PKI (vcluster/vkobe); k3s/k0s internal cert expiry is a separate concern owned by those backends.

## Test

- `cargo build`, `cargo clippy` clean.
- New `test_cert_not_after_unix_parses_generated_cert`: round-trips a freshly generated CA/apiserver cert's expiry and rejects garbage / a private key.
- Existing `pki::*` and `controllers::profile::*` suites green.

Part of #169.