### PR TITLE
feat(readiness): in-cluster SA-token round-trip ReadinessGate (#164)

### DIFF
--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -570,6 +570,8 @@ spec:
                       type: string
                     namespace:
                       type: string
+                    serviceAccount:
+                      type: string
                     type:
                       enum:
                       - CRDExists
@@ -578,6 +580,7 @@ spec:
                       - URLHealthy
                       - SchedulingProbe
                       - DNSHealthy
+                      - InClusterToken
                       type: string
                     url:
                       type: string

--- a/charts/kobe/crds/clusterpools.yaml
+++ b/charts/kobe/crds/clusterpools.yaml
@@ -617,6 +617,8 @@ spec:
                       type: string
                     namespace:
                       type: string
+                    serviceAccount:
+                      type: string
                     type:
                       enum:
                       - CRDExists
@@ -625,6 +627,7 @@ spec:
                       - URLHealthy
                       - SchedulingProbe
                       - DNSHealthy
+                      - InClusterToken
                       type: string
                     url:
                       type: string

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -755,7 +755,80 @@ pub async fn check_readiness_gate_impl(
                 Err(e) => Err(e.into()),
             }
         }
+        ReadinessGate::InClusterToken {
+            namespace,
+            service_account,
+        } => {
+            check_in_cluster_token(vc_client, namespace.as_deref(), service_account.as_deref())
+                .await
+        }
     }
+}
+
+/// Default ServiceAccount for the in-cluster token round-trip — every namespace
+/// has a `default` SA.
+const PROBE_SERVICE_ACCOUNT_DEFAULT: &str = "default";
+
+/// Run the [`ReadinessGate::InClusterToken`] check.
+///
+/// Mints a short-lived token for `service_account` in `namespace` via the guest
+/// apiserver's TokenRequest API, then validates it back through a TokenReview.
+/// Returns `true` only when the apiserver both **issues** the token (its SA
+/// signing key is present and TLS auth for the operator's admin client works)
+/// and **confirms it authenticates** (SA verification key + authentication path
+/// intact) — the exact chain a workload's `rest.InClusterConfig()` depends on.
+///
+/// A not-yet-created ServiceAccount (404) is `false`, not an error: the cluster
+/// is still warming up and the controller requeues, same as the other gates.
+async fn check_in_cluster_token(
+    vc_client: &Client,
+    namespace: Option<&str>,
+    service_account: Option<&str>,
+) -> Result<bool> {
+    use k8s_openapi::api::authentication::v1::{
+        TokenRequest, TokenRequestSpec, TokenReview, TokenReviewSpec,
+    };
+    use k8s_openapi::api::core::v1::ServiceAccount;
+    use kube::api::PostParams;
+
+    let ns = namespace.unwrap_or(PROBE_NAMESPACE_DEFAULT);
+    let sa = service_account.unwrap_or(PROBE_SERVICE_ACCOUNT_DEFAULT);
+
+    // 1. Ask the apiserver to sign a short-lived token for the SA.
+    let sas: Api<ServiceAccount> = Api::namespaced(vc_client.clone(), ns);
+    let request = TokenRequest {
+        metadata: Default::default(),
+        spec: TokenRequestSpec {
+            audiences: vec![],
+            expiration_seconds: Some(600),
+            bound_object_ref: None,
+        },
+        status: None,
+    };
+    let issued = match sas
+        .create_token_request(sa, &PostParams::default(), &request)
+        .await
+    {
+        Ok(t) => t,
+        Err(kube::Error::Api(ae)) if ae.code == 404 => return Ok(false),
+        Err(e) => return Err(e.into()),
+    };
+    let Some(token) = issued.status.map(|s| s.token).filter(|t| !t.is_empty()) else {
+        return Ok(false);
+    };
+
+    // 2. Validate that token back through the apiserver.
+    let reviews: Api<TokenReview> = Api::all(vc_client.clone());
+    let review = TokenReview {
+        metadata: Default::default(),
+        spec: TokenReviewSpec {
+            token: Some(token),
+            audiences: None,
+        },
+        status: None,
+    };
+    let result = reviews.create(&PostParams::default(), &review).await?;
+    Ok(result.status.and_then(|s| s.authenticated).unwrap_or(false))
 }
 
 /// Default namespace for the scheduling-probe pod.
@@ -1420,6 +1493,122 @@ current-context: default
             !ok,
             "kube-dns with no ready endpoints (CoreDNS crashloop) must fail DnsHealthy"
         );
+    }
+
+    #[tokio::test]
+    async fn in_cluster_token_gate_true_when_issued_and_authenticated() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        // apiserver signs a token for the default SA...
+        Mock::given(method("POST"))
+            .and(path(
+                "/api/v1/namespaces/kube-system/serviceaccounts/default/token",
+            ))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "apiVersion": "authentication.k8s.io/v1",
+                "kind": "TokenRequest",
+                "metadata": { "name": "default", "namespace": "kube-system" },
+                "spec": { "audiences": [], "expirationSeconds": 600 },
+                "status": { "token": "signed-token", "expirationTimestamp": "2999-01-01T00:00:00Z" }
+            })))
+            .mount(&server)
+            .await;
+        // ...and validates it back as authenticated.
+        Mock::given(method("POST"))
+            .and(path("/apis/authentication.k8s.io/v1/tokenreviews"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "apiVersion": "authentication.k8s.io/v1",
+                "kind": "TokenReview",
+                "metadata": {},
+                "spec": { "token": "signed-token" },
+                "status": { "authenticated": true, "user": { "username": "system:serviceaccount:kube-system:default" } }
+            })))
+            .mount(&server)
+            .await;
+
+        let gate = ReadinessGate::InClusterToken {
+            namespace: None,
+            service_account: None,
+        };
+        let ok = check_readiness_gate_impl(&client, &gate, "inst")
+            .await
+            .unwrap();
+        assert!(
+            ok,
+            "a SA token that issues and validates must satisfy InClusterToken"
+        );
+    }
+
+    #[tokio::test]
+    async fn in_cluster_token_gate_false_when_token_not_authenticated() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("POST"))
+            .and(path(
+                "/api/v1/namespaces/kube-system/serviceaccounts/default/token",
+            ))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "apiVersion": "authentication.k8s.io/v1",
+                "kind": "TokenRequest",
+                "metadata": { "name": "default", "namespace": "kube-system" },
+                "spec": {},
+                "status": { "token": "signed-token", "expirationTimestamp": "2999-01-01T00:00:00Z" }
+            })))
+            .mount(&server)
+            .await;
+        // The apiserver answers but rejects its own token (broken sa.pub / x509).
+        Mock::given(method("POST"))
+            .and(path("/apis/authentication.k8s.io/v1/tokenreviews"))
+            .respond_with(ResponseTemplate::new(201).set_body_json(serde_json::json!({
+                "apiVersion": "authentication.k8s.io/v1",
+                "kind": "TokenReview",
+                "metadata": {},
+                "spec": { "token": "signed-token" },
+                "status": { "authenticated": false, "error": "invalid bearer token" }
+            })))
+            .mount(&server)
+            .await;
+
+        let gate = ReadinessGate::InClusterToken {
+            namespace: None,
+            service_account: None,
+        };
+        let ok = check_readiness_gate_impl(&client, &gate, "inst")
+            .await
+            .unwrap();
+        assert!(!ok, "a token the apiserver won't authenticate must fail");
+    }
+
+    #[tokio::test]
+    async fn in_cluster_token_gate_false_when_sa_absent() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        // SA not created yet on a warming cluster → 404 → gate false, not error.
+        Mock::given(method("POST"))
+            .and(path(
+                "/api/v1/namespaces/kube-system/serviceaccounts/default/token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(404)
+                    .set_body_json(crate::testutil::k8s_not_found("serviceaccounts", "default")),
+            )
+            .mount(&server)
+            .await;
+
+        let gate = ReadinessGate::InClusterToken {
+            namespace: None,
+            service_account: None,
+        };
+        let ok = check_readiness_gate_impl(&client, &gate, "inst")
+            .await
+            .unwrap();
+        assert!(!ok, "a not-yet-created SA must yield false, not an error");
     }
 
     #[tokio::test]

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1175,6 +1175,29 @@ pub enum ReadinessGate {
         #[serde(default, skip_serializing_if = "Option::is_none")]
         namespace: Option<String>,
     },
+
+    /// In-cluster ServiceAccount token round-trip: mint a short-lived token for
+    /// a ServiceAccount via the guest apiserver's TokenRequest API, then feed it
+    /// back through a TokenReview. Proves the apiserver can both *sign* (SA
+    /// signing key) and *verify* (SA public key) a token over its own TLS — the
+    /// exact chain any workload's `rest.InClusterConfig()` depends on, and the
+    /// silent bad-but-Ready class where the apiserver answers but SA auth is
+    /// broken (mis-provisioned sa.key/sa.pub, x509 mismatch — cf. #42/#92).
+    ///
+    /// Evaluated entirely from the operator's admin client — no probe Pod.
+    /// `namespace` defaults to `kube-system`; `serviceAccount` to `default`
+    /// (present in every namespace).
+    #[serde(rename = "InClusterToken")]
+    InClusterToken {
+        #[serde(default, skip_serializing_if = "Option::is_none")]
+        namespace: Option<String>,
+        #[serde(
+            default,
+            skip_serializing_if = "Option::is_none",
+            rename = "serviceAccount"
+        )]
+        service_account: Option<String>,
+    },
 }
 
 // Manual JsonSchema impl — Kubernetes CRD structural schemas require that
@@ -1198,11 +1221,13 @@ impl JsonSchema for ReadinessGate {
                         "DaemonSetReady",
                         "URLHealthy",
                         "SchedulingProbe",
-                        "DNSHealthy"
+                        "DNSHealthy",
+                        "InClusterToken"
                     ]
                 },
                 "name": { "type": "string" },
                 "namespace": { "type": "string" },
+                "serviceAccount": { "type": "string" },
                 "url": { "type": "string" }
             }
         }))


### PR DESCRIPTION
## What

The first of #164's two asks. It lists two new gates — **CoreDNS DNS+x509** and **in-cluster SA-token round-trip**. The CoreDNS/x509 gate already landed since the issue was filed (`ReadinessGate::DnsHealthy`, which fails when CoreDNS crashloops on an x509 mismatch and its `kube-dns` endpoints go unready). This PR adds the **remaining** one.

**`ReadinessGate::InClusterToken { namespace?, serviceAccount? }`** — catches the silent *bad-but-Ready* class where the guest apiserver answers but ServiceAccount auth is broken (mis-provisioned `sa.key`/`sa.pub`, x509 mismatch — cf. closed #42/#92). That's exactly what a workload's `rest.InClusterConfig()` hits at runtime, i.e. *after* the cluster was handed out on a lease.

How it works — a real issue-then-validate round-trip, entirely from the operator's admin client (no probe Pod/image):
1. `TokenRequest` for the SA via the guest apiserver → exercises the apiserver's **SA signing key**.
2. `TokenReview` of that token → exercises **verification** + the authentication path over apiserver **TLS**.

Ready only when the apiserver both *issues* and *authenticates* the token. `namespace` defaults to `kube-system`, `serviceAccount` to `default` (present in every namespace). A not-yet-created SA (404) is `false`, not an error — the gate requeues while the cluster warms up, same contract as the other gates.

**Opt-in**, via `ClusterPool.spec.readinessGates` — deliberately *not* added to any backend's default gate set, so it doesn't change the readiness contract of existing pools. The conformance suite (the CI half of #164, separate PR) is what will exercise it per backend.

## Test

- `cargo build`, `cargo clippy` clean; regenerated `clusterpools`/`clusterinstances` CRDs (new enum value + `serviceAccount` field — the only diff).
- Three mock-apiserver tests validate the actual request→review handling: token issued+authenticated → **pass**; issued but rejected → **fail**; SA absent (404) → **fail, not error**.
- Full `backend::*`, `crd::profile::*`, `controllers::instance::*` suites green (278 tests).

## Not in this PR

The **CoreDNS/x509 gate** (already exists as `DnsHealthy`) and the **backend-agnostic conformance CI matrix** (#164's other half — the "promote the smoke gate, gate lease handout per backend" part) are separate; the CI job follows next, structured like kunobi-ninja/kache#487. Live behavior of this gate against a real apiserver is covered by the conformance suite, not locally runnable here.

Part of #164.