### PR TITLE
docs: unify README badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 # Kobe
 
 [![Crates.io](https://img.shields.io/crates/v/kobectl.svg)](https://crates.io/crates/kobectl)
-[![Docs.rs](https://img.shields.io/docsrs/kobectl)](https://docs.rs/kobectl)
 [![CI](https://github.com/kunobi-ninja/kobe/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kunobi-ninja/kobe/actions/workflows/ci.yml)
 [![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
 [![MSRV](https://img.shields.io/badge/MSRV-1.94.1-blue.svg)](Cargo.toml)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # Kobe
 
+[![Crates.io](https://img.shields.io/crates/v/kobectl.svg)](https://crates.io/crates/kobectl)
+[![Docs.rs](https://img.shields.io/docsrs/kobectl)](https://docs.rs/kobectl)
+[![CI](https://github.com/kunobi-ninja/kobe/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/kunobi-ninja/kobe/actions/workflows/ci.yml)
+[![License](https://img.shields.io/badge/license-Apache--2.0-blue.svg)](LICENSE)
+[![MSRV](https://img.shields.io/badge/MSRV-1.94.1-blue.svg)](Cargo.toml)
+
 **Premium cattle, managed by ninjas.**
 
 Kobe is a Kubernetes operator that manages fleets of ephemeral clusters. It pre-warms pools across multiple backends (k3s, k0s, [vcluster](https://www.vcluster.com/), CAPI) so your CI pipelines and developers get fully functional, isolated Kubernetes clusters instantly — leased via a simple HTTP API.


### PR DESCRIPTION
Adds the standard badge row. Crates.io points to **kobectl** (the published CLI crate, 0.32.0-rc.1); the operator ships as a container, not a crate, and the crates.io name `kobe` belongs to an unrelated third party.

**No Docs.rs badge:** kobectl is binary-only (`src/main.rs`, no `lib.rs`), so docs.rs has nothing to document. Same decision as kache (#489).

Row: **Crates.io → CI → License → MSRV**.

Part of a cross-repo README badge unification across the kunobi-ninja Rust repos.