### PR TITLE
chore(release): bump workspace version to 0.33.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.32.0-rc.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.32.0-rc.1"
+version = "0.33.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.32.0-rc.1"
+version = "0.33.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -5,7 +5,7 @@ description: >-
   Supports multiple backends: k3s, k0s, CAPI, and kobe-sync.
 type: application
 version: 0.21.17
-appVersion: "0.32.0-rc.1"
+appVersion: "0.33.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
## Why

The `v0.33.0` tag was cut at `c4e89eb` **without running `just bump 0.33.0` first**, so the workspace manifest still declared `0.32.0-rc.1`.

Both release-triggered runs failed in the same pre-flight guard:

```
version consistency FAILED for tag 0.33.0:
  - workspace version '0.32.0-rc.1' != tag version '0.33.0'
```

The guard did its job — it fired *before* anything irreversible, so `publish` and `release-cli` were skipped and **nothing permanent was burned**: `kobectl 0.33.0` was never published to crates.io, and the GitHub Release is an empty shell (0 assets).

## What

`just bump 0.33.0`:
- `[workspace.package].version` → `0.33.0` (inherited by `kobe-operator` + `kobectl`)
- `charts/kobe/Chart.yaml` `appVersion` → `0.33.0` (chart's own `version:` stays decoupled, by design)
- `Cargo.lock` follows

`nix/package.nix` derives its version from `cargoToml.workspace.package.version`, so it tracks automatically — no edit needed.

## Verification

```
$ ./scripts/check-version-consistency.sh v0.33.0
version consistency OK: tag 0.33.0 == workspace == Chart.yaml appVersion
```

## Release plan after merge

1. Delete the empty `v0.33.0` release + tag (still mutable — it predates immutable-releases being enabled)
2. `just release` from synced `main` → signed `v0.33.0` tag
3. Create the GitHub Release from the tag → fires signed-release + package-publish + crates.io

Secrets are being provisioned separately — the repo had **zero** configured while the workflows reference 14.