### PR TITLE
fix(api): serve Ready clusters from Failing pools; capture crashloop dying words

### DIFF
--- a/crates/kobectl/src/commands/lease_create.rs
+++ b/crates/kobectl/src/commands/lease_create.rs
@@ -85,9 +85,18 @@ pub(crate) async fn create_lease_request(
     let status = response.status();
     if !status.is_success() {
         let text = response.text().await.unwrap_or_default();
+        // Keep the server's `detail` (pool phase, consecutive failures, last
+        // failure reason) — a bare "Pool cannot satisfy a new lease" hides
+        // the actionable part of a 503 rejection.
         let msg = serde_json::from_str::<serde_json::Value>(&text)
             .ok()
-            .and_then(|v| v["error"].as_str().map(|s| s.to_string()))
+            .and_then(|v| {
+                let error = v["error"].as_str()?.to_string();
+                Some(match v["detail"].as_str() {
+                    Some(detail) => format!("{error} — {detail}"),
+                    None => error,
+                })
+            })
             .unwrap_or(text);
         anyhow::bail!("Failed to lease cluster (HTTP {status}): {msg}");
     }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -613,10 +613,11 @@ fn infra_error(status: StatusCode, message: &str, err: impl std::fmt::Display) -
 const LEASE_PREFLIGHT_DEFAULT_RETRY_AFTER_SECS: u64 = 30;
 
 /// #189 lease-create pre-flight. Returns `Some(503 response)` when the pool
-/// cannot satisfy a new lease right now — a `Failing` pool, or a `Backoff` pool
-/// with no schedulable headroom (zero Ready and already at its capacity bound).
-/// Returns `None` for a healthy-but-empty / warming pool so the caller proceeds
-/// to the normal 202 Pending path.
+/// cannot satisfy a new lease right now — a `Failing` pool with zero Ready
+/// members, or a `Backoff` pool with no schedulable headroom (zero Ready and
+/// already at its capacity bound). Returns `None` when a Ready member exists
+/// (bindable regardless of pool phase) or for a healthy-but-empty / warming
+/// pool, so the caller proceeds to the normal 202 Pending path.
 ///
 /// The 503 carries a `Retry-After` header (derived from the pool's backoff
 /// `next_attempt_at` when present, else a sane default) and a bounded
@@ -645,12 +646,19 @@ fn pool_preflight_rejection(profile: &str, pool: &ClusterPool) -> Option<Respons
     let at_capacity = in_flight >= capacity;
 
     let reject_reason = match phase {
-        // Sustained failures — won't bind without operator action.
-        Some(ClusterPoolPhase::Failing) => Some(R::PoolExhausted),
+        // Sustained failures AND nothing Ready to hand out — won't bind
+        // without operator action. A Failing pool that still has Ready
+        // members must keep serving them: replacement provisioning being
+        // broken doesn't invalidate the clusters that already came up, and
+        // rejecting those leases turns a background provisioning problem
+        // into a full CI outage (2026-07-20: 5 Ready / 0 leased, every
+        // claim 503'd for hours).
+        Some(ClusterPoolPhase::Failing) if ready == 0 => Some(R::PoolExhausted),
         // In a backoff window AND no headroom to create or hand out a cluster.
         Some(ClusterPoolPhase::Backoff) if ready == 0 && at_capacity => Some(R::CapacityBlocked),
-        // Healthy-but-empty, scaling up, idle, in-backoff-with-headroom, etc.:
-        // a transient warm-up — let the lease queue (202 Pending).
+        // Failing/Backoff with Ready members, healthy-but-empty, scaling up,
+        // idle, etc.: bindable now or a transient warm-up — proceed to the
+        // normal 202 path.
         _ => None,
     };
 
@@ -4277,5 +4285,31 @@ mod tests {
                     .as_str()
             )
         );
+    }
+
+    #[tokio::test]
+    async fn pool_preflight_rejection_serves_failing_pool_with_ready_members() {
+        // A Failing pool that still has Ready clusters must NOT be rejected:
+        // broken replacement provisioning doesn't invalidate the members that
+        // already came up, and the bind path serves Ready clusters regardless
+        // of pool phase (2026-07-20 incident: 5 Ready / 0 leased, every CI
+        // claim 503'd until an operator intervened).
+        let pool: ClusterPool = serde_json::from_value(pool_with_status(
+            "e2e-basic",
+            serde_json::json!({ "phase": "Failing", "consecutiveFailures": 10, "ready": 5 }),
+        ))
+        .unwrap();
+        assert!(
+            pool_preflight_rejection("e2e-basic", &pool).is_none(),
+            "Failing pool with ready>0 must proceed to the 202 path"
+        );
+
+        // Same for Backoff: ready>0 already bypasses via the existing guard.
+        let pool: ClusterPool = serde_json::from_value(pool_with_status(
+            "e2e-basic",
+            serde_json::json!({ "phase": "Backoff", "consecutiveFailures": 2, "ready": 1 }),
+        ))
+        .unwrap();
+        assert!(pool_preflight_rejection("e2e-basic", &pool).is_none());
     }
 }

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -329,8 +329,87 @@ fn pod_crashloop(pod: &Pod, pod_role: crate::metrics::GuestPodRole) -> Option<Gu
             reason,
             restart_count: cs.restart_count,
             message,
+            container: cs.name.clone(),
+            last_log_tail: None,
         })
     })
+}
+
+/// Max lines / bytes of a crashed container's `--previous` log tail we keep.
+/// Bounded so a chatty crasher can't bloat the status message pipeline or the
+/// operator's log line; 40 lines comfortably covers a Go panic + backtrace
+/// head plus the errors leading into it.
+const CRASH_LOG_TAIL_LINES: i64 = 40;
+const CRASH_LOG_TAIL_MAX_BYTES: usize = 4096;
+
+/// Max length of the single distilled "last log" line appended to the crash
+/// message (which flows into `ClusterInstance.status.message` and from there
+/// into pool `lastFailureReason` — keep it status-field sized).
+const CRASH_LOG_LINE_MAX_CHARS: usize = 240;
+
+/// Best-effort fetch of the crashed container's previous-run log tail.
+/// `Ok(None)` covers the benign cases (no previous instance yet, logs
+/// rotated away, empty output); only transport-level errors propagate.
+async fn fetch_crash_log_tail(
+    pods: &Api<Pod>,
+    pod_name: &str,
+    container: &str,
+) -> Result<Option<String>> {
+    let lp = kube::api::LogParams {
+        container: Some(container.to_string()),
+        previous: true,
+        tail_lines: Some(CRASH_LOG_TAIL_LINES),
+        ..Default::default()
+    };
+    match pods.logs(pod_name, &lp).await {
+        Ok(text) => {
+            let text = text.trim_end();
+            if text.is_empty() {
+                return Ok(None);
+            }
+            // Keep the END of the tail when over budget — the fatal line is
+            // at the bottom.
+            let bounded = if text.len() > CRASH_LOG_TAIL_MAX_BYTES {
+                let cut = text.len() - CRASH_LOG_TAIL_MAX_BYTES;
+                // Snap forward to a char boundary, then to the next line start.
+                let mut idx = cut;
+                while idx < text.len() && !text.is_char_boundary(idx) {
+                    idx += 1;
+                }
+                let tail = &text[idx..];
+                tail.split_once('\n').map(|(_, rest)| rest).unwrap_or(tail)
+            } else {
+                text
+            };
+            Ok(Some(bounded.to_string()))
+        }
+        // 400: "previous terminated container not found" (first crash still
+        // being written, or kubelet GC'd it). 404: pod vanished mid-probe.
+        Err(kube::Error::Api(ae)) if ae.code == 400 || ae.code == 404 => Ok(None),
+        Err(e) => Err(e.into()),
+    }
+}
+
+/// Pick the most diagnostic single line out of a crash log tail: the LAST
+/// line matching a fatal pattern (`panic:`, Go `fatal error:`, klog `F...`
+/// fatals, logrus `level=fatal`), else the last non-empty line. Truncated to
+/// [`CRASH_LOG_LINE_MAX_CHARS`].
+fn distill_fatal_line(tail: &str) -> Option<String> {
+    let is_fatal = |l: &str| {
+        l.contains("panic:")
+            || l.contains("fatal error:")
+            || l.contains("level=fatal")
+            || (l.starts_with('F') && l.len() > 1 && l.as_bytes()[1].is_ascii_digit())
+    };
+    let lines = || tail.lines().map(str::trim).filter(|l| !l.is_empty());
+    let picked = lines()
+        .rfind(|l| is_fatal(l))
+        .or_else(|| lines().next_back())?;
+    let mut line: String = picked.chars().take(CRASH_LOG_LINE_MAX_CHARS).collect();
+    if picked.chars().count() > CRASH_LOG_LINE_MAX_CHARS {
+        line.push('…');
+    }
+    Some(line)
 }
 
 /// HA gate: `servers > 1` requires an external (shared) datastore.
@@ -1546,7 +1625,28 @@ impl K3sBackend {
             };
 
             for pod in &pod_list.items {
-                if let Some(crash) = pod_crashloop(pod, pod_role) {
+                if let Some(mut crash) = pod_crashloop(pod, pod_role) {
+                    // Dying-words capture (#197 follow-up): grab a bounded tail
+                    // of the crashed container's previous run and distill its
+                    // fatal line into the message. Best-effort — the crash
+                    // signal itself never depends on log availability.
+                    if let Some(pod_name) = pod.metadata.name.as_deref() {
+                        match fetch_crash_log_tail(&pods, pod_name, &crash.container).await {
+                            Ok(Some(tail)) => {
+                                if let Some(line) = distill_fatal_line(&tail) {
+                                    crash.message = format!("{}; last log: {line}", crash.message);
+                                }
+                                crash.last_log_tail = Some(tail);
+                            }
+                            Ok(None) => {}
+                            Err(e) => debug!(
+                                cluster = name,
+                                pod = pod_name,
+                                error = %e,
+                                "crashloop probe: previous-log fetch failed (continuing without)"
+                            ),
+                        }
+                    }
                     return Ok(Some(crash));
                 }
             }
@@ -4820,6 +4920,8 @@ mod tests {
                 reason: "Error".to_string(),
                 restart_count: 6,
                 message: "guest server pod CrashLoopBackOff: Error exit 2 (x6)".to_string(),
+                container: "k3s-server".to_string(),
+                last_log_tail: None,
             })
         );
     }
@@ -4844,6 +4946,8 @@ mod tests {
                 reason: "Error".to_string(),
                 restart_count: 3,
                 message: "guest server pod CrashLoopBackOff: Error exit 137 (x3)".to_string(),
+                container: "k3s-server".to_string(),
+                last_log_tail: None,
             })
         );
     }
@@ -4989,18 +5093,71 @@ mod tests {
             .mount(&server)
             .await;
 
-        let got = backend.detect_crashloop_impl(cluster, ns).await.unwrap();
+        // Dying-words capture: the previous run's log tail is fetched and its
+        // fatal line is distilled into the message.
+        let tail = "time=\"...\" level=info msg=\"Waiting for control-plane node\"\n\
+                    panic: F0720 08:42:28 csi_plugin.go:323] Failed to initialize CSINode after retrying: timed out waiting for the condition\n\
+                    goroutine 10333 [running]:";
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/api/v1/namespaces/{ns}/pods/pool-test-1-server-0/log"
+            )))
+            .and(query_param("previous", "true"))
+            .and(query_param("container", "k3s-server"))
+            .respond_with(ResponseTemplate::new(200).set_body_string(tail))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let got = backend
+            .detect_crashloop_impl(cluster, ns)
+            .await
+            .unwrap()
+            .expect("crashloop must be detected");
+        assert_eq!(got.pod_role, crate::metrics::GuestPodRole::Server);
+        assert_eq!(got.exit_code, "2");
+        assert_eq!(got.reason, "Error");
+        assert_eq!(got.restart_count, 6);
         assert_eq!(
-            got,
-            Some(GuestPodCrash {
-                pod_role: crate::metrics::GuestPodRole::Server,
-                exit_code: "2".to_string(),
-                reason: "Error".to_string(),
-                restart_count: 6,
-                message: "guest server pod CrashLoopBackOff: Error exit 2 (x6)".to_string(),
-            })
+            got.message,
+            "guest server pod CrashLoopBackOff: Error exit 2 (x6); last log: \
+             panic: F0720 08:42:28 csi_plugin.go:323] Failed to initialize CSINode after retrying: timed out waiting for the condition"
         );
+        assert_eq!(got.last_log_tail.as_deref(), Some(tail));
         // Agent pods are never listed: the server crash short-circuits first.
+    }
+
+    #[test]
+    fn distill_fatal_line_picks_last_fatal_else_last_line() {
+        // Prefers the last fatal-looking line over trailing backtrace noise.
+        let tail = "level=info msg=\"starting\"\n\
+                    panic: something broke\n\
+                    goroutine 1 [running]:";
+        assert_eq!(
+            distill_fatal_line(tail).as_deref(),
+            Some("panic: something broke")
+        );
+
+        // klog fatal (F<digits>...) counts as fatal.
+        let tail = "I0720 boot ok\nF0720 08:42:28 csi_plugin.go:323] boom\ntrailer";
+        assert_eq!(
+            distill_fatal_line(tail).as_deref(),
+            Some("F0720 08:42:28 csi_plugin.go:323] boom")
+        );
+
+        // No fatal pattern → last non-empty line.
+        assert_eq!(
+            distill_fatal_line("line one\nline two\n\n").as_deref(),
+            Some("line two")
+        );
+        // Empty → None.
+        assert_eq!(distill_fatal_line("\n  \n"), None);
+
+        // Over-long lines are truncated with an ellipsis.
+        let long = format!("panic: {}", "x".repeat(400));
+        let got = distill_fatal_line(&long).unwrap();
+        assert_eq!(got.chars().count(), CRASH_LOG_LINE_MAX_CHARS + 1);
+        assert!(got.ends_with('…'));
     }
 
     /// A healthy (Running, no restarts) server pod with no agent pods → not

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -416,8 +416,19 @@ pub struct GuestPodCrash {
     /// Container restart count at observation time, for the human message.
     pub restart_count: i32,
     /// Short human string, e.g.
-    /// `guest server pod CrashLoopBackOff: Error exit 2 (x6)`.
+    /// `guest server pod CrashLoopBackOff: Error exit 2 (x6)`. When the
+    /// backend captured the previous run's logs, a distilled fatal line is
+    /// appended: `...; last log: panic: Failed to initialize CSINode ...`.
     pub message: String,
+    /// Name of the crashlooping container (e.g. `k3s-server`), so callers can
+    /// fetch its logs.
+    pub container: String,
+    /// Bounded tail of the crashed container's `--previous` logs (its dying
+    /// words), best-effort. The instance controller logs this verbatim so the
+    /// evidence survives the instance being recycled — otherwise the only copy
+    /// dies with the pod and an operator has to race the crashloop with
+    /// `kubectl logs --previous`.
+    pub last_log_tail: Option<String>,
 }
 
 /// Backend-agnostic interface for managing virtual cluster lifecycles.

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -624,6 +624,12 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                                     exit_code = %crash.exit_code,
                                     restart_count = crash.restart_count,
                                     message = %crash.message,
+                                    // The crashed container's dying words. This
+                                    // log line is the durable copy: the pod (and
+                                    // its `--previous` logs) is recycled shortly
+                                    // after, so without it the failure cause is
+                                    // unrecoverable post-mortem.
+                                    last_log_tail = %crash.last_log_tail.as_deref().unwrap_or(""),
                                     "Guest Pod crashlooping (observability only; recycle unchanged)"
                                 );
                                 patch_instance_status(

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -160,7 +160,50 @@ mod cluster_instance_tests {
             spec_hash: None,
             scheduling_blocked,
             crashlooping: false,
+            crash_message: None,
         }
+    }
+
+    /// #197 follow-up: a crashlooping member's captured crash message (incl.
+    /// the distilled "last log" fatal line) is cited in the reason, so the
+    /// lease-preflight 503 `detail` built from it answers *why* the pool is
+    /// failing. Newest instance (highest name) wins when several crashloop.
+    #[test]
+    fn backoff_reason_cites_crashloop_evidence() {
+        let profile = profile_with_status(serde_json::json!({
+            "consecutiveFailures": 2, "maxAttemptedIndex": 3, "lastReadyMaxIndex": 1
+        }));
+        let mut clusters = HashMap::new();
+        let mut entry = entry_with_block(ClusterState::Creating, false);
+        entry.crashlooping = true;
+        entry.crash_message = Some(
+            "guest server pod CrashLoopBackOff: Error exit 2 (x6); last log: \
+             panic: Failed to initialize CSINode after retrying: timed out"
+                .to_string(),
+        );
+        clusters.insert("pool-p-3".to_string(), entry);
+        let mut older = entry_with_block(ClusterState::Creating, false);
+        older.crashlooping = true;
+        older.crash_message = Some("older crash".to_string());
+        clusters.insert("pool-p-2".to_string(), older);
+        let pool_state = PoolState { clusters };
+        let counts = crate::pool::manager::StateCounts::default();
+        let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
+
+        let reason = backoff
+            .last_failure_reason
+            .expect("reason populated while failing");
+        assert!(
+            reason.contains("e.g. pool-p-3: guest server pod CrashLoopBackOff"),
+            "expected crashloop evidence from the newest member, got: {reason}"
+        );
+        assert!(
+            reason.contains("Failed to initialize CSINode"),
+            "expected the distilled last-log line, got: {reason}"
+        );
+        assert!(!reason.contains("older crash"), "got: {reason}");
+        // The generic triage pointer is still present.
+        assert!(reason.contains("not reaching Ready"), "got: {reason}");
     }
 
     /// #189 (observability): when the #191 scheduling-blocked backpressure is
@@ -815,6 +858,7 @@ async fn reconcile_profile(
                         // recomputes both from status.message next reconcile.
                         scheduling_blocked: false,
                         crashlooping: false,
+                        crash_message: None,
                     },
                 );
             }
@@ -1152,6 +1196,11 @@ async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState
                 spec_hash: status.spec_hash,
                 scheduling_blocked,
                 crashlooping,
+                // Carry the evidence (crash message incl. the distilled "last
+                // log" line) so `compute_backoff_state` can cite it in the
+                // pool's `lastFailureReason` instead of a bare pointer to
+                // kubectl.
+                crash_message: crashlooping.then(|| status.message.clone()).flatten(),
             },
         );
     }
@@ -1638,12 +1687,26 @@ fn compute_backoff_state(
     // empty — defeating the status field's purpose. This text is human-facing
     // ONLY; the metric label comes from `failure_class` above.
     let last_failure_reason = if new_failures > 0 {
-        let base = format!(
+        let mut base = format!(
             "{new_failures} instance(s) not reaching Ready (attempted up to index \
              {new_max_attempted}, highest Ready {new_last_ready_max}); inspect the \
              Failed/not-Ready ClusterInstances (kubectl get ci -l \
              kobe.kunobi.ninja/pool={profile_name}) and their pod logs/events"
         );
+        // #197 follow-up: when a member is crashlooping we HAVE the concrete
+        // cause (the instance controller stamped it, incl. the distilled
+        // "last log" fatal line) — cite one example so the reason (and the
+        // lease-preflight 503 `detail` built from it) answers *why* instead
+        // of only pointing at kubectl. Highest name wins for determinism
+        // (that's the newest attempt under the pool's naming scheme).
+        if let Some((name, msg)) = pool_state
+            .clusters
+            .iter()
+            .filter_map(|(name, e)| e.crash_message.as_deref().map(|m| (name, m)))
+            .max_by(|a, b| a.0.cmp(b.0))
+        {
+            base.push_str(&format!("; e.g. {name}: {msg}"));
+        }
         // #189 (observability): when the #191 scheduling-blocked backpressure is
         // engaged, prefix the reason so it clearly reads as a capacity wedge
         // (`failure_class` above is already `Capacity`). This is a STRING-ONLY

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -301,6 +301,11 @@ pub struct ClusterEntry {
     /// from `Timeout` to `CrashLooping` so the wedge is attributable. Derived
     /// from the synced status message in `build_pool_state`; `false` otherwise.
     pub crashlooping: bool,
+    /// The crashlooping instance's `status.message` (e.g. `guest server pod
+    /// CrashLoopBackOff: Error exit 2 (x6); last log: panic: ...`), carried so
+    /// the pool's `lastFailureReason` can cite concrete evidence instead of
+    /// only pointing at `kubectl`. `None` unless `crashlooping`.
+    pub crash_message: Option<String>,
 }
 
 /// Decisions the pool manager emits after evaluating state.
@@ -1212,6 +1217,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1224,6 +1230,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1236,6 +1243,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
 
@@ -1268,6 +1276,7 @@ mod tests {
                 spec_hash: Some(current.clone()),
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1280,6 +1289,7 @@ mod tests {
                 spec_hash: Some("ddddffffffffffff".to_string()),
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1292,6 +1302,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1304,6 +1315,7 @@ mod tests {
                 spec_hash: Some("ddddffffffffffff".to_string()),
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -1418,6 +1430,7 @@ mod tests {
             spec_hash: None,
             scheduling_blocked: false,
             crashlooping: false,
+            crash_message: None,
         }
     }
 
@@ -1583,6 +1596,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1595,6 +1609,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -1642,6 +1657,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1654,6 +1670,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -1706,6 +1723,7 @@ mod tests {
                 spec_hash: Some(stale_hash.clone()), // stale
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -1718,6 +1736,7 @@ mod tests {
                 spec_hash: Some(stale_hash.clone()), // stale but leased
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -1931,6 +1950,7 @@ mod tests {
                 spec_hash: Some(current_hash),
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -2299,6 +2319,7 @@ mod tests {
             spec_hash: Some("ddddffffffffffff".to_string()), // never matches the real current hash
             scheduling_blocked: false,
             crashlooping: false,
+            crash_message: None,
         }
     }
 
@@ -2311,6 +2332,7 @@ mod tests {
             spec_hash: Some(current_hash),
             scheduling_blocked: false,
             crashlooping: false,
+            crash_message: None,
         }
     }
 
@@ -2638,6 +2660,7 @@ mod tests {
                 spec_hash: Some(current.clone()),
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -2895,6 +2918,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -2907,6 +2931,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -2962,6 +2987,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -3018,6 +3044,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: true,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         // Clean, equally-old Creating — the control: it MUST be Deleted.
@@ -3031,6 +3058,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -3108,6 +3136,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: true,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };
@@ -3167,6 +3196,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: true,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         clusters.insert(
@@ -3179,6 +3209,7 @@ mod tests {
                 spec_hash: None,
                 scheduling_blocked: false,
                 crashlooping: false,
+                crash_message: None,
             },
         );
         let state = PoolState { clusters };


### PR DESCRIPTION
## Incident (2026-07-20, int-pro `ci-k3s-kunobi`)

Every new instance since ~05:00 UTC crashloops: the guest k3s server panics at ~30s with `Failed to initialize CSINode after retrying: timed out` (node registration races the 30s CSINode deadline and loses; the healthy 5239 won it by 4s). Pool → `Failing`, and then:

1. **The pre-flight 503'd every claim even though the pool had 5 Ready / 0 leased members.** A background provisioning problem became a full CI outage.
2. **The failure cause was invisible**: `lastFailureReason` only said "10 instance(s) not reaching Ready … inspect the ClusterInstances", and the panic evidence dies with the recycled pod unless you race `kubectl logs --previous`.

## Changes

- **Pre-flight**: `Failing` rejects only when `ready == 0` (mirrors the existing `Backoff` guard). Ready members keep serving regardless of pool phase — the bind path always supported this.
- **Crashloop forensics** (#197 follow-up): `detect_crashloop` fetches a bounded tail (40 lines / 4KB) of the crashed container's `--previous` logs, distills the fatal line, and threads it through: crash message → `ClusterInstance.status.message` → pool `lastFailureReason` (`…; e.g. pool-x-5251: guest server pod CrashLoopBackOff: Error exit 2 (x6); last log: panic: Failed to initialize CSINode …`) → lease 503 `detail` → CI output (pairs with kunobi-ninja/kobe-action#7). The full tail is WARN-logged so the evidence survives the recycle in the log pipeline.
- **kobectl**: lease-create errors now include the 503 `detail` instead of dropping it.

## Tests

- `pool_preflight_rejection_serves_failing_pool_with_ready_members` (new), existing Failing/ready-0 503 test unchanged.
- `detect_crashloop_reports_crashlooping_server` extended with a mocked `--previous` log fetch asserting the distilled message + tail.
- `distill_fatal_line_picks_last_fatal_else_last_line`, `backoff_reason_cites_crashloop_evidence` (new).
- 641/641 tests pass, clippy clean.
