### PR TITLE
fix(k3s): back the guest data dir with a volume even without persistence

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.33.0"
+version = "0.34.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.33.0"
+version = "0.34.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, CAPI, and kobe-sync.
 type: application
-version: 0.21.17
-appVersion: "0.33.0"
+version: 0.21.18
+appVersion: "0.34.0"
 keywords:
   - kubernetes
   - operator

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -767,14 +767,21 @@ impl K3sBackend {
             },
         ];
 
-        // If persistence is configured, mount data volume
-        if config.persistence.is_some() {
-            volume_mounts.push(VolumeMount {
-                name: "data".to_string(),
-                mount_path: "/var/lib/rancher/k3s".to_string(),
-                ..Default::default()
-            });
-        }
+        // Always mount the `data` volume at k3s's real data dir. With
+        // persistence it's a per-replica PVC (volumeClaimTemplates); without,
+        // an emptyDir (see `build_server_volumes`). Leaving the data dir in
+        // the container's overlayfs rw layer is what made the 2026-07-20
+        // ci-k3s-kunobi crashloop terminal: the nested containerd can't use
+        // the overlayfs snapshotter on top of overlayfs (slow ~25-35s
+        // runtime-ready, racing the kubelet's fatal CSINode-init deadline),
+        // and every container restart cold-started from scratch, replaying
+        // the lost race forever. An emptyDir gives containerd a real node
+        // filesystem AND lets a restart resume with certs/DB/images intact.
+        volume_mounts.push(VolumeMount {
+            name: "data".to_string(),
+            mount_path: "/var/lib/rancher/k3s".to_string(),
+            ..Default::default()
+        });
 
         // Optional registries.yaml mount — points at the file k3s
         // reads at startup to configure containerd mirrors.
@@ -972,8 +979,18 @@ impl K3sBackend {
         // backed by a per-replica PVC declared in the StatefulSet's
         // `volumeClaimTemplates` (see `build_server_statefulset`), so it is NOT
         // listed here — adding a pod-level volume of the same name would shadow
-        // the claim template. Without persistence, no `data` volume is needed
-        // (the container mount is only added when persistence is set).
+        // the claim template. Without persistence it's an emptyDir: k3s's data
+        // dir (incl. the nested containerd) must live on a real node
+        // filesystem, not the container's overlay rw layer, and must survive
+        // container restarts so a lost startup race self-heals instead of
+        // replaying identically (2026-07-20 CSINode-panic crashloop).
+        if config.persistence.is_none() {
+            volumes.push(Volume {
+                name: "data".to_string(),
+                empty_dir: Some(k8s_openapi::api::core::v1::EmptyDirVolumeSource::default()),
+                ..Default::default()
+            });
+        }
 
         // Optional registries.yaml ConfigMap — only mounted when
         // registry_mirrors was set on the ClusterConfig.
@@ -1260,12 +1277,24 @@ impl K3sBackend {
         let labels = Self::agent_labels(name, pool);
         let domain = cluster_domain(config);
 
-        let mut volume_mounts = vec![VolumeMount {
-            name: "token".to_string(),
-            mount_path: "/var/lib/k3s/token".to_string(),
-            read_only: Some(true),
-            ..Default::default()
-        }];
+        let mut volume_mounts = vec![
+            VolumeMount {
+                name: "token".to_string(),
+                mount_path: "/var/lib/k3s/token".to_string(),
+                read_only: Some(true),
+                ..Default::default()
+            },
+            // k3s data dir on an emptyDir, same rationale as the server (see
+            // `build_server_container`): the agent's nested containerd needs a
+            // real node filesystem, and its state must survive container
+            // restarts — the agent kubelet runs the same fatal
+            // CSINode-init-deadline race on every cold start.
+            VolumeMount {
+                name: "data".to_string(),
+                mount_path: "/var/lib/rancher/k3s".to_string(),
+                ..Default::default()
+            },
+        ];
         if has_registry_mirrors(config) {
             volume_mounts.push(VolumeMount {
                 name: "registries-config".to_string(),
@@ -1322,19 +1351,28 @@ impl K3sBackend {
             ..Default::default()
         };
 
-        let mut volumes = vec![Volume {
-            name: "token".to_string(),
-            secret: Some(SecretVolumeSource {
-                secret_name: Some(format!("{name}-token")),
-                items: Some(vec![KeyToPath {
-                    key: "token".to_string(),
-                    path: "token".to_string(),
+        let mut volumes = vec![
+            Volume {
+                name: "token".to_string(),
+                secret: Some(SecretVolumeSource {
+                    secret_name: Some(format!("{name}-token")),
+                    items: Some(vec![KeyToPath {
+                        key: "token".to_string(),
+                        path: "token".to_string(),
+                        ..Default::default()
+                    }]),
                     ..Default::default()
-                }]),
+                }),
                 ..Default::default()
-            }),
-            ..Default::default()
-        }];
+            },
+            // Agents are stateless across pod replacement — emptyDir is
+            // always the right backing here (no PVC variant like the server).
+            Volume {
+                name: "data".to_string(),
+                empty_dir: Some(k8s_openapi::api::core::v1::EmptyDirVolumeSource::default()),
+                ..Default::default()
+            },
+        ];
         if has_registry_mirrors(config) {
             volumes.push(Volume {
                 name: "registries-config".to_string(),
@@ -2250,6 +2288,83 @@ mod tests {
         assert!(
             sts.spec.unwrap().volume_claim_templates.is_none(),
             "no persistence ⇒ no volumeClaimTemplates"
+        );
+    }
+
+    /// Without persistence, the k3s data dir must STILL be a real volume
+    /// (emptyDir) mounted at /var/lib/rancher/k3s on both server and agent —
+    /// never the container's overlay rw layer. Leaving it on overlay made the
+    /// 2026-07-20 crashloop terminal: nested containerd couldn't use the
+    /// overlayfs snapshotter (~25-35s runtime-ready racing the kubelet's
+    /// ~23s fatal CSINode-init window on k8s ≤1.32), and every restart
+    /// cold-started, replaying the lost race forever.
+    #[test]
+    fn test_no_persistence_data_dir_backed_by_emptydir() {
+        let config = base_config();
+        assert!(config.persistence.is_none(), "test premise: no persistence");
+
+        // Server: pod-level emptyDir `data` volume + container mount.
+        let sts = K3sBackend::build_server_statefulset("c", "ns", &config, None, 1);
+        let pod_spec = sts.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        let data_vol = pod_spec
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| v.name == "data")
+            .expect("server pod must have a `data` volume without persistence");
+        assert!(
+            data_vol.empty_dir.is_some(),
+            "no persistence ⇒ `data` is an emptyDir"
+        );
+        let server_mounts = pod_spec.containers[0].volume_mounts.as_ref().unwrap();
+        assert!(
+            server_mounts
+                .iter()
+                .any(|m| m.name == "data" && m.mount_path == "/var/lib/rancher/k3s"),
+            "server container must mount `data` at /var/lib/rancher/k3s"
+        );
+
+        // With persistence the pod-level volume must NOT appear (it would
+        // shadow the volumeClaimTemplates PVC of the same name).
+        let mut persisted = base_config();
+        persisted.persistence = Some(PersistenceConfig {
+            storage_type: Some("dynamic".to_string()),
+            storage_class_name: None,
+            storage_request_size: None,
+        });
+        let sts = K3sBackend::build_server_statefulset("c", "ns", &persisted, None, 1);
+        let pod_spec = sts.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        assert!(
+            !pod_spec
+                .volumes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|v| v.name == "data"),
+            "persistence ⇒ `data` comes from volumeClaimTemplates, not a pod volume"
+        );
+
+        // Agent: always emptyDir-backed `data` + mount.
+        let dep = K3sBackend::build_agent_deployment("c", "ns", &config, 1);
+        let pod_spec = dep.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        assert!(
+            pod_spec
+                .volumes
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|v| v.name == "data" && v.empty_dir.is_some()),
+            "agent pod must have an emptyDir `data` volume"
+        );
+        assert!(
+            pod_spec.containers[0]
+                .volume_mounts
+                .as_ref()
+                .unwrap()
+                .iter()
+                .any(|m| m.name == "data" && m.mount_path == "/var/lib/rancher/k3s"),
+            "agent container must mount `data` at /var/lib/rancher/k3s"
         );
     }
 

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -164,6 +164,30 @@ mod cluster_instance_tests {
         }
     }
 
+    /// Guest-version guardrail: k8s ≤1.32 carries the ~23s fatal CSINode-init
+    /// window; ≥1.33 (and non-1.x / unparseable) does not.
+    #[test]
+    fn guest_version_narrow_csinode_window_classification() {
+        // The incident version and its neighbors.
+        assert!(guest_version_has_narrow_csinode_window("v1.31.3+k3s1"));
+        assert!(guest_version_has_narrow_csinode_window("v1.32.0-k3s1"));
+        assert!(guest_version_has_narrow_csinode_window("1.28.9"));
+        // Fixed upstream in 1.33.
+        assert!(!guest_version_has_narrow_csinode_window("v1.33.13+k3s1"));
+        assert!(!guest_version_has_narrow_csinode_window("v1.34.0"));
+        // Unparseable / exotic → no advisory without evidence.
+        assert!(!guest_version_has_narrow_csinode_window("latest"));
+        assert!(!guest_version_has_narrow_csinode_window(""));
+        assert!(!guest_version_has_narrow_csinode_window("v2.0.0"));
+
+        // Parser corner cases.
+        assert_eq!(guest_k8s_major_minor("v1.31.3+k3s1"), Some((1, 31)));
+        assert_eq!(guest_k8s_major_minor("1.32"), Some((1, 32)));
+        assert_eq!(guest_k8s_major_minor("v1.31+k0s.0"), Some((1, 31)));
+        assert_eq!(guest_k8s_major_minor("v1..3"), None);
+        assert_eq!(guest_k8s_major_minor("vx.y"), None);
+    }
+
     /// #197 follow-up: a crashlooping member's captured crash message (incl.
     /// the distilled "last log" fatal line) is cited in the reason, so the
     /// lease-preflight 503 `detail` built from it answers *why* the pool is
@@ -978,6 +1002,30 @@ async fn reconcile_profile(
         .with_label_values(&[name.as_str()])
         .set(effective_memory_bytes);
 
+    // Guest-version guardrail (2026-07-20 incident): a guest k8s ≤1.32 kubelet
+    // has only a ~23s FATAL CSINode-init retry window; nested containerd
+    // cold-start can exceed it, panicking the guest server/agent into a
+    // crashloop. k8s 1.33 widened the window to ~140s. kobe can't patch the
+    // kubelet, so for old versions the posture is: (a) this warning + the
+    // `kobe_pool_guest_version_advisory` gauge, and (b) the built-in
+    // mitigation of an emptyDir-backed guest data dir, which makes each
+    // restart resume (warm state) instead of replaying the race from zero.
+    let narrow_window = guest_version_has_narrow_csinode_window(&profile.spec.cluster.version);
+    if narrow_window {
+        warn!(
+            profile = %name,
+            guest_version = %profile.spec.cluster.version,
+            "guest Kubernetes ≤1.32 has a ~23s fatal CSINode-init window: slow \
+             nested-containerd cold starts can panic-crashloop guest pods \
+             (2026-07-20 ci-k3s-kunobi incident). Upgrade spec.cluster.version \
+             to >= v1.33 (window widened to ~140s). Until then the emptyDir \
+             data-dir mitigation limits the blast to self-healing restarts."
+        );
+    }
+    crate::metrics::POOL_GUEST_VERSION_ADVISORY
+        .with_label_values(&[name.as_str(), "narrow_csinode_window"])
+        .set(i64::from(narrow_window));
+
     // #189 (observability): surface "this pool is wedged on capacity" derived
     // from the existing #191 scheduling-blocked state. 1 when any instance is
     // scheduling-blocked (guest Pods unschedulable), else 0. Read-only mirror
@@ -1129,6 +1177,32 @@ fn emit_pool_failure_metrics(profile: &str, signals: &PoolFailureSignals) {
 }
 
 /// Build pool state from ClusterInstance inventory.
+/// Parse the guest Kubernetes `(major, minor)` out of a cluster version
+/// string as kobe accepts them: `v1.31.3+k3s1`, `v1.33.13-k3s1`, `1.32.0`,
+/// `v1.31.3+k0s.0`, … Returns `None` for anything it can't confidently parse
+/// (callers must then make no version-based claims).
+fn guest_k8s_major_minor(version: &str) -> Option<(u32, u32)> {
+    let v = version.trim().trim_start_matches('v');
+    let mut parts = v.split('.');
+    let major: u32 = parts.next()?.parse().ok()?;
+    // Minor may be followed by a patch (`.3+k3s1`) or carry a suffix directly
+    // (`1.31+k3s1`); stop at the first non-digit.
+    let minor_raw = parts.next()?;
+    let digits: String = minor_raw.chars().take_while(|c| c.is_ascii_digit()).collect();
+    if digits.is_empty() {
+        return None;
+    }
+    Some((major, digits.parse().ok()?))
+}
+
+/// True when the guest kubelet carries the ~23s fatal CSINode-init retry
+/// window (k8s ≤1.32; csi_plugin.go backoff 6 steps/15ms/×6). k8s 1.33
+/// widened it to ~140s (30ms/×8), which is what makes nested cold starts
+/// safe. Unparseable versions return `false` — no advisory without evidence.
+fn guest_version_has_narrow_csinode_window(version: &str) -> bool {
+    matches!(guest_k8s_major_minor(version), Some((1, minor)) if minor <= 32)
+}
+
 async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState {
     info!(
         profile = profile_name,

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -1188,7 +1188,10 @@ fn guest_k8s_major_minor(version: &str) -> Option<(u32, u32)> {
     // Minor may be followed by a patch (`.3+k3s1`) or carry a suffix directly
     // (`1.31+k3s1`); stop at the first non-digit.
     let minor_raw = parts.next()?;
-    let digits: String = minor_raw.chars().take_while(|c| c.is_ascii_digit()).collect();
+    let digits: String = minor_raw
+        .chars()
+        .take_while(|c| c.is_ascii_digit())
+        .collect();
     if digits.is_empty() {
         return None;
     }

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1019,6 +1019,23 @@ pub static POOL_CAPACITY_BLOCKED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// 1 when the pool's guest Kubernetes version carries a known operational
+/// hazard, else 0, by bounded `advisory` label. Current advisories:
+/// - `narrow_csinode_window`: guest k8s ≤1.32, whose kubelet has only a ~23s
+///   FATAL CSINode-init retry window (csi_plugin.go: 6 steps, 15ms, ×6) —
+///   nested containerd cold-start can exceed it and panic-crashloop the guest
+///   (2026-07-20 ci-k3s-kunobi incident). k8s 1.33 widened it to ~140s.
+///
+/// Observability only — never an admission gate.
+pub static POOL_GUEST_VERSION_ADVISORY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "kobe_pool_guest_version_advisory",
+        "1 when the pool's guest Kubernetes version has a known hazard (see advisory label), else 0",
+        &["profile", "advisory"]
+    )
+    .unwrap()
+});
+
 /// Effective memory request (bytes) kobe stamps onto each guest pod
 /// (k3s server + agent) for this pool — explicit `requests.memory` or, when
 /// absent, the `limits.memory` the kubelet silently copies into the request.
@@ -1255,6 +1272,7 @@ pub fn init() {
     LazyLock::force(&IPAM_POOL_ALLOCATED);
     LazyLock::force(&POOL_SIZE);
     LazyLock::force(&POOL_EFFECTIVE_CPU_REQUEST_MILLICORES);
+    LazyLock::force(&POOL_GUEST_VERSION_ADVISORY);
     LazyLock::force(&POOL_CAPACITY_BLOCKED);
     LazyLock::force(&POOL_EFFECTIVE_MEMORY_REQUEST_BYTES);
     // Connect proxy


### PR DESCRIPTION
Second half of the 2026-07-20 `ci-k3s-kunobi` incident (#25 was blast-radius + forensics; this is the crashloop itself).

**Root cause (cross-verified Claude + codex, adjudicated against upstream k8s source):** without persistence the whole k3s data dir — including the nested containerd — lives in the guest container's overlayfs rw layer. containerd can't run its overlayfs snapshotter on top of overlayfs, so CRI runtime-ready takes ~25–35s; node registration is gated on it and races the kubelet's **fatal** CSINode-init window, which on k8s ≤1.32 is only **~23s** of backoff (`csi_plugin.go`: Steps 6 / 15ms / ×6 — matches our observed ~26s panics exactly). And because each container restart cold-starts from a fresh rw layer, one lost race replays identically forever — terminal CrashLoopBackOff.

**Change:** mount a pod-level `emptyDir` at `/var/lib/rancher/k3s`:
- server: only when no persistence is configured (with persistence the `volumeClaimTemplates` PVC keeps owning the `data` name — pinned by test);
- agent: always (agents have no PVC variant).

Effects: containerd gets a real node filesystem (overlayfs snapshotter works → runtime-ready in seconds), and restarts resume with certs/DB/images intact — a lost first boot self-heals on restart #2 instead of crashlooping.

**Companion (margin half):** bump the pool's guest k3s to ≥ v1.33 — upstream widened the CSINode-init backoff ~23s → ~140s in release-1.33. That's a pool-config change in tenant-int-pro.

New test: `test_no_persistence_data_dir_backed_by_emptydir` (server emptyDir + mount, no shadowing under persistence, agent emptyDir + mount). 642/642 tests pass, clippy clean.
