### PR TITLE
feat(readiness): add InClusterToken to default k3s/k0s/vcluster admission gates

### DIFF
--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -1034,10 +1034,14 @@ async fn evaluate_leased_instance<B: ClusterBackend + Clone>(
 ///   bug `ci-vkobe-flux` hid behind for 7 days on an internal cluster). Its DNS is
 ///   host-projected, not a standard `kube-dns` Service, so the DNS gate
 ///   below doesn't apply to it.
-/// - **k3s / k0s / vcluster** → `DNSHealthy`. These bundle CoreDNS fronted
-///   by the `kube-dns` Service; gate on DNS *actually serving* so a cluster
-///   whose CoreDNS crashloops on an in-cluster x509 mismatch (#42) —
-///   answering apiserver, dead DNS — is never leased.
+/// - **k3s / k0s / vcluster** → `DNSHealthy` + `InClusterToken` (#10). These
+///   bundle CoreDNS fronted by the `kube-dns` Service; gate on DNS *actually
+///   serving* so a cluster whose CoreDNS crashloops on an in-cluster x509
+///   mismatch (#42) — answering apiserver, dead DNS — is never leased. The
+///   token gate additionally proves the SA sign/verify chain a workload's
+///   `rest.InClusterConfig()` depends on (TokenRequest → TokenReview, both
+///   from the operator's admin client — cheap, no probe Pod), closing the
+///   second bad-but-Ready class from #42/#92.
 /// - **capi** → none. CAPI clusters are provider/distro-defined and
 ///   `kube-dns` is not guaranteed; imposing a DNS gate could wedge a valid
 ///   pool.
@@ -1056,7 +1060,13 @@ fn apply_default_readiness_gates(
     match backend_type {
         BackendType::Vkobe => vec![ReadinessGate::SchedulingProbe { namespace: None }],
         BackendType::K3s | BackendType::K0s | BackendType::Vcluster => {
-            vec![ReadinessGate::DnsHealthy { namespace: None }]
+            vec![
+                ReadinessGate::DnsHealthy { namespace: None },
+                ReadinessGate::InClusterToken {
+                    namespace: None,
+                    service_account: None,
+                },
+            ]
         }
         BackendType::Capi => gates,
     }
@@ -2889,17 +2899,29 @@ mod tests {
         ));
     }
 
-    /// Real-cluster backends (k3s/k0s/vcluster) with no user gates get a
-    /// default `DNSHealthy` — they bundle CoreDNS behind `kube-dns`, so a
-    /// dead-DNS-but-live-apiserver cluster (#42) must not be leased.
+    /// Real-cluster backends (k3s/k0s/vcluster) with no user gates get the
+    /// default functional-admission pair (#10): `DNSHealthy` (they bundle
+    /// CoreDNS behind `kube-dns`, so a dead-DNS-but-live-apiserver cluster
+    /// (#42) must not be leased) + `InClusterToken` (the SA sign/verify chain
+    /// every `rest.InClusterConfig()` workload depends on must round-trip).
     #[test]
-    fn real_cluster_backends_with_no_gates_get_default_dns_healthy() {
+    fn real_cluster_backends_with_no_gates_get_default_dns_and_token() {
         for backend in [BackendType::K3s, BackendType::K0s, BackendType::Vcluster] {
             let gates = apply_default_readiness_gates(backend.clone(), vec![]);
-            assert_eq!(gates.len(), 1, "{backend:?} should get one default gate");
+            assert_eq!(gates.len(), 2, "{backend:?} should get two default gates");
             assert!(
                 matches!(gates[0], ReadinessGate::DnsHealthy { namespace: None }),
-                "{backend:?} default should be DNSHealthy"
+                "{backend:?} first default should be DNSHealthy"
+            );
+            assert!(
+                matches!(
+                    gates[1],
+                    ReadinessGate::InClusterToken {
+                        namespace: None,
+                        service_account: None
+                    }
+                ),
+                "{backend:?} second default should be InClusterToken"
             );
         }
     }


### PR DESCRIPTION
Part of #10 (readiness-gate-as-admission).

Both functional gates from the issue already exist and are implemented+tested (`DNSHealthy`, `InClusterToken`), but the default admission set for real-cluster backends was `DNSHealthy` alone — a guest with working DNS but a broken ServiceAccount sign/verify chain (the #42/#92 bad-but-Ready class) could still be leased.

**Change:** default gates for k3s/k0s/vcluster become `[DNSHealthy, InClusterToken]` — Ready now requires DNS actually serving **and** a TokenRequest → TokenReview round-trip (the exact chain `rest.InClusterConfig()` depends on). Both run from the operator's admin client: no probe Pod, two API calls per readiness evaluation. User-declared gate lists still pass through unchanged (documented opt-out); CAPI/vkobe defaults untouched. The production `ci-k3s-kunobi` pool declares no gates, so it picks this up automatically on the next operator release.

**Still open on #10 after this:** promoting the nightly k3s smoke gate into the per-backend conformance matrix in CI.

Cross-checked: codex review leg on the diff — endorsed, no objections ("correctly adds the in-cluster token gate to the intended backend defaults while preserving explicit user gates and existing CAPI/vkobe behavior"). 643/643 tests, clippy clean, fmt applied.
