### PR TITLE
chore(release): bump workspace version to 0.35.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2716,7 +2716,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.34.0"
+version = "0.35.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.34.0"
+version = "0.35.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, CAPI, and kobe-sync.
 type: application
-version: 0.21.18
-appVersion: "0.34.0"
+version: 0.21.19
+appVersion: "0.35.0"
 keywords:
   - kubernetes
   - operator


### PR DESCRIPTION
Version bump for v0.35.0: default InClusterToken admission gate for k3s/k0s/vcluster pools (#28).
