### PR TITLE
feat(ci): run k3s conformance on main pushes + release tags; enforce backend coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -160,22 +160,34 @@ jobs:
   # (name suffixed by backend) and always tears it down. `fail-fast: false` so
   # one backend's failure doesn't mask the others.
   #
-  # PHASE 1: nightly + manual ONLY, not yet a PR-required check. k3s is the
-  # proven leg (was the standalone `e2e` job); the vkobe legs run the same gate
-  # on the vkobe backend across both datastores (etcd + kine/sqlite). vcluster
-  # and capi have no e2e harness/pool yet — tracked as follow-up before they
-  # join the matrix (and before conformance becomes the admission rule for new
-  # backends, the remaining half of #164). No `container:` block: like
-  # `docker-dry-run`, this needs the host Docker socket for kind + buildx.
+  # PHASE 2 (#10): the k3s leg — the production backend — also runs on every
+  # push to main and on release tags, so a conformance regression is caught
+  # before (main) or at (tag) the release boundary instead of a day later.
+  # The full matrix (k3s + both vkobe datastores) stays nightly + manual; the
+  # vkobe legs run the same gate across etcd + kine/sqlite. vcluster and capi
+  # have no e2e harness/pool yet — tracked as follow-up before they join the
+  # matrix; `backend_conformance_coverage_is_classified` (crd/profile.rs)
+  # forces every new BackendType to be consciously classified against this
+  # matrix. Since #28, reaching Ready on k3s/k0s/vcluster requires the
+  # functional admission gates (DNSHealthy + InClusterToken), so every leg
+  # that provisions to Ready exercises them end-to-end. Deliberately NOT in
+  # `publish.needs` yet: a flaky e2e must not block an urgent release —
+  # promote once the main-push signal proves stable. No `container:` block:
+  # like `docker-dry-run`, this needs the host Docker socket for kind + buildx.
   conformance:
-    if: github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+    if: >-
+      ${{ github.event_name == 'workflow_dispatch' || github.event_name == 'schedule'
+          || (github.event_name == 'push'
+              && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))) }}
     needs: [checks]
     runs-on: kunobi-runners
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
-        backend: [k3s, vkobe-etcd, vkobe-kine]
+        # k3s-only on push (fast feedback on the production backend); the full
+        # matrix nightly / on manual dispatch.
+        backend: ${{ fromJSON(github.event_name == 'push' && '["k3s"]' || '["k3s", "vkobe-etcd", "vkobe-kine"]') }}
     steps:
       - uses: actions/checkout@v4
 

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1639,6 +1639,50 @@ fn default_backup_ttl() -> String {
 mod tests {
     use super::*;
 
+    /// #10: "passes conformance" is the admission rule for backends. The
+    /// exhaustive match is the enforcement: adding a `BackendType` variant
+    /// fails compilation here until the author consciously classifies it —
+    /// either naming its CI conformance-matrix leg(s) or documenting why it
+    /// is exempt. Covered legs are cross-checked against the workflow text so
+    /// this list can't silently drift from `.github/workflows/ci.yml`.
+    #[test]
+    fn backend_conformance_coverage_is_classified() {
+        fn conformance_legs(backend: &BackendType) -> Option<&'static [&'static str]> {
+            match backend {
+                BackendType::K3s => Some(&["\"k3s\""]),
+                BackendType::Vkobe => Some(&["vkobe-etcd", "vkobe-kine"]),
+                // Documented exemptions — NOT yet in the matrix:
+                // - vcluster: no e2e harness pool yet (#10 follow-up; must
+                //   join before it carries production load)
+                // - capi: no CI infrastructure provider yet
+                // - k0s: no e2e pool in the harness yet
+                BackendType::Vcluster | BackendType::Capi | BackendType::K0s => None,
+            }
+        }
+
+        let ci = include_str!("../../.github/workflows/ci.yml");
+        // The iteration list may lag a new variant; that's fine — the
+        // exhaustive match above is what breaks the build for new variants.
+        for backend in [
+            BackendType::K3s,
+            BackendType::K0s,
+            BackendType::Capi,
+            BackendType::Vkobe,
+            BackendType::Vcluster,
+        ] {
+            if let Some(legs) = conformance_legs(&backend) {
+                for leg in legs {
+                    assert!(
+                        ci.contains(leg),
+                        "{backend:?} is classified as conformance-covered by leg {leg}, \
+                         but ci.yml's conformance matrix does not mention it — update \
+                         the matrix or this classification"
+                    );
+                }
+            }
+        }
+    }
+
     /// The canonical user-configurable syncer list. Both
     /// `default_vkobe_syncers` (this module — operator writes it into
     /// the per-cluster ConfigMap) and


### PR DESCRIPTION
Completes #10 (with #28), scoped per discussion to hardening the working k3s path — no new backend legs.

- **k3s conformance leg runs on every main push and on `v*` release tags** (was nightly/manual only). Full matrix stays nightly + manual. Deliberately not gating `publish` yet — a flaky e2e must not block an urgent release; promote once the main-push signal proves stable.
- **Admission rule enforced structurally**: `backend_conformance_coverage_is_classified` exhaustively matches `BackendType` — adding a backend variant fails compilation until it's classified (matrix leg(s), cross-checked against `ci.yml`, or a documented exemption). Current exemptions: vcluster (harness pending), capi (no CI infra provider), k0s (no e2e pool).
- Since #28, Ready on k3s/k0s/vcluster requires `DNSHealthy` + `InClusterToken`, so every conformance leg that provisions to Ready exercises the functional gates end-to-end (noted in the workflow comment).

Closes #10 — the vcluster leg gets its own follow-up issue.

644/644 tests, clippy clean, workflow YAML validated.
