### PR TITLE
docs: reconcile runtime strategy — kobe-sync on hold, vcluster + pkobe current

### DIFF
--- a/docs/kobe-docs/how-it-works/architecture.mdx
+++ b/docs/kobe-docs/how-it-works/architecture.mdx
@@ -1,11 +1,11 @@
 ---
 title: Architecture
-description: The operator, HTTP API, pool manager, and virtual cluster runtime - and how a lease flows through them.
+description: The operator, HTTP API, pool manager, and runtime backends - and how a lease flows through them.
 ---
 
 # Architecture
 
-kobe has four main components: the **operator**, the **HTTP API**, the **pool manager**, and **kobe-sync**. Understanding what each one does makes it easier to configure pools correctly and diagnose problems.
+kobe has three main components — the **operator**, the **HTTP API**, and the **pool manager** — plus pluggable **runtime backends** that do the actual cluster provisioning. Understanding what each one does makes it easier to configure pools correctly and diagnose problems.
 
 ## The operator
 
@@ -45,11 +45,21 @@ Creating -> Ready (warm) -> Leased -> Recycling -> [destroyed, replaced]
 
 The pool manager uses a per-pool lock to prevent races when multiple requests try to assign the same ready instance concurrently.
 
-## kobe-sync
+## Runtime backends
 
-`kobe-sync` is a per-cluster sidecar that runs inside each virtual cluster pod. It acts as a reverse proxy between clients and the virtual kube-apiserver, and synchronizes selected Kubernetes resources between the virtual cluster and the host.
+The instance controller delegates actual cluster provisioning to a per-pool
+backend: nested **k3s** / **k0s** clusters (today's production path),
+**vcluster** for high-density virtual clusters, or **CAPI** for
+provider-managed real infrastructure. All backends satisfy the same
+`ClusterBackend` contract — provision, health-check, readiness-gate, recycle —
+so pools, leases, and admission behave identically regardless of runtime.
+See [Backends](/docs/pools/backends) for configuration and
+[Runtime strategy](/docs/how-it-works/runtime-strategy) for which runtime to
+pick and where the roadmap is heading.
 
-For the vkobe backend, kobe-sync also runs a lightweight kube-apiserver and kube-controller-manager, making the virtual cluster entirely self-contained within a single pod. See [Backends](/docs/pools/backends) for details.
+> **Note:** the in-house `kobe-sync` sidecar and the `vkobe` backend built on
+> it are **retired** — see [Runtime strategy](/docs/how-it-works/runtime-strategy).
+> They remain in the tree only to support migration of existing pools.
 
 ## High availability
 
@@ -60,6 +70,6 @@ The operator supports multi-replica deployments via leader election. Only the le
 | Binary | Role |
 |---|---|
 | `kobe-operator` | Operator + HTTP API server |
-| `kobe-sync` | Per-cluster virtual runtime and proxy |
 | `kobe` | CLI client |
 | `crdgen` | CRD schema generator |
+| `kobe-sync` | Retired per-cluster runtime for the deprecated `vkobe` backend (kept for migration only) |

--- a/docs/kobe-docs/how-it-works/architecture.mdx
+++ b/docs/kobe-docs/how-it-works/architecture.mdx
@@ -57,9 +57,10 @@ See [Backends](/docs/pools/backends) for configuration and
 [Runtime strategy](/docs/how-it-works/runtime-strategy) for which runtime to
 pick and where the roadmap is heading.
 
-> **Note:** the in-house `kobe-sync` sidecar and the `vkobe` backend built on
-> it are **retired** — see [Runtime strategy](/docs/how-it-works/runtime-strategy).
-> They remain in the tree only to support migration of existing pools.
+> **Note:** development of the in-house `kobe-sync` sidecar and the `vkobe`
+> backend built on it is **on hold** — see
+> [Runtime strategy](/docs/how-it-works/runtime-strategy). Existing pools keep
+> working; prefer `vcluster` for new density pools.
 
 ## High availability
 
@@ -72,4 +73,4 @@ The operator supports multi-replica deployments via leader election. Only the le
 | `kobe-operator` | Operator + HTTP API server |
 | `kobe` | CLI client |
 | `crdgen` | CRD schema generator |
-| `kobe-sync` | Retired per-cluster runtime for the deprecated `vkobe` backend (kept for migration only) |
+| `kobe-sync` | Per-cluster runtime for the `vkobe` backend (development on hold) |

--- a/docs/kobe-docs/how-it-works/meta.json
+++ b/docs/kobe-docs/how-it-works/meta.json
@@ -1,4 +1,8 @@
 {
   "title": "How it works",
-  "pages": ["architecture", "pool-lifecycle"]
+  "pages": [
+    "architecture",
+    "runtime-strategy",
+    "pool-lifecycle"
+  ]
 }

--- a/docs/kobe-docs/how-it-works/runtime-strategy.mdx
+++ b/docs/kobe-docs/how-it-works/runtime-strategy.mdx
@@ -1,0 +1,64 @@
+---
+title: Runtime strategy
+description: Which virtual-cluster runtime kobe stands on today, where it is heading, and what is retired.
+---
+
+# Runtime strategy
+
+This page is the authoritative statement of kobe's runtime direction. If any
+other document disagrees with it, this page wins.
+
+kobe's value is the **fleet layer** — pools, leases, multi-backend admission,
+GitOps, golden images, observability — kept uniform across runtimes. The
+runtimes themselves are deliberately pluggable, and the strategy is two-pronged:
+
+## Density: vcluster
+
+For high-density, low-overhead virtual clusters (CI, ephemeral environments),
+kobe stands on **[vcluster](https://www.vcluster.com/)** (loft-sh, Apache 2.0)
+as the `vcluster` backend. The operator deploys one vcluster instance per
+`ClusterInstance` via the upstream Helm chart into a dedicated per-instance
+namespace.
+
+Because this backend inherits vcluster's syncer semantics, it also inherits
+its fidelity boundaries (cloud identity such as IRSA, syncer coverage, version
+skew). Route tenants who need full-fidelity cluster semantics to an
+isolation-tier backend instead.
+
+## Isolation: pkobe (native)
+
+For workloads that need real isolation and full API fidelity — dedicated
+control planes, real worker nodes, native RBAC/CSI/cloud-identity — kobe builds
+its own runtime: **pkobe** (dedicated control plane + real nodes, KubeVirt as
+the primary node provider). This is the backend kobe develops natively, and
+the roadmap's isolation tier. See the roadmap epic
+([#24](https://github.com/kunobi-ninja/kobe/issues/24)) and the pkobe issue
+([#23](https://github.com/kunobi-ninja/kobe/issues/23)).
+
+Until pkobe lands, full isolation is served by the **k3s / k0s** backends
+(nested real clusters) — today's production path — and **CAPI** for
+provider-managed real infrastructure.
+
+## Retired: kobe-sync / vkobe
+
+The in-house proxy-based syncer runtime — the `kobe-sync` sidecar and the
+`vkobe` backend built on it — is **retired**. It is not the path forward:
+maintaining translation fidelity for the full Kubernetes resource surface is a
+whole product in itself, and the effort is better spent on the fleet layer and
+on pkobe.
+
+The code still exists (the `vkobe` backend is marked deprecated in the CRD)
+to support existing pools during migration to `vcluster`, but no new
+functionality is added to it and new pools should not use it. Contributor
+guidance that presents kobe-sync as a core component is stale — this page
+supersedes it.
+
+## Summary
+
+| Need | Backend | Status |
+|---|---|---|
+| Nested real clusters (CI today) | `k3s` / `k0s` | Production |
+| High density, low overhead | `vcluster` | Adopted |
+| Full isolation, native fidelity | `pkobe` | In design (#23) |
+| Provider-managed real infra | `capi` | Available |
+| Proxy-based virtual clusters | `vkobe` (kobe-sync) | **Retired / deprecated** |

--- a/docs/kobe-docs/how-it-works/runtime-strategy.mdx
+++ b/docs/kobe-docs/how-it-works/runtime-strategy.mdx
@@ -39,19 +39,18 @@ Until pkobe lands, full isolation is served by the **k3s / k0s** backends
 (nested real clusters) — today's production path — and **CAPI** for
 provider-managed real infrastructure.
 
-## Retired: kobe-sync / vkobe
+## On hold: kobe-sync / vkobe
 
-The in-house proxy-based syncer runtime — the `kobe-sync` sidecar and the
-`vkobe` backend built on it — is **retired**. It is not the path forward:
-maintaining translation fidelity for the full Kubernetes resource surface is a
-whole product in itself, and the effort is better spent on the fleet layer and
-on pkobe.
+Development of the in-house proxy-based syncer runtime — the `kobe-sync`
+sidecar and the `vkobe` backend built on it — is **on hold**. Maintaining
+translation fidelity for the full Kubernetes resource surface is a whole
+product in itself, and current effort goes to the fleet layer, the vcluster
+backend, and pkobe instead.
 
-The code still exists (the `vkobe` backend is marked deprecated in the CRD)
-to support existing pools during migration to `vcluster`, but no new
-functionality is added to it and new pools should not use it. Contributor
-guidance that presents kobe-sync as a core component is stale — this page
-supersedes it.
+The code remains in the tree and existing vkobe pools keep working, but no
+new functionality is being added while it is on hold — prefer `vcluster` for
+new density pools. Contributor guidance that presents kobe-sync as the
+actively developed runtime is stale — this page supersedes it.
 
 ## Summary
 
@@ -61,4 +60,4 @@ supersedes it.
 | High density, low overhead | `vcluster` | Adopted |
 | Full isolation, native fidelity | `pkobe` | In design (#23) |
 | Provider-managed real infra | `capi` | Available |
-| Proxy-based virtual clusters | `vkobe` (kobe-sync) | **Retired / deprecated** |
+| Proxy-based virtual clusters | `vkobe` (kobe-sync) | **On hold** |

--- a/docs/kobe-docs/pools/backends.mdx
+++ b/docs/kobe-docs/pools/backends.mdx
@@ -1,11 +1,11 @@
 ---
 title: Backends
-description: k3s, k0s, CAPI, and vkobe — how each backend provisions virtual clusters.
+description: k3s, k0s, CAPI, and vcluster — how each backend provisions virtual clusters.
 ---
 
 # Backends
 
-kobe supports four backends for provisioning virtual clusters. The backend is selected per pool via `spec.backend.type`. All backends expose the same lease API; the difference is how each `ClusterInstance` is provisioned and what runtime it uses.
+kobe supports multiple backends for provisioning virtual clusters. The backend is selected per pool via `spec.backend.type`. All backends expose the same lease API; the difference is how each `ClusterInstance` is provisioned and what runtime it uses. For guidance on which runtime to pick — and which are retired — see [Runtime strategy](/docs/how-it-works/runtime-strategy).
 
 ## k3s (default)
 
@@ -69,9 +69,32 @@ spec:
 
 **When to use:** When you need to use an existing CAPI infrastructure provider, or when kobe's built-in backends don't support your target environment.
 
-## vkobe
+## vcluster
 
-vkobe is kobe's lightweight virtual cluster runtime. Each virtual cluster runs as a single pod containing a proxy-based kube-apiserver, an optional kube-controller-manager, and kobe-sync. It does not depend on any third-party virtual cluster runtime.
+The vcluster backend deploys one [vcluster](https://www.vcluster.com/) (loft-sh, Apache 2.0) instance per `ClusterInstance` via the upstream Helm chart, into a dedicated per-instance host namespace — isolating projection scope per instance and making teardown trivially correct (`helm uninstall` + namespace delete).
+
+```yaml
+spec:
+  backend:
+    type: vcluster
+    vcluster:
+      chartVersion: ""        # optional; operator's pinned default applies when unset
+      values: |               # optional; free-form vcluster chart values (YAML),
+        sync:                 # merged on top of the operator's defaults
+          toHost:
+            ingresses:
+              enabled: true
+```
+
+**When to use:** High density and low per-cluster overhead without maintaining an in-house syncer. Note that fidelity boundaries (cloud identity such as IRSA, syncer coverage, version skew) are inherited from vcluster — route tenants who need full cluster semantics to a real-cluster backend.
+
+## vkobe (deprecated)
+
+> **Deprecated.** vkobe and its `kobe-sync` runtime are retired — see
+> [Runtime strategy](/docs/how-it-works/runtime-strategy). Existing pools keep
+> working during migration to `vcluster`; do not create new vkobe pools.
+
+vkobe is kobe's retired in-house virtual cluster runtime. Each virtual cluster runs as a single pod containing a proxy-based kube-apiserver, an optional kube-controller-manager, and kobe-sync. It does not depend on any third-party virtual cluster runtime.
 
 ```yaml
 spec:
@@ -125,11 +148,11 @@ spec:
 
 ## Comparison
 
-| | k3s | k0s | CAPI | vkobe |
-|---|---|---|---|---|
-| Isolation | Full | Full | Full | Namespace |
-| Overhead per cluster | Low | Low | Provider-dependent | Very low |
-| Provision time | ~30s | ~30s | ~60s+ | ~5s |
-| Golden images (Velero) | Yes | Yes | Varies | No |
-| Shared etcd | Via PostgreSQL | Via PostgreSQL | No | Yes (required) |
-| Custom addons | Yes | Yes | Yes | Yes |
+| | k3s | k0s | CAPI | vcluster | vkobe (deprecated) |
+|---|---|---|---|---|---|
+| Isolation | Full | Full | Full | Namespace | Namespace |
+| Overhead per cluster | Low | Low | Provider-dependent | Very low | Very low |
+| Provision time | ~30s | ~30s | ~60s+ | ~15s | ~5s |
+| Golden images (Velero) | Yes | Yes | Varies | No | No |
+| Shared etcd | Via PostgreSQL | Via PostgreSQL | No | No | Yes (required) |
+| Custom addons | Yes | Yes | Yes | Yes | Yes |

--- a/docs/kobe-docs/pools/backends.mdx
+++ b/docs/kobe-docs/pools/backends.mdx
@@ -88,13 +88,13 @@ spec:
 
 **When to use:** High density and low per-cluster overhead without maintaining an in-house syncer. Note that fidelity boundaries (cloud identity such as IRSA, syncer coverage, version skew) are inherited from vcluster — route tenants who need full cluster semantics to a real-cluster backend.
 
-## vkobe (deprecated)
+## vkobe (on hold)
 
-> **Deprecated.** vkobe and its `kobe-sync` runtime are retired — see
+> **On hold.** Development of vkobe and its `kobe-sync` runtime is paused — see
 > [Runtime strategy](/docs/how-it-works/runtime-strategy). Existing pools keep
-> working during migration to `vcluster`; do not create new vkobe pools.
+> working; prefer `vcluster` for new density pools.
 
-vkobe is kobe's retired in-house virtual cluster runtime. Each virtual cluster runs as a single pod containing a proxy-based kube-apiserver, an optional kube-controller-manager, and kobe-sync. It does not depend on any third-party virtual cluster runtime.
+vkobe is kobe's in-house virtual cluster runtime. Each virtual cluster runs as a single pod containing a proxy-based kube-apiserver, an optional kube-controller-manager, and kobe-sync. It does not depend on any third-party virtual cluster runtime.
 
 ```yaml
 spec:
@@ -148,7 +148,7 @@ spec:
 
 ## Comparison
 
-| | k3s | k0s | CAPI | vcluster | vkobe (deprecated) |
+| | k3s | k0s | CAPI | vcluster | vkobe (on hold) |
 |---|---|---|---|---|---|
 | Isolation | Full | Full | Full | Namespace | Namespace |
 | Overhead per cluster | Low | Low | Provider-dependent | Very low | Very low |


### PR DESCRIPTION
Fixes the stale-doc trap from #17: live docs still presented kobe-sync/vkobe as the actively developed path.

- New authoritative page: **how-it-works/runtime-strategy** — vcluster = density backend (adopted); pkobe = native isolation backend (in design, #23); k3s/k0s = today's production path; kobe-sync/vkobe = **on hold** (existing pools keep working, no new functionality while paused; prefer vcluster for new density pools). If any other doc disagrees, this page wins.
- **architecture.mdx**: components are operator + HTTP API + pool manager + pluggable runtime backends; kobe-sync moved from core component to an on-hold note; binaries table updated.
- **backends.mdx**: vcluster documented as a first-class backend (per-instance Helm deploy into a dedicated namespace, chartVersion/values knobs, fidelity caveat); vkobe marked on hold; comparison table updated.

Closes #17.