### PR TITLE
feat(pki): bounded cert validity + recycle-before-expiry

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2698,6 +2698,7 @@ dependencies = [
  "sqlx",
  "tempfile",
  "thiserror 2.0.18",
+ "time",
  "tokio",
  "tokio-rustls 0.26.4",
  "tokio-test",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -103,6 +103,7 @@ bytes = "1"
 
 # kobe-sync: TLS and certificates
 rcgen = { version = "0.13", features = ["x509-parser"] }
+time = "0.3"
 rustls = { version = "0.23", default-features = false, features = ["ring"] }
 tokio-rustls = "0.26"
 rustls-pemfile = "2"

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -161,6 +161,7 @@ mod cluster_instance_tests {
             scheduling_blocked,
             crashlooping: false,
             crash_message: None,
+            cert_horizon_secs: None,
         }
     }
 
@@ -812,6 +813,37 @@ async fn reconcile_profile(
     // happened to succeed at this exact reconcile.
     let bootstrap_specs = resolve_bootstrap_specs(&ctx.client, &ns, &profile).await;
 
+    // #19 recycle-before-expiry: for kobe-managed-PKI backends, read
+    // per-instance cert horizons (also emits the `kobe_cert_expiry_seconds`
+    // gauge) and stamp them BEFORE evaluation, so this reconcile's actions
+    // already treat in-horizon members as drifted (surge-replace, recycle
+    // unclaimed soonest-expiry-first, never leased — the standard drift
+    // machinery). Skipped entirely for self-managed-PKI backends
+    // (k3s/k0s/capi): no `{name}-certs` Secret exists, so probing would only
+    // add per-member API calls to the reconcile path.
+    if matches!(
+        profile.spec.backend.backend_type,
+        crate::crd::BackendType::Vkobe | crate::crd::BackendType::Vcluster
+    ) {
+        let cert_horizons =
+            collect_and_emit_cert_expiry(&ctx.client, &ns, &name, &pool_state).await;
+        for (cluster_name, entry) in pool_state.clusters.iter_mut() {
+            let Some(horizon) = cert_horizons.get(cluster_name) else {
+                continue;
+            };
+            entry.cert_horizon_secs = Some(*horizon);
+            if entry.cert_expiring() {
+                warn!(
+                    profile = %name,
+                    cluster = %cluster_name,
+                    horizon_days = horizon / 86_400,
+                    "instance PKI certificate within the recycle-before-expiry \
+                     horizon; scheduling drift-style recycle (#19)"
+                );
+            }
+        }
+    }
+
     let actions = compute_pool_actions(
         &profile,
         &pool_state,
@@ -883,6 +915,7 @@ async fn reconcile_profile(
                         scheduling_blocked: false,
                         crashlooping: false,
                         crash_message: None,
+                        cert_horizon_secs: None,
                     },
                 );
             }
@@ -940,7 +973,6 @@ async fn reconcile_profile(
         .await
         .insert(name.clone(), pool_state.clone());
     sync_cluster_instance_statuses(&ctx.client, &ns, &pool_state).await;
-    emit_cert_expiry_metrics(&ctx.client, &ns, &name, &pool_state).await;
 
     // Phase metrics here only need the base state taxonomy — pass
     // `None` for `current_hash` so the drift-aware buckets stay 0.
@@ -1278,6 +1310,7 @@ async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState
                 // pool's `lastFailureReason` instead of a bare pointer to
                 // kubectl.
                 crash_message: crashlooping.then(|| status.message.clone()).flatten(),
+                cert_horizon_secs: None,
             },
         );
     }
@@ -1518,17 +1551,22 @@ async fn patch_cluster_instance_status(
     Ok(())
 }
 
-/// Best-effort: emit `kobe_cert_expiry_seconds` for a pool by reading each
-/// instance's `{name}-certs` Secret and tracking the soonest-expiring cert per
-/// component. Never fails a reconcile — a missing secret (k3s/k0s backends,
-/// which manage their own PKI, or an instance not yet provisioned) is simply
-/// skipped, so a pool with no kobe-managed PKI emits nothing. See #169.
-async fn emit_cert_expiry_metrics(
+/// Best-effort: read each instance's `{name}-certs` Secret, emit
+/// `kobe_cert_expiry_seconds` per component (worst across the pool), and
+/// return each instance's soonest cert horizon in seconds — the input for
+/// recycle-before-expiry (#19). Only meaningful for backends using the
+/// kobe-managed PKI (vkobe / vcluster) — callers skip it entirely for
+/// self-managed-PKI backends (k3s/k0s/capi), keeping Secret reads off those
+/// pools' reconcile path. Never fails a reconcile: a missing Secret (instance
+/// not yet provisioned) is skipped silently; a read ERROR is skipped
+/// fail-open but logged, so a persistent RBAC/API problem is visible instead
+/// of silently disabling expiry protection. See #169.
+async fn collect_and_emit_cert_expiry(
     client: &Client,
     namespace: &str,
     profile: &str,
     pool_state: &PoolState,
-) {
+) -> HashMap<String, i64> {
     use k8s_openapi::api::core::v1::Secret;
 
     // Secret data key -> metric `component` label.
@@ -1541,12 +1579,26 @@ async fn emit_cert_expiry_metrics(
     let secrets: Api<Secret> = Api::namespaced(client.clone(), namespace);
     let now = chrono::Utc::now().timestamp();
     let mut worst: HashMap<&str, i64> = HashMap::new();
+    let mut per_instance: HashMap<String, i64> = HashMap::new();
 
     for cluster_name in pool_state.clusters.keys() {
-        // 404 (non-PKI backend / not yet created) or a transient error → skip.
         let secret = match secrets.get_opt(&format!("{cluster_name}-certs")).await {
             Ok(Some(s)) => s,
-            _ => continue,
+            // Not yet provisioned → nothing to measure yet.
+            Ok(None) => continue,
+            // Fail-open (this pass must never wedge a reconcile) but VISIBLE:
+            // a persistent read failure would otherwise silently disable
+            // recycle-before-expiry for this member.
+            Err(e) => {
+                warn!(
+                    profile = %profile,
+                    cluster = %cluster_name,
+                    error = %e,
+                    "cert-expiry probe: failed to read certs Secret (fail-open, \
+                     no expiry protection for this member this reconcile)"
+                );
+                continue;
+            }
         };
         let Some(data) = secret.data else { continue };
         for (key, component) in COMPONENTS {
@@ -1561,6 +1613,10 @@ async fn emit_cert_expiry_metrics(
                 .entry(component)
                 .and_modify(|m| *m = (*m).min(horizon))
                 .or_insert(horizon);
+            per_instance
+                .entry(cluster_name.clone())
+                .and_modify(|m| *m = (*m).min(horizon))
+                .or_insert(horizon);
         }
     }
 
@@ -1569,6 +1625,8 @@ async fn emit_cert_expiry_metrics(
             .with_label_values(&[profile, component])
             .set(horizon);
     }
+
+    per_instance
 }
 
 async fn sync_cluster_instance_statuses(client: &Client, namespace: &str, pool_state: &PoolState) {

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1115,11 +1115,11 @@ pub static LEASE_HOLD_SECONDS: LazyLock<HistogramVec> = LazyLock::new(|| {
 /// this pool has a cert expiring soon" alertable; the specific cluster lives in
 /// logs/traces. Goes negative once a cert is past `NotAfter`.
 ///
-/// Note (#169): the kobe PKI currently sets no explicit validity (rcgen default
-/// → effectively non-expiring), so today this surfaces that state rather than a
-/// tight horizon; bounded validity + recycle-before-expiry is the tracked
-/// follow-up. Emitting the gauge now means the alert/dashboard wiring is ready
-/// the day validity becomes bounded.
+/// Since #19 the kobe PKI carries bounded validity (CA ~10y, leafs ~1y) and
+/// the profile controller recycles members whose soonest cert is within the
+/// recycle-before-expiry horizon (30d), so in a healthy pool this gauge never
+/// approaches zero — alert on it dropping below the horizon: that means the
+/// recycle machinery is failing to keep up.
 pub static CERT_EXPIRY_SECONDS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     register_int_gauge_vec!(
         "kobe_cert_expiry_seconds",

--- a/src/pki.rs
+++ b/src/pki.rs
@@ -383,6 +383,34 @@ pub fn cert_not_after_unix(pem: &str) -> Option<i64> {
 // Internal helpers
 // ---------------------------------------------------------------------------
 
+/// CA certificate validity (days). Mirrors the kubeadm/k3s convention of a
+/// 10-year cluster CA. Bounded (rather than rcgen's effectively-non-expiring
+/// default) so the expiry horizon is real and observable (#19/#169).
+const CA_VALIDITY_DAYS: i64 = 3650;
+
+/// Leaf certificate validity (days) — apiserver serving cert, front-proxy
+/// client cert, kubeconfig client certs. One year, mirroring the kubeadm
+/// convention. The pool controller recycles instances well before this
+/// horizon (recycle-before-expiry, #19), so a leaf expiring in production
+/// means the recycle machinery has been broken for weeks — alert on the
+/// `kobe_cert_expiry_seconds` gauge.
+const LEAF_VALIDITY_DAYS: i64 = 365;
+
+/// Not-before backdate applied to every generated cert, absorbing clock skew
+/// between the operator and whatever validates the cert.
+const NOT_BEFORE_SKEW_HOURS: i64 = 1;
+
+/// Bounded validity window (`not_before`, `not_after`) for a cert generated
+/// "now", as rcgen timestamps. Whole-second precision is plenty for cert
+/// lifetimes; x509 stores seconds anyway.
+fn validity_window(validity_days: i64) -> (time::OffsetDateTime, time::OffsetDateTime) {
+    let now = time::OffsetDateTime::now_utc();
+    (
+        now - time::Duration::hours(NOT_BEFORE_SKEW_HOURS),
+        now + time::Duration::days(validity_days),
+    )
+}
+
 /// Generate a self-signed CA with a specific CN and org.
 fn generate_named_ca(san: &str, cn: &str, org: &str) -> Result<(String, String)> {
     let mut params = CertificateParams::new(vec![san.to_string()])?;
@@ -391,6 +419,7 @@ fn generate_named_ca(san: &str, cn: &str, org: &str) -> Result<(String, String)>
     params
         .distinguished_name
         .push(DnType::OrganizationName, org);
+    (params.not_before, params.not_after) = validity_window(CA_VALIDITY_DAYS);
 
     let key = KeyPair::generate()?;
     let cert = params.self_signed(&key)?;
@@ -430,6 +459,7 @@ fn generate_signed_cert(
     params
         .distinguished_name
         .push(DnType::OrganizationName, org);
+    (params.not_before, params.not_after) = validity_window(LEAF_VALIDITY_DAYS);
 
     let key = KeyPair::generate()?;
     let cert = params.signed_by(&key, &ca_cert, &ca_key)?;
@@ -531,6 +561,38 @@ mod tests {
             None,
             "a private key is not a cert"
         );
+    }
+
+    /// #19: certificates must carry BOUNDED validity (CA ~10y, leafs ~1y) —
+    /// rcgen's default is effectively non-expiring, which made the expiry
+    /// horizon gauge vacuous and recycle-before-expiry impossible.
+    #[test]
+    fn test_generated_certs_have_bounded_validity() {
+        let pki = VirtualClusterPki::generate("test-cluster", &["kubernetes.default"]).unwrap();
+        let now = std::time::SystemTime::now()
+            .duration_since(std::time::UNIX_EPOCH)
+            .unwrap()
+            .as_secs() as i64;
+        const DAY: i64 = 86_400;
+
+        let ca = cert_not_after_unix(&pki.ca_cert).expect("CA NotAfter parses");
+        assert!(
+            (ca - now - CA_VALIDITY_DAYS * DAY).abs() < DAY,
+            "CA NotAfter should be ~{CA_VALIDITY_DAYS}d out, got {}d",
+            (ca - now) / DAY
+        );
+
+        for (name, pem) in [
+            ("apiserver", &pki.apiserver_cert),
+            ("front-proxy-client", &pki.front_proxy_client_cert),
+        ] {
+            let leaf = cert_not_after_unix(pem).expect("leaf NotAfter parses");
+            assert!(
+                (leaf - now - LEAF_VALIDITY_DAYS * DAY).abs() < DAY,
+                "{name} NotAfter should be ~{LEAF_VALIDITY_DAYS}d out, got {}d",
+                (leaf - now) / DAY
+            );
+        }
     }
 
     #[test]

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -306,6 +306,33 @@ pub struct ClusterEntry {
     /// the pool's `lastFailureReason` can cite concrete evidence instead of
     /// only pointing at `kubectl`. `None` unless `crashlooping`.
     pub crash_message: Option<String>,
+    /// Seconds until this instance's soonest-expiring kobe-managed PKI
+    /// certificate (#19), stamped by the profile controller from the
+    /// `{name}-certs` Secret before pool evaluation. `None` for backends with
+    /// self-managed PKI (k3s/k0s) and when the Secret is absent/unreadable
+    /// (fail-open — logged by the collector). An instance inside
+    /// [`CERT_RECYCLE_HORIZON_SECS`] is treated exactly like spec drift:
+    /// unclaimed members recycle (bounded, surge-replaced first, soonest
+    /// expiry first, never leased ones — a leased member self-resolves via
+    /// the post-lease recycle, so the residual exposure is a lease whose TTL
+    /// exceeds the remaining horizon).
+    pub cert_horizon_secs: Option<i64>,
+}
+
+/// Recycle-before-expiry horizon (#19): an instance whose soonest-expiring
+/// kobe-managed cert is within this window is treated as drifted. 30 days
+/// against a 1-year leaf validity leaves ample retry room if recycling is
+/// delayed (backoff, pool wedge) and stays far from the cliff. Lease TTL caps
+/// must stay well below this horizon: a lease outliving the remaining horizon
+/// is the one case recycle-before-expiry cannot cover.
+pub const CERT_RECYCLE_HORIZON_SECS: i64 = 30 * 86_400;
+
+impl ClusterEntry {
+    /// Whether this member's PKI is inside the recycle-before-expiry horizon.
+    pub fn cert_expiring(&self) -> bool {
+        self.cert_horizon_secs
+            .is_some_and(|h| h < CERT_RECYCLE_HORIZON_SECS)
+    }
 }
 
 /// Decisions the pool manager emits after evaluating state.
@@ -604,12 +631,26 @@ pub fn compute_pool_actions(
         .filter(|(name, e)| {
             e.state == ClusterState::Ready
                 && !deleting.contains(*name)
-                && entry_drift_eligible(e.spec_hash.as_ref(), e.state_since, &current_hash, now)
+                && (entry_drift_eligible(e.spec_hash.as_ref(), e.state_since, &current_hash, now)
+                    // #19: PKI approaching expiry recycles exactly like drift.
+                    || e.cert_expiring())
         })
         .collect();
+    // Soonest-expiring PKI first (#19) — an hour-left member must not queue
+    // behind 29-days-left ones under the max_recycling cap. Non-expiring
+    // drifted members keep the historical ordering: longest-Ready first,
+    // name as the deterministic tiebreak.
+    let expiry_key = |e: &ClusterEntry| {
+        if e.cert_expiring() {
+            e.cert_horizon_secs.unwrap_or(i64::MAX)
+        } else {
+            i64::MAX
+        }
+    };
     drifted_ready.sort_by(|a, b| {
-        a.1.state_since
-            .cmp(&b.1.state_since)
+        expiry_key(a.1)
+            .cmp(&expiry_key(b.1))
+            .then_with(|| a.1.state_since.cmp(&b.1.state_since))
             .then_with(|| a.0.cmp(b.0))
     });
 
@@ -1039,24 +1080,23 @@ pub fn count_states(state: &PoolState, current_hash: Option<&SpecHash>) -> State
             ClusterState::Recycling => c.recycling += 1,
         }
         // Only an entry with both a `current_hash` to compare against
-        // AND its own stamped hash can drift. Unstamped entries
+        // AND its own stamped hash can hash-drift. Unstamped entries
         // (`spec_hash == None`) count as clean — see type-level doc.
-        if let (Some(curr), Some(entry_hash)) = (current_hash, &entry.spec_hash) {
-            let drifted = entry_hash != curr;
+        // `cert_expiring` (#19) also counts as drift: a member whose PKI
+        // approaches expiry needs the same treatment as a spec change —
+        // surge-replace, then recycle the unclaimed ones, never leased.
+        if current_hash.is_some() {
+            let hash_drifted = matches!(
+                (current_hash, &entry.spec_hash),
+                (Some(curr), Some(entry_hash)) if entry_hash != curr
+            );
+            let drifted = hash_drifted || entry.cert_expiring();
             match (&entry.state, drifted) {
                 (ClusterState::Ready, true) => c.ready_drifted += 1,
                 (ClusterState::Ready, false) => c.ready_clean += 1,
                 (ClusterState::Creating, true) => c.creating_drifted += 1,
                 (ClusterState::Creating, false) => c.creating_clean += 1,
                 (ClusterState::Leased, true) => c.leased_drifted += 1,
-                _ => {}
-            }
-        } else if current_hash.is_some() {
-            // current_hash provided but entry unstamped → clean bucket.
-            // Keeps `ready_clean + ready_drifted == ready` invariant.
-            match entry.state {
-                ClusterState::Ready => c.ready_clean += 1,
-                ClusterState::Creating => c.creating_clean += 1,
                 _ => {}
             }
         }
@@ -1218,6 +1258,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1231,6 +1272,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1244,6 +1286,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
 
@@ -1277,6 +1320,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1290,6 +1334,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1303,6 +1348,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1316,6 +1362,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -1431,6 +1478,7 @@ mod tests {
             scheduling_blocked: false,
             crashlooping: false,
             crash_message: None,
+            cert_horizon_secs: None,
         }
     }
 
@@ -1597,6 +1645,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1610,6 +1659,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -1658,6 +1708,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1671,6 +1722,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -1724,6 +1776,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -1737,6 +1790,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -1951,6 +2005,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -2320,6 +2375,7 @@ mod tests {
             scheduling_blocked: false,
             crashlooping: false,
             crash_message: None,
+            cert_horizon_secs: None,
         }
     }
 
@@ -2333,6 +2389,7 @@ mod tests {
             scheduling_blocked: false,
             crashlooping: false,
             crash_message: None,
+            cert_horizon_secs: None,
         }
     }
 
@@ -2617,6 +2674,116 @@ mod tests {
         );
     }
 
+    /// #19 recycle-before-expiry: a Ready member flagged `cert_expiring`
+    /// recycles exactly like spec drift — even with a CLEAN hash — while a
+    /// leased cert-expiring member is never deleted (the drift invariant),
+    /// and `count_states` partitions both into the drifted buckets.
+    #[test]
+    fn cert_expiring_ready_recycles_like_drift_leased_untouched() {
+        let profile = make_profile_with_upgrade(2, 1, 1, Some(0));
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+
+        let expiring = ClusterEntry {
+            state: ClusterState::Ready,
+            idle_since: None,
+            health_failures: 0,
+            state_since: Some(chrono::Utc::now() - chrono::Duration::seconds(1000)),
+            // Hash matches current: ONLY the cert horizon drives the recycle.
+            spec_hash: Some(current.clone()),
+            scheduling_blocked: false,
+            crashlooping: false,
+            crash_message: None,
+            cert_horizon_secs: Some(86_400),
+        };
+        let mut clusters = HashMap::new();
+        clusters.insert("pool-test-profile-1".into(), expiring.clone());
+        let mut leased = expiring.clone();
+        leased.state = ClusterState::Leased;
+        clusters.insert("pool-test-profile-2".into(), leased);
+        let mut clean = expiring.clone();
+        clean.cert_horizon_secs = None;
+        clusters.insert("pool-test-profile-3".into(), clean);
+        let state = PoolState { clusters };
+
+        let counts = count_states(&state, Some(&current));
+        assert_eq!(counts.ready_drifted, 1, "cert-expiring Ready is drifted");
+        assert_eq!(
+            counts.ready_clean, 1,
+            "non-expiring clean-hash Ready is clean"
+        );
+        assert_eq!(
+            counts.leased_drifted, 1,
+            "cert-expiring Leased counts drifted"
+        );
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter_map(|a| match a {
+                PoolAction::Delete(n) => Some(n.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            deletes,
+            vec!["pool-test-profile-1"],
+            "only the unclaimed cert-expiring member recycles; leased never"
+        );
+    }
+
+    /// #19: under the `max_recycling` cap, the member with the SOONEST cert
+    /// horizon recycles first — an hour-left member must not queue behind a
+    /// 29-days-left one, regardless of `state_since` age.
+    #[test]
+    fn soonest_expiring_member_recycles_first_under_cap() {
+        let profile = make_profile_with_upgrade(2, 1, 1, Some(0)); // max_recycling=1
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+
+        let entry = |horizon: i64, age_secs: i64| ClusterEntry {
+            state: ClusterState::Ready,
+            idle_since: None,
+            health_failures: 0,
+            state_since: Some(chrono::Utc::now() - chrono::Duration::seconds(age_secs)),
+            spec_hash: Some(current.clone()),
+            scheduling_blocked: false,
+            crashlooping: false,
+            crash_message: None,
+            cert_horizon_secs: Some(horizon),
+        };
+        let mut clusters = HashMap::new();
+        // Older member, but 29 days of horizon left.
+        clusters.insert("pool-test-profile-1".into(), entry(29 * 86_400, 10_000));
+        // Younger member, one hour left — must win the single recycle slot.
+        clusters.insert("pool-test-profile-2".into(), entry(3_600, 10));
+        let state = PoolState { clusters };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter_map(|a| match a {
+                PoolAction::Delete(n) => Some(n.as_str()),
+                _ => None,
+            })
+            .collect();
+        assert_eq!(
+            deletes,
+            vec!["pool-test-profile-2"],
+            "the one-hour-left member takes the capped recycle slot"
+        );
+    }
+
     /// Scale-down is gated on `drift_in_flight == 0`. While even a
     /// single drifted Ready remains, we must not reap fresh
     /// replacements as "excess idle past min_ready" — that would
@@ -2661,6 +2828,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -2919,6 +3087,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -2932,6 +3101,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -2988,6 +3158,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -3045,6 +3216,7 @@ mod tests {
                 scheduling_blocked: true,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         // Clean, equally-old Creating — the control: it MUST be Deleted.
@@ -3059,6 +3231,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -3137,6 +3310,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: true,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };
@@ -3197,6 +3371,7 @@ mod tests {
                 scheduling_blocked: true,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         clusters.insert(
@@ -3210,6 +3385,7 @@ mod tests {
                 scheduling_blocked: false,
                 crashlooping: false,
                 crash_message: None,
+                cert_horizon_secs: None,
             },
         );
         let state = PoolState { clusters };


### PR DESCRIPTION
Closes #19 — completes the loop that the expiry-horizon gauge (#1) opened: expiry is now bounded, observable, and **acted on**.

- **pki.rs**: explicit validity — CA 10y, leafs 1y (kubeadm/k3s convention); rcgen's default was effectively non-expiring, which made the gauge vacuous.
- **Profile controller**: for kobe-PKI backends only (vkobe/vcluster — k3s/k0s/capi pools pay zero cost), per-member cert horizons are read before pool evaluation, the `kobe_cert_expiry_seconds` gauge is emitted from the same pass, and the soonest horizon is stamped onto each pool entry. Secret read errors are fail-open but warn-logged.
- **Pool manager**: a member within the **30-day horizon** is treated exactly like spec drift — surge-replace first, recycle unclaimed members bounded by `max_recycling` and **soonest-expiry first**, never delete leased ones (they self-resolve via the post-lease recycle).

Reviewed cross-family (codex, blind diff review). Its findings and their dispositions:
- *"expiring members remain leasable"* — partially accepted: leases recycle on release, so the residual exposure is a lease TTL > remaining horizon; documented as the operating invariant (TTL caps ≪ 30d).
- *"cert inspection fails open"* — accepted: errors now warn-log (visible) while staying fail-open (a probe must never wedge reconcile).
- *"boolean discards the deadline"* — accepted: entries carry the horizon; recycling is soonest-expiry-first (test pins it).
- *"serial Secret GETs on the hot path"* — accepted: collection is gated to kobe-PKI backends.
- *"existing certs never trigger it"* — refuted in substance: pre-existing certs are effectively non-expiring, so they carry no expiry risk to protect against.

Tests: bounded-validity assertions on generated PKI; cert-expiring member recycles like drift while leased is untouched (partition + actions); soonest-expiry-first under the recycle cap. 647/647 pass, clippy clean.