### PR TITLE
fix(demo): unbreak the Hetzner walkthrough

### DIFF
--- a/demo/_shared/lib.sh
+++ b/demo/_shared/lib.sh
@@ -29,6 +29,10 @@ NAMESPACE="${NAMESPACE:-kobe-system}"
 RELEASE="${RELEASE:-kobe-demo}"
 POOL="${POOL:-demo-k3s-small}"
 DEFAULT_LEASE_TTL="${DEFAULT_LEASE_TTL:-30m}"
+# Named kobe CLI target the script leases/releases against. 'kobe config
+# use' is per-shell (it does not reach this script's subshell), so lease
+# and release pass --target explicitly.
+KOBE_TARGET="${KOBE_TARGET:-demo}"
 KOBE_PORT="${KOBE_PORT:-8080}"
 TLS_PORT="${TLS_PORT:-8443}"
 TLS_DIR="${TLS_DIR:-$HOME/.config/kobe-demo}"
@@ -156,7 +160,7 @@ cmd_lease() {
   pick_kubeconfig
   step "Lease a cluster from pool $POOL (TTL $DEFAULT_LEASE_TTL)"
   note "Make sure './demo tunnel' (or 'forward') is running in another terminal."
-  cmd kobe lease "$POOL" --ttl "$DEFAULT_LEASE_TTL"
+  cmd kobe lease "$POOL" --ttl "$DEFAULT_LEASE_TTL" --target "$KOBE_TARGET"
 
   # Auto-patch the freshly written kubeconfig to use https://localhost:$TLS_PORT
   # so kubectl/Kunobi can talk to the leased cluster (kubectl 1.31+ refuses to
@@ -177,11 +181,11 @@ cmd_release() {
   local lease_id="${1:-}"
   if [[ -n "$lease_id" ]]; then
     step "Release lease $lease_id"
-    cmd kobe release "$lease_id"
+    cmd kobe release "$lease_id" --target "$KOBE_TARGET"
   else
     step "Release all active leases (kobe purge)"
     note "No lease ID given — using 'kobe purge' to release all and clean local kubeconfigs."
-    cmd kobe purge
+    cmd kobe purge --target "$KOBE_TARGET"
   fi
 }
 
@@ -447,7 +451,8 @@ Shared subcommands:
 
 Env overrides: KOBE_REPO, KOBE_VERSION, NAMESPACE, RELEASE, POOL,
                KUBECONFIG, SSH_PUBKEY, KOBE_PORT, DEFAULT_LEASE_TTL,
-               PULL_SECRET_NAME, DOCKER_REGISTRY, DOCKER_HUB_EMAIL
+               KOBE_TARGET, PULL_SECRET_NAME, DOCKER_REGISTRY,
+               DOCKER_HUB_EMAIL
 EOF
   if declare -f usage_extra >/dev/null 2>&1; then
     usage_extra

--- a/demo/exoscale/README.md
+++ b/demo/exoscale/README.md
@@ -38,9 +38,8 @@ cd demo/exoscale
 
 # Back in A — kobe CLI config:
 kobe config set demo --endpoint http://localhost:8080 --auth ssh
-kobe config use demo
 
-./demo lease                             # leases a k3s cluster, auto-patches kubeconfig to https://localhost:8443
+./demo lease                             # leases a k3s cluster (target 'demo'; override with KOBE_TARGET), auto-patches kubeconfig to https://localhost:8443
 KUBECONFIG=<that-path> kubectl get nodes # works (over the TLS tunnel)
 ./demo deploy-ubuntu                     # server-side-applies a sandbox ubuntu pod into the leased cluster
 

--- a/demo/exoscale/README.md
+++ b/demo/exoscale/README.md
@@ -17,7 +17,7 @@ After `./demo up`, the target SKS cluster has:
 
 - `helm` v3.14+ or v4 (verified working on v4.0.4), `kubectl` v1.31+, GNU `bash` v3+, `socat` (for `./demo tunnel`), `yq` (for `./demo deploy-ubuntu`) on your laptop.
 - An Exoscale SKS kubeconfig in `~/.kube/exoscale-*-config` (e.g. one downloaded by Kunobi desktop). The script auto-discovers it; you don't `export KUBECONFIG=...` yourself.
-- The `kobe` CLI installed (`cargo install --path . --bin kobe` from the repo root).
+- The `kobe` CLI installed (`cargo install --path crates/kobectl` from the repo root).
 - An **Ed25519** SSH keypair on disk (`~/.ssh/id_ed25519` by default; override with `SSH_PUBKEY="$(cat /path/to/key.pub)" ./demo up`). The kobe operator rejects RSA keys at AccessPolicy load time.
 - Docker Hub credentials with read access to the `zondax/kobe-operator` and `zondax/kobe-sync` images (today both are private). See `./demo pull-secret` below.
 

--- a/demo/hetzner/README.md
+++ b/demo/hetzner/README.md
@@ -39,8 +39,7 @@ export HCLOUD_TOKEN=...                       # from console.hetzner.cloud
 ./demo tunnel                                 # terminal B — keep running
 
 kobe config set demo --endpoint http://localhost:8080 --auth ssh
-kobe config use demo
-./demo lease                                  # leases a k3s cluster from the pool
+./demo lease                                  # leases a k3s cluster from the pool (target 'demo'; override with KOBE_TARGET)
 KUBECONFIG=<that-path> kubectl get nodes      # works (TLS tunnel)
 ./demo deploy-ubuntu                          # SSA an ubuntu pod into the lease
 

--- a/demo/hetzner/README.md
+++ b/demo/hetzner/README.md
@@ -11,7 +11,7 @@ The whole demo is driven by one script — `./demo` — that narrates each step 
 
 After `./demo tf up` followed by `./demo up`, your Hetzner project has:
 
-- 1 Hetzner Cloud server (`cx22` by default, ~4 €/mo prorated to ~0.006 €/h).
+- 1 Hetzner Cloud server (`cpx22` by default, prorated hourly).
 - 1 private network (`10.0.0.0/16`) and a firewall locking SSH + Kubernetes API to your caller IP.
 - k3s `v1.31.3+k3s1` running as the only node.
 - `~/.kube/hetzner-kobe-demo-config` — a local kubeconfig pointing at the server's public IP (with `insecure-skip-tls-verify: true`, see "Security model" below).
@@ -57,7 +57,7 @@ KUBECONFIG=<that-path> kubectl get nodes      # works (TLS tunnel)
 |---|---|---|
 | `name` | `kobe-demo` | Prefixes all Hetzner resources + the kubeconfig filename. |
 | `location` | `nbg1` | Hetzner DC. `fsn1`, `hel1` also work; `ash` / `hil` need a matching `network_zone` change in `main.tf`. |
-| `server_type` | `cx22` | 2 vCPU / 4 GB. Step up to `cx32` if you push the pool larger. |
+| `server_type` | `cpx22` | 2 vCPU / 4 GB. Step up to `cpx32` if you push the pool larger. |
 | `node_count` | `1` | 1 = single-node. >1 = 1 server + (n-1) agents. |
 | `ssh_public_key_path` | `~/.ssh/id_ed25519.pub` | Same key the kobe AccessPolicy expects. |
 | `k3s_version` | `v1.31.3+k3s1` | Match the inner pool's k3s. |

--- a/demo/hetzner/README.md
+++ b/demo/hetzner/README.md
@@ -22,7 +22,7 @@ After `./demo tf up` followed by `./demo up`, your Hetzner project has:
 - `helm` v3.14+ (verified on v4), `kubectl` v1.31+, GNU `bash` v3+, `socat` (for `./demo tunnel`), `yq` (for `./demo deploy-ubuntu`), and `terraform` v1.5+ **or** OpenTofu v1.6+ (`brew install opentofu`) on your laptop. The `./demo` script auto-detects whichever is on PATH.
 - A Hetzner Cloud project + API token (Read & Write) exported as `HCLOUD_TOKEN`.
 - An **Ed25519** SSH keypair on disk (`~/.ssh/id_ed25519` by default). The kobe operator rejects RSA keys at AccessPolicy load time.
-- The `kobe` CLI installed (`cargo install --path . --bin kobe` from the repo root).
+- The `kobe` CLI installed (`cargo install --path crates/kobectl` from the repo root).
 - Docker Hub credentials with read access to the `zondax/kobe-operator` and `zondax/kobe-sync` images (today both are private). See `./demo pull-secret`.
 
 ## Walkthrough

--- a/demo/hetzner/terraform/main.tf
+++ b/demo/hetzner/terraform/main.tf
@@ -144,6 +144,7 @@ resource "null_resource" "fetch_kubeconfig" {
     server_id  = hcloud_server.k3s_server[0].id
     public_ip  = hcloud_server.k3s_server[0].ipv4_address
     config_out = pathexpand("~/.kube/hetzner-${var.name}-config")
+    ctx_name   = "${var.name}-hetzner"
   }
 
   provisioner "local-exec" {
@@ -154,7 +155,7 @@ resource "null_resource" "fetch_kubeconfig" {
       OUT="${self.triggers.config_out}"
       echo "Waiting for SSH on $IP (up to 180s)..."
       for i in $(seq 1 60); do
-        if ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+        if ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
                -o ConnectTimeout=3 root@"$IP" 'exit 0' 2>/dev/null; then
           echo "SSH ready (attempt $i)."
           break
@@ -164,7 +165,7 @@ resource "null_resource" "fetch_kubeconfig" {
 
       echo "Waiting for /etc/rancher/k3s/k3s.yaml on $IP (up to 180s)..."
       for i in $(seq 1 60); do
-        if ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+        if ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
                root@"$IP" 'test -f /etc/rancher/k3s/k3s.yaml' 2>/dev/null; then
           echo "k3s kubeconfig present (attempt $i)."
           break
@@ -173,10 +174,14 @@ resource "null_resource" "fetch_kubeconfig" {
       done
 
       mkdir -p "$(dirname "$OUT")"
-      ssh -o BatchMode=yes -o StrictHostKeyChecking=accept-new \
+      export CTX="${self.triggers.ctx_name}"
+      ssh -o BatchMode=yes -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
           root@"$IP" 'cat /etc/rancher/k3s/k3s.yaml' \
         | sed "s|127.0.0.1|$IP|" \
-        | yq '.clusters[].cluster."insecure-skip-tls-verify" = true' \
+        | yq 'del(.clusters[].cluster."certificate-authority-data")
+              | .clusters[].cluster."insecure-skip-tls-verify" = true
+              | (.clusters[].name, .contexts[].name, .contexts[].context.cluster,
+                 .contexts[].context.user, .users[].name, ."current-context") = strenv(CTX)' \
         > "$OUT"
       chmod 0600 "$OUT"
       echo "Wrote $OUT"

--- a/demo/hetzner/terraform/variables.tf
+++ b/demo/hetzner/terraform/variables.tf
@@ -11,9 +11,9 @@ variable "location" {
 }
 
 variable "server_type" {
-  description = "Hetzner Cloud server type. cx22 = 2 vCPU / 4 GB / ~4 EUR/mo, enough for the demo."
+  description = "Hetzner Cloud server type. cpx22 = 2 vCPU / 4 GB, enough for the demo."
   type        = string
-  default     = "cx22"
+  default     = "cpx22"
 }
 
 variable "node_count" {


### PR DESCRIPTION
Running the Hetzner demo from a fresh clone currently fails at four separate points before the walkthrough completes.

**Why**

- The `cx22` server type no longer exists: Hetzner replaced that cx generation (the current line is `cx23`/`cx33`/...), and the API no longer resolves the old names, so `./demo tf up` fails with "server type cx22 not found". The successor `cx23` is not offered in `nbg1`, the demo's default location.
- The fetched kubeconfig sets both `certificate-authority-data` and `insecure-skip-tls-verify`. Recent kubectl rejects that combination ("specifying a root certificates file with the insecure flag is not allowed"), so every subsequent `./demo` step fails at its first kubectl call.
- Hetzner reuses public IPs. When a recreated server lands on a previously-seen IP, `StrictHostKeyChecking=accept-new` fails on the stale `known_hosts` entry and the kubeconfig fetch loop spins until it times out.
- `kobe config use` stores the selected target per shell (session state is keyed by the calling shell's pid), so it never reaches the `kobe` invocations inside `./demo`, and `./demo lease` fails with "No current target configured for this shell".

**What changed**

- `cpx22` is the new default server type: the same 2 vCPU / 4 GB shape, and available in `nbg1`.
- The kubeconfig fetch drops the CA data (verify-skip is the demo's documented security model), renames the k3s `default` context/cluster/user to `<name>-hetzner`, and skips host-key verification for this firewall-gated throwaway server.
- `kobe lease`/`release`/`purge` receive an explicit `--target` (default `demo`, matching the target the walkthrough creates; `KOBE_TARGET` overrides). Both demo READMEs drop the ineffective `kobe config use` step.
- README install command corrected to `cargo install --path crates/kobectl`; the root package has no `kobe` bin target.