### PR TITLE
fix(demo): make two warm clusters fit the default demo server

### DIFF
--- a/demo/_shared/chart/templates/cluster-pool.yaml
+++ b/demo/_shared/chart/templates/cluster-pool.yaml
@@ -29,6 +29,9 @@ spec:
     scaleDownAfter: 30m
     queueTimeout: 5m
   resources:
+    # Kubernetes reserves the full limit as the request on every guest pod,
+    # so two warm 1-CPU instances can never schedule on a 2-vCPU demo node.
+    # 750m fits two alongside the operator and kube-system.
     limits:
-      cpu: "1"
+      cpu: "750m"
       memory: 1Gi

--- a/demo/_shared/chart/values.yaml
+++ b/demo/_shared/chart/values.yaml
@@ -10,7 +10,7 @@ sshPublicKey: ""
 pool:
   name: demo-k3s-small
   size: 2                       # warm-pool target
-  minReady: 1
+  minReady: 2                   # the operator warms to minReady, not size
   maxClusters: 3
   ttl: 1h
   maxTtlPerLease: 2h
@@ -18,7 +18,9 @@ pool:
   k3s:
     version: v1.31.3+k3s1
     servers: 1
-    agents: 1
+    # Single-node inner clusters: with agents, two warm server+agent pairs
+    # do not fit the demo clouds' 2-vCPU default nodes.
+    agents: 0
 
 # Default OFF — k3s ships local-path-provisioner already. Clouds whose
 # managed k8s doesn't ship a default StorageClass (e.g. Exoscale SKS) flip

--- a/demo/exoscale/README.md
+++ b/demo/exoscale/README.md
@@ -10,7 +10,7 @@ After `./demo up`, the target SKS cluster has:
 
 - `kobe-system` namespace with the kobe operator (1 replica, image `v0.9.1`).
 - One `AccessPolicy` named `demo-ssh` accepting your SSH key.
-- One `ClusterPool` named `demo-k3s-small` pre-warming **2 k3s clusters** as pods on the SKS worker nodes (1 always Ready, max 3 total). Leasing one takes seconds.
+- One `ClusterPool` named `demo-k3s-small` pre-warming **2 k3s clusters** as pods on the SKS worker nodes (2 always Ready, max 3 total). Leasing one takes seconds.
 - `local-path-storage` namespace with Rancher's local-path-provisioner installed as the default StorageClass (since SKS doesn't ship one).
 
 ## Prerequisites


### PR DESCRIPTION
**Why**

Both demo READMEs advertise a pool of two warm k3s clusters, but the defaults cannot produce that on the documented server sizes, for two stacked reasons:

- The operator warms the pool to `scaling.minReady` (1), not `spec.size` (2), so a second warm instance is never attempted.
- Each instance is a server pod plus an agent pod with a 1-CPU limit each, and the operator maps that limit onto the pods' requests (it logs a warning about exactly this). Two warm instances would reserve 4 CPUs before the operator and kube-system are counted, so on a 2-vCPU node the extra pods sit Pending with "Insufficient cpu" and the pool accumulates failures.

**What changed**

- `minReady: 2`, matching the advertised behaviour.
- Single-node inner clusters (`agents: 0`) with a 750m CPU limit, so two warm instances plus the operator and kube-system fit the 2-vCPU default server, and the replacement for a leased instance can still schedule after a release.

Two judgment calls for maintainers: whether the demo pool should use single-node inner clusters (nothing in the walkthrough exercises the agent, but it changes what the demo shows), and whether `size` acting as documentation while `minReady` drives warming is intended operator behaviour.