### PR TITLE
docs: add Scoop (Windows) install instructions

### DIFF
--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -69,8 +69,13 @@ All release binaries are signed (macOS codesigned + notarized, Windows code-sign
     Add the Kunobi bucket once, then install from it:
 
     ```powershell
-    scoop bucket add kunobi https://github.com/kunobi-ninja/scoop-bucket
+    scoop bucket add kunobi https://github.com/kunobi-ninja/scoop-kunobi
+
+    # Stable
     scoop install kunobi/kobe
+
+    # Pre-release channel
+    scoop install kunobi/kobe-unstable
     ```
   </Tab>
   <Tab value="cargo">

--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -11,7 +11,7 @@ The `kobe` CLI is a self-contained binary. It connects to a kobe operator endpoi
 
 All release binaries are signed (macOS codesigned + notarized, Windows code-signed, Linux/apt PGP-signed via GCP-KMS).
 
-<Tabs items={["mise (recommended)", "Homebrew", "apt (Debian/Ubuntu)", "winget (Windows)", "cargo", "Nix", "from source"]}>
+<Tabs items={["mise (recommended)", "Homebrew", "apt (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "cargo", "Nix", "from source"]}>
   <Tab value="mise (recommended)">
     [mise](https://mise.jdx.dev) downloads the pre-built binary from GitHub releases and pins the version per project or globally.
 
@@ -64,6 +64,14 @@ All release binaries are signed (macOS codesigned + notarized, Windows code-sign
     ```
 
     Pre-release builds: `winget install kunobi-ninja.kobe.Unstable`.
+  </Tab>
+  <Tab value="Scoop (Windows)">
+    Add the Kunobi bucket once, then install from it:
+
+    ```powershell
+    scoop bucket add kunobi https://github.com/kunobi-ninja/scoop-bucket
+    scoop install kunobi/kobe
+    ```
   </Tab>
   <Tab value="cargo">
     The CLI is published to crates.io as `kobectl` (the crate name `kobe` was taken; the installed binary is still `kobe`).


### PR DESCRIPTION
Adds a **Scoop (Windows)** tab to `docs/kobe-docs/getting-started/installation.mdx`, alongside the existing winget/Homebrew/apt options.

```powershell
scoop bucket add kunobi https://github.com/kunobi-ninja/scoop-bucket
scoop install kunobi/kobe
```

Backed by the new `kunobi-ninja/scoop-bucket` (`bucket/kobe.json`). kobe is stable-only, so there's no `kobe-unstable` variant. Docs-only.