### PR TITLE
ci(package-publish): trigger Scoop bucket autoupdate on release

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -321,7 +321,7 @@ jobs:
             --submit
 
   # ---------------------------------------------------------------------------
-  # scoop — kick the self-hosted Scoop bucket (kunobi-ninja/scoop-bucket) to
+  # scoop — kick the self-hosted Scoop bucket (kunobi-ninja/scoop-kunobi) to
   # autoupdate. The bucket's Excavator workflow runs checkver + autoupdate: it
   # discovers the new version from GitHub Releases and pulls hashes from the
   # .sha256 sidecars, so no version/hash payload is needed here — just the kick.
@@ -337,9 +337,9 @@ jobs:
       - name: Trigger Scoop bucket autoupdate
         uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
         with:
-          # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-bucket
+          # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-kunobi
           # (classic `repo`, or a fine-grained token scoped to that repo). Distinct
           # from HOMEBREW_DISPATCH_TOKEN — this one targets the Scoop bucket.
           token: ${{ secrets.SCOOP_DISPATCH_TOKEN }}
-          repository: kunobi-ninja/scoop-bucket
+          repository: kunobi-ninja/scoop-kunobi
           event-type: release

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -37,6 +37,7 @@ on:
           - apt
           - brew
           - winget
+          - scoop
         default: 'all'
 
 # OIDC for GCP WIF (KMS PGP signing); read-only repo contents; actions:read so
@@ -318,3 +319,27 @@ jobs:
             --version "$VERSION" \
             --release-notes-url "$NOTES_URL" \
             --submit
+
+  # ---------------------------------------------------------------------------
+  # scoop — kick the self-hosted Scoop bucket (kunobi-ninja/scoop-bucket) to
+  # autoupdate. The bucket's Excavator workflow runs checkver + autoupdate: it
+  # discovers the new version from GitHub Releases and pulls hashes from the
+  # .sha256 sidecars, so no version/hash payload is needed here — just the kick.
+  # One dispatch re-excavates every manifest; only the one whose version changed
+  # is committed (updates the kobe manifest on a kobe release).
+  # ---------------------------------------------------------------------------
+  scoop:
+    needs: [resolve, gate]
+    if: ${{ github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'scoop' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Trigger Scoop bucket autoupdate
+        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        with:
+          # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-bucket
+          # (classic `repo`, or a fine-grained token scoped to that repo). Distinct
+          # from HOMEBREW_DISPATCH_TOKEN — this one targets the Scoop bucket.
+          token: ${{ secrets.SCOOP_DISPATCH_TOKEN }}
+          repository: kunobi-ninja/scoop-bucket
+          event-type: release


### PR DESCRIPTION
Adds a `scoop` job to `package-publish.yml` that fires a `repository_dispatch` (event `release`) to **`kunobi-ninja/scoop-kunobi`** after a release, so the bucket's Excavator runs `checkver` + `autoupdate` on the `kobe` / `kobe-unstable` manifests immediately instead of waiting for its 4-hourly schedule.

No version/sha payload is computed — Excavator discovers the version from GitHub Releases and reads hashes from the `.sha256` sidecars itself. Also adds `scoop` to the `only` `workflow_dispatch` input.

### ⚠️ Requires a new secret
`SCOOP_DISPATCH_TOKEN` — a PAT with `contents:write` on `kunobi-ninja/scoop-kunobi`, **separate** from `HOMEBREW_DISPATCH_TOKEN`. Until set, only the scoop job fails; other tracks are unaffected.

Mirrors kunobi-ninja/kache#576. Bucket (`scoop-kunobi`) already accepts `repository_dispatch: types: [release]`.