### PR TITLE
docs: add Chocolatey (Windows) install instructions

### DIFF
--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -11,7 +11,7 @@ The `kobe` CLI is a self-contained binary. It connects to a kobe operator endpoi
 
 All release binaries are signed (macOS codesigned + notarized, Windows code-signed, Linux/apt PGP-signed via GCP-KMS).
 
-<Tabs items={["mise (recommended)", "Homebrew", "apt (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "cargo", "Nix", "from source"]}>
+<Tabs items={["mise (recommended)", "Homebrew", "apt (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "Chocolatey (Windows)", "cargo", "Nix", "from source"]}>
   <Tab value="mise (recommended)">
     [mise](https://mise.jdx.dev) downloads the pre-built binary from GitHub releases and pins the version per project or globally.
 
@@ -77,6 +77,13 @@ All release binaries are signed (macOS codesigned + notarized, Windows code-sign
     # Pre-release channel
     scoop install kunobi/kobe-unstable
     ```
+  </Tab>
+  <Tab value="Chocolatey (Windows)">
+    ```powershell
+    choco install kobe
+    ```
+
+    Pre-release builds: `choco install kobe --pre`.
   </Tab>
   <Tab value="cargo">
     The CLI is published to crates.io as `kobectl` (the crate name `kobe` was taken; the installed binary is still `kobe`).


### PR DESCRIPTION
Adds a **Chocolatey (Windows)** tab to `docs/kobe-docs/getting-started/installation.mdx`:

```powershell
choco install kobe
```

Package: https://community.chocolatey.org/packages/kobe (0.35.0 pending Chocolatey moderation). Docs-only.