### PR TITLE
ci(aur): publish official kobe-bin to the AUR

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -39,6 +39,7 @@ on:
           - winget
           - scoop
           - choco
+          - aur
         default: 'all'
 
 # OIDC for GCP WIF (KMS PGP signing); read-only repo contents; actions:read so
@@ -397,3 +398,42 @@ jobs:
               "sha256_x64": "${{ steps.sha.outputs.x64 }}",
               "sha256_arm64": "${{ steps.sha.outputs.arm64 }}"
             }
+
+  # ---------------------------------------------------------------------------
+  # aur — publish the official `kobe-bin` package to the Arch User Repository.
+  # An AUR package is a tiny git repo hosted by the AUR itself
+  # (ssh://aur@aur.archlinux.org/kobe-bin.git) — NOT a GitHub repo; it holds just
+  # PKGBUILD + .SRCINFO. The recipe lives in-repo at aur/kobe-bin/PKGBUILD; this
+  # job refreshes pkgver + checksums and pushes. STABLE only — AUR pkgver can't
+  # carry a pre-release '-' and AUR tracks the latest stable. Requires the
+  # AUR_SSH_KEY secret (private key of the key registered on the kunobi-ninja
+  # AUR account).
+  # ---------------------------------------------------------------------------
+  aur:
+    needs: [resolve, gate]
+    if: ${{ (github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'aur') && needs.resolve.outputs.channel == 'stable' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout (for the PKGBUILD)
+        uses: actions/checkout@v4
+
+      - name: Set pkgver in the PKGBUILD
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+        run: |
+          set -euo pipefail
+          sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" aur/kobe-bin/PKGBUILD
+          echo "--- PKGBUILD (checksums refreshed by updpkgsums in the deploy step) ---"
+          cat aur/kobe-bin/PKGBUILD
+
+      - name: Publish kobe-bin to the AUR
+        uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
+        with:
+          pkgname: kobe-bin
+          pkgbuild: aur/kobe-bin/PKGBUILD
+          commit_username: kunobi-ninja
+          commit_email: feedback@kunobi.ninja
+          ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
+          commit_message: "kobe-bin: update to ${{ needs.resolve.outputs.version }}"
+          updpkgsums: true

--- a/aur/kobe-bin/PKGBUILD
+++ b/aur/kobe-bin/PKGBUILD
@@ -1,0 +1,21 @@
+# Maintainer: Kunobi Ninja <feedback@kunobi.ninja>
+# This PKGBUILD is generated/updated by kunobi-ninja/kobe CI on each stable
+# release (pkgver + checksums refreshed, then pushed to the AUR). It installs
+# the official prebuilt, statically linked musl binary from GitHub Releases.
+pkgname=kobe-bin
+pkgver=0.35.0
+pkgrel=1
+pkgdesc='CLI for pools of pre-warmed Kubernetes virtual clusters (prebuilt binary)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/kunobi-ninja/kobe'
+license=('Apache-2.0')
+provides=('kobe')
+conflicts=('kobe')
+source_x86_64=("kobe-$pkgver-x86_64.tar.gz::https://github.com/kunobi-ninja/kobe/releases/download/v$pkgver/kobe-x86_64-unknown-linux-musl.tar.gz")
+source_aarch64=("kobe-$pkgver-aarch64.tar.gz::https://github.com/kunobi-ninja/kobe/releases/download/v$pkgver/kobe-aarch64-unknown-linux-musl.tar.gz")
+sha256sums_x86_64=('07a6e6b6209c535d3e38ee812c90bce6a9eb4d033573a0b2406f0201daa2ebdc')
+sha256sums_aarch64=('9934c7bc4543739aa160dfcc8fc6cdcd1d4af72f9127b35cec4d4b65d32e2953')
+
+package() {
+  install -Dm0755 "$srcdir/kobe" "$pkgdir/usr/bin/kobe"
+}

--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -11,7 +11,7 @@ The `kobe` CLI is a self-contained binary. It connects to a kobe operator endpoi
 
 All release binaries are signed (macOS codesigned + notarized, Windows code-signed, Linux/apt PGP-signed via GCP-KMS).
 
-<Tabs items={["mise (recommended)", "Homebrew", "apt (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "Chocolatey (Windows)", "cargo", "Nix", "from source"]}>
+<Tabs items={["mise (recommended)", "Homebrew", "apt (Debian/Ubuntu)", "winget (Windows)", "Scoop (Windows)", "Chocolatey (Windows)", "AUR (Arch Linux)", "cargo", "Nix", "from source"]}>
   <Tab value="mise (recommended)">
     [mise](https://mise.jdx.dev) downloads the pre-built binary from GitHub releases and pins the version per project or globally.
 
@@ -84,6 +84,13 @@ All release binaries are signed (macOS codesigned + notarized, Windows code-sign
     ```
 
     Pre-release builds: `choco install kobe --pre`.
+  </Tab>
+  <Tab value="AUR (Arch Linux)">
+    The official prebuilt-binary package is [`kobe-bin`](https://aur.archlinux.org/packages/kobe-bin) (statically linked, x86_64 + aarch64). Install it with your preferred AUR helper:
+
+    ```sh
+    paru -S kobe-bin   # or: yay -S kobe-bin
+    ```
   </Tab>
   <Tab value="cargo">
     The CLI is published to crates.io as `kobectl` (the crate name `kobe` was taken; the installed binary is still `kobe`).


### PR DESCRIPTION
Stands up an **official, Zondax-owned** AUR package `kobe-bin`.

- **`aur/kobe-bin/PKGBUILD`** — installs the prebuilt, statically-linked musl binary from GitHub Releases (x86_64 + aarch64), `provides`/`conflicts` `kobe`. Pinned to v0.35.0.
- **`aur` job** in `package-publish.yml` — on each **stable** release, refreshes `pkgver` + checksums (`updpkgsums`) and pushes to `ssh://aur@aur.archlinux.org/kobe-bin.git` via `KSXGitHub/github-actions-deploy-aur@v4.2.0` (SHA-pinned). Stable-only.

### ⚠️ Prerequisite (one-time, yours)
An AUR package is a git repo hosted by the AUR — not a GitHub repo. Needs a **kunobi-ninja account on aur.archlinux.org** + an **SSH key** registered, with the private key stored as the **`AUR_SSH_KEY`** secret here. The first push auto-creates `kobe-bin` on the AUR. Until set, only the `aur` job fails.

Mirrors kunobi-ninja/kache#579. Install (once live): `paru -S kobe-bin` / `yay -S kobe-bin`.