### PR TITLE
ci: publish the kobe Helm chart as an OCI artifact on a helm_v* tag

### DIFF
--- a/.github/workflows/publish-chart.yml
+++ b/.github/workflows/publish-chart.yml
@@ -1,0 +1,62 @@
+name: Publish Helm Chart
+
+# Chart releases ride their own tag, decoupled from the operator's v* release
+# tags: push a `helm_v<chart-version>` tag (e.g. helm_v0.0.1) to publish the
+# chart. The tag version must match `version:` in charts/kobe/Chart.yaml, so the
+# published OCI version and the chart's declared version can never drift.
+on:
+  push:
+    tags: ["helm_v*"]
+  workflow_dispatch:
+
+concurrency:
+  group: publish-chart-${{ github.ref }}
+  cancel-in-progress: false
+
+jobs:
+  publish-chart:
+    runs-on: kunobi-runners
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: azure/setup-helm@v4
+
+      - name: Assert tag version matches Chart.yaml
+        if: startsWith(github.ref, 'refs/tags/helm_v')
+        env:
+          REF_NAME: ${{ github.ref_name }}
+        run: |
+          tag_version="${REF_NAME#helm_v}"
+          chart_version="$(grep -E '^version:' charts/kobe/Chart.yaml | awk '{print $2}' | tr -d '"')"
+          echo "tag version: $tag_version | Chart.yaml version: $chart_version"
+          if [ "$tag_version" != "$chart_version" ]; then
+            echo "::error::tag $REF_NAME (version $tag_version) does not match charts/kobe/Chart.yaml version $chart_version"
+            exit 1
+          fi
+
+      - uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USER }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Verify the operator image exists for this appVersion
+        run: |
+          app_version="$(grep -E '^appVersion:' charts/kobe/Chart.yaml | awk '{print $2}' | tr -d '"')"
+          image="zondax/kobe-operator:${app_version}"
+          echo "Checking $image exists..."
+          if ! docker manifest inspect "$image" >/dev/null 2>&1; then
+            echo "::error::operator image $image not found — cut the operator release (v${app_version}) before tagging the chart"
+            exit 1
+          fi
+
+      - name: Package & push Helm chart (OCI)
+        env:
+          DOCKERHUB_USER: ${{ secrets.DOCKERHUB_USER }}
+          DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
+        run: |
+          helm registry login registry-1.docker.io -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
+          helm repo add bitnami https://charts.bitnami.com/bitnami
+          helm dependency build charts/kobe
+          helm package charts/kobe
+          helm push kobe-*.tgz oci://registry-1.docker.io/zondax


### PR DESCRIPTION
## What's New

Publishes the `kobe` Helm chart as an OCI artifact, so it can be installed directly without cloning the repo:

```bash
helm install kobe oci://registry-1.docker.io/zondax/kobe --version 0.0.1 -f values.yaml
```

## Technical Details

- New standalone workflow `.github/workflows/publish-chart.yml` triggered **only** on `helm_v*` tags — decoupled from the operator's `v*` release tags, so chart releases are an explicit, separate action and never rebuild/re-push the image. (`v*` globs don't match `helm_v*`, so `ci.yml` is untouched at runtime.)
- **Version match:** asserts the tag version (`helm_v0.0.1` → `0.0.1`) equals `version:` in `charts/kobe/Chart.yaml` before publishing.
- **Operator image check:** asserts `zondax/kobe-operator:<appVersion>` exists in the registry before publishing, so a chart release can't point at an operator version that was never built.
- Reuses the existing `DOCKERHUB_USER`/`DOCKERHUB_TOKEN`: `helm registry login` → `dependency build` → `package` → `helm push … oci://registry-1.docker.io/zondax`.
- Credentials and the tag name are passed via `env:` and referenced quoted — no untrusted input reaches the `run:` block.

**To cut a chart release:** set `charts/kobe/Chart.yaml` `version:` to `X.Y.Z`, then push tag `helm_vX.Y.Z`.

## Still to confirm

- **Docker Hub repo.** `zondax/kobe` doesn't exist yet — the first push creates it **private**, so it must be flipped to **public** once, and the CI token needs rights to push a new repo under `zondax`.
