### PR TITLE
fix: preserve node tokens and gate topology readiness

### DIFF
--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -218,7 +218,7 @@ spec:
                 properties:
                   agents:
                     description: |-
-                      Number of k3s agent replicas (k3s backend only).
+                      Number of agent replicas (k3s and k0s backends only).
                       When set, creates a separate agent Deployment that joins the server.
                     format: uint32
                     minimum: 0.0
@@ -566,6 +566,10 @@ spec:
                 description: Standalone readiness gates. Pool-managed instances derive this from the pool.
                 items:
                   properties:
+                    count:
+                      format: uint32
+                      minimum: 0.0
+                      type: integer
                     name:
                       type: string
                     namespace:
@@ -575,6 +579,7 @@ spec:
                     type:
                       enum:
                       - CRDExists
+                      - NodesReady
                       - DeploymentReady
                       - DaemonSetReady
                       - URLHealthy

--- a/charts/kobe/crds/clusterpools.yaml
+++ b/charts/kobe/crds/clusterpools.yaml
@@ -240,7 +240,7 @@ spec:
                 properties:
                   agents:
                     description: |-
-                      Number of k3s agent replicas (k3s backend only).
+                      Number of agent replicas (k3s and k0s backends only).
                       When set, creates a separate agent Deployment that joins the server.
                     format: uint32
                     minimum: 0.0
@@ -613,6 +613,10 @@ spec:
                   Clusters stay in Creating phase until all gates are satisfied.
                 items:
                   properties:
+                    count:
+                      format: uint32
+                      minimum: 0.0
+                      type: integer
                     name:
                       type: string
                     namespace:
@@ -622,6 +626,7 @@ spec:
                     type:
                       enum:
                       - CRDExists
+                      - NodesReady
                       - DeploymentReady
                       - DaemonSetReady
                       - URLHealthy

--- a/src/backend/k0s.rs
+++ b/src/backend/k0s.rs
@@ -25,7 +25,9 @@ use k8s_openapi::api::core::v1::{
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::Client;
-use kube::api::{Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PropagationPolicy};
+use kube::api::{
+    Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, PropagationPolicy,
+};
 use std::collections::BTreeMap;
 use tracing::{debug, info, warn};
 
@@ -85,6 +87,19 @@ impl K0sBackend {
         let mut rng = rand::rng();
         let bytes: Vec<u8> = (0..32).map(|_| rng.random()).collect();
         hex::encode(bytes)
+    }
+
+    /// Validate that a persisted node-token Secret is usable.
+    fn validate_token_secret(secret: &Secret, secret_name: &str) -> Result<()> {
+        secret
+            .data
+            .as_ref()
+            .and_then(|data| data.get("token"))
+            .filter(|token| !token.0.is_empty())
+            .with_context(|| {
+                format!("Token secret {secret_name} is missing non-empty data.token")
+            })?;
+        Ok(())
     }
 
     /// Standard labels for resources belonging to a cluster.
@@ -239,12 +254,30 @@ spec:
         }
     }
 
-    /// Create the token Secret for k0s node authentication.
+    /// Ensure the token Secret for k0s node authentication exists.
+    ///
+    /// The Secret is create-once: an existing non-empty `data.token` is never
+    /// patched or replaced because a running controller may have persisted its
+    /// original token. Creation uses POST, and a concurrent creator winning the
+    /// race is read back and validated.
     async fn create_token_secret(&self, name: &str, namespace: &str) -> Result<()> {
-        let token = Self::generate_token();
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
         let secret_name = format!("{name}-token");
 
+        match secrets.get(&secret_name).await {
+            Ok(existing) => {
+                Self::validate_token_secret(&existing, &secret_name)?;
+                debug!(cluster = name, "Token secret already exists; preserving it");
+                return Ok(());
+            }
+            Err(kube::Error::Api(ae)) if ae.code == 404 => {}
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("Failed to read token secret {secret_name}"));
+            }
+        }
+
+        let token = Self::generate_token();
         let secret = Secret {
             metadata: ObjectMeta {
                 name: Some(secret_name.clone()),
@@ -260,16 +293,24 @@ spec:
             ..Default::default()
         };
 
-        secrets
-            .patch(
-                &secret_name,
-                &PatchParams::apply("kobe-operator").force(),
-                &Patch::Apply(&secret),
-            )
-            .await
-            .with_context(|| format!("Failed to apply token secret {secret_name}"))?;
+        match secrets.create(&PostParams::default(), &secret).await {
+            Ok(_) => debug!(cluster = name, "Token secret created"),
+            Err(kube::Error::Api(ae)) if ae.code == 409 => {
+                let winner = secrets.get(&secret_name).await.with_context(|| {
+                    format!("Failed to read token secret {secret_name} after create conflict")
+                })?;
+                Self::validate_token_secret(&winner, &secret_name)?;
+                debug!(
+                    cluster = name,
+                    "Concurrent token secret creator won; preserving it"
+                );
+            }
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("Failed to create token secret {secret_name}"));
+            }
+        }
 
-        debug!(cluster = name, "Token secret applied");
         Ok(())
     }
 
@@ -1305,6 +1346,8 @@ impl ClusterBackend for K0sBackend {
 mod tests {
     use super::*;
     use crate::crd::{ClusterConfig, ExposeConfig, PersistenceConfig};
+    use base64::Engine as _;
+    use std::sync::{Arc, Mutex};
 
     fn base_config() -> ClusterConfig {
         ClusterConfig {
@@ -2189,6 +2232,17 @@ mod tests {
         })
     }
 
+    fn token_secret_response(name: &str, namespace: &str, token: &[u8]) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": { "name": name, "namespace": namespace },
+            "data": {
+                "token": base64::engine::general_purpose::STANDARD.encode(token)
+            }
+        })
+    }
+
     fn generic_response(
         api_version: &str,
         kind: &str,
@@ -2203,18 +2257,190 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_token_secret_keeps_existing_bytes() {
+        let server = MockServer::start().await;
+        let client = mock_client(&server);
+        let backend = K0sBackend::new(client, Default::default());
+        let persisted_token = Arc::new(Mutex::new(None::<Vec<u8>>));
+        let reader_token = Arc::clone(&persisted_token);
+        let responder_token = Arc::clone(&persisted_token);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(move |_request: &wiremock::Request| {
+                let persisted = reader_token.lock().unwrap().clone();
+                match persisted {
+                    Some(token) => ResponseTemplate::new(200).set_body_json(token_secret_response(
+                        "test-cluster-token",
+                        "test-ns",
+                        &token,
+                    )),
+                    None => ResponseTemplate::new(404).set_body_json(
+                        crate::testutil::k8s_not_found("secrets", "test-cluster-token"),
+                    ),
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(move |request: &wiremock::Request| {
+                let candidate: serde_json::Value =
+                    serde_json::from_slice(&request.body).expect("Secret request must be JSON");
+                let candidate = candidate["stringData"]["token"]
+                    .as_str()
+                    .expect("Secret must contain stringData.token")
+                    .as_bytes()
+                    .to_vec();
+                let mut persisted = responder_token.lock().unwrap();
+                if persisted.is_none() {
+                    *persisted = Some(candidate);
+                    ResponseTemplate::new(201)
+                        .set_body_json(secret_response("test-cluster-token", "test-ns"))
+                } else {
+                    ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                        "apiVersion": "v1",
+                        "kind": "Status",
+                        "status": "Failure",
+                        "message": "secrets \"test-cluster-token\" already exists",
+                        "reason": "AlreadyExists",
+                        "details": {
+                            "name": "test-cluster-token",
+                            "kind": "secrets"
+                        },
+                        "code": 409
+                    }))
+                }
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+        let original = persisted_token.lock().unwrap().clone().unwrap();
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            persisted_token.lock().unwrap().as_deref(),
+            Some(original.as_slice()),
+            "a repeated create must not rotate the persisted node token"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_token_secret_reads_concurrent_winner() {
+        let server = MockServer::start().await;
+        let client = mock_client(&server);
+        let backend = K0sBackend::new(client, Default::default());
+        let winner = b"concurrent-winner-token";
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(crate::testutil::k8s_not_found(
+                    "secrets",
+                    "test-cluster-token",
+                )),
+            )
+            .up_to_n_times(1)
+            .with_priority(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(token_secret_response(
+                    "test-cluster-token",
+                    "test-ns",
+                    winner,
+                )),
+            )
+            .with_priority(2)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "message": "secrets \"test-cluster-token\" already exists",
+                "reason": "AlreadyExists",
+                "details": {
+                    "name": "test-cluster-token",
+                    "kind": "secrets"
+                },
+                "code": 409
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_token_secret_rejects_empty_token() {
+        let secret = Secret {
+            data: Some(BTreeMap::from([(
+                "token".to_string(),
+                k8s_openapi::ByteString(Vec::new()),
+            )])),
+            ..Default::default()
+        };
+
+        let error = K0sBackend::validate_token_secret(&secret, "cluster-token").unwrap_err();
+        assert!(
+            error.to_string().contains("missing non-empty data.token"),
+            "malformed existing Secrets must fail clearly: {error:#}"
+        );
+    }
+
+    #[tokio::test]
     async fn test_create_cluster_basic() {
         let server = MockServer::start().await;
         let client = mock_client(&server);
         let backend = K0sBackend::new(client, Default::default());
 
-        // Mock: PATCH token secret (server-side apply)
-        Mock::given(method("PATCH"))
+        // Mock: GET token Secret (absent before create)
+        Mock::given(method("GET"))
             .and(path(
                 "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
             ))
             .respond_with(
-                ResponseTemplate::new(200)
+                ResponseTemplate::new(404).set_body_json(crate::testutil::k8s_not_found(
+                    "secrets",
+                    "test-cluster-token",
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        // Mock: POST token secret (create-once)
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(
+                ResponseTemplate::new(201)
                     .set_body_json(secret_response("test-cluster-token", "test-ns")),
             )
             .mount(&server)

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -24,7 +24,9 @@ use k8s_openapi::api::policy::v1::{PodDisruptionBudget, PodDisruptionBudgetSpec}
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
 use k8s_openapi::apimachinery::pkg::util::intstr::IntOrString;
 use kube::Client;
-use kube::api::{Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PropagationPolicy};
+use kube::api::{
+    Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, PropagationPolicy,
+};
 use std::collections::BTreeMap;
 use tracing::{debug, info, warn};
 
@@ -535,6 +537,19 @@ impl K3sBackend {
         hex::encode(bytes)
     }
 
+    /// Validate that a persisted node-token Secret is usable.
+    fn validate_token_secret(secret: &Secret, secret_name: &str) -> Result<()> {
+        secret
+            .data
+            .as_ref()
+            .and_then(|data| data.get("token"))
+            .filter(|token| !token.0.is_empty())
+            .with_context(|| {
+                format!("Token secret {secret_name} is missing non-empty data.token")
+            })?;
+        Ok(())
+    }
+
     /// Standard labels for resources belonging to a cluster.
     ///
     /// When `pool_name` is `Some`, also stamps
@@ -569,12 +584,30 @@ impl K3sBackend {
         labels
     }
 
-    /// Create the token Secret for k3s node authentication.
+    /// Ensure the token Secret for k3s node authentication exists.
+    ///
+    /// The Secret is create-once: an existing non-empty `data.token` is never
+    /// patched or replaced because a running server may have persisted its
+    /// original token. Creation uses POST, and a concurrent creator winning the
+    /// race is read back and validated.
     async fn create_token_secret(&self, name: &str, namespace: &str) -> Result<()> {
-        let token = Self::generate_token();
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
         let secret_name = format!("{name}-token");
 
+        match secrets.get(&secret_name).await {
+            Ok(existing) => {
+                Self::validate_token_secret(&existing, &secret_name)?;
+                debug!(cluster = name, "Token secret already exists; preserving it");
+                return Ok(());
+            }
+            Err(kube::Error::Api(ae)) if ae.code == 404 => {}
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("Failed to read token secret {secret_name}"));
+            }
+        }
+
+        let token = Self::generate_token();
         let secret = Secret {
             metadata: ObjectMeta {
                 name: Some(secret_name.clone()),
@@ -590,16 +623,24 @@ impl K3sBackend {
             ..Default::default()
         };
 
-        secrets
-            .patch(
-                &secret_name,
-                &PatchParams::apply("kobe-operator").force(),
-                &Patch::Apply(&secret),
-            )
-            .await
-            .with_context(|| format!("Failed to apply token secret {secret_name}"))?;
+        match secrets.create(&PostParams::default(), &secret).await {
+            Ok(_) => debug!(cluster = name, "Token secret created"),
+            Err(kube::Error::Api(ae)) if ae.code == 409 => {
+                let winner = secrets.get(&secret_name).await.with_context(|| {
+                    format!("Failed to read token secret {secret_name} after create conflict")
+                })?;
+                Self::validate_token_secret(&winner, &secret_name)?;
+                debug!(
+                    cluster = name,
+                    "Concurrent token secret creator won; preserving it"
+                );
+            }
+            Err(e) => {
+                return Err(e)
+                    .with_context(|| format!("Failed to create token secret {secret_name}"));
+            }
+        }
 
-        debug!(cluster = name, "Token secret applied");
         Ok(())
     }
 
@@ -2086,6 +2127,8 @@ impl ClusterBackend for K3sBackend {
 mod tests {
     use super::*;
     use crate::crd::{ClusterConfig, ExposeConfig, KubeletSharedMountConfig, PersistenceConfig};
+    use base64::Engine as _;
+    use std::sync::{Arc, Mutex};
 
     fn base_config() -> ClusterConfig {
         ClusterConfig {
@@ -2930,6 +2973,17 @@ mod tests {
         })
     }
 
+    fn token_secret_response(name: &str, namespace: &str, token: &[u8]) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": { "name": name, "namespace": namespace },
+            "data": {
+                "token": base64::engine::general_purpose::STANDARD.encode(token)
+            }
+        })
+    }
+
     fn generic_response(
         api_version: &str,
         kind: &str,
@@ -2941,6 +2995,166 @@ mod tests {
             "kind": kind,
             "metadata": { "name": name, "namespace": namespace }
         })
+    }
+
+    #[tokio::test]
+    async fn create_token_secret_keeps_existing_bytes() {
+        let server = MockServer::start().await;
+        let client = mock_client(&server);
+        let backend = K3sBackend::new(client, Default::default());
+        let persisted_token = Arc::new(Mutex::new(None::<Vec<u8>>));
+        let reader_token = Arc::clone(&persisted_token);
+        let responder_token = Arc::clone(&persisted_token);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(move |_request: &wiremock::Request| {
+                let persisted = reader_token.lock().unwrap().clone();
+                match persisted {
+                    Some(token) => ResponseTemplate::new(200).set_body_json(token_secret_response(
+                        "test-cluster-token",
+                        "test-ns",
+                        &token,
+                    )),
+                    None => ResponseTemplate::new(404).set_body_json(
+                        crate::testutil::k8s_not_found("secrets", "test-cluster-token"),
+                    ),
+                }
+            })
+            .expect(2)
+            .mount(&server)
+            .await;
+
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(move |request: &wiremock::Request| {
+                let candidate: serde_json::Value =
+                    serde_json::from_slice(&request.body).expect("Secret request must be JSON");
+                let candidate = candidate["stringData"]["token"]
+                    .as_str()
+                    .expect("Secret must contain stringData.token")
+                    .as_bytes()
+                    .to_vec();
+                let mut persisted = responder_token.lock().unwrap();
+                if persisted.is_none() {
+                    *persisted = Some(candidate);
+                    ResponseTemplate::new(201)
+                        .set_body_json(secret_response("test-cluster-token", "test-ns"))
+                } else {
+                    ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                        "apiVersion": "v1",
+                        "kind": "Status",
+                        "status": "Failure",
+                        "message": "secrets \"test-cluster-token\" already exists",
+                        "reason": "AlreadyExists",
+                        "details": {
+                            "name": "test-cluster-token",
+                            "kind": "secrets"
+                        },
+                        "code": 409
+                    }))
+                }
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+        let original = persisted_token.lock().unwrap().clone().unwrap();
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+
+        assert_eq!(
+            persisted_token.lock().unwrap().as_deref(),
+            Some(original.as_slice()),
+            "a repeated create must not rotate the persisted node token"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_token_secret_reads_concurrent_winner() {
+        let server = MockServer::start().await;
+        let client = mock_client(&server);
+        let backend = K3sBackend::new(client, Default::default());
+        let winner = b"concurrent-winner-token";
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(crate::testutil::k8s_not_found(
+                    "secrets",
+                    "test-cluster-token",
+                )),
+            )
+            .up_to_n_times(1)
+            .with_priority(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(token_secret_response(
+                    "test-cluster-token",
+                    "test-ns",
+                    winner,
+                )),
+            )
+            .with_priority(2)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "message": "secrets \"test-cluster-token\" already exists",
+                "reason": "AlreadyExists",
+                "details": {
+                    "name": "test-cluster-token",
+                    "kind": "secrets"
+                },
+                "code": 409
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn validate_token_secret_rejects_empty_token() {
+        let secret = Secret {
+            data: Some(BTreeMap::from([(
+                "token".to_string(),
+                k8s_openapi::ByteString(Vec::new()),
+            )])),
+            ..Default::default()
+        };
+
+        let error = K3sBackend::validate_token_secret(&secret, "cluster-token").unwrap_err();
+        assert!(
+            error.to_string().contains("missing non-empty data.token"),
+            "malformed existing Secrets must fail clearly: {error:#}"
+        );
     }
 
     /// A StatefulSet GET response whose status reports `replicas` desired and
@@ -2961,13 +3175,25 @@ mod tests {
         let client = mock_client(&server);
         let backend = K3sBackend::new(client, Default::default());
 
-        // Mock: PATCH token secret (server-side apply)
-        Mock::given(method("PATCH"))
+        // Mock: GET token Secret (absent before create)
+        Mock::given(method("GET"))
             .and(path(
                 "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
             ))
             .respond_with(
-                ResponseTemplate::new(200)
+                ResponseTemplate::new(404).set_body_json(crate::testutil::k8s_not_found(
+                    "secrets",
+                    "test-cluster-token",
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        // Mock: POST token secret (create-once)
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(
+                ResponseTemplate::new(201)
                     .set_body_json(secret_response("test-cluster-token", "test-ns")),
             )
             .mount(&server)

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -10,13 +10,13 @@ use std::net::{IpAddr, ToSocketAddrs};
 
 use anyhow::{Context, Result};
 use k8s_openapi::api::core::v1::{
-    Endpoints, NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm,
+    Endpoints, Node, NodeAffinity, NodeSelector, NodeSelectorRequirement, NodeSelectorTerm,
     PersistentVolumeClaim, PersistentVolumeClaimSpec, PodAffinityTerm, PodAntiAffinity, Secret,
     VolumeResourceRequirements, WeightedPodAffinityTerm,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::{LabelSelector, ObjectMeta, OwnerReference};
-use kube::api::{Api, Patch, PatchParams};
+use kube::api::{Api, ListParams, Patch, PatchParams};
 use kube::{Client, Config, ResourceExt};
 use tracing::{debug, info, warn};
 
@@ -692,6 +692,26 @@ pub async fn check_readiness_gate_impl(
                 Err(kube::Error::Api(ae)) if ae.code == 404 => Ok(false),
                 Err(e) => Err(e.into()),
             }
+        }
+        ReadinessGate::NodesReady { count } => {
+            let nodes: Api<Node> = Api::all(vc_client.clone());
+            let ready = nodes
+                .list(&ListParams::default())
+                .await?
+                .items
+                .iter()
+                .filter(|node| {
+                    node.status
+                        .as_ref()
+                        .and_then(|status| status.conditions.as_ref())
+                        .is_some_and(|conditions| {
+                            conditions.iter().any(|condition| {
+                                condition.type_ == "Ready" && condition.status == "True"
+                            })
+                        })
+                })
+                .count() as u32;
+            Ok(ready >= *count)
         }
         ReadinessGate::DeploymentReady {
             name: deploy_name,
@@ -1448,6 +1468,137 @@ current-context: default
                 .contains("flux-system")
         );
         assert!(addons[0].url.is_none());
+    }
+
+    #[tokio::test]
+    async fn nodes_ready_gate_passes_only_when_requested_nodes_report_ready() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/nodes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "NodeList",
+                "metadata": {},
+                "items": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "Node",
+                        "metadata": { "name": "server-0" },
+                        "status": {
+                            "conditions": [
+                                { "type": "Ready", "status": "True", "lastHeartbeatTime": null, "lastTransitionTime": null }
+                            ]
+                        }
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "kind": "Node",
+                        "metadata": { "name": "agent-0" },
+                        "status": {
+                            "conditions": [
+                                { "type": "Ready", "status": "True", "lastHeartbeatTime": null, "lastTransitionTime": null }
+                            ]
+                        }
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let gate = ReadinessGate::NodesReady { count: 2 };
+        assert!(
+            check_readiness_gate_impl(&client, &gate, "inst")
+                .await
+                .unwrap(),
+            "all requested nodes reporting Ready=True should satisfy NodesReady"
+        );
+    }
+
+    #[tokio::test]
+    async fn nodes_ready_gate_rejects_joined_but_unready_nodes() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/nodes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "NodeList",
+                "metadata": {},
+                "items": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "Node",
+                        "metadata": { "name": "server-0" },
+                        "status": {
+                            "conditions": [
+                                { "type": "Ready", "status": "True", "lastHeartbeatTime": null, "lastTransitionTime": null }
+                            ]
+                        }
+                    },
+                    {
+                        "apiVersion": "v1",
+                        "kind": "Node",
+                        "metadata": { "name": "agent-0" },
+                        "status": {
+                            "conditions": [
+                                { "type": "Ready", "status": "False", "lastHeartbeatTime": null, "lastTransitionTime": null }
+                            ]
+                        }
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let gate = ReadinessGate::NodesReady { count: 2 };
+        assert!(
+            !check_readiness_gate_impl(&client, &gate, "inst")
+                .await
+                .unwrap(),
+            "a registered node without Ready=True must not satisfy NodesReady"
+        );
+    }
+
+    #[tokio::test]
+    async fn nodes_ready_gate_rejects_missing_nodes() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("GET"))
+            .and(path("/api/v1/nodes"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "NodeList",
+                "metadata": {},
+                "items": [
+                    {
+                        "apiVersion": "v1",
+                        "kind": "Node",
+                        "metadata": { "name": "server-0" },
+                        "status": {
+                            "conditions": [
+                                { "type": "Ready", "status": "True", "lastHeartbeatTime": null, "lastTransitionTime": null }
+                            ]
+                        }
+                    }
+                ]
+            })))
+            .mount(&server)
+            .await;
+
+        let gate = ReadinessGate::NodesReady { count: 2 };
+        assert!(
+            !check_readiness_gate_impl(&client, &gate, "inst")
+                .await
+                .unwrap(),
+            "a missing agent node must keep the topology gate unsatisfied"
+        );
     }
 
     #[tokio::test]

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -1034,7 +1034,11 @@ async fn evaluate_leased_instance<B: ClusterBackend + Clone>(
 ///   bug `ci-vkobe-flux` hid behind for 7 days on an internal cluster). Its DNS is
 ///   host-projected, not a standard `kube-dns` Service, so the DNS gate
 ///   below doesn't apply to it.
-/// - **k3s / k0s / vcluster** → `DNSHealthy` + `InClusterToken` (#10). These
+/// - **k3s / k0s** → `NodesReady` + `DNSHealthy` + `InClusterToken`. The node
+///   gate requires every declared server and agent to have joined and report
+///   `Ready=True`; a control-plane-only cluster therefore cannot enter the
+///   lease pool when an agent is missing (#48).
+/// - **vcluster** → `DNSHealthy` + `InClusterToken` (#10). These
 ///   bundle CoreDNS fronted by the `kube-dns` Service; gate on DNS *actually
 ///   serving* so a cluster whose CoreDNS crashloops on an in-cluster x509
 ///   mismatch (#42) — answering apiserver, dead DNS — is never leased. The
@@ -1052,6 +1056,7 @@ async fn evaluate_leased_instance<B: ClusterBackend + Clone>(
 /// own gate(s) and the default is skipped.
 fn apply_default_readiness_gates(
     backend_type: BackendType,
+    cluster: &ClusterConfig,
     gates: Vec<ReadinessGate>,
 ) -> Vec<ReadinessGate> {
     if !gates.is_empty() {
@@ -1059,15 +1064,26 @@ fn apply_default_readiness_gates(
     }
     match backend_type {
         BackendType::Vkobe => vec![ReadinessGate::SchedulingProbe { namespace: None }],
-        BackendType::K3s | BackendType::K0s | BackendType::Vcluster => {
-            vec![
-                ReadinessGate::DnsHealthy { namespace: None },
-                ReadinessGate::InClusterToken {
-                    namespace: None,
-                    service_account: None,
-                },
-            ]
-        }
+        BackendType::K3s | BackendType::K0s => vec![
+            ReadinessGate::NodesReady {
+                count: cluster
+                    .servers
+                    .max(1)
+                    .saturating_add(cluster.agents.unwrap_or_default()),
+            },
+            ReadinessGate::DnsHealthy { namespace: None },
+            ReadinessGate::InClusterToken {
+                namespace: None,
+                service_account: None,
+            },
+        ],
+        BackendType::Vcluster => vec![
+            ReadinessGate::DnsHealthy { namespace: None },
+            ReadinessGate::InClusterToken {
+                namespace: None,
+                service_account: None,
+            },
+        ],
         BackendType::Capi => gates,
     }
 }
@@ -1116,6 +1132,8 @@ async fn resolve_instance_config(
         // siblings of the SAME pool rather than every kobe-managed
         // server pod on the host cluster.
         cluster.pool_name = Some(owner_name.clone());
+        let readiness_gates =
+            apply_default_readiness_gates(backend_type, &cluster, spec.readiness_gates);
         return Ok(ResolvedInstanceConfig {
             owner_name,
             backend: spec.backend,
@@ -1123,7 +1141,7 @@ async fn resolve_instance_config(
             addons: spec.addons,
             bootstraps: spec.bootstraps,
             health_check: spec.health_check,
-            readiness_gates: apply_default_readiness_gates(backend_type, spec.readiness_gates),
+            readiness_gates,
             snapshot: spec.snapshot,
         });
     }
@@ -1140,6 +1158,11 @@ async fn resolve_instance_config(
         .ok_or_else(|| anyhow::anyhow!("Standalone ClusterInstance missing spec.cluster"))?;
 
     let backend_type = backend.backend_type.clone();
+    let readiness_gates = apply_default_readiness_gates(
+        backend_type,
+        &cluster,
+        instance.spec.readiness_gates.clone(),
+    );
     Ok(ResolvedInstanceConfig {
         owner_name: instance.name_any(),
         backend,
@@ -1147,10 +1170,7 @@ async fn resolve_instance_config(
         addons: instance.spec.addons.clone(),
         bootstraps: instance.spec.bootstraps.clone(),
         health_check: instance.spec.health_check.clone(),
-        readiness_gates: apply_default_readiness_gates(
-            backend_type,
-            instance.spec.readiness_gates.clone(),
-        ),
+        readiness_gates,
         snapshot: instance.spec.snapshot.clone(),
     })
 }
@@ -2891,7 +2911,8 @@ mod tests {
     /// behind for 7 days on an internal cluster.
     #[test]
     fn vkobe_pool_with_no_gates_gets_default_scheduling_probe() {
-        let gates = apply_default_readiness_gates(BackendType::Vkobe, vec![]);
+        let gates =
+            apply_default_readiness_gates(BackendType::Vkobe, &ClusterConfig::default(), vec![]);
         assert_eq!(gates.len(), 1);
         assert!(matches!(
             gates[0],
@@ -2899,38 +2920,87 @@ mod tests {
         ));
     }
 
-    /// Real-cluster backends (k3s/k0s/vcluster) with no user gates get the
-    /// default functional-admission pair (#10): `DNSHealthy` (they bundle
-    /// CoreDNS behind `kube-dns`, so a dead-DNS-but-live-apiserver cluster
-    /// (#42) must not be leased) + `InClusterToken` (the SA sign/verify chain
-    /// every `rest.InClusterConfig()` workload depends on must round-trip).
+    /// k3s/k0s default admission includes the declared topology: every server
+    /// and agent must join and report Ready before the instance can be leased.
+    /// This contains the agent join failure from #47 instead of rotating an
+    /// unusable control-plane-only cluster through the pool (#48).
     #[test]
-    fn real_cluster_backends_with_no_gates_get_default_dns_and_token() {
-        for backend in [BackendType::K3s, BackendType::K0s, BackendType::Vcluster] {
-            let gates = apply_default_readiness_gates(backend.clone(), vec![]);
-            assert_eq!(gates.len(), 2, "{backend:?} should get two default gates");
+    fn k3s_k0s_default_readiness_requires_declared_server_and_agent_nodes_ready() {
+        let cluster = ClusterConfig {
+            servers: 1,
+            agents: Some(2),
+            ..Default::default()
+        };
+        for backend in [BackendType::K3s, BackendType::K0s] {
+            let gates = apply_default_readiness_gates(backend.clone(), &cluster, vec![]);
+            assert_eq!(gates.len(), 3, "{backend:?} should get three default gates");
             assert!(
-                matches!(gates[0], ReadinessGate::DnsHealthy { namespace: None }),
-                "{backend:?} first default should be DNSHealthy"
+                matches!(gates[0], ReadinessGate::NodesReady { count: 3 }),
+                "{backend:?} first default should require all declared nodes"
+            );
+            assert!(
+                matches!(gates[1], ReadinessGate::DnsHealthy { namespace: None }),
+                "{backend:?} second default should be DNSHealthy"
             );
             assert!(
                 matches!(
-                    gates[1],
+                    gates[2],
                     ReadinessGate::InClusterToken {
                         namespace: None,
                         service_account: None
                     }
                 ),
-                "{backend:?} second default should be InClusterToken"
+                "{backend:?} third default should be InClusterToken"
             );
         }
+    }
+
+    /// Both backends provision one server when `servers: 0` (k3s clamps the
+    /// StatefulSet replica count and k0s has one fixed controller). The
+    /// topology gate must count that runtime server so one joined node cannot
+    /// hide a missing declared agent.
+    #[test]
+    fn k3s_k0s_default_readiness_counts_runtime_server_when_servers_is_zero() {
+        let cluster = ClusterConfig {
+            servers: 0,
+            agents: Some(1),
+            ..Default::default()
+        };
+        for backend in [BackendType::K3s, BackendType::K0s] {
+            let gates = apply_default_readiness_gates(backend, &cluster, vec![]);
+            assert!(
+                matches!(gates[0], ReadinessGate::NodesReady { count: 2 }),
+                "runtime server plus declared agent should require two ready nodes"
+            );
+        }
+    }
+
+    /// vcluster does not create guest server/agent nodes from ClusterConfig,
+    /// so it retains the functional DNS + token admission pair.
+    #[test]
+    fn vcluster_with_no_gates_gets_default_dns_and_token() {
+        let gates =
+            apply_default_readiness_gates(BackendType::Vcluster, &ClusterConfig::default(), vec![]);
+        assert_eq!(gates.len(), 2);
+        assert!(matches!(
+            gates[0],
+            ReadinessGate::DnsHealthy { namespace: None }
+        ));
+        assert!(matches!(
+            gates[1],
+            ReadinessGate::InClusterToken {
+                namespace: None,
+                service_account: None
+            }
+        ));
     }
 
     /// CAPI clusters are provider-defined; `kube-dns` is not guaranteed, so
     /// no default gate is imposed (one could wedge an otherwise-valid pool).
     #[test]
     fn capi_pool_with_no_gates_gets_no_default() {
-        let gates = apply_default_readiness_gates(BackendType::Capi, vec![]);
+        let gates =
+            apply_default_readiness_gates(BackendType::Capi, &ClusterConfig::default(), vec![]);
         assert!(gates.is_empty(), "capi should not gain a default gate");
     }
 
@@ -2943,7 +3013,11 @@ mod tests {
         let user_gates = vec![ReadinessGate::CrdExists {
             name: "kustomizations.kustomize.toolkit.fluxcd.io".to_string(),
         }];
-        let result = apply_default_readiness_gates(BackendType::Vkobe, user_gates.clone());
+        let result = apply_default_readiness_gates(
+            BackendType::Vkobe,
+            &ClusterConfig::default(),
+            user_gates.clone(),
+        );
         assert_eq!(result.len(), 1);
         assert!(matches!(result[0], ReadinessGate::CrdExists { .. }));
     }

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -376,7 +376,7 @@ pub struct ClusterConfig {
     #[serde(default = "default_servers")]
     pub servers: u32,
 
-    /// Number of k3s agent replicas (k3s backend only).
+    /// Number of agent replicas (k3s and k0s backends only).
     /// When set, creates a separate agent Deployment that joins the server.
     #[serde(default)]
     pub agents: Option<u32>,
@@ -1133,6 +1133,13 @@ pub enum ReadinessGate {
     #[serde(rename = "CRDExists")]
     CrdExists { name: String },
 
+    /// Check that at least `count` cluster nodes report the Kubernetes
+    /// `Ready=True` condition. This asserts that the declared server and
+    /// agent topology actually joined, rather than accepting a
+    /// control-plane-only cluster whose apiserver happens to respond.
+    #[serde(rename = "NodesReady")]
+    NodesReady { count: u32 },
+
     /// Check that a Deployment is available (ready replicas > 0).
     #[serde(rename = "DeploymentReady")]
     DeploymentReady { name: String, namespace: String },
@@ -1217,6 +1224,7 @@ impl JsonSchema for ReadinessGate {
                     "type": "string",
                     "enum": [
                         "CRDExists",
+                        "NodesReady",
                         "DeploymentReady",
                         "DaemonSetReady",
                         "URLHealthy",
@@ -1224,6 +1232,11 @@ impl JsonSchema for ReadinessGate {
                         "DNSHealthy",
                         "InClusterToken"
                     ]
+                },
+                "count": {
+                    "type": "integer",
+                    "format": "uint32",
+                    "minimum": 0
                 },
                 "name": { "type": "string" },
                 "namespace": { "type": "string" },


### PR DESCRIPTION
## Summary

- make k3s and k0s node-token Secrets create-once and validate persisted tokens
- preserve the concurrent winner when multiple reconcilers race to create the Secret
- add a `NodesReady` gate to default k3s/k0s readiness using the effective server count plus declared agents
- regenerate the ClusterPool and ClusterInstance CRDs

## Root cause

Backend `create()` regenerated and force-applied a new token on each invocation. A running server could retain the original persisted token while agent pods observed the replacement, leaving agents permanently unauthorized. Existing readiness defaults checked DNS and ServiceAccount tokens but not whether the declared nodes had joined, so a control-plane-only member could still enter the lease pool.

## Impact

Repeated or concurrent provisioning no longer rotates an existing node token. Default k3s/k0s pools also remain in `Creating` until every provisioned server and agent reports `Ready=True`, preventing incomplete members from serving leases.

Closes #47
Closes #48

## Validation

- `cargo fmt -- --check`
- `cargo test` (950 passed)
- `cargo clippy -- -D warnings`
- generated ClusterPool and ClusterInstance CRDs match `crdgen` output
