### PR TITLE
feat(aur): add kobe (source) + kobe-git + config-driven aur publishing

### DIFF
--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -400,40 +400,62 @@ jobs:
             }
 
   # ---------------------------------------------------------------------------
-  # aur — publish the official `kobe-bin` package to the Arch User Repository.
-  # An AUR package is a tiny git repo hosted by the AUR itself
-  # (ssh://aur@aur.archlinux.org/kobe-bin.git) — NOT a GitHub repo; it holds just
-  # PKGBUILD + .SRCINFO. The recipe lives in-repo at aur/kobe-bin/PKGBUILD; this
-  # job refreshes pkgver + checksums and pushes. STABLE only — AUR pkgver can't
-  # carry a pre-release '-' and AUR tracks the latest stable. Requires the
-  # AUR_SSH_KEY secret (private key of the key registered on the kunobi-ninja
-  # AUR account).
+  # aur — publish official Arch User Repository packages. Each aur/<name>/ folder
+  # is one AUR package (a tiny git repo hosted by the AUR itself,
+  # ssh://aur@aur.archlinux.org/<name>.git — NOT a GitHub repo, just
+  # PKGBUILD + .SRCINFO). Enable/disable a flavor per project by adding/removing
+  # its aur/<name>/ folder. Versioned packages (-bin, source) get pkgver
+  # refreshed to the release; VCS packages (-git) keep their git-derived pkgver
+  # (so a stable release is a no-op for them — allow_empty_commits:false). STABLE
+  # only — AUR pkgver can't carry a pre-release '-'. Requires the AUR_SSH_KEY secret.
   # ---------------------------------------------------------------------------
-  aur:
-    needs: [resolve, gate]
+  aur-list:
+    needs: resolve
     if: ${{ (github.event_name == 'release' || inputs.only == 'all' || inputs.only == 'aur') && needs.resolve.outputs.channel == 'stable' }}
     runs-on: ubuntu-latest
-    timeout-minutes: 10
+    timeout-minutes: 5
+    outputs:
+      pkgs: ${{ steps.list.outputs.pkgs }}
     steps:
-      - name: Checkout (for the PKGBUILD)
-        uses: actions/checkout@v4
-
-      - name: Set pkgver in the PKGBUILD
-        env:
-          VERSION: ${{ needs.resolve.outputs.version }}
+      - uses: actions/checkout@v4
+      - id: list
         run: |
           set -euo pipefail
-          sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" aur/kobe-bin/PKGBUILD
-          echo "--- PKGBUILD (checksums refreshed by updpkgsums in the deploy step) ---"
-          cat aur/kobe-bin/PKGBUILD
+          PKGS=$(ls -d aur/*/ 2>/dev/null | xargs -rn1 basename | jq -R . | jq -sc . || echo '[]')
+          echo "pkgs=${PKGS:-[]}" >> "$GITHUB_OUTPUT"
+          echo "AUR packages: ${PKGS:-[]}"
 
-      - name: Publish kobe-bin to the AUR
+  aur:
+    needs: [resolve, gate, aur-list]
+    if: ${{ needs.aur-list.outputs.pkgs != '' && needs.aur-list.outputs.pkgs != '[]' }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    strategy:
+      fail-fast: false
+      matrix:
+        pkg: ${{ fromJson(needs.aur-list.outputs.pkgs) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Refresh pkgver for versioned packages (skip -git)
+        env:
+          VERSION: ${{ needs.resolve.outputs.version }}
+          PKG: ${{ matrix.pkg }}
+        run: |
+          set -euo pipefail
+          if [[ "$PKG" != *-git ]]; then
+            sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" "aur/${PKG}/PKGBUILD"
+          fi
+          echo "--- aur/${PKG}/PKGBUILD ---"; cat "aur/${PKG}/PKGBUILD"
+
+      - name: Publish ${{ matrix.pkg }} to the AUR
         uses: KSXGitHub/github-actions-deploy-aur@084b0d9b15415bf9cdb65d44dad1efe37a354050 # v4.2.0
         with:
-          pkgname: kobe-bin
-          pkgbuild: aur/kobe-bin/PKGBUILD
+          pkgname: ${{ matrix.pkg }}
+          pkgbuild: aur/${{ matrix.pkg }}/PKGBUILD
           commit_username: kunobi-ninja
           commit_email: feedback@kunobi.ninja
           ssh_private_key: ${{ secrets.AUR_SSH_KEY }}
-          commit_message: "kobe-bin: update to ${{ needs.resolve.outputs.version }}"
+          commit_message: "${{ matrix.pkg }}: update to ${{ needs.resolve.outputs.version }}"
           updpkgsums: true
+          allow_empty_commits: false

--- a/aur/kobe-git/PKGBUILD
+++ b/aur/kobe-git/PKGBUILD
@@ -1,0 +1,42 @@
+# Maintainer: Kunobi Ninja <feedback@kunobi.ninja>
+# Builds kobe from the latest `main`. pkgver() derives the version from git,
+# so this tracks unreleased/dev code — rebuild to update. The CLI lives in the
+# `kobectl` workspace crate and installs as the `kobe` binary.
+pkgname=kobe-git
+pkgver=0.0.0.r0.g0000000
+pkgrel=1
+pkgdesc='CLI for pools of pre-warmed Kubernetes virtual clusters (latest git main)'
+arch=('x86_64' 'aarch64')
+url='https://github.com/kunobi-ninja/kobe'
+license=('Apache-2.0')
+depends=('gcc-libs')
+makedepends=('git' 'cargo')
+provides=('kobe')
+conflicts=('kobe')
+options=('!lto')
+source=("kobe::git+https://github.com/kunobi-ninja/kobe.git")
+sha256sums=('SKIP')
+
+pkgver() {
+  cd "$srcdir/kobe"
+  printf '%s.r%s.g%s' \
+    "$(git describe --tags --abbrev=0 2>/dev/null | sed 's/^v//' || echo 0.0.0)" \
+    "$(git rev-list --count HEAD)" \
+    "$(git rev-parse --short=7 HEAD)"
+}
+
+prepare() {
+  cd "$srcdir/kobe"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "$srcdir/kobe"
+  CARGO_TARGET_DIR=target cargo build --frozen --release -p kobectl
+}
+
+package() {
+  cd "$srcdir/kobe"
+  install -Dm0755 target/release/kobe "$pkgdir/usr/bin/kobe"
+  install -Dm0644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/aur/kobe/PKGBUILD
+++ b/aur/kobe/PKGBUILD
@@ -1,0 +1,32 @@
+# Maintainer: Kunobi Ninja <feedback@kunobi.ninja>
+# Builds the kobe CLI from the release source tarball. The CLI lives in the
+# `kobectl` workspace crate and installs as the `kobe` binary.
+# pkgver + checksum are refreshed by kunobi-ninja/kobe CI on each stable release.
+pkgname=kobe
+pkgver=0.37.0
+pkgrel=1
+pkgdesc='CLI for pools of pre-warmed Kubernetes virtual clusters'
+arch=('x86_64' 'aarch64')
+url='https://github.com/kunobi-ninja/kobe'
+license=('Apache-2.0')
+depends=('gcc-libs')
+makedepends=('cargo')
+options=('!lto')
+source=("$pkgname-$pkgver.tar.gz::https://github.com/kunobi-ninja/kobe/archive/v$pkgver.tar.gz")
+sha256sums=('54efc39e63710319716c33354f9aafde8788d29a67e091f5dfb9715cd0820cfc')
+
+prepare() {
+  cd "kobe-$pkgver"
+  cargo fetch --locked --target "$(rustc -vV | sed -n 's/host: //p')"
+}
+
+build() {
+  cd "kobe-$pkgver"
+  CARGO_TARGET_DIR=target cargo build --frozen --release -p kobectl
+}
+
+package() {
+  cd "kobe-$pkgver"
+  install -Dm0755 target/release/kobe "$pkgdir/usr/bin/kobe"
+  install -Dm0644 LICENSE "$pkgdir/usr/share/licenses/$pkgname/LICENSE"
+}

--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -86,10 +86,17 @@ All release binaries are signed (macOS codesigned + notarized, Windows code-sign
     Pre-release builds: `choco install kobe --pre`.
   </Tab>
   <Tab value="AUR (Arch Linux)">
-    The official prebuilt-binary package is [`kobe-bin`](https://aur.archlinux.org/packages/kobe-bin) (statically linked, x86_64 + aarch64). Install it with your preferred AUR helper:
+    Three official packages are available (all provide the `kobe` command — install one):
 
     ```sh
-    paru -S kobe-bin   # or: yay -S kobe-bin
+    # Prebuilt binary — recommended (statically linked, x86_64 + aarch64, no compile)
+    paru -S kobe-bin
+
+    # Builds the latest main from source
+    paru -S kobe-git
+
+    # Builds the latest release from source
+    paru -S kobe
     ```
   </Tab>
   <Tab value="cargo">


### PR DESCRIPTION
Rounds out kobe's AUR presence with all three flavors and makes publishing config-driven.

- **`aur/kobe`** — source-tarball build (compiles the `kobectl` crate → `kobe` binary).
- **`aur/kobe-git`** — builds the latest `main` from git.
- (existing **`kobe-bin`** — prebuilt binary.)

The `aur` job now publishes **every `aur/<name>/` folder** via a matrix — add/remove a folder to enable/disable a flavor per project. Versioned packages (`kobe`, `kobe-bin`) get `pkgver` refreshed to the release; `kobe-git` keeps its git-derived `pkgver` (`allow_empty_commits: false` → a release is a no-op for it). Stable-only.

All three `provides`/`conflicts` `kobe`, so a user installs exactly one. Mirrors kunobi-ninja/kache#637.