### PR TITLE
docs: fix contradictory size and scaling in the ClusterPool example

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,22 +105,28 @@ metadata:
   name: ci-small
   namespace: kunobi-pool
 spec:
-  size: 3                 # warm clusters to keep ready
+  size: 3                 # warm clusters to keep ready (fixed-size pool)
   ttl: "1h"               # default lease duration
   backend:
     type: k3s             # k3s | k0s | vcluster | capi
   cluster:
     version: "v1.31.3+k3s1"
     servers: 1
-  scaling:
-    minReady: 0
-    maxClusters: 6
-    scaleDownAfter: "5m"
-    queueTimeout: "5m"
   resources:
     limits:
       cpu: "1"
       memory: "1Gi"
+```
+
+To autoscale instead of holding a fixed count, add a `scaling` block. It replaces `size` entirely: the warm target becomes `minReady` and the ceiling `maxClusters`, and `size` is ignored for as long as `scaling` is set.
+
+```yaml
+spec:
+  scaling:
+    minReady: 1
+    maxClusters: 6
+    scaleDownAfter: "5m"
+    queueTimeout: "5m"
 ```
 
 ### ClusterLease


### PR DESCRIPTION
The `ClusterPool` example in the README set `size: 3` and `scaling.minReady: 0` at the same time. Only one of them applies:

```rust
// src/pool/manager.rs:538-548 — compute_pool_actions
let (min_ready, max_clusters, _scale_up_threshold, scale_down_after) =
    if let Some(scaling) = &spec.scaling {
        (scaling.min_ready, scaling.max_clusters, ...)
    } else {
        // Fixed pool: size is both min and max ready.
        (spec.size, spec.size + 10, 0, None)
    };
```

`spec.size` is never read once a `scaling` block is present, which matches the field's own doc comment ("Ignored when `scaling` is set"). So the example as published keeps **zero** clusters warm, the opposite of what the section is illustrating, and anyone copying it gets a pool that provisions nothing until a lease arrives and then makes them wait for it.

Confirmed by running `compute_pool_actions` against that exact config on an empty pool: it returns no actions.

The fix shows a fixed-size pool on its own, then the autoscaling alternative as a separate snippet, and states the override explicitly. No fields were dropped. `docs/kobe-docs/pools/overview.mdx` already documents this correctly (`size: 3  # Ignored when scaling is set`); the README was the only place that disagreed.

Docs-only.
