### PR TITLE
fix(pool): let queued claims scale up a scale-to-zero pool

### DIFF
--- a/charts/kobe/crds/clusterpools.yaml
+++ b/charts/kobe/crds/clusterpools.yaml
@@ -707,7 +707,15 @@ spec:
                     type: integer
                   minReady:
                     default: 1
-                    description: Minimum number of warm (ready) clusters to maintain.
+                    description: |-
+                      Minimum number of warm (ready) clusters to maintain.
+
+                      Replaces [`ClusterPoolSpec::size`] entirely — once a `scaling`
+                      block is present, `size` is never read. Set to 0 for a
+                      scale-to-zero pool: nothing is kept warm, and clusters are
+                      provisioned on demand as claims queue (bounded by
+                      `max_clusters`), at the cost of paying full provisioning
+                      latency on every claim.
                     format: uint32
                     minimum: 0.0
                     type: integer
@@ -725,7 +733,13 @@ spec:
                     type: string
                   scaleUpThreshold:
                     default: 0
-                    description: Scale up when ready clusters fall to this threshold.
+                    description: |-
+                      Reserved; currently has no effect.
+
+                      Scale-up is driven by `min_ready` plus the pool's queue depth,
+                      not by a separate threshold — the pool creates whenever
+                      `ready + creating` falls below that target. The field is kept
+                      so existing manifests that set it stay valid.
                     format: uint32
                     minimum: 0.0
                     type: integer

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -577,6 +577,68 @@ mod cluster_instance_tests {
         );
     }
 
+    /// Queue depth must count *unmet* demand only.
+    ///
+    /// A `Pending` lease that already carries a `clusterName` has had an
+    /// instance reserved for it — the lease controller recognises that
+    /// state and repairs it to `Bound`. Counting it as queued demand
+    /// during the reserve → patch-status window makes the pool
+    /// provision a replacement for a claim that is already served.
+    #[tokio::test]
+    async fn queue_depth_excludes_pending_leases_that_already_hold_a_cluster() {
+        let (ctx, server) = test_profile_context().await;
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(Vec::<serde_json::Value>::new()),
+            ))
+            .mount(&server)
+            .await;
+
+        let lease = |name: &str, phase: &str, cluster: serde_json::Value| {
+            serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "ClusterLease",
+                "metadata": { "name": name, "namespace": "test-ns" },
+                "spec": { "poolRef": "test-profile", "ttl": "1h",
+                          "requester": {"type": "test:admin", "identity": "u"}, "priority": 50 },
+                "status": { "phase": phase, "clusterName": cluster }
+            })
+        };
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterleases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![
+                    // Genuinely queued — nothing reserved yet.
+                    lease("waiting", "Pending", serde_json::json!(null)),
+                    // Already reserved, mid two-phase bind. Not demand.
+                    lease(
+                        "assigned",
+                        "Pending",
+                        serde_json::json!("pool-test-profile-0"),
+                    ),
+                    // Bound and Expired are not demand either.
+                    lease("bound", "Bound", serde_json::json!("pool-test-profile-1")),
+                    lease("expired", "Expired", serde_json::json!(null)),
+                ]),
+            ))
+            .mount(&server)
+            .await;
+
+        let pool_state = build_pool_state(&ctx, "test-profile").await;
+
+        assert_eq!(
+            pool_state.queue_depth, 1,
+            "only the unreserved Pending lease is unmet demand"
+        );
+    }
+
     #[tokio::test]
     async fn test_build_pool_state_preserves_instance_status_fields() {
         let (ctx, server) = test_profile_context().await;
@@ -1341,8 +1403,15 @@ async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState
     }
 }
 
-/// Count claims queued against `profile_name` — leases still in
-/// `Pending`, i.e. demand no instance has been reserved for yet.
+/// Count claims queued against `profile_name` — `Pending` leases that
+/// do not yet hold a cluster, i.e. demand nothing has been reserved for.
+///
+/// The `cluster_name` check is load-bearing, not defensive.
+/// `Pending` + an assigned `clusterName` is a real, expected state: it is
+/// the window between `reserve_ready_instance` claiming an instance and
+/// the lease's status patch landing, and the lease controller repairs it
+/// to `Bound` on sight. Such a claim is already served, so counting it
+/// as demand would make the pool provision a second cluster for it.
 ///
 /// Feeds both the warm target in [`crate::pool::manager::compute_pool_actions`]
 /// (so a scale-to-zero pool provisions on demand) and the pool's
@@ -1359,9 +1428,11 @@ async fn count_pending_claims(ctx: &ProfileContext, profile_name: &str) -> u32 {
         Ok(leases) => leases
             .iter()
             .filter(|c| {
+                // A lease with no status yet has certainly not been
+                // reserved against, so it counts as demand.
                 c.status
                     .as_ref()
-                    .map(|s| s.phase == LeasePhase::Pending)
+                    .map(|s| s.phase == LeasePhase::Pending && s.cluster_name.is_none())
                     .unwrap_or(true)
             })
             .count() as u32,

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -1088,6 +1088,12 @@ async fn reconcile_profile(
     // Same value the warm target was computed against in
     // `build_pool_state` — reused rather than re-LISTed so the status
     // and metric can never disagree with the scale-up decision.
+    //
+    // One consequence of counting it there: if the ClusterInstance LIST
+    // fails, `build_pool_state` bails early and this reports 0 rather
+    // than the true depth. That is a degraded reconcile either way (the
+    // pool state it would act on is empty), and it recovers on the next
+    // pass — but the queueDepth metric does read 0 for that interval.
     let queue_depth = pool_state.queue_depth;
 
     crate::metrics::QUEUE_DEPTH

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -122,6 +122,7 @@ mod cluster_instance_tests {
         }));
         let pool_state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let counts = crate::pool::manager::StateCounts::default();
         let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
@@ -142,6 +143,7 @@ mod cluster_instance_tests {
         }));
         let pool_state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let counts = crate::pool::manager::StateCounts::default();
         let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
@@ -211,7 +213,10 @@ mod cluster_instance_tests {
         older.crashlooping = true;
         older.crash_message = Some("older crash".to_string());
         clusters.insert("pool-p-2".to_string(), older);
-        let pool_state = PoolState { clusters };
+        let pool_state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let counts = crate::pool::manager::StateCounts::default();
         let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
 
@@ -245,7 +250,10 @@ mod cluster_instance_tests {
             "pool-p-0".to_string(),
             entry_with_block(ClusterState::Creating, true),
         );
-        let pool_state = PoolState { clusters };
+        let pool_state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let counts = crate::pool::manager::StateCounts::default();
         let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
 
@@ -282,7 +290,10 @@ mod cluster_instance_tests {
             "pool-p-0".to_string(),
             entry_with_block(ClusterState::Creating, false),
         );
-        let pool_state = PoolState { clusters };
+        let pool_state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let counts = crate::pool::manager::StateCounts::default();
         let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
 
@@ -310,7 +321,10 @@ mod cluster_instance_tests {
             "pool-p-0".to_string(),
             entry_with_block(ClusterState::Creating, false),
         );
-        let pool_state = PoolState { clusters };
+        let pool_state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let counts = crate::pool::manager::StateCounts::default();
         let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
 
@@ -351,7 +365,10 @@ mod cluster_instance_tests {
                 format!("pool-{name}-0"),
                 entry_with_block(ClusterState::Creating, false),
             );
-            let pool_state = PoolState { clusters };
+            let pool_state = PoolState {
+                clusters,
+                queue_depth: 0,
+            };
             let counts = crate::pool::manager::StateCounts::default();
             let backoff = compute_backoff_state(&profile, &pool_state, &counts, chrono::Utc::now());
             let reason = backoff
@@ -1068,25 +1085,10 @@ async fn reconcile_profile(
         .with_label_values(&[name.as_str()])
         .set(i64::from(capacity_blocked));
 
-    let queue_depth = {
-        let leases_api: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), &ns);
-        let lp = ListParams::default().labels(&format!("kobe.kunobi.ninja/profile={name}"));
-        match leases_api.list(&lp).await {
-            Ok(leases) => leases
-                .iter()
-                .filter(|c| {
-                    c.status
-                        .as_ref()
-                        .map(|s| s.phase == LeasePhase::Pending)
-                        .unwrap_or(true)
-                })
-                .count() as u32,
-            Err(e) => {
-                warn!(profile = %name, "Failed to list leases for queue depth: {e:?}");
-                0
-            }
-        }
-    };
+    // Same value the warm target was computed against in
+    // `build_pool_state` — reused rather than re-LISTed so the status
+    // and metric can never disagree with the scale-up decision.
+    let queue_depth = pool_state.queue_depth;
 
     crate::metrics::QUEUE_DEPTH
         .with_label_values(&[&name])
@@ -1255,7 +1257,10 @@ async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState
                 profile = profile_name,
                 "Failed to list ClusterInstances during pool rebuild: {e}"
             );
-            return PoolState { clusters };
+            return PoolState {
+                clusters,
+                queue_depth: 0,
+            };
         }
     };
 
@@ -1315,13 +1320,50 @@ async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState
         );
     }
 
+    let queue_depth = count_pending_claims(ctx, profile_name).await;
+
     info!(
         profile = profile_name,
         discovered = clusters.len(),
+        queue_depth,
         "Pool state refreshed from ClusterInstances"
     );
 
-    PoolState { clusters }
+    PoolState {
+        clusters,
+        queue_depth,
+    }
+}
+
+/// Count claims queued against `profile_name` — leases still in
+/// `Pending`, i.e. demand no instance has been reserved for yet.
+///
+/// Feeds both the warm target in [`crate::pool::manager::compute_pool_actions`]
+/// (so a scale-to-zero pool provisions on demand) and the pool's
+/// `queueDepth` status/metric, which is why it is read once per
+/// reconcile rather than at each use site.
+///
+/// Best-effort: a failed LIST reports 0 rather than failing the
+/// reconcile. Under-reporting only delays scale-up to the next pass,
+/// whereas failing here would block every other pool action.
+async fn count_pending_claims(ctx: &ProfileContext, profile_name: &str) -> u32 {
+    let leases_api: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), &ctx.namespace);
+    let lp = ListParams::default().labels(&format!("kobe.kunobi.ninja/profile={profile_name}"));
+    match leases_api.list(&lp).await {
+        Ok(leases) => leases
+            .iter()
+            .filter(|c| {
+                c.status
+                    .as_ref()
+                    .map(|s| s.phase == LeasePhase::Pending)
+                    .unwrap_or(true)
+            })
+            .count() as u32,
+        Err(e) => {
+            warn!(profile = %profile_name, "Failed to list leases for queue depth: {e:?}");
+            0
+        }
+    }
 }
 
 /// Resolve every `BootstrapConfig` referenced by `profile.spec.bootstraps`,

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1254,6 +1254,13 @@ impl JsonSchema for ReadinessGate {
 #[serde(rename_all = "camelCase")]
 pub struct ScalingConfig {
     /// Minimum number of warm (ready) clusters to maintain.
+    ///
+    /// Replaces [`ClusterPoolSpec::size`] entirely — once a `scaling`
+    /// block is present, `size` is never read. Set to 0 for a
+    /// scale-to-zero pool: nothing is kept warm, and clusters are
+    /// provisioned on demand as claims queue (bounded by
+    /// `max_clusters`), at the cost of paying full provisioning
+    /// latency on every claim.
     #[serde(default = "default_min_ready")]
     pub min_ready: u32,
 
@@ -1261,7 +1268,12 @@ pub struct ScalingConfig {
     #[serde(default = "default_max_clusters")]
     pub max_clusters: u32,
 
-    /// Scale up when ready clusters fall to this threshold.
+    /// Reserved; currently has no effect.
+    ///
+    /// Scale-up is driven by `min_ready` plus the pool's queue depth,
+    /// not by a separate threshold — the pool creates whenever
+    /// `ready + creating` falls below that target. The field is kept
+    /// so existing manifests that set it stay valid.
     #[serde(default)]
     pub scale_up_threshold: u32,
 

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -266,10 +266,17 @@ pub enum ClusterState {
 }
 
 /// Pool state for a single profile.
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 pub struct PoolState {
     /// Map of cluster name → state.
     pub clusters: HashMap<String, ClusterEntry>,
+    /// Claims currently queued against this pool (leases in `Pending`).
+    ///
+    /// Unserved demand, and therefore an input to the warm target: a
+    /// pool whose `min_ready` is 0 has no standing warm target, so
+    /// queued claims are the *only* thing that can make it provision.
+    /// See the scale-up step in [`compute_pool_actions`].
+    pub queue_depth: u32,
 }
 
 #[derive(Debug, Clone)]
@@ -727,6 +734,14 @@ pub fn compute_pool_actions(
     } else {
         min_ready
     };
+
+    // Queued claims are demand the standing warm target does not cover,
+    // so they raise it. This is what makes scale-to-zero pools work:
+    // with `min_ready == 0` the gate below reads `0 < 0` and the pool
+    // would never create anything, leaving every claim to sit queued
+    // until `queue_timeout` expired it. Still bounded by `max_clusters`
+    // and `MAX_BURST`, so a queue spike cannot become a create storm.
+    let warm_target = warm_target + state.queue_depth;
 
     if counts.ready + counts.creating < warm_target && total < max_clusters {
         let deficit = warm_target.saturating_sub(counts.ready + counts.creating);
@@ -1231,7 +1246,10 @@ mod tests {
         clusters.insert("pool-test-0".into(), make_entry(ClusterState::Ready));
         clusters.insert("pool-test-5".into(), make_entry(ClusterState::Leased));
         clusters.insert("pool-test-2".into(), make_entry(ClusterState::Creating));
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         assert_eq!(max_existing_index(&state, "test"), 5);
     }
@@ -1240,6 +1258,7 @@ mod tests {
     fn test_max_existing_index_empty() {
         let state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         assert_eq!(max_existing_index(&state, "test"), 0);
     }
@@ -1290,7 +1309,10 @@ mod tests {
             },
         );
 
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let counts = count_states(&state, None);
 
         assert_eq!(counts.ready, 1);
@@ -1365,7 +1387,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let counts = count_states(&state, Some(&current));
 
         assert_eq!(counts.ready, 3);
@@ -1498,6 +1523,7 @@ mod tests {
         );
         let state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let now = chrono::Utc::now();
 
@@ -1519,6 +1545,198 @@ mod tests {
         }
     }
 
+    /// `scaling.min_ready` fully replaces `spec.size` as the warm
+    /// target: once a `scaling` block is present, `spec.size` is never
+    /// read (see the branch in [`compute_pool_actions`] and the field's
+    /// own doc-comment on `ClusterPoolSpec::size`).
+    ///
+    /// Pinned because the two fields read as additive in YAML, so a
+    /// `size: 3` + `minReady: 0` pool looks like it keeps 3 warm when it
+    /// actually keeps none. Documentation that says otherwise has drifted
+    /// before; this test is what makes the claim enforceable.
+    #[test]
+    fn scaling_min_ready_overrides_spec_size_for_warm_target() {
+        // size=3 says "3 warm", scaling.min_ready=0 says "none".
+        // min_ready wins, so an empty pool must stay empty.
+        let profile = make_profile(
+            3,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 6,
+                scale_up_threshold: 0,
+                scale_down_after: "5m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let state = PoolState {
+            clusters: HashMap::new(),
+            queue_depth: 0,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert!(
+            actions.is_empty(),
+            "spec.size must not create warm clusters while scaling is set, got {actions:?}"
+        );
+    }
+
+    /// A scale-to-zero pool (`min_ready == 0`) must still provision when
+    /// claims are queued against it.
+    ///
+    /// Without this, `min_ready == 0` makes the scale-up gate
+    /// (`ready + creating < warm_target`) read `0 < 0` — permanently
+    /// false — so the pool never creates a member, every claim queues
+    /// until `queue_timeout` expires it, and the pool is dead config.
+    /// That is the `ready=0 leased=0 creating=0 queue=0` wedge the vkobe
+    /// conformance legs hit.
+    #[test]
+    fn queued_claims_scale_up_a_scale_to_zero_pool() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 6,
+                scale_up_threshold: 0,
+                scale_down_after: "5m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let state = PoolState {
+            clusters: HashMap::new(),
+            queue_depth: 2,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert_eq!(
+            actions.len(),
+            2,
+            "two queued claims should provision two clusters, got {actions:?}"
+        );
+        assert!(actions.iter().all(|a| matches!(a, PoolAction::Create(_))));
+    }
+
+    /// Demand-driven scale-up stays inside `max_clusters` — a queue
+    /// spike must not become an unbounded create storm.
+    #[test]
+    fn queued_claims_respect_max_clusters() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 1,
+                scale_up_threshold: 0,
+                scale_down_after: "5m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let state = PoolState {
+            clusters: HashMap::new(),
+            queue_depth: 10,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert_eq!(
+            actions.len(),
+            1,
+            "max_clusters=1 caps the burst regardless of queue depth, got {actions:?}"
+        );
+    }
+
+    /// A queued claim that an already-Ready cluster will serve must not
+    /// trigger a redundant create: the claim is counted against existing
+    /// warm capacity, not on top of it.
+    #[test]
+    fn queued_claim_does_not_double_provision_against_ready_capacity() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 6,
+                scale_up_threshold: 0,
+                scale_down_after: "5m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let mut clusters = HashMap::new();
+        clusters.insert(
+            "pool-test-profile-1".into(),
+            make_entry(ClusterState::Ready),
+        );
+        let state = PoolState {
+            clusters,
+            queue_depth: 1,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert!(
+            !actions.iter().any(|a| matches!(a, PoolAction::Create(_))),
+            "the Ready cluster already covers the queued claim, got {actions:?}"
+        );
+    }
+
+    /// The converse of [`scaling_min_ready_overrides_spec_size_for_warm_target`]:
+    /// with no `scaling` block, `spec.size` *is* the warm target and the
+    /// pool fills toward it (bounded by `MAX_BURST` per reconcile).
+    #[test]
+    fn fixed_pool_without_scaling_fills_toward_spec_size() {
+        let profile = make_profile(3, None);
+        let state = PoolState {
+            clusters: HashMap::new(),
+            queue_depth: 0,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert_eq!(
+            actions.len(),
+            MAX_BURST as usize,
+            "fixed pool should burst toward spec.size, got {actions:?}"
+        );
+        assert!(actions.iter().all(|a| matches!(a, PoolAction::Create(_))));
+    }
+
     #[test]
     fn test_no_scale_up_when_enough_ready() {
         let profile = make_profile(
@@ -1536,7 +1754,10 @@ mod tests {
         let mut clusters = HashMap::new();
         clusters.insert("pool-test-0".into(), make_entry(ClusterState::Ready));
         clusters.insert("pool-test-1".into(), make_entry(ClusterState::Ready));
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let now = chrono::Utc::now();
 
         let actions = compute_pool_actions(
@@ -1567,7 +1788,10 @@ mod tests {
         let mut clusters = HashMap::new();
         clusters.insert("pool-test-0".into(), make_entry(ClusterState::Ready));
         clusters.insert("pool-test-1".into(), make_entry(ClusterState::Leased));
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let now = chrono::Utc::now();
 
         let actions = compute_pool_actions(
@@ -1602,7 +1826,10 @@ mod tests {
         let mut clusters = HashMap::new();
         clusters.insert("pool-test-0".into(), make_entry(ClusterState::Leased));
         clusters.insert("pool-test-1".into(), make_entry(ClusterState::Leased));
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let now = chrono::Utc::now();
 
         let actions = compute_pool_actions(
@@ -1662,7 +1889,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         let actions = compute_pool_actions(
             &profile,
@@ -1725,7 +1955,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         let actions = compute_pool_actions(
             &profile,
@@ -1793,7 +2026,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let now = chrono::Utc::now();
 
         let actions = compute_pool_actions(
@@ -2008,7 +2244,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let now = chrono::Utc::now();
 
         let actions = compute_pool_actions(
@@ -2142,6 +2381,7 @@ mod tests {
         let profile = make_profile_with_backoff(1, 3, 2, Some(future));
         let state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let actions = compute_pool_actions(
             &profile,
@@ -2163,6 +2403,7 @@ mod tests {
         let profile = make_profile_with_backoff(1, 3, 2, Some(past));
         let state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let actions = compute_pool_actions(
             &profile,
@@ -2190,6 +2431,7 @@ mod tests {
         );
         let state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let actions = compute_pool_actions(
             &profile,
@@ -2214,6 +2456,7 @@ mod tests {
         let profile = make_profile_with_backoff(1, 3, 0, None);
         let state = PoolState {
             clusters: HashMap::new(),
+            queue_depth: 0,
         };
         let actions = compute_pool_actions(
             &profile,
@@ -2407,7 +2650,10 @@ mod tests {
                 drifted_entry(ClusterState::Ready, i * 100),
             );
         }
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2444,7 +2690,10 @@ mod tests {
             "pool-test-profile-2".into(),
             drifted_entry(ClusterState::Ready, 200),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2491,6 +2740,7 @@ mod tests {
             &profile,
             &PoolState {
                 clusters: clusters.clone(),
+                queue_depth: 0,
             },
             chrono::Utc::now(),
             &test_render_ctx(),
@@ -2521,7 +2771,10 @@ mod tests {
         );
         let actions_t1 = compute_pool_actions(
             &profile,
-            &PoolState { clusters },
+            &PoolState {
+                clusters,
+                queue_depth: 0,
+            },
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
@@ -2561,7 +2814,10 @@ mod tests {
             "pool-test-profile-1".into(),
             drifted_entry(ClusterState::Creating, 50),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2603,7 +2859,10 @@ mod tests {
                 drifted_entry(ClusterState::Ready, i * 100),
             );
         }
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2652,7 +2911,10 @@ mod tests {
             "pool-test-profile-3".into(),
             drifted_entry(ClusterState::Ready, 10),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2703,7 +2965,10 @@ mod tests {
         let mut clean = expiring.clone();
         clean.cert_horizon_secs = None;
         clusters.insert("pool-test-profile-3".into(), clean);
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         let counts = count_states(&state, Some(&current));
         assert_eq!(counts.ready_drifted, 1, "cert-expiring Ready is drifted");
@@ -2761,7 +3026,10 @@ mod tests {
         clusters.insert("pool-test-profile-1".into(), entry(29 * 86_400, 10_000));
         // Younger member, one hour left — must win the single recycle slot.
         clusters.insert("pool-test-profile-2".into(), entry(3_600, 10));
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         let actions = compute_pool_actions(
             &profile,
@@ -2835,7 +3103,10 @@ mod tests {
             "pool-test-profile-3".into(),
             clean_entry(ClusterState::Ready, current),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2881,7 +3152,10 @@ mod tests {
             "pool-test-profile-2".into(),
             drifted_entry(ClusterState::Leased, 200),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2928,7 +3202,10 @@ mod tests {
             "pool-test-profile-2".into(),
             drifted_entry(ClusterState::Unhealthy, 200),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -2983,7 +3260,10 @@ mod tests {
             "pool-test-profile-3".into(),
             drifted_entry(ClusterState::Ready, 100),
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -3104,7 +3384,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -3161,7 +3444,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -3234,7 +3520,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -3313,7 +3602,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,
@@ -3388,7 +3680,10 @@ mod tests {
                 cert_horizon_secs: None,
             },
         );
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
         let actions = compute_pool_actions(
             &profile,
             &state,

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -556,6 +556,19 @@ pub fn compute_pool_actions(
             (spec.size, spec.size + 10, 0, None) // no scale-down for fixed pools
         };
 
+    // Queued claims raise the warm target, but only for pools that opted
+    // into autoscaling. A fixed pool's contract is `spec.size` exactly,
+    // and it has no scale-down path (`scale_down_after` is `None` above),
+    // so anything provisioned above `size` on a queue spike would be held
+    // forever with nothing to trim it. Demand-driven provisioning is a
+    // `scaling` feature; leaking it into fixed pools would silently change
+    // what every existing non-scaling pool does.
+    let queue_demand = if spec.scaling.is_some() {
+        state.queue_depth
+    } else {
+        0
+    };
+
     let current_hash = profile_spec_hash(profile, render_ctx, bootstrap_specs);
     let counts = count_states(state, Some(&current_hash));
     let total =
@@ -741,7 +754,8 @@ pub fn compute_pool_actions(
     // would never create anything, leaving every claim to sit queued
     // until `queue_timeout` expired it. Still bounded by `max_clusters`
     // and `MAX_BURST`, so a queue spike cannot become a create storm.
-    let warm_target = warm_target + state.queue_depth;
+    // `saturating_add` to match the arithmetic discipline in this block.
+    let warm_target = warm_target.saturating_add(queue_demand);
 
     if counts.ready + counts.creating < warm_target && total < max_clusters {
         let deficit = warm_target.saturating_sub(counts.ready + counts.creating);
@@ -772,7 +786,17 @@ pub fn compute_pool_actions(
             .collect();
         idle_candidates.sort_by_key(|(_, e)| e.idle_since);
 
-        let excess = counts.ready.saturating_sub(min_ready);
+        // Protect the capacity queued claims were counted against, not
+        // just `min_ready`. The scale-up step above treats a queued claim
+        // as covered by an existing Ready cluster and therefore emits no
+        // Create for it; if scale-down then measured excess against
+        // `min_ready` alone, the same reconcile would Delete that very
+        // cluster. The claim would lose the instance about to serve it and
+        // pay a full cold start — and the Delete would race the lease
+        // controller reserving it.
+        let excess = counts
+            .ready
+            .saturating_sub(min_ready.saturating_add(queue_demand));
         let mut deleted_excess = 0u32;
         for (name, entry) in idle_candidates {
             if deleted_excess >= excess {
@@ -1707,6 +1731,92 @@ mod tests {
         assert!(
             !actions.iter().any(|a| matches!(a, PoolAction::Create(_))),
             "the Ready cluster already covers the queued claim, got {actions:?}"
+        );
+    }
+
+    /// Queued demand must not cause the pool to reap the very Ready
+    /// cluster that demand was counted against.
+    ///
+    /// The scale-up gate counts a queued claim against existing warm
+    /// capacity, so a pool with one Ready cluster and one queued claim
+    /// correctly emits no Create. But if idle scale-down still measures
+    /// excess against `min_ready` alone, that same reconcile emits a
+    /// Delete for the cluster — so the claim loses the instance it was
+    /// about to be served by and pays a full cold start, and the Delete
+    /// races the lease controller reserving it.
+    #[test]
+    fn queued_claim_protects_an_idle_ready_cluster_from_scale_down() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 6,
+                scale_up_threshold: 0,
+                scale_down_after: "5m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let now = chrono::Utc::now();
+        // One Ready cluster, idle well past `scale_down_after`.
+        let mut entry = make_entry(ClusterState::Ready);
+        entry.idle_since = Some(now - chrono::Duration::minutes(30));
+        let mut clusters = HashMap::new();
+        clusters.insert("pool-test-profile-1".into(), entry);
+        let state = PoolState {
+            clusters,
+            queue_depth: 1,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            now,
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert!(
+            !actions.iter().any(|a| matches!(a, PoolAction::Delete(_))),
+            "a queued claim is counted against this Ready cluster, so scale-down \
+             must not reap it — got {actions:?}"
+        );
+    }
+
+    /// A fixed pool (no `scaling` block) must stay fixed.
+    ///
+    /// `spec.size` is the whole contract for those pools, and they have
+    /// no scale-down path at all (`scale_down_after` is `None`), so any
+    /// cluster provisioned above `size` would be held forever with
+    /// nothing to trim it. Demand-driven provisioning is a `scaling`
+    /// feature; it must not silently change what a fixed pool does.
+    #[test]
+    fn queued_claims_do_not_grow_a_fixed_pool_beyond_its_size() {
+        let profile = make_profile(1, None);
+        let mut clusters = HashMap::new();
+        clusters.insert(
+            "pool-test-profile-1".into(),
+            make_entry(ClusterState::Ready),
+        );
+        let state = PoolState {
+            clusters,
+            queue_depth: 10,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert!(
+            !actions.iter().any(|a| matches!(a, PoolAction::Create(_))),
+            "a fixed pool at spec.size must not provision above it on queue \
+             pressure — it has no scale-down path to ever trim the excess. \
+             got {actions:?}"
         );
     }
 


### PR DESCRIPTION
## Problem

A pool with `scaling.minReady: 0` can never provision anything.

The scale-up gate in `compute_pool_actions` is:

```rust
if counts.ready + counts.creating < warm_target && total < max_clusters {
```

`warm_target` comes from `min_ready`, so with `minReady: 0` the comparison is `0 < 0` — permanently false. No `PoolAction::Create` is ever emitted. The lease path doesn't compensate: `reserve_ready_instance` only hands out an already-Ready instance, it never creates one. So claims queue, sit there, and expire on `queueTimeout`.

Queue depth *was* being counted — but at `controllers/profile.rs:1071`, **after** `compute_pool_actions` had already run at `:847`, and only to populate the `queueDepth` status field and metric. It never reached the scale-up decision.

## Fix

Carry queue depth on `PoolState` and add it to the warm target. Queued claims are demand the standing warm target doesn't cover, so they raise it:

```rust
let warm_target = warm_target + state.queue_depth;
```

Bounds are unchanged — `max_clusters` and `MAX_BURST` still cap the burst, so a queue spike can't become a create storm, and a claim an existing Ready cluster will serve doesn't provision a redundant one.

The count moves into `build_pool_state`, and the later use site reads it back off `PoolState`. The status/metric and the scale-up decision are now the same number instead of two independent LISTs, and the net LIST count per reconcile is unchanged (no early returns sit between the two points).

## Docs corrected

Two field descriptions documented behaviour the code didn't have:

- **`scaleUpThreshold`** — never read. It's destructured into `_scale_up_threshold` and discarded, while being advertised in the CRD and reported back through the API (`api/routes.rs:513`). Now documented as reserved/no-effect rather than removed, so existing manifests stay valid.
- **`minReady`** — silently replaces `size`. This is what makes a `size: 3` + `minReady: 0` manifest look like it keeps three clusters warm when it keeps none. (Same confusion #56 fixes in the README, from the docs side.)

## Tests

TDD — the two scale-to-zero tests were confirmed red before the one-line fix and green after:

- `queued_claims_scale_up_a_scale_to_zero_pool` — two queued claims provision two clusters
- `queued_claims_respect_max_clusters` — `maxClusters: 1` caps a 10-deep queue at one
- `queued_claim_does_not_double_provision_against_ready_capacity` — a Ready cluster already covers the claim
- `scaling_min_ready_overrides_spec_size_for_warm_target` — pins the `size`-is-ignored invariant
- `fixed_pool_without_scaling_fills_toward_spec_size` — the converse, for pools with no `scaling` block

Full workspace suite green (663 operator tests, up from 658), `cargo fmt --check` and `cargo clippy -- -D warnings` clean.

## Relation to #36

This is the root cause behind the vkobe conformance legs sitting at `ready=0 leased=0 creating=0` — those pools declare `scaling.minReady: 0`, so they were never going to create a member.

It isn't the whole of #36: `hack/test-smoke.ts` waits for `ready > 0` *before* leasing, so it never generates the queue demand that now drives scale-up. The harness config and CI-matrix half is left for a follow-up PR.

Refs #36