### PR TITLE
ci(conformance): add the vcluster leg and unwedge the on-demand smokes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,9 +171,11 @@ jobs:
   # push to main and on release tags, so a conformance regression is caught
   # before (main) or at (tag) the release boundary instead of a day later.
   # The full matrix (k3s + both vkobe datastores) stays nightly + manual; the
-  # vkobe legs run the same gate across etcd + kine/sqlite. vcluster and capi
-  # have no e2e harness/pool yet — tracked as follow-up before they join the
-  # matrix; `backend_conformance_coverage_is_classified` (crd/profile.rs)
+  # vkobe legs run the same gate across etcd + kine/sqlite, and vcluster joins
+  # nightly against the upstream loft-sh chart (#31). capi still has no CI
+  # infrastructure provider, and k0s has a harness pool but no smoke recipe —
+  # both tracked as follow-ups before they join the matrix;
+  # `backend_conformance_coverage_is_classified` (crd/profile.rs)
   # forces every new BackendType to be consciously classified against this
   # matrix. Since #28, reaching Ready on k3s/k0s/vcluster requires the
   # functional admission gates (DNSHealthy + InClusterToken), so every leg
@@ -201,7 +203,7 @@ jobs:
       matrix:
         # k3s-only on push (fast feedback on the production backend); the full
         # matrix nightly / on manual dispatch.
-        backend: ${{ fromJSON(github.event_name == 'push' && '["k3s"]' || '["k3s", "vkobe-etcd", "vkobe-kine"]') }}
+        backend: ${{ fromJSON(github.event_name == 'push' && '["k3s"]' || '["k3s", "vkobe-etcd", "vkobe-kine", "vcluster"]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -239,6 +241,7 @@ jobs:
             k3s)        mise exec -- just test-smoke-k3s "$CLUSTER" ;;
             vkobe-etcd) mise exec -- just test-smoke-vkobe ;;
             vkobe-kine) mise exec -- just test-smoke-vkobe-kine ;;
+            vcluster)   mise exec -- just test-smoke-vcluster ;;
             *) echo "unknown backend ${{ matrix.backend }}" >&2; exit 1 ;;
           esac
 

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -801,6 +801,11 @@ spec:
     # cap, so a shorter value here expires the queued claim regardless of
     # how long the client waits (scale-to-zero pools provision on demand).
     queueTimeout: "12m"
+    # One provisioning attempt must fit inside this, or the operator
+    # recycles the instance as wedged before the claim can be served —
+    # capping the effective budget below the waits above. Ordering:
+    # creatingTimeout < LEASE_WAIT_TIMEOUT (recipe) < queueTimeout.
+    creatingTimeout: "8m"
   resources:
     limits:
       cpu: "500m"
@@ -882,6 +887,11 @@ spec:
     # cap, so a shorter value here expires the queued claim regardless of
     # how long the client waits (scale-to-zero pools provision on demand).
     queueTimeout: "12m"
+    # One provisioning attempt must fit inside this, or the operator
+    # recycles the instance as wedged before the claim can be served —
+    # capping the effective budget below the waits above. Ordering:
+    # creatingTimeout < LEASE_WAIT_TIMEOUT (recipe) < queueTimeout.
+    creatingTimeout: "8m"
   resources:
     limits:
       cpu: "500m"
@@ -960,6 +970,11 @@ spec:
     # cap, so a shorter value here expires the queued claim regardless of
     # how long the client waits (scale-to-zero pools provision on demand).
     queueTimeout: "20m"
+    # One provisioning attempt must fit inside this, or the operator
+    # recycles the instance as wedged before the claim can be served —
+    # capping the effective budget below the waits above. Ordering:
+    # creatingTimeout < LEASE_WAIT_TIMEOUT (recipe) < queueTimeout.
+    creatingTimeout: "12m"
   resources:
     limits:
       cpu: "500m"

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -801,10 +801,11 @@ spec:
     # cap, so a shorter value here expires the queued claim regardless of
     # how long the client waits (scale-to-zero pools provision on demand).
     queueTimeout: "12m"
-    # One provisioning attempt must fit inside this, or the operator
-    # recycles the instance as wedged before the claim can be served —
-    # capping the effective budget below the waits above. Ordering:
-    # creatingTimeout < LEASE_WAIT_TIMEOUT (recipe) < queueTimeout.
+    # Caps ONE provisioning attempt: past it the operator recycles that
+    # instance as wedged. The claim itself survives and a later attempt can
+    # still serve it, up to the waits above — so this is a chosen retry
+    # policy, not a hard bound on the claim. Sized to fit a cold start in
+    # one attempt so the leg measures provisioning rather than retries.
     creatingTimeout: "8m"
   resources:
     limits:
@@ -887,10 +888,11 @@ spec:
     # cap, so a shorter value here expires the queued claim regardless of
     # how long the client waits (scale-to-zero pools provision on demand).
     queueTimeout: "12m"
-    # One provisioning attempt must fit inside this, or the operator
-    # recycles the instance as wedged before the claim can be served —
-    # capping the effective budget below the waits above. Ordering:
-    # creatingTimeout < LEASE_WAIT_TIMEOUT (recipe) < queueTimeout.
+    # Caps ONE provisioning attempt: past it the operator recycles that
+    # instance as wedged. The claim itself survives and a later attempt can
+    # still serve it, up to the waits above — so this is a chosen retry
+    # policy, not a hard bound on the claim. Sized to fit a cold start in
+    # one attempt so the leg measures provisioning rather than retries.
     creatingTimeout: "8m"
   resources:
     limits:
@@ -970,10 +972,11 @@ spec:
     # cap, so a shorter value here expires the queued claim regardless of
     # how long the client waits (scale-to-zero pools provision on demand).
     queueTimeout: "20m"
-    # One provisioning attempt must fit inside this, or the operator
-    # recycles the instance as wedged before the claim can be served —
-    # capping the effective budget below the waits above. Ordering:
-    # creatingTimeout < LEASE_WAIT_TIMEOUT (recipe) < queueTimeout.
+    # Caps ONE provisioning attempt: past it the operator recycles that
+    # instance as wedged. The claim itself survives and a later attempt can
+    # still serve it, up to the waits above — so this is a chosen retry
+    # policy, not a hard bound on the claim. Sized to fit a cold start in
+    # one attempt so the leg measures provisioning rather than retries.
     creatingTimeout: "12m"
   resources:
     limits:

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -797,7 +797,10 @@ spec:
     maxClusters: 2
     scaleUpThreshold: 0
     scaleDownAfter: "5m"
-    queueTimeout: "5m"
+    # Must exceed the recipe LEASE_WAIT_TIMEOUT: this is a server-side
+    # cap, so a shorter value here expires the queued claim regardless of
+    # how long the client waits (scale-to-zero pools provision on demand).
+    queueTimeout: "12m"
   resources:
     limits:
       cpu: "500m"
@@ -875,7 +878,10 @@ spec:
     maxClusters: 2
     scaleUpThreshold: 0
     scaleDownAfter: "5m"
-    queueTimeout: "5m"
+    # Must exceed the recipe LEASE_WAIT_TIMEOUT: this is a server-side
+    # cap, so a shorter value here expires the queued claim regardless of
+    # how long the client waits (scale-to-zero pools provision on demand).
+    queueTimeout: "12m"
   resources:
     limits:
       cpu: "500m"
@@ -950,7 +956,10 @@ spec:
     maxClusters: 2
     scaleUpThreshold: 0
     scaleDownAfter: "5m"
-    queueTimeout: "5m"
+    # Must exceed the recipe LEASE_WAIT_TIMEOUT: this is a server-side
+    # cap, so a shorter value here expires the queued claim regardless of
+    # how long the client waits (scale-to-zero pools provision on demand).
+    queueTimeout: "20m"
   resources:
     limits:
       cpu: "500m"

--- a/hack/test-smoke.ts
+++ b/hack/test-smoke.ts
@@ -480,7 +480,7 @@ async function main(): Promise<void> {
     if (message.includes("ended in phase")) {
       errorLine(message);
       await printLeaseWaitDiagnostics(
-        "claim reached a terminal phase before it was usable — if this is Expired, the pool's scaling.queueTimeout is shorter than the cold-provision time",
+        "claim reached a terminal phase before it was usable — if this is Expired, the claim outlived the pool's scaling.queueTimeout (a cold start slower than the budget, contention for capacity, or the pool making no progress at all; the pool state below distinguishes them)",
       );
       process.exitCode = 1;
       return;

--- a/hack/test-smoke.ts
+++ b/hack/test-smoke.ts
@@ -439,7 +439,8 @@ async function main(): Promise<void> {
     );
   }
   if (onDemand) {
-    poolBefore = selectPool(await fetchStatus(), pool);
+    // `poolBefore` is already the status fetched above; nothing has run
+    // since that could have changed it, so no re-fetch.
     info(
       `Pool '${pool}' is on-demand (POOL_ON_DEMAND set): skipping the warm-capacity wait — the lease request below is what drives provisioning.`,
     );
@@ -468,6 +469,19 @@ async function main(): Promise<void> {
     if (message.includes("Timed out waiting for lease")) {
       errorLine(message);
       await printLeaseWaitDiagnostics("lease did not become ready within the acquisition timeout");
+      process.exitCode = 1;
+      return;
+    }
+    // A claim the operator expired server-side (queueTimeout) surfaces as a
+    // terminal phase, NOT as a client timeout — so it would otherwise skip
+    // the diagnostics below and rethrow bare. That is the single most likely
+    // on-demand failure, and the one where "why didn't the pool provision?"
+    // is exactly the question the diagnostics answer.
+    if (message.includes("ended in phase")) {
+      errorLine(message);
+      await printLeaseWaitDiagnostics(
+        "claim reached a terminal phase before it was usable — if this is Expired, the pool's scaling.queueTimeout is shorter than the cold-provision time",
+      );
       process.exitCode = 1;
       return;
     }

--- a/hack/test-smoke.ts
+++ b/hack/test-smoke.ts
@@ -57,6 +57,13 @@ const connectRetrySeconds = parsePositiveInt(
   "CONNECT_RETRY_SECONDS",
 );
 const minEndpointVersion = Bun.env.MIN_ENDPOINT_VERSION ?? "v0.8.11";
+// Scale-to-zero pools (`scaling.minReady: 0`) hold nothing warm by design —
+// the queued claim is what drives provisioning. Waiting for `ready > 0`
+// before requesting a lease would therefore time out against a pool that is
+// behaving exactly as configured, which is what wedged the vkobe legs at
+// `ready=0 creating=0` (#36). Set POOL_ON_DEMAND=1 for those pools and give
+// LEASE_WAIT_TIMEOUT enough room to cover a cold provision.
+const onDemand = (Bun.env.POOL_ON_DEMAND ?? "") !== "";
 
 let leaseId = "";
 let released = false;
@@ -431,7 +438,14 @@ async function main(): Promise<void> {
       `🚫 Endpoint ${endpointVersion} is too old for this smoke test.\n   Expected at least ${minEndpointVersion}.\n   Reason: this smoke test assumes the warm-cluster readiness fix.\n   Bail out: no lease requested.`,
     );
   }
-  poolBefore = await waitForWarmPool(pool);
+  if (onDemand) {
+    poolBefore = selectPool(await fetchStatus(), pool);
+    info(
+      `Pool '${pool}' is on-demand (POOL_ON_DEMAND set): skipping the warm-capacity wait — the lease request below is what drives provisioning.`,
+    );
+  } else {
+    poolBefore = await waitForWarmPool(pool);
+  }
 
   info(`Pool '${pool}': ${renderPool(poolBefore)}`);
   info(`Requesting lease from pool '${pool}' (ttl=${ttl}, lease wait timeout=${leaseWaitTimeout})...`);

--- a/justfile
+++ b/justfile
@@ -53,15 +53,26 @@ run *args:
 test-smoke pool='ci-small' ttl='2m' *args:
     @mise exec -- bun run ./hack/test-smoke.ts {{ pool }} {{ ttl }} {{ args }}
 
-# Lease a local vkobe warm cluster, verify kubectl can reach it, then release it
+# Lease a local vkobe cluster on demand, verify kubectl can reach it, then
+# release it. The pool is scale-to-zero (scaling.minReady: 0), so the lease
+# request itself is what provisions — hence POOL_ON_DEMAND and a lease wait
+# long enough to cover a cold start.
 [group('dev')]
 test-smoke-vkobe ttl='2m' *args:
-    @mise exec -- bun run ./hack/test-smoke.ts e2e-vkobe-etcd {{ ttl }} {{ args }}
+    @env POOL_ON_DEMAND=1 LEASE_WAIT_TIMEOUT=10m mise exec -- bun run ./hack/test-smoke.ts e2e-vkobe-etcd {{ ttl }} {{ args }}
 
-# Lease a local vkobe+kine-sqlite warm cluster, verify API discovery, then release it
+# Lease a local vkobe+kine-sqlite cluster on demand, verify API discovery, then release it
 [group('dev')]
 test-smoke-vkobe-kine ttl='2m' *args:
-    @mise exec -- bun run ./hack/test-smoke.ts e2e-vkobe-kine-sqlite {{ ttl }} {{ args }}
+    @env POOL_ON_DEMAND=1 LEASE_WAIT_TIMEOUT=10m mise exec -- bun run ./hack/test-smoke.ts e2e-vkobe-kine-sqlite {{ ttl }} {{ args }}
+
+# Lease a local vcluster (upstream loft-sh chart) on demand, verify kubectl
+# can reach it, then release it. Same scale-to-zero shape as the vkobe
+# recipes; the Helm install makes a cold start slower, so the lease wait is
+# correspondingly generous.
+[group('dev')]
+test-smoke-vcluster ttl='2m' *args:
+    @env POOL_ON_DEMAND=1 LEASE_WAIT_TIMEOUT=15m mise exec -- bun run ./hack/test-smoke.ts e2e-vcluster {{ ttl }} {{ args }}
 
 # Lease a local bootstrap-enabled vkobe cluster and verify bootstrap resources exist
 [group('dev')]

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1668,24 +1668,50 @@ mod tests {
     /// exhaustive match is the enforcement: adding a `BackendType` variant
     /// fails compilation here until the author consciously classifies it —
     /// either naming its CI conformance-matrix leg(s) or documenting why it
-    /// is exempt. Covered legs are cross-checked against the workflow text so
+    /// is exempt. Covered legs are cross-checked against the workflow so
     /// this list can't silently drift from `.github/workflows/ci.yml`.
+    ///
+    /// The cross-check reads the matrix *declaration* specifically, not the
+    /// whole file. Searching the whole file was too weak to enforce
+    /// anything: every backend name appears somewhere in ci.yml's prose, so
+    /// a backend could be classified as covered while having no leg at all —
+    /// which is exactly the state vcluster was in before #31.
     #[test]
     fn backend_conformance_coverage_is_classified() {
         fn conformance_legs(backend: &BackendType) -> Option<&'static [&'static str]> {
             match backend {
-                BackendType::K3s => Some(&["\"k3s\""]),
+                BackendType::K3s => Some(&["k3s"]),
                 BackendType::Vkobe => Some(&["vkobe-etcd", "vkobe-kine"]),
+                BackendType::Vcluster => Some(&["vcluster"]),
                 // Documented exemptions — NOT yet in the matrix:
-                // - vcluster: no e2e harness pool yet (#10 follow-up; must
-                //   join before it carries production load)
                 // - capi: no CI infrastructure provider yet
-                // - k0s: no e2e pool in the harness yet
-                BackendType::Vcluster | BackendType::Capi | BackendType::K0s => None,
+                // - k0s: the harness has an `e2e-k0s` pool, but no smoke
+                //   recipe drives it, so nothing asserts conformance
+                BackendType::Capi | BackendType::K0s => None,
             }
         }
 
         let ci = include_str!("../../.github/workflows/ci.yml");
+
+        // The `backend:` line inside the conformance job's matrix, which
+        // holds the JSON arrays of leg names. Anchoring on it is what makes
+        // this assertion mean "has a leg" rather than "is mentioned".
+        let matrix_line = ci
+            .lines()
+            .find(|l| l.trim_start().starts_with("backend: ${{ fromJSON("))
+            .expect(
+                "conformance matrix's `backend:` line not found in ci.yml — \
+                 if the matrix was restructured, retarget this assertion",
+            );
+
+        // Every leg must also be dispatched to a smoke recipe, or the matrix
+        // entry would just hit the `unknown backend` guard at runtime.
+        let dispatch_arms = ci
+            .lines()
+            .filter(|l| l.contains("mise exec -- just test-smoke"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
         // The iteration list may lag a new variant; that's fine — the
         // exhaustive match above is what breaks the build for new variants.
         for backend in [
@@ -1697,11 +1723,18 @@ mod tests {
         ] {
             if let Some(legs) = conformance_legs(&backend) {
                 for leg in legs {
+                    let quoted = format!("\"{leg}\"");
                     assert!(
-                        ci.contains(leg),
+                        matrix_line.contains(&quoted),
                         "{backend:?} is classified as conformance-covered by leg {leg}, \
-                         but ci.yml's conformance matrix does not mention it — update \
-                         the matrix or this classification"
+                         but ci.yml's conformance matrix does not include it — update \
+                         the matrix or this classification.\nmatrix line: {matrix_line}"
+                    );
+                    assert!(
+                        dispatch_arms.contains(&format!("{leg})"))
+                            || dispatch_arms.contains(&format!("{leg}) ")),
+                        "leg {leg} is in the conformance matrix but no case arm runs a \
+                         smoke recipe for it — it would fall through to `unknown backend`"
                     );
                 }
             }


### PR DESCRIPTION
> **Stacked on #57** — base is `fix/scale-to-zero-pools`, not `main`. The on-demand smoke path only works once queued claims drive scale-up. Merge #57 first; this will retarget to `main` automatically.

Closes the CI half of #36 and the remaining checklist of #31.

## Why the vkobe legs were wedged (#36)

The pools are scale-to-zero (`scaling.minReady: 0`), but `hack/test-smoke.ts` waits for `ready > 0` **before** requesting a lease. Nothing was ever going to make those pools warm, so that wait could only time out — the reported `ready=0 leased=0 creating=0 queue=0` was the pool behaving exactly as configured, and the smoke driver asking it for something it was never going to give.

With #57, the lease request itself is what provisions a scale-to-zero pool. So the driver gains `POOL_ON_DEMAND`, which skips the warm-capacity wait and goes straight to leasing; the vkobe recipes set it, with a lease wait long enough to cover a cold provision.

**Why not just set `minReady: 1`?** `e2e.ts up` applies *every* pool in *every* leg. Warming them all would make each leg pay to provision the backends it isn't testing — on a kind node that's a lot of CPU for no signal. Keeping them scale-to-zero means only the pool under test provisions, and it exercises the on-demand path end to end in real CI as a side effect.

## vcluster leg (#31)

The harness has had `e2e-vcluster` / `e2e-vcluster-bootstrap` pools since #81, but nothing drove them: no recipe, no matrix leg. They're scale-to-zero too, so they'd have hit the identical wedge on day one — that dependency wasn't noted on either issue.

- `just test-smoke-vcluster` (on-demand, generous lease wait — the Helm install makes a cold start slower)
- `vcluster` added to the nightly matrix + its `case` arm
- vcluster flipped from documented-exemption to conformance-covered

## Drift guard tightened while I was in it

`backend_conformance_coverage_is_classified` asserted `ci.contains(leg)` against the **whole file**. Every backend name appears somewhere in ci.yml's prose, so a backend could be classified as conformance-covered while having no leg at all — which is precisely the state vcluster was in. The check was passing for a backend that wasn't running.

It now:
1. reads the matrix `backend:` declaration specifically, and
2. additionally requires a `case` arm that runs a smoke recipe, so a leg can't be added to the matrix without a runner (it would otherwise fall through to `unknown backend` at runtime).

Both failure modes mutation-checked: removing `"vcluster"` from the matrix, and removing its `case` arm, each fail the test. Under the old assertion, neither did.

## Deliberately not included

The vkobe legs stay `continue-on-error`. This PR makes them able to *provision*; whether the vkobe guests then reach Ready in kind is untested, and vcluster has never run in CI at all. Flipping that gate belongs in a follow-up once a nightly proves them green — turning it off now would just trade a known-red signal for an unknown-red one.

`k0s` also stays exempt: the harness has an `e2e-k0s` pool, but no smoke recipe drives it. The stale comment claiming it has no pool is corrected.

## Verification

`cargo test --workspace` green (663), `cargo fmt -- --check` and `cargo clippy -- -D warnings` clean, and `hack/test-smoke.ts` type-checks under bun.

The kind harness itself can only be validated by a nightly/dispatch run — worth dispatching one against this branch before merge.

Refs #36, #31