### PR TITLE
fix(pool,lease): three correctness bugs found by audit

### DIFF
--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -216,14 +216,17 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
             Ok(current) => Arc::new(current),
             Err(kube::Error::Api(ae)) if ae.code == 404 => {
                 debug!(lease = %name, "Lease disappeared before reconcile could load current state");
-                // Evict it from the priority queue on the way out. Every
-                // other `remove_from_queue` call site needs a live lease to
-                // reconcile, so a hard DELETE (kubectl, owner GC, or the
-                // loser of a create race) would otherwise strand the entry
-                // permanently. Because the queue sorts oldest-first within a
-                // priority, that ghost sits at the head and every later lease
-                // for the pool sees `is_head == false` — so the pool stops
-                // binding entirely until the operator restarts.
+                // Evict on the way out. This covers only the narrow race
+                // where the delete lands after this reconcile was
+                // dispatched (store hit) but before its apiserver GET.
+                // It is NOT the fix for deletes in general: kube-runtime
+                // drives the controller from `applied_objects()`, which
+                // drops Deleted events, and requeues resolve through the
+                // reflector store — so a `kubectl delete` of a queued
+                // lease produces no reconcile here at all. The reaper's
+                // sweep (`prune_queues_against_live`) is what actually
+                // guarantees the entry goes away; this just gets there
+                // sooner when the race does happen.
                 remove_from_queue(&ctx.queues, &lease.spec.pool_ref, &name).await;
                 return Ok(Action::await_change());
             }
@@ -908,6 +911,36 @@ async fn run_reaper<B: ClusterBackend>(
 
         let now = chrono::Utc::now();
 
+        // Reconcile the in-memory queues against what the apiserver
+        // actually holds. This is the only place a lease deleted outside
+        // a reconcile can be evicted — see `prune_queues_against_live`
+        // for why the reconcile path cannot do it — and a stranded entry
+        // head-blocks its whole pool, so it is worth the one pass over an
+        // already-fetched list.
+        {
+            let live_pending: std::collections::HashSet<String> = leases
+                .iter()
+                .filter(|l| {
+                    l.status
+                        .as_ref()
+                        .map(|s| s.phase == LeasePhase::Pending)
+                        .unwrap_or(true)
+                })
+                .map(|l| l.name_any())
+                .collect();
+
+            let evicted = {
+                let mut queues = ctx.queues.write().await;
+                prune_queues_against_live(&mut queues, &live_pending)
+            };
+            if !evicted.is_empty() {
+                warn!(
+                    leases = ?evicted,
+                    "Reaper: evicted queue entries with no live Pending lease (would otherwise head-block the pool)"
+                );
+            }
+        }
+
         for lease in leases {
             let name = lease.name_any();
             let status = lease.status.clone().unwrap_or_default();
@@ -973,6 +1006,45 @@ async fn remove_from_queue(
     if let Some(queue) = queues.get_mut(profile) {
         queue.retain(|p| p.lease_name != lease_name);
     }
+}
+
+/// Drop queue entries whose lease is no longer `Pending` on the
+/// apiserver, returning the names evicted.
+///
+/// This is the authoritative cleanup, and it exists because the
+/// reconcile path cannot be. kube-runtime's `Controller` is driven by
+/// `applied_objects()`, which drops Deleted events, and every scheduled
+/// requeue resolves through the reflector store first — so once a
+/// deleted lease leaves the store, **no reconcile ever runs for it**.
+/// The 404 branch in `reconcile_lease` therefore only catches the narrow
+/// race where a delete lands mid-reconcile; a plain `kubectl delete` of
+/// a queued lease never reaches it.
+///
+/// That matters because a stranded entry is not a leak but a deadlock:
+/// the queue is sorted oldest-first within a priority, so the ghost sits
+/// at the head and every later lease for that pool sees `is_head ==
+/// false` and never binds.
+///
+/// Sweeping from a LIST is safe against the obvious race — a lease
+/// created after the LIST could be pruned here, but the queue insert in
+/// `reconcile_lease` is idempotent and runs on a 5s requeue, so it
+/// re-inserts itself on the next pass. A transient drop self-heals; a
+/// permanent ghost does not.
+fn prune_queues_against_live(
+    queues: &mut HashMap<String, Vec<PendingLease>>,
+    live_pending: &std::collections::HashSet<String>,
+) -> Vec<String> {
+    let mut evicted = Vec::new();
+    for queue in queues.values_mut() {
+        queue.retain(|p| {
+            let keep = live_pending.contains(&p.lease_name);
+            if !keep {
+                evicted.push(p.lease_name.clone());
+            }
+            keep
+        });
+    }
+    evicted
 }
 
 /// Build the `{ "status": { ... } }` merge patch that transitions a lease to
@@ -1424,6 +1496,93 @@ mod tests {
             Some("real-1"),
             "the lease behind the ghost must become head and be able to bind"
         );
+    }
+
+    /// The reaper sweep is what actually un-wedges a pool after a lease
+    /// is deleted outside a reconcile.
+    ///
+    /// `reconcile_lease`'s 404 branch cannot do it: kube-runtime drives
+    /// the controller from `applied_objects()` (Deleted events dropped),
+    /// and requeues resolve through the reflector store, so a
+    /// `kubectl delete` of a queued lease produces no reconcile at all.
+    /// Only a sweep against a live LIST sees the ghost.
+    #[test]
+    fn prune_evicts_queue_entries_with_no_live_pending_lease() {
+        let mut queues: HashMap<String, Vec<PendingLease>> = HashMap::new();
+        let at = |mins: i64| chrono::Utc::now() - chrono::Duration::minutes(mins);
+        queues.insert(
+            "pool-a".to_string(),
+            vec![
+                // Deleted out from under us — oldest, so it holds the head.
+                PendingLease {
+                    lease_name: "ghost".into(),
+                    priority: 50,
+                    created_at: at(10),
+                },
+                PendingLease {
+                    lease_name: "real".into(),
+                    priority: 50,
+                    created_at: at(1),
+                },
+            ],
+        );
+        // A second pool proves the sweep is not scoped to one queue —
+        // the reconcile path only ever knew about a lease's own pool.
+        queues.insert(
+            "pool-b".to_string(),
+            vec![PendingLease {
+                lease_name: "stale-elsewhere".into(),
+                priority: 50,
+                created_at: at(5),
+            }],
+        );
+
+        let live: std::collections::HashSet<String> = ["real".to_string()].into_iter().collect();
+        let mut evicted = prune_queues_against_live(&mut queues, &live);
+        evicted.sort();
+
+        assert_eq!(
+            evicted,
+            vec!["ghost".to_string(), "stale-elsewhere".to_string()]
+        );
+        assert_eq!(
+            queues["pool-a"]
+                .iter()
+                .map(|p| p.lease_name.as_str())
+                .collect::<Vec<_>>(),
+            vec!["real"],
+            "the surviving lease must become head and be able to bind"
+        );
+        assert!(queues["pool-b"].is_empty());
+    }
+
+    /// A pool whose queue is entirely live must be left alone — the
+    /// sweep must not churn the common case.
+    #[test]
+    fn prune_leaves_a_fully_live_queue_untouched() {
+        let mut queues: HashMap<String, Vec<PendingLease>> = HashMap::new();
+        queues.insert(
+            "pool-a".to_string(),
+            vec![
+                PendingLease {
+                    lease_name: "a".into(),
+                    priority: 50,
+                    created_at: chrono::Utc::now(),
+                },
+                PendingLease {
+                    lease_name: "b".into(),
+                    priority: 10,
+                    created_at: chrono::Utc::now(),
+                },
+            ],
+        );
+        let live: std::collections::HashSet<String> =
+            ["a".to_string(), "b".to_string()].into_iter().collect();
+
+        let evicted = prune_queues_against_live(&mut queues, &live);
+
+        assert!(evicted.is_empty());
+        assert_eq!(queues["pool-a"].len(), 2);
     }
 
     #[tokio::test]

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -216,6 +216,15 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
             Ok(current) => Arc::new(current),
             Err(kube::Error::Api(ae)) if ae.code == 404 => {
                 debug!(lease = %name, "Lease disappeared before reconcile could load current state");
+                // Evict it from the priority queue on the way out. Every
+                // other `remove_from_queue` call site needs a live lease to
+                // reconcile, so a hard DELETE (kubectl, owner GC, or the
+                // loser of a create race) would otherwise strand the entry
+                // permanently. Because the queue sorts oldest-first within a
+                // priority, that ghost sits at the head and every later lease
+                // for the pool sees `is_head == false` — so the pool stops
+                // binding entirely until the operator restarts.
+                remove_from_queue(&ctx.queues, &lease.spec.pool_ref, &name).await;
                 return Ok(Action::await_change());
             }
             Err(err) => return Err(LeaseError::Kube(err)),
@@ -1328,6 +1337,93 @@ mod tests {
         let queue = q.get("test-profile").unwrap();
         assert_eq!(queue.len(), 1);
         assert_eq!(queue[0].lease_name, "lease-b");
+    }
+
+    /// A lease that disappears while `Pending` must leave the in-memory
+    /// priority queue with it.
+    ///
+    /// Every other eviction site needs a live lease to reconcile, so a
+    /// hard `DELETE` (kubectl, owner GC, or the loser of a create race)
+    /// used to strand its entry forever. That is not a leak so much as a
+    /// deadlock: the queue sorts oldest-first within a priority, so the
+    /// ghost sits at the head, every later lease for the pool computes
+    /// `is_head == false`, and nothing in that pool can bind again until
+    /// the operator restarts — `rebuild_queues` runs only at startup and
+    /// only inserts.
+    #[tokio::test]
+    async fn disappeared_pending_lease_is_evicted_from_the_queue() {
+        let (ctx, server) = test_lease_context().await;
+
+        // The ghost, plus a real lease queued behind it.
+        {
+            let mut q = ctx.queues.write().await;
+            q.insert(
+                "test-profile".to_string(),
+                vec![
+                    PendingLease {
+                        lease_name: "ghost-1".to_string(),
+                        priority: 50,
+                        created_at: chrono::Utc::now() - chrono::Duration::minutes(5),
+                    },
+                    PendingLease {
+                        lease_name: "real-1".to_string(),
+                        priority: 50,
+                        created_at: chrono::Utc::now(),
+                    },
+                ],
+            );
+        }
+
+        // A cached object carrying a resourceVersion, so the reconciler
+        // re-reads it from the apiserver — which is where it learns the
+        // lease is gone.
+        let lease: Arc<ClusterLease> = Arc::new(
+            serde_json::from_value(serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "ClusterLease",
+                "metadata": {
+                    "name": "ghost-1",
+                    "namespace": "test-ns",
+                    "resourceVersion": "42"
+                },
+                "spec": {
+                    "poolRef": "test-profile",
+                    "ttl": "1h",
+                    "requester": { "type": "test:admin", "identity": "user@test.com" },
+                    "priority": 50
+                },
+                "status": { "phase": "Pending" }
+            }))
+            .unwrap(),
+        );
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterleases/ghost-1",
+            ))
+            .respond_with(
+                ResponseTemplate::new(404)
+                    .set_body_json(crate::testutil::k8s_not_found("clusterleases", "ghost-1")),
+            )
+            .mount(&server)
+            .await;
+
+        let action = reconcile_lease(lease, ctx.clone()).await.unwrap();
+        assert_eq!(action, Action::await_change());
+
+        let queues = ctx.queues.read().await;
+        let queue = queues
+            .get("test-profile")
+            .expect("pool queue still present");
+        assert!(
+            !queue.iter().any(|p| p.lease_name == "ghost-1"),
+            "deleted lease must not remain queued — it would block the pool head forever"
+        );
+        assert_eq!(
+            queue.first().map(|p| p.lease_name.as_str()),
+            Some("real-1"),
+            "the lease behind the ghost must become head and be able to bind"
+        );
     }
 
     #[tokio::test]

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -690,15 +690,23 @@ pub fn compute_pool_actions(
     //
     // `.take(max_recycling)` caps the per-reconcile rate; the floor
     // check inside the loop handles the early-break case.
-    // How many Ready members step 4 actually wants to roll. This is NOT
-    // the same as `counts.ready_drifted`: `count_states` partitions purely
-    // on hash equality, so it counts an unstamped legacy member as *clean*
-    // and ignores PKI expiry entirely, whereas the candidate list above
-    // uses `entry_drift_eligible` (which recycles unstamped members past
-    // the grace period) plus `cert_expiring`. Step 6 sizes the surge off
-    // this number, because sizing it off `ready_drifted` would leave both
-    // of those cases with a floor they can never clear — the recycle would
-    // block forever with no surge to buy headroom.
+    // How many Ready members step 4 actually wants to roll. Step 6 sizes
+    // the surge off this rather than off `counts.ready_drifted`, because
+    // the two disagree for *unstamped* members: `count_states` partitions
+    // on hash equality and counts `spec_hash == None` as clean, while
+    // `entry_drift_eligible` recycles it once past the grace period. Sized
+    // off `ready_drifted`, such a pool sees a floor it can never clear —
+    // the recycle blocks with no surge to buy headroom, forever.
+    //
+    // Cert expiry is NOT part of that divergence: `count_states` already
+    // folds `cert_expiring()` into its `drifted` predicate, so PKI-expiring
+    // members were always counted and always got their surge.
+    //
+    // This is a superset of `ready_drifted`, not merely usually larger:
+    // `drifted_ready` is every non-`deleting` Ready member that is
+    // hash-drifted, cert-expiring, or unstamped-past-grace, and nothing
+    // Ready can be in `deleting` before this point. So no `.max()` against
+    // `ready_drifted` is needed — it would always pick this value anyway.
     let recycle_candidates = drifted_ready.len() as u32;
 
     let mut remaining_ready = counts.ready;
@@ -750,14 +758,19 @@ pub fn compute_pool_actions(
     // Surge only fires when there's drift to absorb. A fresh pool
     // boot (no drift) refills exactly to `min_ready`, never above —
     // so existing tests for clean pools see byte-identical behavior.
-    // `recycle_candidates` rather than `counts.ready_drifted`: the two
-    // differ for unstamped legacy members and for PKI-expiring ones, and
-    // in both cases it is the candidate list that decides whether step 4
-    // is trying to recycle. Taking the larger of the two keeps every
-    // hash-drift path byte-identical while ensuring a blocked recycle
-    // always gets its surge. Not creating_drifted — those got Deleted in
+    // `recycle_candidates` rather than `counts.ready_drifted`: it is the
+    // candidate list that decides whether step 4 is trying to recycle, and
+    // for unstamped members the two disagree (see step 4). Identical to
+    // `ready_drifted` on every hash-drift and cert-expiry path, so those
+    // stay byte-identical. Not creating_drifted — those got Deleted in
     // step 3 so they're already accounted for in the deficit calculation.
-    let drift_in_flight = counts.ready_drifted.max(recycle_candidates);
+    //
+    // This also feeds `upgrade_in_progress` in step 7, so a pool holding
+    // unstamped members now suppresses idle scale-down until they are
+    // recycled. That is the intended behaviour — scale-down would
+    // otherwise reap the very surge replacements bought here — but it is a
+    // change for existing pools carrying legacy members.
+    let drift_in_flight = recycle_candidates;
     let warm_target = if drift_in_flight > 0 {
         min_ready + policy.max_surge.min(drift_in_flight)
     } else {

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -690,6 +690,17 @@ pub fn compute_pool_actions(
     //
     // `.take(max_recycling)` caps the per-reconcile rate; the floor
     // check inside the loop handles the early-break case.
+    // How many Ready members step 4 actually wants to roll. This is NOT
+    // the same as `counts.ready_drifted`: `count_states` partitions purely
+    // on hash equality, so it counts an unstamped legacy member as *clean*
+    // and ignores PKI expiry entirely, whereas the candidate list above
+    // uses `entry_drift_eligible` (which recycles unstamped members past
+    // the grace period) plus `cert_expiring`. Step 6 sizes the surge off
+    // this number, because sizing it off `ready_drifted` would leave both
+    // of those cases with a floor they can never clear — the recycle would
+    // block forever with no surge to buy headroom.
+    let recycle_candidates = drifted_ready.len() as u32;
+
     let mut remaining_ready = counts.ready;
     for (name, _entry) in drifted_ready.iter().take(policy.max_recycling as usize) {
         if remaining_ready <= policy.min_ready_during_upgrade {
@@ -739,9 +750,14 @@ pub fn compute_pool_actions(
     // Surge only fires when there's drift to absorb. A fresh pool
     // boot (no drift) refills exactly to `min_ready`, never above —
     // so existing tests for clean pools see byte-identical behavior.
-    let drift_in_flight = counts.ready_drifted; // not creating_drifted —
-    // those got Deleted in step 3 so they're already accounted for in
-    // the deficit calculation.
+    // `recycle_candidates` rather than `counts.ready_drifted`: the two
+    // differ for unstamped legacy members and for PKI-expiring ones, and
+    // in both cases it is the candidate list that decides whether step 4
+    // is trying to recycle. Taking the larger of the two keeps every
+    // hash-drift path byte-identical while ensuring a blocked recycle
+    // always gets its surge. Not creating_drifted — those got Deleted in
+    // step 3 so they're already accounted for in the deficit calculation.
+    let drift_in_flight = counts.ready_drifted.max(recycle_candidates);
     let warm_target = if drift_in_flight > 0 {
         min_ready + policy.max_surge.min(drift_in_flight)
     } else {
@@ -897,9 +913,15 @@ pub fn backoff_delay_for(
     // 2^(n-1), saturating against u32 overflow at n >= 32.
     let shift = consecutive_failures.saturating_sub(1).min(31);
     let factor = (multiplier as u64).saturating_pow(shift);
+    // `factor` is deliberately saturating, so it can be `u64::MAX` for a
+    // large multiplier — and `u64::MAX as i64` is `-1`, which would turn
+    // the whole delay negative. `.min(max)` would not catch that: it only
+    // bounds the result from above, so a negative delay sails through and
+    // `next_attempt_at = now + delay` lands in the past, disabling the
+    // backoff at precisely the failure count it exists to throttle.
     let secs = base
         .num_seconds()
-        .saturating_mul(factor as i64)
+        .saturating_mul(i64::try_from(factor).unwrap_or(i64::MAX))
         .min(max.num_seconds());
     Some(chrono::Duration::seconds(secs))
 }
@@ -2430,6 +2452,110 @@ mod tests {
             backoff_delay_for(&p, 99),
             Some(chrono::Duration::seconds(30))
         );
+    }
+
+    /// A pool of unstamped legacy members must still make progress.
+    ///
+    /// Two predicates decide "is this drifted", and they disagreed about
+    /// `spec_hash == None`: [`entry_drift_eligible`] treats an unstamped
+    /// member past the grace period as drift-eligible (so upgrades clean
+    /// it up automatically), while [`count_states`] counts it as *clean*.
+    ///
+    /// That disagreement deadlocks the rolling recycle. Step 4 finds the
+    /// members recycle-eligible but the `min_ready_during_upgrade` floor
+    /// blocks the Delete, and the surge that is supposed to buy the
+    /// headroom never fires, because it is sized off `ready_drifted` —
+    /// which is 0. The pool then emits no actions at all, forever, and
+    /// the doc-comment promise that legacy members get cleaned up
+    /// "instead of requiring a manual delete" quietly fails to hold.
+    #[test]
+    fn unstamped_legacy_ready_members_surge_instead_of_deadlocking() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 2,
+                max_clusters: 10,
+                scale_up_threshold: 0,
+                scale_down_after: "30m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let now = chrono::Utc::now();
+        // Both members are legacy: no stamped hash, and long past the
+        // grace period that guards a not-yet-round-tripped new cluster.
+        let mut clusters = HashMap::new();
+        for i in 0..2 {
+            let mut e = make_entry(ClusterState::Ready);
+            e.spec_hash = None;
+            e.state_since = Some(now - chrono::Duration::hours(1));
+            clusters.insert(format!("pool-test-profile-{i}"), e);
+        }
+        let state = PoolState { clusters };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            now,
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        // The floor legitimately blocks deleting either member right now.
+        // What must NOT happen is emitting nothing: without a surge create
+        // the floor can never be cleared, so the pool never converges.
+        assert!(
+            actions.iter().any(|a| matches!(a, PoolAction::Create(_))),
+            "unstamped legacy members are recycle-eligible but blocked by the \
+             floor, so the pool must surge to buy headroom — got {actions:?}"
+        );
+    }
+
+    /// Backoff is a delay, so it must never be negative — otherwise
+    /// `next_attempt_at = now + delay` lands in the *past* and the
+    /// backoff gate stops throttling exactly when it is needed most.
+    ///
+    /// The failure mode this pins is arithmetic, not logical: a large
+    /// multiplier saturates the `u64` growth factor, and reinterpreting
+    /// `u64::MAX` as `i64` yields `-1`. The `.min(max)` cap looks like
+    /// it bounds the result, but it only bounds it from above.
+    #[test]
+    fn backoff_delay_is_never_negative_for_any_multiplier() {
+        for multiplier in [2u32, 3, 5, 10, 100, u32::MAX] {
+            let mut p = make_profile(
+                0,
+                Some(crate::crd::ScalingConfig {
+                    min_ready: 1,
+                    max_clusters: 3,
+                    scale_up_threshold: 0,
+                    scale_down_after: "30m".to_string(),
+                    queue_timeout: "5m".to_string(),
+                    creating_timeout: "10m".to_string(),
+                    failure_backoff: Some(crate::crd::FailureBackoffConfig {
+                        base: "5s".to_string(),
+                        multiplier,
+                        max: "120s".to_string(),
+                    }),
+                }),
+            );
+            p.status = None;
+
+            for failures in 1..=64u32 {
+                let delay = backoff_delay_for(&p, failures).expect("non-zero failures back off");
+                assert!(
+                    delay >= chrono::Duration::zero(),
+                    "multiplier={multiplier} failures={failures} produced a negative \
+                     backoff of {delay:?}, which resolves to a next-attempt time in \
+                     the past and disables throttling"
+                );
+                assert!(
+                    delay <= chrono::Duration::seconds(120),
+                    "multiplier={multiplier} failures={failures} exceeded the \
+                     configured 120s cap with {delay:?}"
+                );
+            }
+        }
     }
 
     #[test]

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -2521,7 +2521,10 @@ mod tests {
             e.idle_since = Some(now - chrono::Duration::hours(1));
             clusters.insert(format!("pool-test-profile-{i}"), e);
         }
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         let actions = compute_pool_actions(
             &profile,
@@ -2566,7 +2569,10 @@ mod tests {
             e.state_since = Some(now - chrono::Duration::hours(1));
             clusters.insert(format!("pool-test-profile-{i}"), e);
         }
-        let state = PoolState { clusters };
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
 
         let actions = compute_pool_actions(
             &profile,

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -707,7 +707,19 @@ pub fn compute_pool_actions(
     // hash-drifted, cert-expiring, or unstamped-past-grace, and nothing
     // Ready can be in `deleting` before this point. So no `.max()` against
     // `ready_drifted` is needed — it would always pick this value anyway.
-    let recycle_candidates = drifted_ready.len() as u32;
+    //
+    // Zero when `max_recycling == 0`, which the CRD documents as pausing
+    // drift recycling. Surging exists to buy headroom for a recycle; with
+    // recycling paused there is no recycle to buy headroom for, and the
+    // surplus would never drain: the candidates cannot be rolled, so they
+    // stay candidates, holding `upgrade_in_progress` true and suppressing
+    // idle scale-down forever. That would turn a kill-switch into a
+    // permanent capacity leak.
+    let recycle_candidates = if policy.max_recycling == 0 {
+        0
+    } else {
+        drifted_ready.len() as u32
+    };
 
     let mut remaining_ready = counts.ready;
     for (name, _entry) in drifted_ready.iter().take(policy.max_recycling as usize) {
@@ -2481,6 +2493,55 @@ mod tests {
     /// which is 0. The pool then emits no actions at all, forever, and
     /// the doc-comment promise that legacy members get cleaned up
     /// "instead of requiring a manual delete" quietly fails to hold.
+    #[test]
+    fn paused_recycling_does_not_surge_for_legacy_members() {
+        // `maxRecycling: 0` is documented as pausing drift recycling. The
+        // surge exists to buy headroom FOR a recycle, so with recycling
+        // paused it must not fire: the candidates cannot be rolled, so the
+        // surplus would never drain, and they would hold
+        // `upgrade_in_progress` true — suppressing idle scale-down forever.
+        // A kill-switch must not become a permanent capacity leak.
+        let mut profile = make_profile_with_upgrade(0, 0, 1, None);
+        profile.spec.scaling = Some(crate::crd::ScalingConfig {
+            min_ready: 2,
+            max_clusters: 10,
+            scale_up_threshold: 0,
+            scale_down_after: "30m".to_string(),
+            queue_timeout: "5m".to_string(),
+            creating_timeout: "10m".to_string(),
+            failure_backoff: None,
+        });
+
+        let now = chrono::Utc::now();
+        let mut clusters = HashMap::new();
+        for i in 0..2 {
+            let mut e = make_entry(ClusterState::Ready);
+            e.spec_hash = None; // legacy, unstamped
+            e.state_since = Some(now - chrono::Duration::hours(1));
+            e.idle_since = Some(now - chrono::Duration::hours(1));
+            clusters.insert(format!("pool-test-profile-{i}"), e);
+        }
+        let state = PoolState { clusters };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            now,
+            &test_render_ctx(),
+            &Default::default(),
+        );
+
+        assert!(
+            !actions.iter().any(|a| matches!(a, PoolAction::Create(_))),
+            "recycling is paused, so there is no recycle to buy headroom for — \
+             surging here leaks capacity that can never drain. got {actions:?}"
+        );
+        assert!(
+            !actions.iter().any(|a| matches!(a, PoolAction::Delete(_))),
+            "maxRecycling: 0 must not recycle anything. got {actions:?}"
+        );
+    }
+
     #[test]
     fn unstamped_legacy_ready_members_surge_instead_of_deadlocking() {
         let profile = make_profile(


### PR DESCRIPTION
Three independent defects found while auditing the pool/lease logic. Each has a test that was **confirmed red before the fix and green after**.

---

## 1. A deleted `Pending` lease deadlocks the entire pool

**`src/controllers/lease.rs`** — most severe of the three.

Every `remove_from_queue` call site needs a *live* lease to reconcile. A hard `DELETE` reaches none of them:

```rust
Err(kube::Error::Api(ae)) if ae.code == 404 => {
    debug!(lease = %name, "Lease disappeared before reconcile could load current state");
    return Ok(Action::await_change());   // <-- no queue eviction
}
```

The queue sorts `priority DESC, created_at ASC`, so the stranded entry sits at the **head**. Every later lease for that pool then computes `is_head == false` and returns before reaching `reserve_ready_instance`:

```rust
let head = queue.first().map(|h| h.lease_name == name).unwrap_or(false);
...
if !is_head { return Ok(Action::requeue(5s)); }
```

**No lease for that pool can bind again until the operator process restarts** — `rebuild_queues` runs only at startup, and only inserts.

Reachable via `kubectl delete clusterlease`, owner-reference GC, or kobe's own code: `create_lease` hard-deletes still-`Pending` leases on the quota-race and alias-race loser paths. (The normal client path is safe — `DELETE /v1/leases/{id}` patches `phase: Released` rather than deleting.)

**Fix:** evict from the queue on the 404 branch.

*Residual, not addressed here:* this relies on a reconcile actually being dispatched for the deleted object, which is the normal path. A periodic queue reconciliation would close the gap fully; that's a larger change and didn't seem warranted yet.

---

## 2. `backoff_delay_for` can return a **negative** delay

**`src/pool/manager.rs`**

```rust
let factor = (multiplier as u64).saturating_pow(shift);
let secs = base.num_seconds()
    .saturating_mul(factor as i64)      // u64::MAX as i64 == -1
    .min(max.num_seconds());
```

`factor` is deliberately saturating, so a large multiplier makes it `u64::MAX` — and `u64::MAX as i64` is `-1`. The delay flips sign. `.min(max)` doesn't catch it: it only bounds from *above*.

`next_attempt_at = now + delay` then lands in the **past**, `backoff_active` returns false, and a pool that has failed ~30 times consecutively resumes creating at full rate — precisely the condition the backoff exists to throttle.

The shipped default (`multiplier: 2`) is safe, which is why no existing test caught it. At `multiplier: 5` the delay goes negative from 29 consecutive failures onward:

```
multiplier=5 failures=29 produced a negative backoff of TimeDelta { secs: -5 }
```

**Fix:** `i64::try_from(factor).unwrap_or(i64::MAX)`. The new test is a property test over multipliers `[2, 3, 5, 10, 100, u32::MAX]` × failures `1..=64`, asserting the delay stays within `[0, cap]`.

---

## 3. Unstamped legacy members deadlock the rolling recycle

**`src/pool/manager.rs`**

Two predicates decide "is this drifted", and they disagree about `spec_hash == None`:

- `entry_drift_eligible` — an unstamped member past `UNSTAMPED_RECYCLE_GRACE` **is** drift-eligible
- `count_states` — partitions purely on hash equality, so unstamped counts as **clean**

The consequence is a permanent stall. Step 4 finds the members recycle-eligible, the `min_ready_during_upgrade` floor blocks the Delete, and the surge that is supposed to buy that headroom never fires — it's sized off `counts.ready_drifted`, which is `0`. The pool emits **no actions at all**, indefinitely:

```
unstamped legacy members are recycle-eligible but blocked by the floor,
so the pool must surge to buy headroom — got []
```

This silently breaks the promise in `entry_drift_eligible`'s own doc-comment — that legacy members get cleaned up "so future upgrades clean it up automatically instead of requiring a manual delete".

Affects kobe < 0.12.2 legacy members, and current-version members whose post-create status patch failed (after an operator restart, `build_pool_state` reads `None` from disk permanently). **PKI-expiring members hit the identical trap**, since `count_states` ignores cert expiry too.

**Fix:** size the surge off the step-4 candidate list, which already uses the correct predicate. Takes `.max()` of the two so every hash-drift path stays byte-identical — confirmed by the existing suite.

---

## Also found, not fixed here

A fourth issue was identified but is more invasive and lower confidence, so it's being filed separately: `sync_cluster_instance_statuses` writes `phase` from the stale in-memory entry while reading `lease_ref` fresh, so a cluster leased mid-reconcile can be written back to `Ready` with its `leaseRef` still set. `reserve_ready_instance` already defends the double-lease symptom (and its comment names this exact race), but `compute_pool_actions` has no lease awareness, so drift-recycle and idle scale-down can both target a cluster a tenant is holding.

## Verification

`cargo test --workspace` green (661), `cargo fmt -- --check` and `cargo clippy --workspace --all-targets` clean.