### PR TITLE
test: cover the CRD instance types, CLI config, and kobe-sync syncers

### DIFF
--- a/crates/kobectl/src/commands/config.rs
+++ b/crates/kobectl/src/commands/config.rs
@@ -903,18 +903,25 @@ fn print_config(config: &CliConfig, target_override: Option<&str>) -> Result<()>
     Ok(())
 }
 
+/// Render a bearer token for display, never revealing enough of it to
+/// be usable.
+///
+/// Tokens longer than 8 characters keep a 4-char head and tail so a user
+/// can tell *which* token is configured; anything shorter is replaced
+/// wholesale, because a 4+4 elision of an 8-char secret would print the
+/// entire value. `None` renders as `(not set)`.
+fn mask_token(token: Option<&str>) -> String {
+    match token {
+        Some(t) if t.len() > 8 => format!("{}...{}", &t[..4], &t[t.len() - 4..]),
+        Some(_) => "****".to_string(),
+        None => "(not set)".to_string(),
+    }
+}
+
 fn print_auth(auth: &AuthMode, token: Option<&str>, ssh_fingerprint: Option<&str>) {
     println!("auth:     {auth}");
     if auth == &AuthMode::Token {
-        let masked = token
-            .map(|t| {
-                if t.len() > 8 {
-                    format!("{}...{}", &t[..4], &t[t.len() - 4..])
-                } else {
-                    "****".to_string()
-                }
-            })
-            .unwrap_or_else(|| "(not set)".to_string());
+        let masked = mask_token(token);
         println!("token:    {masked}");
     }
     if auth == &AuthMode::Ssh {
@@ -935,7 +942,193 @@ pub fn parse_auth_mode(value: &str) -> Result<AuthMode> {
 
 #[cfg(test)]
 mod tests {
-    use super::{AuthMode, CliConfig};
+    use super::{AuthMode, CliConfig, KobeTarget, Scope, mask_token, parse_auth_mode};
+    use std::path::PathBuf;
+    use std::sync::{Mutex, MutexGuard, OnceLock};
+
+    fn target(endpoint: &str) -> KobeTarget {
+        KobeTarget {
+            endpoint: endpoint.to_string(),
+            auth: AuthMode::Oidc,
+            token: None,
+            ssh_fingerprint: None,
+        }
+    }
+
+    fn config_with(targets: &[(&str, &str)]) -> CliConfig {
+        let mut c = CliConfig::default();
+        for (name, endpoint) in targets {
+            c.targets.insert(name.to_string(), target(endpoint));
+            c.target_scopes.insert(name.to_string(), Scope::Global);
+        }
+        c
+    }
+
+    // ── Session isolation ─────────────────────────────────────────────
+    //
+    // `CliConfig::resolve` consults the per-shell session file, so the
+    // resolve tests must not read (or write) the developer's real one.
+    // `KUNOBI_SESSIONS_DIR` redirects it; the mutex serializes the tests
+    // that touch that process-global.
+
+    struct SessionSandbox {
+        _lock: MutexGuard<'static, ()>,
+        previous: Option<std::ffi::OsString>,
+        dir: PathBuf,
+    }
+
+    impl SessionSandbox {
+        /// Point session storage at a fresh empty directory. Nothing in
+        /// it, so `session::load()` reports "no active target".
+        fn new(tag: &str) -> Self {
+            static LOCK: OnceLock<Mutex<()>> = OnceLock::new();
+            let lock = LOCK
+                .get_or_init(|| Mutex::new(()))
+                .lock()
+                .unwrap_or_else(|e| e.into_inner());
+
+            let dir = std::env::temp_dir().join(format!("kobe-cfg-{}-{tag}", std::process::id()));
+            let _ = std::fs::remove_dir_all(&dir);
+            std::fs::create_dir_all(&dir).unwrap();
+            let previous = std::env::var_os("KUNOBI_SESSIONS_DIR");
+            // SAFETY: the mutex above guarantees no other test in this
+            // binary reads or writes this variable concurrently, and
+            // nothing else in kobectl touches it.
+            unsafe { std::env::set_var("KUNOBI_SESSIONS_DIR", &dir) };
+            Self {
+                _lock: lock,
+                previous,
+                dir,
+            }
+        }
+    }
+
+    impl Drop for SessionSandbox {
+        fn drop(&mut self) {
+            // SAFETY: same as in `new` — still holding the lock.
+            unsafe {
+                match self.previous.take() {
+                    Some(v) => std::env::set_var("KUNOBI_SESSIONS_DIR", v),
+                    None => std::env::remove_var("KUNOBI_SESSIONS_DIR"),
+                }
+            }
+            let _ = std::fs::remove_dir_all(&self.dir);
+        }
+    }
+
+    // ── overlay: local `.kobe.toml` on top of the global library ──────
+
+    /// A target defined in both files resolves to the **local**
+    /// definition and is flagged `Both`, which is what makes `kobe
+    /// config list` warn about the shadowing instead of silently
+    /// pointing at a different cluster than the user's global config
+    /// says.
+    #[test]
+    fn overlay_local_target_shadows_the_global_one_and_is_marked_both() {
+        let mut global = config_with(&[("prod", "https://global.test")]);
+        let mut local = CliConfig::default();
+        local
+            .targets
+            .insert("prod".to_string(), target("https://local.test"));
+
+        global.overlay(local);
+
+        assert_eq!(global.targets["prod"].endpoint, "https://local.test");
+        assert_eq!(global.target_scopes["prod"], Scope::Both);
+    }
+
+    /// A target that only the project file defines is `Local`, and one
+    /// that only the global library defines stays `Global`. These three
+    /// scopes are the entire contract of the SCOPE column.
+    #[test]
+    fn overlay_tags_local_only_and_global_only_targets_distinctly() {
+        let mut global = config_with(&[("prod", "https://global.test")]);
+        let mut local = CliConfig::default();
+        local
+            .targets
+            .insert("staging".to_string(), target("https://staging.test"));
+
+        global.overlay(local);
+
+        assert_eq!(global.target_scopes["prod"], Scope::Global);
+        assert_eq!(global.target_scopes["staging"], Scope::Local);
+        assert_eq!(global.targets.len(), 2);
+    }
+
+    /// Local values only override when they are actually set. An
+    /// endpoint-only `.kobe.toml` must not blank out a token that lives
+    /// in the global config.
+    #[test]
+    fn overlay_only_applies_local_fields_that_are_set() {
+        let mut global = CliConfig {
+            current_target: Some("prod".to_string()),
+            endpoint: Some("https://global.test".to_string()),
+            token: Some("global-token".to_string()),
+            ssh_fingerprint: Some("SHA256:global".to_string()),
+            ..CliConfig::default()
+        };
+
+        global.overlay(CliConfig::default());
+
+        assert_eq!(global.current_target.as_deref(), Some("prod"));
+        assert_eq!(global.endpoint.as_deref(), Some("https://global.test"));
+        assert_eq!(global.token.as_deref(), Some("global-token"));
+        assert_eq!(global.ssh_fingerprint.as_deref(), Some("SHA256:global"));
+    }
+
+    /// …and when they *are* set, local wins for every legacy field plus
+    /// the active-target name.
+    #[test]
+    fn overlay_local_values_win_when_present() {
+        let mut global = CliConfig {
+            current_target: Some("prod".to_string()),
+            endpoint: Some("https://global.test".to_string()),
+            auth: AuthMode::Oidc,
+            token: Some("global-token".to_string()),
+            ssh_fingerprint: Some("SHA256:global".to_string()),
+            ..CliConfig::default()
+        };
+        let local = CliConfig {
+            current_target: Some("staging".to_string()),
+            endpoint: Some("https://local.test".to_string()),
+            auth: AuthMode::Token,
+            token: Some("local-token".to_string()),
+            ssh_fingerprint: Some("SHA256:local".to_string()),
+            ..CliConfig::default()
+        };
+
+        global.overlay(local);
+
+        assert_eq!(global.current_target.as_deref(), Some("staging"));
+        assert_eq!(global.endpoint.as_deref(), Some("https://local.test"));
+        assert_eq!(global.auth, AuthMode::Token);
+        assert_eq!(global.token.as_deref(), Some("local-token"));
+        assert_eq!(global.ssh_fingerprint.as_deref(), Some("SHA256:local"));
+    }
+
+    /// Documented asymmetry: `auth` is overlaid only when the local
+    /// value differs from the default (`oidc`), because TOML cannot tell
+    /// "absent" from "explicitly oidc". A project file that spells out
+    /// `auth = "oidc"` therefore cannot pull a global `token` target
+    /// back to OIDC. Pinned so the limitation is a decision, not a
+    /// surprise.
+    #[test]
+    fn overlay_cannot_reset_auth_to_the_default_mode() {
+        let mut global = CliConfig {
+            auth: AuthMode::Token,
+            ..CliConfig::default()
+        };
+        let local = CliConfig {
+            auth: AuthMode::Oidc,
+            ..CliConfig::default()
+        };
+
+        global.overlay(local);
+
+        assert_eq!(global.auth, AuthMode::Token);
+    }
+
+    // ── legacy migration ──────────────────────────────────────────────
 
     #[test]
     fn migrates_legacy_flat_config_into_default_target() {
@@ -979,5 +1172,510 @@ mod tests {
             config.endpoint.as_deref(),
             Some("https://legacy.example.test")
         );
+    }
+
+    /// A config that already names a current target has been through the
+    /// migration (or was written by a modern kobe). Re-running it would
+    /// clobber that choice with a synthesised `default`.
+    #[test]
+    fn does_not_migrate_when_a_current_target_is_already_set() {
+        let mut config = CliConfig {
+            current_target: Some("prod".to_string()),
+            endpoint: Some("https://legacy.example.test".to_string()),
+            ..CliConfig::default()
+        };
+
+        assert!(!config.migrate_legacy_to_default_target());
+        assert!(config.targets.is_empty());
+        assert_eq!(config.current_target.as_deref(), Some("prod"));
+    }
+
+    /// A pristine config has nothing to migrate, and `save()` must not
+    /// be triggered — `load_global` writes the file back whenever this
+    /// returns true, so a spurious `true` would rewrite (and re-chmod)
+    /// the user's config on every single command.
+    #[test]
+    fn does_not_migrate_an_empty_config() {
+        let mut config = CliConfig::default();
+        assert!(!config.migrate_legacy_to_default_target());
+        assert!(config.targets.is_empty());
+        assert!(config.current_target.is_none());
+    }
+
+    /// A legacy config with credentials but no endpoint cannot become a
+    /// target (a target requires an endpoint). It must be left exactly
+    /// as it was — in particular *not* half-migrated with the flat
+    /// fields cleared, which would silently destroy the user's token.
+    #[test]
+    fn does_not_migrate_a_legacy_config_that_has_no_endpoint() {
+        let mut config = CliConfig {
+            endpoint: None,
+            auth: AuthMode::Token,
+            token: Some("secret-token".to_string()),
+            ..CliConfig::default()
+        };
+
+        assert!(!config.migrate_legacy_to_default_target());
+        assert!(config.targets.is_empty());
+        assert!(config.current_target.is_none());
+        assert_eq!(config.auth, AuthMode::Token);
+        assert_eq!(config.token.as_deref(), Some("secret-token"));
+    }
+
+    // ── resolve: which endpoint does this invocation talk to? ─────────
+
+    /// `--target` beats the per-shell session *and* the legacy
+    /// `current_target`. It is the documented one-shot escape hatch, so
+    /// it has to sit at the top of the precedence chain.
+    #[test]
+    fn resolve_prefers_the_explicit_target_override() {
+        let _sandbox = SessionSandbox::new("override");
+        let mut config = config_with(&[("prod", "https://prod.test"), ("dev", "https://dev.test")]);
+        config.current_target = Some("prod".to_string());
+        super::session::save(&super::session::SessionState {
+            current_target: "prod".to_string(),
+        })
+        .ok();
+
+        let resolved = config.resolve(Some("dev"), None).unwrap();
+        assert_eq!(resolved.target.as_deref(), Some("dev"));
+        assert_eq!(resolved.endpoint, "https://dev.test");
+    }
+
+    /// With no `--target`, the per-shell session file wins over the
+    /// legacy `current_target` in the config. That is the whole point of
+    /// per-shell sessions: two terminals pointing at different clusters
+    /// while sharing one config file.
+    #[test]
+    fn resolve_prefers_the_session_target_over_the_config_field() {
+        let sandbox = SessionSandbox::new("session-wins");
+        if super::session::save(&super::session::SessionState {
+            current_target: "dev".to_string(),
+        })
+        .is_err()
+        {
+            // Parent PID unavailable (no shell parent) — per-shell state
+            // is genuinely unusable here, nothing to assert.
+            drop(sandbox);
+            return;
+        }
+
+        let mut config = config_with(&[("prod", "https://prod.test"), ("dev", "https://dev.test")]);
+        config.current_target = Some("prod".to_string());
+
+        let resolved = config.resolve(None, None).unwrap();
+        assert_eq!(resolved.target.as_deref(), Some("dev"));
+        assert_eq!(resolved.endpoint, "https://dev.test");
+    }
+
+    /// Without a session file the legacy `current_target` still works —
+    /// configs written before per-shell sessions existed (and `kobe
+    /// config import` payloads) must keep resolving.
+    #[test]
+    fn resolve_falls_back_to_the_legacy_current_target() {
+        let _sandbox = SessionSandbox::new("legacy-current");
+        let mut config = config_with(&[("prod", "https://prod.test")]);
+        config.current_target = Some("prod".to_string());
+
+        let resolved = config.resolve(None, None).unwrap();
+        assert_eq!(resolved.target.as_deref(), Some("prod"));
+        assert_eq!(resolved.endpoint, "https://prod.test");
+    }
+
+    /// The pre-targets flat config still resolves, with no target name.
+    #[test]
+    fn resolve_falls_back_to_the_flat_legacy_endpoint() {
+        let _sandbox = SessionSandbox::new("flat");
+        let config = CliConfig {
+            endpoint: Some("https://legacy.test".to_string()),
+            auth: AuthMode::Token,
+            token: Some("t".to_string()),
+            ..CliConfig::default()
+        };
+
+        let resolved = config.resolve(None, None).unwrap();
+        assert!(resolved.target.is_none());
+        assert_eq!(resolved.endpoint, "https://legacy.test");
+        assert_eq!(resolved.auth, AuthMode::Token);
+        assert_eq!(resolved.token.as_deref(), Some("t"));
+    }
+
+    /// A name that isn't defined is an error, not a silent fallback to
+    /// some other target — pointing a CI job at the wrong cluster is far
+    /// worse than failing.
+    #[test]
+    fn resolve_rejects_an_unknown_target_name() {
+        let _sandbox = SessionSandbox::new("unknown");
+        let config = config_with(&[("prod", "https://prod.test")]);
+
+        let err = config.resolve(Some("nope"), None).unwrap_err().to_string();
+        assert!(err.contains("Unknown target 'nope'"), "got: {err}");
+    }
+
+    /// `-e/--endpoint` overrides only the URL: auth mode, token and SSH
+    /// fingerprint still come from the resolved target. Dropping the
+    /// auth would silently downgrade an authenticated call to anonymous.
+    #[test]
+    fn resolve_endpoint_override_keeps_the_targets_credentials() {
+        let _sandbox = SessionSandbox::new("endpoint-override");
+        let mut config = CliConfig::default();
+        config.targets.insert(
+            "prod".to_string(),
+            KobeTarget {
+                endpoint: "https://prod.test".to_string(),
+                auth: AuthMode::Token,
+                token: Some("prod-token".to_string()),
+                ssh_fingerprint: None,
+            },
+        );
+        config.current_target = Some("prod".to_string());
+
+        let resolved = config.resolve(None, Some("http://127.0.0.1:8080")).unwrap();
+        assert_eq!(resolved.endpoint, "http://127.0.0.1:8080");
+        assert_eq!(resolved.target.as_deref(), Some("prod"));
+        assert_eq!(resolved.auth, AuthMode::Token);
+        assert_eq!(resolved.token.as_deref(), Some("prod-token"));
+    }
+
+    /// `--endpoint` with no target at all resolves anonymously against
+    /// the legacy top-level auth — this is the `kobe -e http://localhost`
+    /// port-forward path, which must work on a machine with no config.
+    #[test]
+    fn resolve_endpoint_override_works_with_no_target_configured() {
+        let _sandbox = SessionSandbox::new("endpoint-only");
+        let config = CliConfig::default();
+
+        let resolved = config.resolve(None, Some("http://127.0.0.1:8080")).unwrap();
+        assert_eq!(resolved.endpoint, "http://127.0.0.1:8080");
+        assert!(resolved.target.is_none());
+        assert_eq!(resolved.auth, AuthMode::Oidc);
+    }
+
+    /// The two "nothing resolved" failures give different advice:
+    /// with targets defined the user needs `kobe config use`, without
+    /// them they need `kobe config set`. Pin both, because the message
+    /// *is* the UX for a first-run user.
+    #[test]
+    fn resolve_error_distinguishes_no_active_target_from_no_config_at_all() {
+        let _sandbox = SessionSandbox::new("errors");
+
+        let with_targets = config_with(&[("prod", "https://prod.test")]);
+        let err = with_targets.resolve(None, None).unwrap_err().to_string();
+        assert!(err.contains("kobe config use <name>"), "got: {err}");
+
+        let empty = CliConfig::default();
+        let err = empty.resolve(None, None).unwrap_err().to_string();
+        assert!(err.contains("kobe config set <name>"), "got: {err}");
+        assert!(
+            !err.contains("kobe config use"),
+            "must not suggest selecting among zero targets: {err}"
+        );
+    }
+
+    // ── Serde: on-disk compatibility of the config file ───────────────
+
+    /// `contexts` / `current_context` are the pre-rename field names.
+    /// Configs written by those versions are still on developers' disks;
+    /// dropping the aliases would silently present them with an empty
+    /// target list.
+    #[test]
+    fn config_still_reads_the_pre_rename_context_field_names() {
+        let config: CliConfig = serde_json::from_str(
+            r#"{
+                "current_context": "prod",
+                "contexts": {
+                    "prod": { "endpoint": "https://prod.test", "auth": "token", "token": "t" }
+                }
+            }"#,
+        )
+        .unwrap();
+
+        assert_eq!(config.current_target.as_deref(), Some("prod"));
+        assert_eq!(config.targets["prod"].endpoint, "https://prod.test");
+        assert_eq!(config.targets["prod"].auth, AuthMode::Token);
+    }
+
+    /// A target with no `auth` key predates the auth modes and must
+    /// default to OIDC — the same default a freshly created target gets.
+    #[test]
+    fn target_without_an_auth_key_defaults_to_oidc() {
+        let t: KobeTarget = serde_json::from_str(r#"{ "endpoint": "https://x.test" }"#).unwrap();
+        assert_eq!(t.auth, AuthMode::Oidc);
+        assert!(t.token.is_none());
+        assert!(t.ssh_fingerprint.is_none());
+    }
+
+    /// The saved file stays minimal: the default auth mode, an empty
+    /// target map and unset secrets are all omitted. `target_scopes` is
+    /// runtime-only metadata and must never be written — round-tripping
+    /// it would make a *local* target look global on the next load.
+    #[test]
+    fn saved_config_omits_defaults_and_runtime_only_metadata() {
+        let mut config = config_with(&[("prod", "https://prod.test")]);
+        config.target_scopes.insert("prod".into(), Scope::Local);
+
+        let v: serde_json::Value = serde_json::to_value(&config).unwrap();
+        assert!(v.get("auth").is_none(), "default auth must be omitted: {v}");
+        assert!(v.get("endpoint").is_none(), "unset endpoint omitted: {v}");
+        assert!(v.get("token").is_none(), "unset token omitted: {v}");
+        assert!(
+            v.get("target_scopes").is_none() && v.get("targetScopes").is_none(),
+            "runtime-only scope metadata must never be persisted: {v}"
+        );
+        assert!(v["targets"]["prod"].get("token").is_none());
+
+        let empty = serde_json::to_value(CliConfig::default()).unwrap();
+        assert_eq!(empty, serde_json::json!({}), "a pristine config is `{{}}`");
+    }
+
+    /// Serialized configs round-trip through the JSON the `config
+    /// export` / `config import` pair uses.
+    #[test]
+    fn config_round_trips_through_export_import_json() {
+        let mut config = CliConfig {
+            current_target: Some("prod".to_string()),
+            ..CliConfig::default()
+        };
+        config.targets.insert(
+            "prod".to_string(),
+            KobeTarget {
+                endpoint: "https://prod.test".to_string(),
+                auth: AuthMode::Ssh,
+                token: None,
+                ssh_fingerprint: Some("SHA256:abc".to_string()),
+            },
+        );
+
+        let json = serde_json::to_string(&config).unwrap();
+        let back: CliConfig = serde_json::from_str(&json).unwrap();
+
+        assert_eq!(back.current_target.as_deref(), Some("prod"));
+        assert_eq!(back.targets["prod"].auth, AuthMode::Ssh);
+        assert_eq!(
+            back.targets["prod"].ssh_fingerprint.as_deref(),
+            Some("SHA256:abc")
+        );
+        assert!(
+            back.target_scopes.is_empty(),
+            "scopes are recomputed on load, never read from the file"
+        );
+    }
+
+    /// The local project file is TOML. A target defined there must
+    /// survive `toml::to_string_pretty` → `toml::from_str`, which is
+    /// exactly what `write_target_to_local` does on every
+    /// `kobe config set`.
+    #[test]
+    fn local_target_round_trips_through_toml() {
+        let mut local = CliConfig::default();
+        local.targets.insert(
+            "ci".to_string(),
+            KobeTarget {
+                endpoint: "https://ci.test".to_string(),
+                auth: AuthMode::Token,
+                token: Some("ci-token".to_string()),
+                ssh_fingerprint: None,
+            },
+        );
+
+        let rendered = toml::to_string_pretty(&local).expect("local config must serialize to TOML");
+        let back: CliConfig = toml::from_str(&rendered).unwrap();
+        assert_eq!(back.targets["ci"].endpoint, "https://ci.test");
+        assert_eq!(back.targets["ci"].auth, AuthMode::Token);
+        assert_eq!(back.targets["ci"].token.as_deref(), Some("ci-token"));
+    }
+
+    /// `write_target_to_local` re-serializes whatever is already in
+    /// `./.kobe.toml` before adding the new target. If that file still
+    /// carries pre-targets flat keys (`endpoint`, `token`, …), the
+    /// struct now holds a scalar *after* a table — the classic TOML
+    /// "values must be emitted before tables" hazard. `kobe config set`
+    /// must not blow up on such a file.
+    #[test]
+    fn local_config_with_both_flat_legacy_keys_and_targets_still_serializes() {
+        let mut local = CliConfig {
+            endpoint: Some("https://legacy.test".to_string()),
+            auth: AuthMode::Token,
+            token: Some("legacy-token".to_string()),
+            ..CliConfig::default()
+        };
+        local
+            .targets
+            .insert("ci".to_string(), target("https://ci.test"));
+
+        let rendered = toml::to_string_pretty(&local)
+            .expect("a legacy-plus-targets local config must still serialize");
+        let back: CliConfig = toml::from_str(&rendered).unwrap();
+        assert_eq!(back.endpoint.as_deref(), Some("https://legacy.test"));
+        assert_eq!(back.token.as_deref(), Some("legacy-token"));
+        assert_eq!(back.targets["ci"].endpoint, "https://ci.test");
+    }
+
+    // ── Auth mode + scope vocabulary ──────────────────────────────────
+
+    /// The four accepted `--auth` spellings, and the exact set. A typo
+    /// must be rejected with a message that lists the valid values
+    /// rather than silently falling back to OIDC.
+    #[test]
+    fn parse_auth_mode_accepts_exactly_the_four_documented_modes() {
+        assert_eq!(parse_auth_mode("none").unwrap(), AuthMode::None);
+        assert_eq!(parse_auth_mode("token").unwrap(), AuthMode::Token);
+        assert_eq!(parse_auth_mode("oidc").unwrap(), AuthMode::Oidc);
+        assert_eq!(parse_auth_mode("ssh").unwrap(), AuthMode::Ssh);
+
+        for bad in ["OIDC", "bearer", "", "oidc "] {
+            let err = parse_auth_mode(bad).unwrap_err().to_string();
+            assert!(
+                err.contains("Valid: none, token, oidc, ssh"),
+                "`{bad}` must be rejected with the valid list; got: {err}"
+            );
+        }
+    }
+
+    /// `AuthMode`'s `Display` (used in `config list`'s AUTH column) and
+    /// its serde form (written to disk and to `--output json`) must
+    /// agree — otherwise the value a user copies out of the table is not
+    /// the value `--auth` accepts back.
+    #[test]
+    fn auth_mode_display_matches_its_serde_form() {
+        for mode in [
+            AuthMode::None,
+            AuthMode::Token,
+            AuthMode::Oidc,
+            AuthMode::Ssh,
+        ] {
+            let wire = serde_json::to_value(&mode).unwrap();
+            assert_eq!(wire, serde_json::json!(mode.to_string()));
+            assert_eq!(parse_auth_mode(&mode.to_string()).unwrap(), mode);
+        }
+        assert_eq!(AuthMode::default(), AuthMode::Oidc);
+    }
+
+    /// Same contract for `Scope`, which appears both in the text table
+    /// and in the `config list --output json` payload.
+    #[test]
+    fn scope_display_matches_its_serde_form() {
+        for scope in [Scope::Global, Scope::Local, Scope::Both] {
+            assert_eq!(
+                serde_json::to_value(scope).unwrap(),
+                serde_json::json!(scope.to_string())
+            );
+        }
+        assert_eq!(Scope::Global.to_string(), "global");
+        assert_eq!(Scope::Local.to_string(), "local");
+        assert_eq!(Scope::Both.to_string(), "both");
+    }
+
+    // ── Secret handling ───────────────────────────────────────────────
+
+    /// `kobe config show` prints the configured bearer token. It must
+    /// never print enough of it to be reusable: short tokens are fully
+    /// elided, and long ones keep only a 4+4 fingerprint. A regression
+    /// here leaks a credential into terminal scrollback and CI logs.
+    #[test]
+    fn token_display_never_reveals_a_usable_secret() {
+        assert_eq!(mask_token(None), "(not set)");
+        // 8 chars or fewer: a 4+4 elision would print the whole thing.
+        assert_eq!(mask_token(Some("")), "****");
+        assert_eq!(mask_token(Some("short")), "****");
+        assert_eq!(mask_token(Some("12345678")), "****");
+        // 9+ chars: head and tail only, and never the middle.
+        assert_eq!(mask_token(Some("123456789")), "1234...6789");
+        let secret = "kobe_live_ABCDEFGHIJKLMNOP";
+        let masked = mask_token(Some(secret));
+        assert_eq!(masked, "kobe...MNOP");
+        assert!(
+            !masked.contains("live_ABCDEFGHIJKL"),
+            "the body of the token must not appear: {masked}"
+        );
+    }
+
+    // ── JSON output shapes ────────────────────────────────────────────
+
+    /// The `legacy` block in `config show --output json` exists only to
+    /// tell a user they still have a pre-targets config. It must be
+    /// absent for a modern config so scripts can use its presence as the
+    /// "needs migration" signal.
+    #[test]
+    fn legacy_json_block_appears_only_for_pre_targets_configs() {
+        assert!(super::legacy_output(&config_with(&[("prod", "https://p.test")])).is_none());
+        assert!(super::legacy_output(&CliConfig::default()).is_none());
+
+        let legacy = CliConfig {
+            endpoint: Some("https://legacy.test".to_string()),
+            ..CliConfig::default()
+        };
+        let out = super::legacy_output(&legacy).expect("legacy block expected");
+        assert_eq!(out.endpoint.as_deref(), Some("https://legacy.test"));
+
+        // A non-default auth alone is enough to count as legacy.
+        let auth_only = CliConfig {
+            auth: AuthMode::Token,
+            ..CliConfig::default()
+        };
+        assert!(super::legacy_output(&auth_only).is_some());
+    }
+
+    /// `config show --output json` is a scripted surface: keys are
+    /// camelCase, absent optionals are omitted (not null), and the
+    /// resolved block reflects the same precedence `resolve` applies.
+    #[test]
+    fn config_view_json_uses_camel_case_and_omits_absent_optionals() {
+        let _sandbox = SessionSandbox::new("view");
+        let mut config = CliConfig::default();
+        config.targets.insert(
+            "prod".to_string(),
+            KobeTarget {
+                endpoint: "https://prod.test".to_string(),
+                auth: AuthMode::Ssh,
+                token: None,
+                ssh_fingerprint: Some("SHA256:abc".to_string()),
+            },
+        );
+        config.current_target = Some("prod".to_string());
+
+        let v = serde_json::to_value(super::config_view_output(&config, None)).unwrap();
+
+        assert_eq!(v["currentTarget"], "prod");
+        assert_eq!(v["targets"]["prod"]["sshFingerprint"], "SHA256:abc");
+        assert!(
+            v["targets"]["prod"].get("token").is_none(),
+            "an unset token must be omitted, not null: {v}"
+        );
+        assert!(v.get("legacy").is_none(), "no legacy block expected: {v}");
+        assert_eq!(v["resolved"]["target"], "prod");
+        assert_eq!(v["resolved"]["endpoint"], "https://prod.test");
+        assert_eq!(v["resolved"]["auth"], "ssh");
+    }
+
+    /// When nothing resolves, the `resolved` key is omitted entirely
+    /// rather than emitted as null — `config show --output json` on a
+    /// fresh machine must still be valid, parseable output.
+    #[test]
+    fn config_view_json_omits_resolved_when_nothing_is_configured() {
+        let _sandbox = SessionSandbox::new("view-empty");
+        let v =
+            serde_json::to_value(super::config_view_output(&CliConfig::default(), None)).unwrap();
+
+        assert!(v.get("resolved").is_none(), "got: {v}");
+        assert!(v.get("currentTarget").is_none(), "got: {v}");
+        assert_eq!(v["targets"], serde_json::json!({}));
+        assert!(v["path"].is_string());
+        assert!(v["exists"].is_boolean());
+    }
+
+    /// Guard against `BTreeMap` being swapped for a `HashMap`: the
+    /// targets map is rendered directly into `config list`, so a
+    /// non-deterministic order would reshuffle the table (and the JSON)
+    /// on every invocation.
+    #[test]
+    fn targets_iterate_in_stable_alphabetical_order() {
+        let config = config_with(&[
+            ("zeta", "https://z.test"),
+            ("alpha", "https://a.test"),
+            ("mid", "https://m.test"),
+        ]);
+        let names: Vec<&str> = config.targets.keys().map(String::as_str).collect();
+        assert_eq!(names, vec!["alpha", "mid", "zeta"]);
     }
 }

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -321,3 +321,524 @@ pub struct ClusterInstanceProvenance {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub backend_type: Option<crate::crd::BackendType>,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::BackendType;
+    use kube::CustomResourceExt;
+    use serde_json::json;
+
+    /// A status with every field populated, used by the round-trip and
+    /// key-shape tests below.
+    fn populated_status() -> ClusterInstanceStatus {
+        ClusterInstanceStatus {
+            phase: ClusterInstancePhase::Leased,
+            provisioned: true,
+            bootstrapped: true,
+            lease_ref: Some(ResourceRef {
+                name: "lease-abc".into(),
+            }),
+            active_bootstrap: Some("flux".into()),
+            idle_since: Some("2026-01-02T03:04:05Z".into()),
+            state_since: Some("2026-01-02T03:04:06Z".into()),
+            health_failures: 3,
+            spec_hash: Some("0123456789abcdef".into()),
+            network: Some(ClusterInstanceNetwork {
+                service_cidr: "10.245.32.0/20".into(),
+                cluster_cidr: "10.253.32.0/20".into(),
+            }),
+            created_with: Some(ClusterInstanceProvenance {
+                operator_version: "0.37.0".into(),
+                kobe_sync_image: Some("zondax/kobe-sync:v0.16.0".into()),
+                backend_type: Some(BackendType::K0s),
+            }),
+            message: Some("running bootstrap 'flux'".into()),
+            conditions: vec![ClusterInstanceCondition {
+                condition_type: "Ready".into(),
+                status: "True".into(),
+                reason: "Ready".into(),
+                message: String::new(),
+                last_transition_time: Some("2026-01-02T03:04:06Z".into()),
+            }],
+        }
+    }
+
+    // ── Merge-Patch semantics: actively-managed vs. write-once fields ──
+    //
+    // These four tests pin the `skip_serializing_if` policy documented on
+    // `ClusterInstanceStatus`. Under RFC 7396 (JSON Merge Patch) an
+    // explicit `null` DELETES the on-disk key while an ABSENT key
+    // PRESERVES it. Getting the split wrong is silently destructive in
+    // both directions, so each side gets its own test.
+
+    /// `lease_ref`, `idle_since` and `state_since` are actively managed:
+    /// the instance controller writes `None` to *clear* them. They must
+    /// therefore serialize as explicit `null`, otherwise a released
+    /// instance keeps a stale lease forever and the scale-down decision
+    /// in `pool::manager` reads a stale idle timestamp.
+    #[test]
+    fn actively_managed_fields_serialize_none_as_explicit_null() {
+        let status = ClusterInstanceStatus::default();
+        let v = serde_json::to_value(&status).unwrap();
+
+        for key in ["leaseRef", "idleSince", "stateSince"] {
+            assert!(
+                v.get(key).is_some(),
+                "`{key}` must be present so a Merge Patch can CLEAR it; got: {v}"
+            );
+            assert!(
+                v[key].is_null(),
+                "`{key}` must serialize as explicit null (RFC 7396 delete); got: {}",
+                v[key]
+            );
+        }
+    }
+
+    /// `spec_hash`, `created_with`, `message` and `active_bootstrap` are
+    /// owned by another writer (the profile controller) or are purely
+    /// informational. The instance controller round-trips them through
+    /// every status patch, so a `None` MUST be omitted — emitting
+    /// `"specHash": null` would wipe the profile controller's write
+    /// whenever the instance controller loses the read/write race.
+    #[test]
+    fn write_once_fields_are_omitted_when_none_so_merge_patch_preserves_them() {
+        let status = ClusterInstanceStatus::default();
+        let v = serde_json::to_value(&status).unwrap();
+
+        for key in [
+            "specHash",
+            "createdWith",
+            "message",
+            "activeBootstrap",
+            "network",
+        ] {
+            assert!(
+                v.get(key).is_none(),
+                "`{key}` must be ABSENT when None so a Merge Patch preserves the on-disk value; got: {v}"
+            );
+        }
+    }
+
+    /// An empty condition list must be omitted rather than serialized as
+    /// `[]`: JSON Merge Patch replaces arrays wholesale, so a status
+    /// write from the profile controller (which never derives
+    /// conditions) would otherwise erase the instance controller's list.
+    #[test]
+    fn empty_conditions_are_omitted_so_merge_patch_cannot_erase_them() {
+        let empty = serde_json::to_value(ClusterInstanceStatus::default()).unwrap();
+        assert!(
+            empty.get("conditions").is_none(),
+            "empty conditions must be omitted; got: {empty}"
+        );
+
+        let populated = serde_json::to_value(populated_status()).unwrap();
+        assert_eq!(
+            populated["conditions"].as_array().map(Vec::len),
+            Some(1),
+            "non-empty conditions must still serialize: {populated}"
+        );
+    }
+
+    // ── Wire-format naming ────────────────────────────────────────────
+
+    /// The stored CR is camelCase. Pin the exact key set of a fully
+    /// populated status so a field rename (or a dropped
+    /// `rename_all = "camelCase"`) can never silently orphan data
+    /// already on disk.
+    #[test]
+    fn status_keys_are_camel_case() {
+        let v = serde_json::to_value(populated_status()).unwrap();
+        let mut keys: Vec<&str> = v.as_object().unwrap().keys().map(String::as_str).collect();
+        keys.sort_unstable();
+        assert_eq!(
+            keys,
+            vec![
+                "activeBootstrap",
+                "bootstrapped",
+                "conditions",
+                "createdWith",
+                "healthFailures",
+                "idleSince",
+                "leaseRef",
+                "message",
+                "network",
+                "phase",
+                "provisioned",
+                "specHash",
+                "stateSince",
+            ]
+        );
+    }
+
+    /// `ClusterInstanceSpec` is camelCase on the wire too. A snake_case
+    /// key is silently ignored by serde, so an operator who hand-writes
+    /// `pool_ref:` would get a standalone instance instead of a
+    /// pool-managed one — pin the accepted spelling.
+    #[test]
+    fn spec_accepts_camel_case_keys_only() {
+        let spec: ClusterInstanceSpec = serde_json::from_value(json!({
+            "poolRef": { "name": "e2e-basic" },
+            "healthCheck": { "intervalSeconds": 15 },
+            "readinessGates": [ { "type": "NodesReady", "count": 1 } ],
+        }))
+        .unwrap();
+        assert_eq!(
+            spec.pool_ref.as_ref().map(|r| r.name.as_str()),
+            Some("e2e-basic")
+        );
+        assert!(spec.health_check.is_some());
+        assert_eq!(spec.readiness_gates.len(), 1);
+
+        let snake: ClusterInstanceSpec =
+            serde_json::from_value(json!({ "pool_ref": { "name": "e2e-basic" } })).unwrap();
+        assert!(
+            snake.pool_ref.is_none(),
+            "snake_case keys are NOT part of the wire format and must not bind"
+        );
+
+        // …and the serialized form uses camelCase, so a spec read back
+        // from the apiserver round-trips.
+        let out = serde_json::to_value(&spec).unwrap();
+        assert!(out.get("poolRef").is_some(), "got: {out}");
+        assert!(out.get("healthCheck").is_some(), "got: {out}");
+        assert!(out.get("readinessGates").is_some(), "got: {out}");
+    }
+
+    /// `ClusterInstanceNetwork` is consumed by the k3s/k0s backends
+    /// straight off `status.network`. Pin the camelCase spelling of both
+    /// CIDR keys — a rename would make every backend silently fall back
+    /// to its hardcoded defaults and re-introduce the host-routing
+    /// collision the allocator exists to prevent.
+    #[test]
+    fn network_cidrs_use_camel_case_keys_and_round_trip() {
+        let net = ClusterInstanceNetwork {
+            service_cidr: "10.245.32.0/20".into(),
+            cluster_cidr: "10.253.32.0/20".into(),
+        };
+        let v = serde_json::to_value(&net).unwrap();
+        assert_eq!(v["serviceCidr"], "10.245.32.0/20");
+        assert_eq!(v["clusterCidr"], "10.253.32.0/20");
+
+        let back: ClusterInstanceNetwork = serde_json::from_value(v).unwrap();
+        assert_eq!(back, net);
+    }
+
+    /// The condition's Rust field is `condition_type` but the wire key
+    /// must be `type` — that is what `kubectl`, `kubectl wait
+    /// --for=condition=Ready` and every generic condition-reading tool
+    /// look for. camelCase alone would render it as `conditionType`.
+    #[test]
+    fn condition_type_field_is_named_type_on_the_wire() {
+        let cond = ClusterInstanceCondition {
+            condition_type: "Ready".into(),
+            status: "False".into(),
+            reason: "Creating".into(),
+            message: "provisioning backend resources".into(),
+            last_transition_time: Some("2026-01-02T03:04:05Z".into()),
+        };
+        let v = serde_json::to_value(&cond).unwrap();
+        assert_eq!(v["type"], "Ready");
+        assert!(
+            v.get("conditionType").is_none(),
+            "must not leak the Rust field name: {v}"
+        );
+        assert_eq!(v["lastTransitionTime"], "2026-01-02T03:04:05Z");
+
+        let back: ClusterInstanceCondition = serde_json::from_value(v).unwrap();
+        assert_eq!(back, cond);
+    }
+
+    /// A condition that never transitioned omits `lastTransitionTime`
+    /// entirely rather than writing `null`, so a later patch that does
+    /// know the timestamp does not have to fight an on-disk null.
+    #[test]
+    fn condition_omits_last_transition_time_when_unset() {
+        let cond = ClusterInstanceCondition {
+            condition_type: "Bootstrapped".into(),
+            status: "Unknown".into(),
+            reason: "Creating".into(),
+            message: String::new(),
+            last_transition_time: None,
+        };
+        let v = serde_json::to_value(&cond).unwrap();
+        assert!(
+            v.get("lastTransitionTime").is_none(),
+            "unset transition time must be omitted, not null: {v}"
+        );
+    }
+
+    // ── Phase ─────────────────────────────────────────────────────────
+
+    /// Phase is stored as a bare PascalCase string, and a freshly
+    /// constructed status starts at `Creating` — the pool manager's
+    /// stuck-instance timeout keys off exactly that value.
+    #[test]
+    fn phase_defaults_to_creating_and_round_trips_as_pascal_case() {
+        assert_eq!(
+            ClusterInstancePhase::default(),
+            ClusterInstancePhase::Creating
+        );
+
+        let cases = [
+            (ClusterInstancePhase::Creating, "Creating"),
+            (ClusterInstancePhase::Ready, "Ready"),
+            (ClusterInstancePhase::Leased, "Leased"),
+            (ClusterInstancePhase::Recycling, "Recycling"),
+            (ClusterInstancePhase::Unhealthy, "Unhealthy"),
+            (ClusterInstancePhase::Failed, "Failed"),
+        ];
+        for (phase, wire) in cases {
+            assert_eq!(serde_json::to_value(&phase).unwrap(), json!(wire));
+            let back: ClusterInstancePhase = serde_json::from_str(&format!("\"{wire}\"")).unwrap();
+            assert_eq!(back, phase);
+        }
+    }
+
+    // ── Provenance ────────────────────────────────────────────────────
+
+    /// Provenance carries the two optional components only when they are
+    /// known. `kobeSyncImage` is Vkobe-only and `backendType` did not
+    /// exist before 0.23.1 — emitting `null` for either would write
+    /// noise into every non-vkobe instance and, worse, wipe the value on
+    /// a subsequent Merge Patch.
+    #[test]
+    fn provenance_omits_unknown_components() {
+        let p = ClusterInstanceProvenance {
+            operator_version: "0.37.0".into(),
+            kobe_sync_image: None,
+            backend_type: None,
+        };
+        let v = serde_json::to_value(&p).unwrap();
+        assert_eq!(v["operatorVersion"], "0.37.0");
+        assert!(v.get("kobeSyncImage").is_none(), "got: {v}");
+        assert!(v.get("backendType").is_none(), "got: {v}");
+        assert_eq!(v.as_object().unwrap().len(), 1);
+    }
+
+    /// Instances stamped by kobe < 0.23.1 have no `backendType`. They
+    /// must keep deserializing — consumers fall back to
+    /// `ClusterPool.spec.backend.type` for those. If this ever became a
+    /// hard requirement, every pre-0.23.1 instance would fail to parse
+    /// and the operator would stop reconciling them entirely.
+    #[test]
+    fn provenance_from_pre_0_23_1_deserializes_without_backend_type() {
+        let p: ClusterInstanceProvenance =
+            serde_json::from_value(json!({ "operatorVersion": "0.17.0" })).unwrap();
+        assert_eq!(p.operator_version, "0.17.0");
+        assert!(p.backend_type.is_none());
+        assert!(p.kobe_sync_image.is_none());
+    }
+
+    /// The pinned backend must survive the round trip verbatim — it is
+    /// what decides which backend tears the instance down, so a
+    /// mis-parse would leave orphaned host resources after a pool-level
+    /// backend migration.
+    #[test]
+    fn provenance_backend_type_round_trips_for_every_backend() {
+        for (bt, wire) in [
+            (BackendType::K3s, "k3s"),
+            (BackendType::K0s, "k0s"),
+            (BackendType::Capi, "capi"),
+            (BackendType::Vkobe, "vkobe"),
+            (BackendType::Vcluster, "vcluster"),
+        ] {
+            let p = ClusterInstanceProvenance {
+                operator_version: "0.37.0".into(),
+                kobe_sync_image: None,
+                backend_type: Some(bt),
+            };
+            let v = serde_json::to_value(&p).unwrap();
+            assert_eq!(v["backendType"], json!(wire));
+            let back: ClusterInstanceProvenance = serde_json::from_value(v).unwrap();
+            assert_eq!(back, p);
+        }
+    }
+
+    // ── Compatibility ─────────────────────────────────────────────────
+
+    /// A status written by kobe < 0.17 has no provenance, no network, no
+    /// conditions and no message. It must still parse, defaulting the
+    /// missing fields, or the operator would refuse to reconcile every
+    /// instance created before the upgrade.
+    #[test]
+    fn status_from_older_kobe_deserializes_with_defaults() {
+        let status: ClusterInstanceStatus = serde_json::from_value(json!({
+            "phase": "Ready",
+            "provisioned": true,
+            "leaseRef": null,
+            "healthFailures": 0
+        }))
+        .unwrap();
+
+        assert_eq!(status.phase, ClusterInstancePhase::Ready);
+        assert!(status.provisioned);
+        assert!(!status.bootstrapped);
+        assert!(status.lease_ref.is_none());
+        assert!(status.created_with.is_none());
+        assert!(status.network.is_none());
+        assert!(status.message.is_none());
+        assert!(status.conditions.is_empty());
+    }
+
+    /// An entirely empty status object must parse — during a rolling
+    /// upgrade the operator reads CRs whose `status` subresource has not
+    /// been written yet.
+    #[test]
+    fn status_deserializes_from_empty_object() {
+        let status: ClusterInstanceStatus = serde_json::from_value(json!({})).unwrap();
+        assert_eq!(status.phase, ClusterInstancePhase::Creating);
+        assert_eq!(status.health_failures, 0);
+        assert!(!status.provisioned);
+        assert!(!status.bootstrapped);
+    }
+
+    /// Forward compatibility: during a rolling upgrade an older operator
+    /// pod reads CRs written by the newer one. Unknown keys must be
+    /// ignored, not rejected — `deny_unknown_fields` here would take the
+    /// old replicas offline mid-upgrade.
+    #[test]
+    fn status_ignores_fields_written_by_a_newer_operator() {
+        let status: ClusterInstanceStatus = serde_json::from_value(json!({
+            "phase": "Ready",
+            "someFutureField": { "nested": true },
+            "anotherOne": 42
+        }))
+        .unwrap();
+        assert_eq!(status.phase, ClusterInstancePhase::Ready);
+    }
+
+    /// Full serialize → deserialize → serialize must be a fixed point.
+    /// Every status patch the instance controller issues is built from a
+    /// value it just read back, so any lossy field would drift a little
+    /// further on each reconcile.
+    #[test]
+    fn status_round_trips_through_json_without_loss() {
+        let first = serde_json::to_value(populated_status()).unwrap();
+        let parsed: ClusterInstanceStatus = serde_json::from_value(first.clone()).unwrap();
+        let second = serde_json::to_value(&parsed).unwrap();
+        assert_eq!(first, second);
+    }
+
+    /// `spec` round-trips too, including the `Vec` fields that default
+    /// to empty and the options that default to `None`.
+    #[test]
+    fn spec_round_trips_through_json_without_loss() {
+        let spec: ClusterInstanceSpec = serde_json::from_value(json!({
+            "backend": { "type": "k0s" },
+            "cluster": { "version": "v1.31.3+k3s1" },
+            "addons": [ { "name": "metrics-server" } ],
+            "bootstraps": [ { "name": "flux" } ],
+        }))
+        .unwrap();
+
+        let first = serde_json::to_value(&spec).unwrap();
+        let parsed: ClusterInstanceSpec = serde_json::from_value(first.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&parsed).unwrap(), first);
+        assert_eq!(parsed.addons.len(), 1);
+        assert_eq!(parsed.bootstraps.len(), 1);
+    }
+
+    // ── Generated CRD ─────────────────────────────────────────────────
+
+    /// The CRD identity is part of kobe's public API: `kubectl get ci`,
+    /// every RBAC rule in the chart, and every stored object's
+    /// `apiVersion` depend on these exact strings. Changing any of them
+    /// orphans data already in etcd.
+    #[test]
+    fn crd_identity_is_stable() {
+        let crd = serde_json::to_value(ClusterInstance::crd()).unwrap();
+
+        assert_eq!(crd["spec"]["group"], "kobe.kunobi.ninja");
+        assert_eq!(crd["spec"]["scope"], "Namespaced");
+        assert_eq!(crd["spec"]["names"]["kind"], "ClusterInstance");
+        assert_eq!(crd["spec"]["names"]["plural"], "clusterinstances");
+        assert_eq!(crd["spec"]["names"]["shortNames"][0], "ci");
+        assert_eq!(
+            crd["metadata"]["name"],
+            "clusterinstances.kobe.kunobi.ninja"
+        );
+
+        let versions = crd["spec"]["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["name"], "v1alpha1");
+        assert_eq!(versions[0]["served"], true);
+        assert_eq!(versions[0]["storage"], true);
+    }
+
+    /// `status` must be a real subresource. Without it the apiserver
+    /// silently drops every `patch_status` the controllers issue and the
+    /// instance stays in `Creating` forever.
+    #[test]
+    fn crd_declares_status_subresource() {
+        let crd = serde_json::to_value(ClusterInstance::crd()).unwrap();
+        let subresources = &crd["spec"]["versions"][0]["subresources"];
+        assert!(
+            subresources.get("status").is_some(),
+            "status subresource must be declared: {subresources}"
+        );
+    }
+
+    /// `specHash` is deliberately a **string**, not an integer:
+    /// Kubernetes' structural-schema validator parses numbers through
+    /// `float64` and rejects u64 hashes outside ±2⁵³−1 with
+    /// `specHash in body must be of type integer`. Pin the schema type so
+    /// nobody "simplifies" it back to a number.
+    #[test]
+    fn crd_schema_types_spec_hash_as_string() {
+        let crd = serde_json::to_value(ClusterInstance::crd()).unwrap();
+        let status_props = &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["status"]
+            ["properties"];
+        assert_eq!(
+            status_props["specHash"]["type"], "string",
+            "specHash must be a string in the OpenAPI schema: {status_props}"
+        );
+    }
+
+    /// The generated OpenAPI schema must advertise the same camelCase
+    /// property names the serde impls emit — a mismatch means the
+    /// apiserver prunes fields the operator then cannot read back.
+    #[test]
+    fn crd_schema_property_names_match_serde_camel_case() {
+        let crd = serde_json::to_value(ClusterInstance::crd()).unwrap();
+        let schema = &crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"];
+
+        for key in ["poolRef", "healthCheck", "readinessGates", "bootstraps"] {
+            assert!(
+                schema["spec"]["properties"].get(key).is_some(),
+                "spec schema must expose `{key}`: {}",
+                schema["spec"]["properties"]
+            );
+        }
+        for key in [
+            "leaseRef",
+            "idleSince",
+            "stateSince",
+            "healthFailures",
+            "createdWith",
+            "activeBootstrap",
+            "conditions",
+            "network",
+        ] {
+            assert!(
+                schema["status"]["properties"].get(key).is_some(),
+                "status schema must expose `{key}`: {}",
+                schema["status"]["properties"]
+            );
+        }
+    }
+
+    /// `ResourceRef` is a one-field wrapper, but it is the shape stored
+    /// in `spec.poolRef` and `status.leaseRef`. Flattening it to a bare
+    /// string would break every existing object.
+    #[test]
+    fn resource_ref_serializes_as_an_object_with_a_name_key() {
+        let r = ResourceRef {
+            name: "pool-e2e-basic".into(),
+        };
+        assert_eq!(
+            serde_json::to_value(&r).unwrap(),
+            json!({ "name": "pool-e2e-basic" })
+        );
+    }
+}

--- a/src/kobe_sync/bootstrap.rs
+++ b/src/kobe_sync/bootstrap.rs
@@ -338,4 +338,290 @@ mod tests {
             Some(KOBE_SYNC_ROLE)
         );
     }
+
+    // ── Privilege containment ─────────────────────────────────────────
+
+    /// The whole point of this module is to avoid running kobe-sync as
+    /// `system:masters`. A wildcard anywhere in the role would quietly
+    /// give it back cluster-admin-equivalent reach on the virtual
+    /// apiserver, so reject `*` in every position.
+    #[test]
+    fn cluster_role_contains_no_wildcards() {
+        for rule in build_cluster_role().rules.unwrap_or_default() {
+            assert!(
+                !rule.verbs.iter().any(|v| v == "*"),
+                "wildcard verb in rule: {rule:?}"
+            );
+            assert!(
+                !rule
+                    .resources
+                    .clone()
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|r| r == "*"),
+                "wildcard resource in rule: {rule:?}"
+            );
+            assert!(
+                !rule
+                    .api_groups
+                    .clone()
+                    .unwrap_or_default()
+                    .iter()
+                    .any(|g| g == "*"),
+                "wildcard apiGroup in rule: {rule:?}"
+            );
+            assert!(
+                rule.resource_names.is_none(),
+                "resourceNames are not used by kobe-sync; an entry here would silently \
+                 narrow a rule the syncers rely on: {rule:?}"
+            );
+        }
+    }
+
+    /// Secrets are watched (the SecretSyncer projects them to the host)
+    /// but never written back to the virtual apiserver. Granting write
+    /// here would let a compromised kobe-sync mint credentials inside a
+    /// leased cluster. Same for the other read-only watch targets.
+    #[test]
+    fn read_only_watch_targets_are_granted_no_write_verbs() {
+        const READ_ONLY: &[&str] = &[
+            "pods",
+            "services",
+            "configmaps",
+            "endpoints",
+            "secrets",
+            "persistentvolumeclaims",
+            "networkpolicies",
+            "ingresses",
+        ];
+        const WRITE_VERBS: &[&str] = &[
+            "create",
+            "update",
+            "patch",
+            "delete",
+            "deletecollection",
+            "*",
+        ];
+
+        for rule in build_cluster_role().rules.unwrap_or_default() {
+            let resources = rule.resources.clone().unwrap_or_default();
+            for res in &resources {
+                if !READ_ONLY.contains(&res.as_str()) {
+                    continue;
+                }
+                for verb in &rule.verbs {
+                    assert!(
+                        !WRITE_VERBS.contains(&verb.as_str()),
+                        "`{res}` is a read-only watch target but the role grants `{verb}`"
+                    );
+                }
+            }
+        }
+    }
+
+    /// ClusterRole and ClusterRoleBinding are cluster-scoped. A stray
+    /// namespace in `metadata` would make the server-side apply in
+    /// [`ensure_rbac`] target a namespaced path that does not exist.
+    #[test]
+    fn rbac_objects_are_cluster_scoped() {
+        assert!(build_cluster_role().metadata.namespace.is_none());
+        assert!(build_cluster_role_binding().metadata.namespace.is_none());
+        assert_eq!(
+            build_cluster_role_binding().role_ref.api_group,
+            "rbac.authorization.k8s.io"
+        );
+    }
+
+    // ── ensure_rbac against a fake apiserver ──────────────────────────
+
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn client(server: &MockServer) -> kube::Client {
+        crate::kobe_sync::testkit::mock_client(server)
+    }
+
+    const ROLE_PATH: &str = "/apis/rbac.authorization.k8s.io/v1/clusterroles/kobe-sync";
+    const BINDING_PATH: &str = "/apis/rbac.authorization.k8s.io/v1/clusterrolebindings/kobe-sync";
+
+    /// Both applies succeed, each echoing back the object it was sent —
+    /// which is what a real apiserver does for a server-side apply.
+    async fn mount_happy_path(server: &MockServer) {
+        Mock::given(method("PATCH"))
+            .and(path(ROLE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_cluster_role()))
+            .mount(server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(BINDING_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_cluster_role_binding()))
+            .mount(server)
+            .await;
+    }
+
+    /// `ensure_rbac` must hit exactly the two cluster-scoped RBAC
+    /// endpoints named after [`KOBE_SYNC_ROLE`], and nothing else — the
+    /// bootstrap client holds `system:masters`, so every extra call it
+    /// makes is privileged.
+    #[tokio::test]
+    async fn ensure_rbac_applies_exactly_the_role_and_the_binding() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(ROLE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_cluster_role()))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(BINDING_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_cluster_role_binding()))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        ensure_rbac(&client(&server)).await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 2, "no other apiserver calls may be made");
+        assert_eq!(reqs[0].url.path(), ROLE_PATH);
+        assert_eq!(
+            reqs[1].url.path(),
+            BINDING_PATH,
+            "the role must be applied BEFORE the binding that references it"
+        );
+    }
+
+    /// The two objects go up as **server-side apply** (not a merge
+    /// patch) under the `kobe-sync` field manager, with `force` set.
+    /// Without `force`, a rerun after a kobe upgrade that changes the
+    /// rule set fails with a field-manager conflict and the pod
+    /// crash-loops; without the apply content-type the apiserver
+    /// interprets the body as a merge patch and never prunes removed
+    /// rules.
+    #[tokio::test]
+    async fn ensure_rbac_uses_forced_server_side_apply_as_kobe_sync() {
+        let server = MockServer::start().await;
+        mount_happy_path(&server).await;
+
+        ensure_rbac(&client(&server)).await.unwrap();
+
+        for req in server.received_requests().await.unwrap() {
+            let query: std::collections::HashMap<_, _> = req.url.query_pairs().collect();
+            assert_eq!(
+                query.get("fieldManager").map(|v| v.as_ref()),
+                Some(FIELD_MANAGER),
+                "field manager must be `{FIELD_MANAGER}`; query was {:?}",
+                req.url.query()
+            );
+            assert_eq!(
+                query.get("force").map(|v| v.as_ref()),
+                Some("true"),
+                "apply must be forced; query was {:?}",
+                req.url.query()
+            );
+
+            let ct = req
+                .headers
+                .get("content-type")
+                .expect("content-type must be set")
+                .to_str()
+                .unwrap();
+            assert!(
+                ct.starts_with("application/apply-patch"),
+                "must be a server-side apply patch, got `{ct}`"
+            );
+        }
+    }
+
+    /// Server-side apply is rejected by the apiserver unless the body
+    /// carries `apiVersion` and `kind`. The typed k8s-openapi structs
+    /// supply them; a refactor to a hand-rolled JSON body that dropped
+    /// either would fail at runtime only, inside a bootstrap path that
+    /// runs before any syncer starts.
+    #[tokio::test]
+    async fn ensure_rbac_bodies_carry_api_version_and_kind() {
+        let server = MockServer::start().await;
+        mount_happy_path(&server).await;
+
+        ensure_rbac(&client(&server)).await.unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        let role: serde_json::Value = serde_json::from_slice(&reqs[0].body).unwrap();
+        assert_eq!(role["apiVersion"], "rbac.authorization.k8s.io/v1");
+        assert_eq!(role["kind"], "ClusterRole");
+        assert_eq!(role["metadata"]["name"], KOBE_SYNC_ROLE);
+
+        let binding: serde_json::Value = serde_json::from_slice(&reqs[1].body).unwrap();
+        assert_eq!(binding["apiVersion"], "rbac.authorization.k8s.io/v1");
+        assert_eq!(binding["kind"], "ClusterRoleBinding");
+        assert_eq!(binding["subjects"][0]["name"], KOBE_SYNC_USER);
+        assert_eq!(binding["roleRef"]["name"], KOBE_SYNC_ROLE);
+    }
+
+    /// If the ClusterRole apply fails, the binding must NOT be applied:
+    /// a binding pointing at a role that does not exist grants nothing,
+    /// so kobe-sync would start up and 403 on its first list with a
+    /// confusing "forbidden" instead of the actual bootstrap error. The
+    /// error also has to name the object that failed.
+    #[tokio::test]
+    async fn ensure_rbac_aborts_before_the_binding_when_the_role_apply_fails() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(ROLE_PATH))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "message": "clusterroles.rbac.authorization.k8s.io is forbidden",
+                "reason": "Forbidden",
+                "code": 403,
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(BINDING_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_cluster_role_binding()))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let err = ensure_rbac(&client(&server)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("ClusterRole `kobe-sync`"),
+            "error must name the failing object, got: {err}"
+        );
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 1, "binding must not be attempted");
+    }
+
+    /// A failure on the binding is surfaced too — it is the half that
+    /// actually grants the permissions, so swallowing it would leave a
+    /// role nobody is bound to and kobe-sync 403ing at runtime.
+    #[tokio::test]
+    async fn ensure_rbac_surfaces_a_binding_failure() {
+        let server = MockServer::start().await;
+        Mock::given(method("PATCH"))
+            .and(path(ROLE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(build_cluster_role()))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(BINDING_PATH))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "message": "etcdserver: request timed out",
+                "code": 500,
+            })))
+            .mount(&server)
+            .await;
+
+        let err = ensure_rbac(&client(&server)).await.unwrap_err();
+        assert!(
+            err.to_string().contains("ClusterRoleBinding `kobe-sync`"),
+            "error must name the failing object, got: {err}"
+        );
+    }
 }

--- a/src/kobe_sync/mod.rs
+++ b/src/kobe_sync/mod.rs
@@ -18,3 +18,6 @@ pub mod config;
 pub mod proxy;
 pub mod syncer;
 pub mod upgrade;
+
+#[cfg(test)]
+pub mod testkit;

--- a/src/kobe_sync/syncer/pvcs.rs
+++ b/src/kobe_sync/syncer/pvcs.rs
@@ -286,4 +286,452 @@ mod tests {
         let host_pvc = translate_pvc_to_host(&pvc, &t, "default").unwrap();
         assert!(host_pvc.status.is_none());
     }
+
+    /// The *virtual* status describes a binding that only exists in the
+    /// virtual cluster's view. Carrying it onto the host would claim the
+    /// host PVC is already `Bound` to a PersistentVolume that the host
+    /// has never heard of. The status must be dropped even when the
+    /// source object has a fully populated one.
+    #[test]
+    fn translate_pvc_drops_a_populated_virtual_status() {
+        use k8s_openapi::api::core::v1::PersistentVolumeClaimStatus;
+        let t = make_translator();
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some("bound".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            status: Some(PersistentVolumeClaimStatus {
+                phase: Some("Bound".into()),
+                capacity: Some({
+                    let mut m = BTreeMap::new();
+                    m.insert("storage".to_string(), Quantity("10Gi".into()));
+                    m
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let host_pvc = translate_pvc_to_host(&pvc, &t, "default").unwrap();
+        assert!(
+            host_pvc.status.is_none(),
+            "virtual PVC status must never be projected onto the host"
+        );
+    }
+
+    /// A spec-less PVC stays spec-less rather than gaining a defaulted
+    /// (and therefore invalid — no accessModes, no resources) spec.
+    #[test]
+    fn translate_pvc_leaves_an_absent_spec_absent() {
+        let t = make_translator();
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some("bare".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(
+            translate_pvc_to_host(&pvc, &t, "default")
+                .unwrap()
+                .spec
+                .is_none()
+        );
+    }
+
+    /// The spec is passed through untouched — including `volumeName`,
+    /// `volumeMode` and `selector`, which are *not* name-translated
+    /// because PersistentVolumes and storage classes are cluster-scoped
+    /// on the host and share no namespace with the virtual cluster.
+    #[test]
+    fn translate_pvc_passes_the_whole_spec_through_verbatim() {
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::LabelSelector;
+        let t = make_translator();
+        let spec = PersistentVolumeClaimSpec {
+            access_modes: Some(vec!["ReadWriteMany".into()]),
+            storage_class_name: Some("fast".into()),
+            volume_name: Some("pv-0001".into()),
+            volume_mode: Some("Block".into()),
+            selector: Some(LabelSelector {
+                match_labels: Some({
+                    let mut m = BTreeMap::new();
+                    m.insert("tier".to_string(), "ssd".to_string());
+                    m
+                }),
+                ..Default::default()
+            }),
+            ..Default::default()
+        };
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some("verbatim".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            spec: Some(spec.clone()),
+            ..Default::default()
+        };
+        let host_pvc = translate_pvc_to_host(&pvc, &t, "default").unwrap();
+        assert_eq!(
+            serde_json::to_value(host_pvc.spec.as_ref().unwrap()).unwrap(),
+            serde_json::to_value(&spec).unwrap()
+        );
+    }
+
+    /// Server-assigned identity from the virtual apiserver must not ride
+    /// along: a `resourceVersion` makes the host create fail outright,
+    /// and an `ownerReferences` entry pointing at a virtual object gets
+    /// the host PVC garbage-collected the moment the host GC runs.
+    #[test]
+    fn translate_pvc_strips_virtual_side_identity() {
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+        let t = make_translator();
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some("owned".into()),
+                namespace: Some("default".into()),
+                uid: Some("11111111-2222-3333-4444-555555555555".into()),
+                resource_version: Some("4242".into()),
+                owner_references: Some(vec![OwnerReference {
+                    api_version: "apps/v1".into(),
+                    kind: "StatefulSet".into(),
+                    name: "virtual-sts".into(),
+                    uid: "deadbeef".into(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let host_pvc = translate_pvc_to_host(&pvc, &t, "default").unwrap();
+        assert!(host_pvc.metadata.uid.is_none());
+        assert!(host_pvc.metadata.resource_version.is_none());
+        assert!(host_pvc.metadata.owner_references.is_none());
+        assert!(host_pvc.metadata.creation_timestamp.is_none());
+    }
+
+    /// A name carrying the `-x-` translation separator is ambiguous and
+    /// must be rejected rather than mapped onto a host name that could
+    /// collide with another tenant's volume.
+    #[test]
+    fn translate_pvc_rejects_names_containing_the_separator() {
+        let t = make_translator();
+        let pvc = PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some("data-x-vol".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(translate_pvc_to_host(&pvc, &t, "default").is_err());
+    }
+
+    // ── Event handling against a fake host apiserver ──────────────────
+
+    use crate::kobe_sync::testkit::{HOST_NS, k8s_not_found, syncer_ctx};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn pvc_collection() -> String {
+        format!("/api/v1/namespaces/{HOST_NS}/persistentvolumeclaims")
+    }
+
+    fn pvc_item(name: &str) -> String {
+        format!("{}/{name}", pvc_collection())
+    }
+
+    fn virtual_pvc(name: &str, ns: &str) -> PersistentVolumeClaim {
+        PersistentVolumeClaim {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                namespace: Some(ns.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    fn host_api_of(ctx: &SyncerContext) -> Api<PersistentVolumeClaim> {
+        Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace)
+    }
+
+    /// Unknown on the host ⇒ CREATE, under the translated name in the
+    /// pool's host namespace. The pod syncer rewrites
+    /// `volumes[].persistentVolumeClaim.claimName` to the same
+    /// translated name, so a mismatch here strands every projected pod
+    /// in `Pending` on an unbound claim.
+    #[tokio::test]
+    async fn apply_event_creates_the_host_pvc_when_absent() {
+        let server = MockServer::start().await;
+        let host = "my-data-x-default-x-vc";
+        Mock::given(method("GET"))
+            .and(path(pvc_item(host)))
+            .respond_with(
+                ResponseTemplate::new(404)
+                    .set_body_json(k8s_not_found("persistentvolumeclaims", host)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(pvc_collection()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(virtual_pvc(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        handle_pvc_event(
+            &Event::Apply(virtual_pvc("my-data", "default")),
+            &ctx,
+            &host_api_of(&ctx),
+        )
+        .await
+        .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 2, "expected a GET probe then a POST create");
+        let body: serde_json::Value = serde_json::from_slice(&reqs[1].body).unwrap();
+        assert_eq!(body["metadata"]["name"], host);
+        assert_eq!(body["metadata"]["namespace"], HOST_NS);
+        assert!(
+            body.get("status").is_none() || body["status"].is_null(),
+            "no virtual status may be sent on create: {body}"
+        );
+    }
+
+    /// Already present on the host ⇒ forced server-side apply under the
+    /// `kobe-sync` field manager, never a second create.
+    #[tokio::test]
+    async fn apply_event_force_applies_the_existing_host_pvc() {
+        let server = MockServer::start().await;
+        let host = "my-data-x-default-x-vc";
+        Mock::given(method("GET"))
+            .and(path(pvc_item(host)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(virtual_pvc(host, HOST_NS)))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(pvc_item(host)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(virtual_pvc(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(pvc_collection()))
+            .respond_with(ResponseTemplate::new(201))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        handle_pvc_event(
+            &Event::Apply(virtual_pvc("my-data", "default")),
+            &ctx,
+            &host_api_of(&ctx),
+        )
+        .await
+        .unwrap();
+
+        let patch = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|r| r.method.as_str() == "PATCH")
+            .expect("a PATCH must have been issued");
+        let query: std::collections::HashMap<_, _> = patch.url.query_pairs().collect();
+        assert_eq!(
+            query.get("fieldManager").map(|v| v.as_ref()),
+            Some("kobe-sync")
+        );
+        assert_eq!(query.get("force").map(|v| v.as_ref()), Some("true"));
+    }
+
+    /// `InitApply` (initial-list replay) syncs exactly like `Apply`, so
+    /// PVCs that predate the kobe-sync process are mirrored too.
+    #[tokio::test]
+    async fn init_apply_event_syncs_like_apply() {
+        let server = MockServer::start().await;
+        let host = "old-data-x-default-x-vc";
+        Mock::given(method("GET"))
+            .and(path(pvc_item(host)))
+            .respond_with(
+                ResponseTemplate::new(404)
+                    .set_body_json(k8s_not_found("persistentvolumeclaims", host)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(pvc_collection()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(virtual_pvc(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        handle_pvc_event(
+            &Event::InitApply(virtual_pvc("old-data", "default")),
+            &ctx,
+            &host_api_of(&ctx),
+        )
+        .await
+        .unwrap();
+
+        server.verify().await;
+    }
+
+    /// Skipped namespaces never reach the host apiserver, on any event
+    /// kind — not even the existence probe.
+    #[tokio::test]
+    async fn skipped_namespaces_produce_no_host_traffic_at_all() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &["kube-system"]);
+        let host_api = host_api_of(&ctx);
+
+        for ev in [
+            Event::Apply(virtual_pvc("d", "kube-system")),
+            Event::InitApply(virtual_pvc("d", "kube-system")),
+            Event::Delete(virtual_pvc("d", "kube-system")),
+        ] {
+            handle_pvc_event(&ev, &ctx, &host_api).await.unwrap();
+        }
+
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    /// Watcher bookmarks are pure no-ops.
+    #[tokio::test]
+    async fn init_and_init_done_bookmarks_are_no_ops() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api = host_api_of(&ctx);
+
+        handle_pvc_event(&Event::Init, &ctx, &host_api)
+            .await
+            .unwrap();
+        handle_pvc_event(&Event::InitDone, &ctx, &host_api)
+            .await
+            .unwrap();
+
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    /// A virtual delete deletes the translated host PVC — the backing
+    /// volume is only reclaimed once the *host* claim goes away.
+    #[tokio::test]
+    async fn delete_event_deletes_the_translated_host_pvc() {
+        let server = MockServer::start().await;
+        let host = "gone-x-default-x-vc";
+        Mock::given(method("DELETE"))
+            .and(path(pvc_item(host)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(virtual_pvc(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        handle_pvc_event(
+            &Event::Delete(virtual_pvc("gone", "default")),
+            &ctx,
+            &host_api_of(&ctx),
+        )
+        .await
+        .unwrap();
+
+        server.verify().await;
+    }
+
+    /// An already-deleted host PVC is the normal teardown race and must
+    /// not be reported as an error.
+    #[tokio::test]
+    async fn delete_event_tolerates_a_host_pvc_that_is_already_gone() {
+        let server = MockServer::start().await;
+        let host = "vanished-x-default-x-vc";
+        Mock::given(method("DELETE"))
+            .and(path(pvc_item(host)))
+            .respond_with(
+                ResponseTemplate::new(404)
+                    .set_body_json(k8s_not_found("persistentvolumeclaims", host)),
+            )
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        handle_pvc_event(
+            &Event::Delete(virtual_pvc("vanished", "default")),
+            &ctx,
+            &host_api_of(&ctx),
+        )
+        .await
+        .expect("404 on delete must be treated as success");
+    }
+
+    /// Any non-404 delete failure surfaces, so a leaked host PVC (which
+    /// keeps a real volume allocated) is at least logged.
+    #[tokio::test]
+    async fn delete_event_propagates_non_404_failures() {
+        let server = MockServer::start().await;
+        let host = "stuck-x-default-x-vc";
+        Mock::given(method("DELETE"))
+            .and(path(pvc_item(host)))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "message": "Operation cannot be fulfilled", "code": 409,
+            })))
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        assert!(
+            handle_pvc_event(
+                &Event::Delete(virtual_pvc("stuck", "default")),
+                &ctx,
+                &host_api_of(&ctx)
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    /// An untranslatable name was never mirrored, so its delete must be
+    /// a silent no-op — issuing a DELETE at a guessed name could destroy
+    /// another tenant's volume.
+    #[tokio::test]
+    async fn delete_event_of_an_untranslatable_name_issues_no_request() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &[]);
+
+        handle_pvc_event(
+            &Event::Delete(virtual_pvc("data-x-vol", "default")),
+            &ctx,
+            &host_api_of(&ctx),
+        )
+        .await
+        .expect("an untranslatable delete is a no-op, not an error");
+
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    /// On the apply path an untranslatable name is an error (the user
+    /// created something kobe-sync cannot mirror), and no host request
+    /// is made.
+    #[tokio::test]
+    async fn apply_event_of_an_untranslatable_name_errors_without_touching_the_host() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &[]);
+
+        assert!(
+            handle_pvc_event(
+                &Event::Apply(virtual_pvc("data-x-vol", "default")),
+                &ctx,
+                &host_api_of(&ctx)
+            )
+            .await
+            .is_err()
+        );
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
 }

--- a/src/kobe_sync/syncer/service_accounts.rs
+++ b/src/kobe_sync/syncer/service_accounts.rs
@@ -307,4 +307,412 @@ mod tests {
         assert_eq!(labels.get(LABEL_MANAGED).map(String::as_str), Some("true"));
         assert_eq!(labels.get(LABEL_VNS).map(String::as_str), Some("default"));
     }
+
+    /// `automountServiceAccountToken: false` is a deliberate hardening
+    /// choice on the virtual SA. Dropping it (or coercing it to the
+    /// `None` default, which the host apiserver reads as *true*) would
+    /// silently mount a token into every projected pod that opted out.
+    /// Both explicit values must survive verbatim.
+    #[test]
+    fn translate_service_account_preserves_automount_opt_out() {
+        let t = make_translator();
+        for want in [Some(false), Some(true), None] {
+            let sa = ServiceAccount {
+                metadata: ObjectMeta {
+                    name: Some("hardened".into()),
+                    namespace: Some("default".into()),
+                    ..Default::default()
+                },
+                automount_service_account_token: want,
+                ..Default::default()
+            };
+            let host_sa = translate_service_account_to_host(&sa, &t, "default").unwrap();
+            assert_eq!(
+                host_sa.automount_service_account_token, want,
+                "automountServiceAccountToken must round-trip verbatim"
+            );
+        }
+    }
+
+    /// Server-assigned identity from the *virtual* apiserver
+    /// (uid / resourceVersion / creationTimestamp / ownerReferences)
+    /// must not be carried onto the host object. A create carrying a
+    /// foreign `resourceVersion` is rejected outright, and a stale
+    /// `ownerReferences` entry pointing at a virtual object would make
+    /// the host garbage collector delete the SA immediately.
+    #[test]
+    fn translate_service_account_strips_virtual_side_identity() {
+        use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+        let t = make_translator();
+        let sa = ServiceAccount {
+            metadata: ObjectMeta {
+                name: Some("owned".into()),
+                namespace: Some("default".into()),
+                uid: Some("11111111-2222-3333-4444-555555555555".into()),
+                resource_version: Some("98765".into()),
+                owner_references: Some(vec![OwnerReference {
+                    api_version: "v1".into(),
+                    kind: "Deployment".into(),
+                    name: "virtual-owner".into(),
+                    uid: "deadbeef".into(),
+                    ..Default::default()
+                }]),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        let host_sa = translate_service_account_to_host(&sa, &t, "default").unwrap();
+        assert!(host_sa.metadata.uid.is_none());
+        assert!(host_sa.metadata.resource_version.is_none());
+        assert!(host_sa.metadata.owner_references.is_none());
+        assert!(host_sa.metadata.creation_timestamp.is_none());
+    }
+
+    /// A virtual name carrying the `-x-` translation separator is
+    /// ambiguous (see `translator::to_host_name`), so translation must
+    /// fail loudly rather than produce a host name that could collide
+    /// with a different tenant's object.
+    #[test]
+    fn translate_service_account_rejects_names_containing_the_separator() {
+        let t = make_translator();
+        let sa = ServiceAccount {
+            metadata: ObjectMeta {
+                name: Some("evil-x-sa".into()),
+                namespace: Some("default".into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        };
+        assert!(translate_service_account_to_host(&sa, &t, "default").is_err());
+    }
+
+    // ── Event handling against a fake host apiserver ──────────────────
+
+    use crate::kobe_sync::testkit::{HOST_NS, k8s_not_found, syncer_ctx};
+    use wiremock::matchers::{method, path};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// Namespaced ServiceAccount collection path on the fake host.
+    fn sa_collection() -> String {
+        format!("/api/v1/namespaces/{HOST_NS}/serviceaccounts")
+    }
+
+    fn sa_item(name: &str) -> String {
+        format!("{}/{name}", sa_collection())
+    }
+
+    fn virtual_sa(name: &str, ns: &str) -> ServiceAccount {
+        ServiceAccount {
+            metadata: ObjectMeta {
+                name: Some(name.into()),
+                namespace: Some(ns.into()),
+                ..Default::default()
+            },
+            ..Default::default()
+        }
+    }
+
+    /// First sight of a virtual SA: the host has nothing, so the syncer
+    /// must CREATE — under the translated name, in the pool's host
+    /// namespace. A wrong name here is exactly the
+    /// `serviceaccount "<sa>" not found` pod-admission failure this
+    /// syncer exists to prevent.
+    #[tokio::test]
+    async fn apply_event_creates_the_host_sa_when_absent() {
+        let server = MockServer::start().await;
+        let host = "source-controller-x-flux-system-x-vc";
+        Mock::given(method("GET"))
+            .and(path(sa_item(host)))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(k8s_not_found("serviceaccounts", host)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(sa_collection()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(virtual_sa(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+        let ev = Event::Apply(virtual_sa("source-controller", "flux-system"));
+
+        handle_service_account_event(&ev, &ctx, &host_api)
+            .await
+            .unwrap();
+
+        let reqs = server.received_requests().await.unwrap();
+        assert_eq!(reqs.len(), 2, "expected a GET probe then a POST create");
+        let body: serde_json::Value = serde_json::from_slice(&reqs[1].body).unwrap();
+        assert_eq!(body["metadata"]["name"], host);
+        assert_eq!(body["metadata"]["namespace"], HOST_NS);
+    }
+
+    /// When the host SA already exists the syncer must reconcile it with
+    /// a forced server-side apply under the `kobe-sync` field manager —
+    /// not a second create (409 Conflict) and not an unforced patch
+    /// (field-manager conflict after an operator upgrade).
+    #[tokio::test]
+    async fn apply_event_force_applies_the_existing_host_sa() {
+        let server = MockServer::start().await;
+        let host = "my-sa-x-default-x-vc";
+        Mock::given(method("GET"))
+            .and(path(sa_item(host)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(virtual_sa(host, HOST_NS)))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(sa_item(host)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(virtual_sa(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(sa_collection()))
+            .respond_with(ResponseTemplate::new(201))
+            .expect(0)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        handle_service_account_event(
+            &Event::Apply(virtual_sa("my-sa", "default")),
+            &ctx,
+            &host_api,
+        )
+        .await
+        .unwrap();
+
+        let patch = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|r| r.method.as_str() == "PATCH")
+            .expect("a PATCH must have been issued");
+        let query: std::collections::HashMap<_, _> = patch.url.query_pairs().collect();
+        assert_eq!(
+            query.get("fieldManager").map(|v| v.as_ref()),
+            Some("kobe-sync")
+        );
+        assert_eq!(query.get("force").map(|v| v.as_ref()), Some("true"));
+    }
+
+    /// `InitApply` (the replay of the initial list) must take the same
+    /// path as `Apply`. Treating it as a no-op would leave every SA that
+    /// existed before kobe-sync started unmirrored until it happened to
+    /// be edited.
+    #[tokio::test]
+    async fn init_apply_event_syncs_like_apply() {
+        let server = MockServer::start().await;
+        let host = "pre-existing-x-default-x-vc";
+        Mock::given(method("GET"))
+            .and(path(sa_item(host)))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(k8s_not_found("serviceaccounts", host)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(sa_collection()))
+            .respond_with(ResponseTemplate::new(201).set_body_json(virtual_sa(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        handle_service_account_event(
+            &Event::InitApply(virtual_sa("pre-existing", "default")),
+            &ctx,
+            &host_api,
+        )
+        .await
+        .unwrap();
+
+        server.verify().await;
+    }
+
+    /// Namespaces in `skip_namespaces` are invisible to the syncer: not
+    /// even the existence probe may go out. `kube-system` SAs belong to
+    /// the virtual control plane and mirroring them would collide with
+    /// the host's own.
+    #[tokio::test]
+    async fn skipped_namespaces_produce_no_host_traffic_at_all() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &["kube-system"]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        for ev in [
+            Event::Apply(virtual_sa("default", "kube-system")),
+            Event::InitApply(virtual_sa("default", "kube-system")),
+            Event::Delete(virtual_sa("default", "kube-system")),
+        ] {
+            handle_service_account_event(&ev, &ctx, &host_api)
+                .await
+                .unwrap();
+        }
+
+        assert!(
+            server.received_requests().await.unwrap().is_empty(),
+            "skipped namespaces must not reach the host apiserver"
+        );
+    }
+
+    /// Watcher bookmarks carry no object; they must be pure no-ops
+    /// rather than triggering a spurious host call.
+    #[tokio::test]
+    async fn init_and_init_done_bookmarks_are_no_ops() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        handle_service_account_event(&Event::Init, &ctx, &host_api)
+            .await
+            .unwrap();
+        handle_service_account_event(&Event::InitDone, &ctx, &host_api)
+            .await
+            .unwrap();
+
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    /// A virtual delete must delete the *translated* host object.
+    #[tokio::test]
+    async fn delete_event_deletes_the_translated_host_sa() {
+        let server = MockServer::start().await;
+        let host = "gone-x-default-x-vc";
+        Mock::given(method("DELETE"))
+            .and(path(sa_item(host)))
+            .respond_with(ResponseTemplate::new(200).set_body_json(virtual_sa(host, HOST_NS)))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        handle_service_account_event(
+            &Event::Delete(virtual_sa("gone", "default")),
+            &ctx,
+            &host_api,
+        )
+        .await
+        .unwrap();
+
+        server.verify().await;
+    }
+
+    /// Deleting an already-absent host SA is the normal race (the host
+    /// object was reaped first, or the watch replayed). It must be
+    /// swallowed, otherwise the syncer logs a spurious error on every
+    /// namespace teardown.
+    #[tokio::test]
+    async fn delete_event_tolerates_a_host_sa_that_is_already_gone() {
+        let server = MockServer::start().await;
+        let host = "vanished-x-default-x-vc";
+        Mock::given(method("DELETE"))
+            .and(path(sa_item(host)))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(k8s_not_found("serviceaccounts", host)),
+            )
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        handle_service_account_event(
+            &Event::Delete(virtual_sa("vanished", "default")),
+            &ctx,
+            &host_api,
+        )
+        .await
+        .expect("404 on delete must be treated as success");
+    }
+
+    /// Any delete failure that is *not* 404 must surface, so the syncer
+    /// loop logs it instead of leaking a host SA forever.
+    #[tokio::test]
+    async fn delete_event_propagates_non_404_failures() {
+        let server = MockServer::start().await;
+        let host = "stuck-x-default-x-vc";
+        Mock::given(method("DELETE"))
+            .and(path(sa_item(host)))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "message": "etcdserver: request timed out", "code": 500,
+            })))
+            .mount(&server)
+            .await;
+
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        assert!(
+            handle_service_account_event(
+                &Event::Delete(virtual_sa("stuck", "default")),
+                &ctx,
+                &host_api
+            )
+            .await
+            .is_err()
+        );
+    }
+
+    /// An untranslatable virtual name was never mirrored (the apply path
+    /// errored out), so its delete has nothing to do — and must not fire
+    /// a DELETE at a guessed name that could belong to another tenant.
+    #[tokio::test]
+    async fn delete_event_of_an_untranslatable_name_issues_no_request() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        handle_service_account_event(
+            &Event::Delete(virtual_sa("evil-x-sa", "default")),
+            &ctx,
+            &host_api,
+        )
+        .await
+        .expect("an untranslatable delete is a no-op, not an error");
+
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    /// An untranslatable name on the *apply* path is an error, not a
+    /// silent skip: it means a user created an object kobe-sync cannot
+    /// mirror, and the syncer loop should log it.
+    #[tokio::test]
+    async fn apply_event_of_an_untranslatable_name_errors_without_touching_the_host() {
+        let server = MockServer::start().await;
+        let ctx = syncer_ctx(&server, &[]);
+        let host_api: Api<ServiceAccount> =
+            Api::namespaced(ctx.host_client.clone(), &ctx.host_namespace);
+
+        assert!(
+            handle_service_account_event(
+                &Event::Apply(virtual_sa("evil-x-sa", "default")),
+                &ctx,
+                &host_api
+            )
+            .await
+            .is_err()
+        );
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
 }

--- a/src/kobe_sync/testkit.rs
+++ b/src/kobe_sync/testkit.rs
@@ -1,0 +1,67 @@
+//! Test-only helpers shared by the kobe-sync unit tests.
+//!
+//! Compiled under `#[cfg(test)]` only. The operator binary has its own
+//! equivalent in `src/testutil.rs`; kobe-sync cannot reuse it because
+//! `src/kobe_sync_bin.rs` deliberately does not pull in the operator's
+//! module tree (`crate::backend`, `crate::crd`, …).
+
+use std::sync::Arc;
+
+use kube::Client;
+use wiremock::MockServer;
+
+use super::syncer::traits::SyncerContext;
+use super::syncer::translator::NameTranslator;
+
+/// Host namespace used by every syncer test, matching the pool-member
+/// naming the real deployment uses.
+pub const HOST_NS: &str = "pool-test";
+
+/// Build a `kube::Client` that talks plain HTTP to a local
+/// [`wiremock::MockServer`].
+///
+/// `root_cert: Some(vec![])` is deliberate: it hands kube an empty trust
+/// store instead of letting it fall through to `with_native_roots()`.
+/// The connection is plain HTTP so the store is never consulted, and
+/// skipping the native load avoids the macOS Security-framework
+/// `-36 I/O error` that surfaces when many tests build clients in
+/// parallel.
+pub fn mock_client(server: &MockServer) -> Client {
+    let config = kube::Config {
+        cluster_url: server.uri().parse().unwrap(),
+        default_namespace: HOST_NS.into(),
+        root_cert: Some(Vec::new()),
+        ..kube::Config::new(server.uri().parse().unwrap())
+    };
+    Client::try_from(config).unwrap()
+}
+
+/// Build a [`SyncerContext`] whose *host* client points at `server`.
+///
+/// The virtual client points at the same server; syncer event handlers
+/// only ever touch the host side (the virtual side is the watch stream,
+/// which tests feed directly as [`kube::runtime::watcher::Event`]s).
+pub fn syncer_ctx(server: &MockServer, skip_namespaces: &[&str]) -> SyncerContext {
+    SyncerContext {
+        virtual_client: mock_client(server),
+        host_client: mock_client(server),
+        translator: Arc::new(NameTranslator::new(HOST_NS.to_string())),
+        host_namespace: HOST_NS.to_string(),
+        skip_namespaces: skip_namespaces.iter().map(|s| s.to_string()).collect(),
+    }
+}
+
+/// Kubernetes-style 404 `Status` body, as returned by a real apiserver
+/// for a missing namespaced object.
+pub fn k8s_not_found(resource: &str, name: &str) -> serde_json::Value {
+    serde_json::json!({
+        "apiVersion": "v1",
+        "kind": "Status",
+        "metadata": {},
+        "status": "Failure",
+        "message": format!("{resource} \"{name}\" not found"),
+        "reason": "NotFound",
+        "details": { "name": name, "kind": resource },
+        "code": 404,
+    })
+}

--- a/src/kobe_sync/testkit.rs
+++ b/src/kobe_sync/testkit.rs
@@ -26,7 +26,18 @@ pub const HOST_NS: &str = "pool-test";
 /// skipping the native load avoids the macOS Security-framework
 /// `-36 I/O error` that surfaces when many tests build clients in
 /// parallel.
+///
+/// The provider install is not optional. This build enables both `ring`
+/// and `aws-lc-rs`, so rustls cannot pick a process-level
+/// `CryptoProvider` on its own and `Client::try_from` panics unless one
+/// was already installed. Without this line the kobe-sync tests pass
+/// only when some earlier test in the same binary happened to install
+/// it first — so the suite goes green while any single test run in
+/// isolation (`cargo test --exact <name>`, or a filtered run) panics.
+/// `install_default` returns `Err` once a provider exists, which is the
+/// normal case here and is deliberately ignored.
 pub fn mock_client(server: &MockServer) -> Client {
+    let _ = rustls::crypto::ring::default_provider().install_default();
     let config = kube::Config {
         cluster_url: server.uri().parse().unwrap(),
         default_namespace: HOST_NS.into(),

--- a/src/testutil.rs
+++ b/src/testutil.rs
@@ -235,11 +235,22 @@ impl ClusterBackend for MockBackend {
 // ---------------------------------------------------------------------------
 
 /// Build a `kube::Client` that talks to a local [`wiremock::MockServer`].
+///
+/// `root_cert: Some(vec![])` hands kube an empty trust store instead of
+/// letting it fall through to rustls' `with_native_roots()`. The mock
+/// server speaks plain HTTP so the store is never consulted, and
+/// skipping the native load avoids a load-dependent flake: under a
+/// heavily parallel `cargo test`, macOS' Security framework
+/// intermittently fails the trust-settings read with `Os(-36) I/O
+/// error`, which surfaces as `RustlsTls(NoValidNativeRootCA)` and fails
+/// whichever wiremock-backed tests happened to build a client at that
+/// moment.
 #[allow(dead_code)]
 pub fn mock_k8s_client(server: &wiremock::MockServer) -> kube::Client {
     let config = kube::Config {
         cluster_url: server.uri().parse().unwrap(),
         default_namespace: "test-ns".into(),
+        root_cert: Some(Vec::new()),
         ..kube::Config::new(server.uri().parse().unwrap())
     };
     kube::Client::try_from(config).unwrap()


### PR DESCRIPTION
Adds **88 tests** across the five files with zero or near-zero coverage relative to their size. Companion to #58 (which covered `src/backend/vcluster.rs`); no overlap.

| File | Before | After |
|---|---|---|
| `src/crd/instance.rs` | **0** | 22 |
| `crates/kobectl/src/commands/config.rs` | 2 | 32 |
| `src/kobe_sync/syncer/pvcs.rs` | 4 | 19 |
| `src/kobe_sync/syncer/service_accounts.rs` | 4 | 17 |
| `src/kobe_sync/bootstrap.rs` | 3 | 11 |

## What's pinned, and why it matters

**`src/crd/instance.rs`** — mostly serde contracts that are load-bearing and fail *silently*:

- The Merge-Patch split between fields that must serialize `None` as an explicit `null` to clear them (`leaseRef`, `idleSince`, `stateSince`) and fields that must be **omitted** to survive a patch (`specHash`, `createdWith`, `message`, `activeBootstrap`, `network`). Getting this backwards either fails to release a lease or erases provenance.
- A condition's Rust `condition_type` serializes as `type` — that's what `kubectl wait --for=condition=` reads.
- Empty `conditions` is omitted, so a foreign status writer can't array-replace the list away.
- Forward and backward compat: a status written by a *newer* operator still deserializes (rolling-upgrade safety), and so do statuses from kobe < 0.17 and provenance from < 0.23.1.
- The generated CRD keeps its identity (group / kind / plural / `ci` shortname / single served+storage version / status subresource) and types `specHash` as a **string**, per the float64 structural-validator constraint its doc-comment explains.

**`crates/kobectl/src/commands/config.rs`** — resolution precedence (`--target` > session > legacy `current_target` > flat legacy `endpoint`), the local/global overlay and its `Scope` reporting, and legacy migration being a no-op in each case where it could otherwise destroy a token. Also that `--endpoint` keeps the target's auth rather than silently downgrading to anonymous, and that token masking can never reveal a usable secret.

**`pvcs.rs` / `service_accounts.rs`** — translation purity, plus each syncer's event handling against a wiremock apiserver: create when absent, forced SSA when present, **skipped namespaces producing zero host traffic on any event kind**, delete tolerating 404 but propagating other errors, and untranslatable names never reaching the host.

**`bootstrap.rs`** — the RBAC kobe-sync grants itself: no wildcard verbs/resources, no write verbs on read-only watch targets, both objects applied as forced SSA with the role before the binding. This runs with `system:masters`, so the shape of that Role is the only thing bounding it.

## Mutation-checked

Nine seeded regressions, all caught, all reverted:

| Mutation | Caught by |
|---|---|
| add `skip_serializing_if` to `lease_ref` | `actively_managed_fields_serialize_none_as_explicit_null` |
| remove `skip_serializing_if` from `spec_hash` | `write_once_fields_are_omitted_when_none_…` |
| `shortname = "ci"` → `"cinst"` | `crd_identity_is_stable` |
| drop `.force()` from `PatchParams::apply` | `ensure_rbac_uses_forced_server_side_apply_as_kobe_sync` |
| SA delete `err.code == 404` → `410` | `delete_event_tolerates_a_host_sa_that_is_already_gone` |
| disable the SA skip-namespace guard | `skipped_namespaces_produce_no_host_traffic_at_all` |
| PVC `status: None` → `pvc.status.clone()` | `translate_pvc_drops_a_populated_virtual_status` |
| mask boundary `len() > 8` → `>= 8` | `token_display_never_reveals_a_usable_secret` |
| overlay `Scope::Both` → `Scope::Local` | `overlay_local_target_shadows_…_marked_both` |

## Production changes — two, both minimal

1. **`mask_token` extracted** out of `print_auth` (config.rs). Logic byte-identical; it was unreachable from a test because `print_auth` only writes to stdout, and a credential-leak guard is worth pinning.
2. **`mock_k8s_client` passes an empty `root_cert`** (`src/testutil.rs`, `#[cfg(test)]`-gated). This fixes a **pre-existing flake**, not something this PR introduced: without it kube falls through to rustls' `with_native_roots()`, and under a heavily parallel `cargo test` macOS' Security framework intermittently fails the trust-settings read with `Os(-36) I/O error`, surfacing as `RustlsTls(NoValidNativeRootCA)`. Reproduced twice locally — three `backend::k3s` tests failed under load and passed 3/3 in isolation. The mock server speaks plain HTTP, so the trust store is never consulted. **No production TLS path was touched.** Worth knowing if CI ever moves to macOS runners.

`kobe-sync` can't reuse `src/testutil.rs` (`kobe_sync_bin` deliberately doesn't pull in the operator's module tree), so it gets its own `#[cfg(test)] mod testkit`.

## Documented limitation pinned, not changed

`config.rs` `overlay` applies a local `auth` only when it differs from the default, so a `.kobe.toml` that explicitly writes `auth = "oidc"` can't pull a global `token` target back to OIDC. TOML can't distinguish "absent" from "explicitly default", so this is arguably intentional — `overlay_cannot_reset_auth_to_the_default_mode` pins it so it stays a decision rather than drifting.

## Verification

`cargo test --workspace` green (1112 total), `cargo fmt -- --check` and `cargo clippy --workspace --all-targets` clean.