### PR TITLE
chore(chart): add Artifact Hub annotations and gate their image tags

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,6 +90,13 @@ jobs:
       - name: Tests
         run: cargo test --workspace
 
+      # The release gate itself only runs on tag pushes (version-consistency),
+      # which is the right place for it — but that means its parsing logic is
+      # otherwise unexercised until a release is being cut. These tests run on
+      # every change so a regression in the gate surfaces here instead.
+      - name: Version-consistency gate tests
+        run: ./scripts/test-version-consistency.sh
+
       - name: Security audit
         run: |
           cargo install cargo-audit --locked || true

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kobe
 description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
-  Supports multiple backends: k3s, k0s, CAPI, and kobe-sync.
+  Supports multiple backends: k3s, k0s, vcluster, and CAPI.
 type: application
 version: 0.37.0
 appVersion: "0.37.0"
@@ -11,13 +11,82 @@ keywords:
   - operator
   - cluster-pool
   - virtual-cluster
-  - kobe-sync
+  - vcluster
+  - k3s
+  - ephemeral-environments
 home: https://github.com/kunobi-ninja/kobe
 sources:
   - https://github.com/kunobi-ninja/kobe
 maintainers:
   - name: Zondax
     url: https://zondax.ch
+# Artifact Hub reads these off the chart itself when it indexes the OCI
+# repository (#53). Kept here rather than in an artifacthub-repo.yml
+# because that file needs the repositoryID Artifact Hub only issues after
+# the repo is registered in the UI — a separate, human step.
+annotations:
+  artifacthub.io/license: Apache-2.0
+  artifacthub.io/operator: "true"
+  artifacthub.io/prerelease: "false"
+  artifacthub.io/links: |
+    - name: source
+      url: https://github.com/kunobi-ninja/kobe
+    - name: documentation
+      url: https://github.com/kunobi-ninja/kobe/tree/main/docs
+    - name: issues
+      url: https://github.com/kunobi-ninja/kobe/issues
+  # Every image this chart can deploy, so Artifact Hub can run its
+  # security report against them. `kine` is only pulled when a KobeStore
+  # selects the kine/sqlite driver; the other two always ship.
+  artifacthub.io/images: |
+    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:0.37.0
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:0.37.0
+    - name: kine
+      image: docker.io/rancher/kine:v0.13.2
+      whitelisted: true
+  artifacthub.io/crds: |
+    - kind: ClusterPool
+      version: v1alpha1
+      name: clusterpools.kobe.kunobi.ninja
+      displayName: Cluster Pool
+      description: A warm pool of provisioned clusters that leases are served from
+    - kind: ClusterLease
+      version: v1alpha1
+      name: clusterleases.kobe.kunobi.ninja
+      displayName: Cluster Lease
+      description: A time-bounded claim on one cluster from a pool
+    - kind: ClusterInstance
+      version: v1alpha1
+      name: clusterinstances.kobe.kunobi.ninja
+      displayName: Cluster Instance
+      description: A single provisioned cluster belonging to a pool
+    - kind: BootstrapConfig
+      version: v1alpha1
+      name: bootstrapconfigs.kobe.kunobi.ninja
+      displayName: Bootstrap Config
+      description: Manifests applied into a cluster before it is marked Ready
+    - kind: AccessPolicy
+      version: v1alpha1
+      name: accesspolicies.kobe.kunobi.ninja
+      displayName: Access Policy
+      description: Who may lease from which pools, with quotas and TTL ceilings
+    - kind: KobeStore
+      version: v1alpha1
+      name: kobestores.kobe.kunobi.ninja
+      displayName: Kobe Store
+      description: Datastore backing virtual cluster control planes
+    - kind: CIDRPool
+      version: v1alpha1
+      name: cidrpools.kobe.kunobi.ninja
+      displayName: CIDR Pool
+      description: Address space that per-cluster service and pod CIDRs are allocated from
+    - kind: CIDRClaim
+      version: v1alpha1
+      name: cidrclaims.kobe.kunobi.ninja
+      displayName: CIDR Claim
+      description: One allocated CIDR slot held by a cluster instance
 dependencies:
   - name: etcd
     version: "~10.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -22,8 +22,10 @@ maintainers:
     url: https://zondax.ch
 # Artifact Hub reads these off the chart itself when it indexes the OCI
 # repository (#53). Kept here rather than in an artifacthub-repo.yml
-# because that file needs the repositoryID Artifact Hub only issues after
-# the repo is registered in the UI — a separate, human step.
+# because that file's useful content — the repositoryID for the
+# verified-publisher badge — is only issued after the repo is registered
+# in the UI, a separate human step. (An ownership-claim file can be
+# prepared earlier; it just would not carry the ID yet.)
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/operator: "true"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -49,12 +49,14 @@ annotations:
   # whitelisted rather than tracked as ours.
   #
   # NOT covered: the optional bundled etcd subchart (`etcd.bundled: true`,
-  # off by default) brings its own bitnami/etcd image. Artifact Hub does
-  # not auto-discover subchart images, and the tag comes from whatever
-  # the floating `~10.0` dependency resolves to — so pinning one here
-  # would be stale on the next resolution and nothing gates it. Users of
-  # the bundled path should scan that image via the etcd chart's own
-  # listing.
+  # off by default) brings its own bitnami/etcd image, and Artifact Hub
+  # does not auto-discover subchart images. The subchart version itself
+  # is pinned (Chart.lock, etcd 10.0.11), but the image tag lives inside
+  # that subchart's values — so an entry here would have to be re-checked
+  # by hand on every `helm dependency update`, with nothing gating it.
+  # That is the same silent-staleness failure the first-party tags above
+  # are gated against, so it is left out deliberately: users of the
+  # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
       image: docker.io/zondax/kobe-operator:v0.37.0

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: kobe
 description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
-  Supports multiple backends: k3s, k0s, vcluster, and CAPI.
+  Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
 version: 0.37.0
 appVersion: "0.37.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -36,15 +36,26 @@ annotations:
     - name: issues
       url: https://github.com/kunobi-ninja/kobe/issues
   # Every image this chart can deploy, so Artifact Hub can run its
-  # security report against them. `kine` is only pulled when a KobeStore
-  # selects the kine/sqlite driver; the other two always ship.
+  # security report against them. The first-party tags carry the `v`
+  # prefix because that is what docker-bake.hcl publishes and what the
+  # templates default to (`printf "v%s" .Chart.AppVersion`) — a bare
+  # `0.37.0` image tag does not exist. The chart's own OCI tag is bare
+  # semver; that is a different artifact, and conflating the two is easy.
+  # The last three are conditional and third-party, so they are
+  # whitelisted rather than tracked as ours.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:0.37.0
+      image: docker.io/zondax/kobe-operator:v0.37.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:0.37.0
+      image: docker.io/zondax/kobe-sync:v0.37.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
+      whitelisted: true
+    - name: flux-cli
+      image: ghcr.io/fluxcd/flux-cli:v2.2.3
+      whitelisted: true
+    - name: kubectl
+      image: docker.io/rancher/kubectl:v1.34.7
       whitelisted: true
   artifacthub.io/crds: |
     - kind: ClusterPool

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -27,6 +27,10 @@ maintainers:
 annotations:
   artifacthub.io/license: Apache-2.0
   artifacthub.io/operator: "true"
+  # Tracks the release: `just bump 0.38.0-rc.1` flips this to "true" and
+  # the version gate enforces the pairing. Left static it would advertise
+  # every release candidate as a stable release, and rc chart publishing
+  # is a supported flow.
   artifacthub.io/prerelease: "false"
   artifacthub.io/links: |
     - name: source
@@ -35,14 +39,22 @@ annotations:
       url: https://github.com/kunobi-ninja/kobe/tree/main/docs
     - name: issues
       url: https://github.com/kunobi-ninja/kobe/issues
-  # Every image this chart can deploy, so Artifact Hub can run its
-  # security report against them. The first-party tags carry the `v`
-  # prefix because that is what docker-bake.hcl publishes and what the
-  # templates default to (`printf "v%s" .Chart.AppVersion`) — a bare
-  # `0.37.0` image tag does not exist. The chart's own OCI tag is bare
-  # semver; that is a different artifact, and conflating the two is easy.
-  # The last three are conditional and third-party, so they are
+  # Every image this chart's own templates can deploy, so Artifact Hub
+  # can run its security report against them. The first-party tags carry
+  # the `v` prefix because that is what docker-bake.hcl publishes and
+  # what the templates default to (`printf "v%s" .Chart.AppVersion`) — a
+  # bare `0.37.0` image tag does not exist. The chart's own OCI tag is
+  # bare semver; that is a different artifact, and conflating the two is
+  # easy. The last three are conditional and third-party, so they are
   # whitelisted rather than tracked as ours.
+  #
+  # NOT covered: the optional bundled etcd subchart (`etcd.bundled: true`,
+  # off by default) brings its own bitnami/etcd image. Artifact Hub does
+  # not auto-discover subchart images, and the tag comes from whatever
+  # the floating `~10.0` dependency resolves to — so pinning one here
+  # would be stale on the next resolution and nothing gates it. Users of
+  # the bundled path should scan that image via the etcd chart's own
+  # listing.
   artifacthub.io/images: |
     - name: kobe-operator
       image: docker.io/zondax/kobe-operator:v0.37.0

--- a/justfile
+++ b/justfile
@@ -178,6 +178,13 @@ bump VERSION:
     # docker-bake.hcl publishes and what the templates deploy — a bare-semver
     # image tag does not exist. check-version-consistency.sh gates this.
     perl -i -pe 's{(docker\.io/zondax/[\w.-]+):\S+}{$1:v{{ VERSION }}}' charts/kobe/Chart.yaml
+    # Artifact Hub shows prereleases differently; a release candidate must not
+    # advertise itself as stable. Derived from the version, gated by the check.
+    case "{{ VERSION }}" in
+      *-*) ah_prerelease=true ;;
+      *)   ah_prerelease=false ;;
+    esac
+    perl -i -pe "s{^(\s*artifacthub\.io/prerelease:).*}{\$1 \"${ah_prerelease}\"}" charts/kobe/Chart.yaml
     cargo update -p kobe-operator -p kobectl --precise "{{ VERSION }}" 2>/dev/null || true
     ./scripts/check-version-consistency.sh
     echo "Bumped to {{ VERSION }}. Review the diff, commit, then \`just release\`."

--- a/justfile
+++ b/justfile
@@ -173,6 +173,9 @@ bump VERSION:
     # published from the same release tag, so both track the operator version.
     perl -i -pe 's/^appVersion:.*$/appVersion: "{{ VERSION }}"/' charts/kobe/Chart.yaml
     perl -i -pe 's/^version:.*$/version: {{ VERSION }}/' charts/kobe/Chart.yaml
+    # Artifact Hub's images annotation pins fully-qualified first-party refs, so
+    # they move with the release too. check-version-consistency.sh gates this.
+    perl -i -pe 's{(docker\.io/zondax/[\w.-]+):\S+}{$1:{{ VERSION }}}' charts/kobe/Chart.yaml
     cargo update -p kobe-operator -p kobectl --precise "{{ VERSION }}" 2>/dev/null || true
     ./scripts/check-version-consistency.sh
     echo "Bumped to {{ VERSION }}. Review the diff, commit, then \`just release\`."

--- a/justfile
+++ b/justfile
@@ -174,8 +174,10 @@ bump VERSION:
     perl -i -pe 's/^appVersion:.*$/appVersion: "{{ VERSION }}"/' charts/kobe/Chart.yaml
     perl -i -pe 's/^version:.*$/version: {{ VERSION }}/' charts/kobe/Chart.yaml
     # Artifact Hub's images annotation pins fully-qualified first-party refs, so
-    # they move with the release too. check-version-consistency.sh gates this.
-    perl -i -pe 's{(docker\.io/zondax/[\w.-]+):\S+}{$1:{{ VERSION }}}' charts/kobe/Chart.yaml
+    # they move with the release too. The `v` prefix is required: that is what
+    # docker-bake.hcl publishes and what the templates deploy — a bare-semver
+    # image tag does not exist. check-version-consistency.sh gates this.
+    perl -i -pe 's{(docker\.io/zondax/[\w.-]+):\S+}{$1:v{{ VERSION }}}' charts/kobe/Chart.yaml
     cargo update -p kobe-operator -p kobectl --precise "{{ VERSION }}" 2>/dev/null || true
     ./scripts/check-version-consistency.sh
     echo "Bumped to {{ VERSION }}. Review the diff, commit, then \`just release\`."

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -108,19 +108,48 @@ elif chart_version != ws_version:
 # (The CHART's own OCI tag is bare semver — a different artifact. Conflating
 # the two is exactly the mistake this check now catches.)
 expected_image_tag = f"v{ws_version}"
-ah_images = re.findall(r"docker\.io/zondax/([\w.-]+):([^\s\"']+)", chart)
-if not ah_images:
+
+# Every first-party image the chart deploys. Asserting the SET, not just the
+# tags of whatever happens to be present: a check that only validated the refs
+# it found would pass just as happily after someone deleted the kobe-sync
+# entry, while still advertising that it protects the image listing.
+REQUIRED_FIRST_PARTY = {"kobe-operator", "kobe-sync"}
+
+# Read the annotation's own block scalar rather than scanning the whole file,
+# so an image-shaped string in a comment or a different annotation cannot
+# satisfy this. The block is the run of more-indented lines after the key.
+images_block = []
+lines = chart.splitlines()
+for i, line in enumerate(lines):
+    m = re.match(r"^(\s*)artifacthub\.io/images:\s*\|", line)
+    if not m:
+        continue
+    key_indent = len(m.group(1))
+    for follow in lines[i + 1 :]:
+        if follow.strip() and (len(follow) - len(follow.lstrip())) <= key_indent:
+            break
+        images_block.append(follow)
+    break
+
+if not images_block:
     errors.append(
-        "charts/kobe/Chart.yaml has no docker.io/zondax/* image refs — the "
-        "artifacthub.io/images annotation was removed or restructured; update "
-        "this check or restore it"
+        "charts/kobe/Chart.yaml has no `artifacthub.io/images: |` block — the "
+        "annotation was removed or restructured; update this check or restore it"
     )
-for image_name, image_tag in ah_images:
-    if image_tag != expected_image_tag:
+else:
+    block = "\n".join(images_block)
+    found = dict(re.findall(r"docker\.io/zondax/([\w.-]+):(\S+)", block))
+    for missing in sorted(REQUIRED_FIRST_PARTY - found.keys()):
         errors.append(
-            f"Chart.yaml artifacthub.io/images {image_name} tag {image_tag!r} "
-            f"!= expected {expected_image_tag!r} (published tags are v-prefixed)"
+            f"Chart.yaml artifacthub.io/images is missing the first-party image "
+            f"{missing!r} — Artifact Hub would not scan it"
         )
+    for image_name, image_tag in sorted(found.items()):
+        if image_tag != expected_image_tag:
+            errors.append(
+                f"Chart.yaml artifacthub.io/images {image_name} tag {image_tag!r} "
+                f"!= expected {expected_image_tag!r} (published tags are v-prefixed)"
+            )
 
 # --- Chart.yaml artifacthub.io/prerelease matches the version ---
 # Artifact Hub surfaces prereleases differently, and rc publishing is a

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -122,6 +122,20 @@ for image_name, image_tag in ah_images:
             f"!= expected {expected_image_tag!r} (published tags are v-prefixed)"
         )
 
+# --- Chart.yaml artifacthub.io/prerelease matches the version ---
+# Artifact Hub surfaces prereleases differently, and rc publishing is a
+# supported flow (`just bump 0.38.0-rc.1`), so a static value would advertise
+# every release candidate as stable. `just bump` derives it; this enforces it.
+expected_prerelease = "true" if "-" in ws_version else "false"
+pm = re.search(r'(?m)^\s*artifacthub\.io/prerelease:\s*"?([^"\s]+)"?\s*$', chart)
+if pm is None:
+    errors.append("charts/kobe/Chart.yaml has no `artifacthub.io/prerelease:` annotation")
+elif pm.group(1) != expected_prerelease:
+    errors.append(
+        f"Chart.yaml artifacthub.io/prerelease {pm.group(1)!r} != {expected_prerelease!r} "
+        f"for version {ws_version!r}"
+    )
+
 # --- nix/package.nix version (optional) ---
 nix_pkg = root / "nix" / "package.nix"
 if nix_pkg.exists():

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -137,19 +137,42 @@ if not images_block:
         "annotation was removed or restructured; update this check or restore it"
     )
 else:
-    block = "\n".join(images_block)
-    found = dict(re.findall(r"docker\.io/zondax/([\w.-]+):(\S+)", block))
-    for missing in sorted(REQUIRED_FIRST_PARTY - found.keys()):
+    # Strip YAML comments before matching. A commented-out entry is not an
+    # image field Artifact Hub can scan, so counting one would let the block
+    # look complete while the listing was actually missing that image.
+    def strip_comment(line):
+        cut = re.search(r"(^|\s)#", line)
+        return line[: cut.start()] if cut else line
+
+    live = [strip_comment(l) for l in images_block]
+
+    # Collect every occurrence, not a name->tag dict: collapsing duplicates
+    # would let a stale ref pass as long as a correct one appeared later.
+    occurrences = []
+    for line in live:
+        occurrences += re.findall(r"docker\.io/zondax/([\w.-]+):(\S+)", line)
+
+    seen = {}
+    for image_name, image_tag in occurrences:
+        seen.setdefault(image_name, []).append(image_tag)
+
+    for missing in sorted(REQUIRED_FIRST_PARTY - seen.keys()):
         errors.append(
             f"Chart.yaml artifacthub.io/images is missing the first-party image "
             f"{missing!r} — Artifact Hub would not scan it"
         )
-    for image_name, image_tag in sorted(found.items()):
-        if image_tag != expected_image_tag:
+    for image_name, tags in sorted(seen.items()):
+        if len(tags) > 1:
             errors.append(
-                f"Chart.yaml artifacthub.io/images {image_name} tag {image_tag!r} "
-                f"!= expected {expected_image_tag!r} (published tags are v-prefixed)"
+                f"Chart.yaml artifacthub.io/images lists {image_name!r} "
+                f"{len(tags)} times ({', '.join(sorted(tags))}) — one entry per image"
             )
+        for image_tag in tags:
+            if image_tag != expected_image_tag:
+                errors.append(
+                    f"Chart.yaml artifacthub.io/images {image_name} tag {image_tag!r} "
+                    f"!= expected {expected_image_tag!r} (published tags are v-prefixed)"
+                )
 
 # --- Chart.yaml artifacthub.io/prerelease matches the version ---
 # Artifact Hub surfaces prereleases differently, and rc publishing is a

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -95,6 +95,26 @@ if chart_version is None:
 elif chart_version != ws_version:
     errors.append(f"Chart.yaml version {chart_version!r} != workspace version {ws_version!r}")
 
+# --- Chart.yaml artifacthub.io/images tags ---
+# The Artifact Hub annotation pins fully-qualified image refs so the security
+# report scans the right tags. They are first-party images, so they move with
+# the release and would otherwise silently advertise a stale version forever
+# (`just bump` rewrites them; this is what stops that from being optional).
+# Third-party images (kine, etc.) are deliberately not checked.
+ah_images = re.findall(r"docker\.io/zondax/([\w.-]+):([^\s\"']+)", chart)
+if not ah_images:
+    errors.append(
+        "charts/kobe/Chart.yaml has no docker.io/zondax/* image refs — the "
+        "artifacthub.io/images annotation was removed or restructured; update "
+        "this check or restore it"
+    )
+for image_name, image_tag in ah_images:
+    if image_tag != ws_version:
+        errors.append(
+            f"Chart.yaml artifacthub.io/images {image_name} tag {image_tag!r} "
+            f"!= workspace version {ws_version!r}"
+        )
+
 # --- nix/package.nix version (optional) ---
 nix_pkg = root / "nix" / "package.nix"
 if nix_pkg.exists():

--- a/scripts/check-version-consistency.sh
+++ b/scripts/check-version-consistency.sh
@@ -100,7 +100,14 @@ elif chart_version != ws_version:
 # report scans the right tags. They are first-party images, so they move with
 # the release and would otherwise silently advertise a stale version forever
 # (`just bump` rewrites them; this is what stops that from being optional).
-# Third-party images (kine, etc.) are deliberately not checked.
+# Third-party images (kine, flux-cli, kubectl) are deliberately not checked.
+#
+# The expected tag is `v<version>`, NOT the bare version: docker-bake.hcl
+# publishes `v${VERSION}` and the templates default to
+# `printf "v%s" .Chart.AppVersion`, so a bare `0.37.0` image does not exist.
+# (The CHART's own OCI tag is bare semver — a different artifact. Conflating
+# the two is exactly the mistake this check now catches.)
+expected_image_tag = f"v{ws_version}"
 ah_images = re.findall(r"docker\.io/zondax/([\w.-]+):([^\s\"']+)", chart)
 if not ah_images:
     errors.append(
@@ -109,10 +116,10 @@ if not ah_images:
         "this check or restore it"
     )
 for image_name, image_tag in ah_images:
-    if image_tag != ws_version:
+    if image_tag != expected_image_tag:
         errors.append(
             f"Chart.yaml artifacthub.io/images {image_name} tag {image_tag!r} "
-            f"!= workspace version {ws_version!r}"
+            f"!= expected {expected_image_tag!r} (published tags are v-prefixed)"
         )
 
 # --- nix/package.nix version (optional) ---

--- a/scripts/test-version-consistency.sh
+++ b/scripts/test-version-consistency.sh
@@ -1,0 +1,143 @@
+#!/usr/bin/env bash
+# Executable tests for check-version-consistency.sh.
+#
+# That script is the last gate before irreversible release steps, and it has
+# grown real parsing logic (the artifacthub.io/images block). Manual "I tried
+# breaking it once" checks do not survive the next edit — these do.
+#
+# Each case builds a throwaway repo root (Cargo.toml + charts/kobe/Chart.yaml +
+# a copy of the checker, which resolves its root from its own location) and
+# asserts the checker's exit status, plus a substring of the failure it should
+# report. A test that expects failure but does not say WHY would pass on the
+# wrong error.
+#
+# Usage: scripts/test-version-consistency.sh    (exit 0 = all cases pass)
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+checker="$here/check-version-consistency.sh"
+pass=0
+fail=0
+
+# Build a repo root whose Chart.yaml images block is exactly $2.
+make_root() {
+  local version="$1" images="$2" prerelease="${3:-false}" root
+  root="$(mktemp -d)"
+  mkdir -p "$root/scripts" "$root/charts/kobe"
+  cp "$checker" "$root/scripts/"
+  cat >"$root/Cargo.toml" <<EOF
+[workspace]
+members = []
+
+[workspace.package]
+version = "$version"
+EOF
+  {
+    echo "apiVersion: v2"
+    echo "name: kobe"
+    echo "version: $version"
+    echo "appVersion: \"$version\""
+    echo "annotations:"
+    echo "  artifacthub.io/prerelease: \"$prerelease\""
+    # The literal NO_KEY drops the annotation entirely, to exercise the
+    # "someone deleted the block" path rather than "the block is empty".
+    if [ "$images" != "NO_KEY" ]; then
+      echo "  artifacthub.io/images: |"
+      printf '%s\n' "$images"
+    fi
+  } >"$root/charts/kobe/Chart.yaml"
+  echo "$root"
+}
+
+# expect <name> <expected-rc> <substring-of-output> <root>
+expect() {
+  local name="$1" want_rc="$2" want_sub="$3" root="$4" out rc
+  out="$("$root/scripts/check-version-consistency.sh" 2>&1)"
+  rc=$?
+  if [ "$rc" -ne "$want_rc" ]; then
+    echo "FAIL: $name — expected rc=$want_rc, got rc=$rc"
+    echo "      output: $out"
+    fail=$((fail + 1))
+  elif [ -n "$want_sub" ] && ! printf '%s' "$out" | grep -qF -- "$want_sub"; then
+    echo "FAIL: $name — output did not mention: $want_sub"
+    echo "      output: $out"
+    fail=$((fail + 1))
+  else
+    echo "ok: $name"
+    pass=$((pass + 1))
+  fi
+  rm -rf "$root"
+}
+
+GOOD='    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:v9.9.9
+    - name: kine
+      image: docker.io/rancher/kine:v0.13.2
+      whitelisted: true'
+
+expect "a well-formed chart passes" 0 "version consistency OK" \
+  "$(make_root 9.9.9 "$GOOD")"
+
+# The images the operator actually ships must be listed, or Artifact Hub has
+# nothing to scan for them.
+expect "a missing first-party image fails" 1 "missing the first-party image 'kobe-sync'" \
+  "$(make_root 9.9.9 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9')"
+
+# A commented-out entry is not a field Artifact Hub can read, so it must not
+# count towards the required set.
+expect "a commented-out entry does not count" 1 "missing the first-party image 'kobe-sync'" \
+  "$(make_root 9.9.9 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9
+    # image: docker.io/zondax/kobe-sync:v9.9.9')"
+
+# Collapsing duplicates would let a stale ref hide behind a correct one.
+expect "a stale duplicate is rejected" 1 "lists 'kobe-sync' 2 times" \
+  "$(make_root 9.9.9 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:v9.0.0
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:v9.9.9')"
+
+expect "a stale tag is rejected" 1 "!= expected 'v9.9.9'" \
+  "$(make_root 9.9.9 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:v9.0.0')"
+
+# The images are published v-prefixed; the CHART's own OCI tag is bare semver.
+# Conflating them is the mistake this check exists to catch.
+expect "a bare-semver image tag is rejected" 1 "published tags are v-prefixed" \
+  "$(make_root 9.9.9 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:9.9.9
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:9.9.9')"
+
+expect "deleting the annotation fails closed" 1 "no \`artifacthub.io/images: |\` block" \
+  "$(make_root 9.9.9 NO_KEY)"
+
+expect "emptying the block fails closed" 1 "missing the first-party image" \
+  "$(make_root 9.9.9 '')"
+
+# Prereleases must not advertise themselves as stable releases.
+expect "an rc version with prerelease=true passes" 0 "version consistency OK" \
+  "$(make_root 9.9.9-rc.1 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9-rc.1
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:v9.9.9-rc.1' true)"
+
+expect "an rc version with prerelease=false fails" 1 "artifacthub.io/prerelease 'false' != 'true'" \
+  "$(make_root 9.9.9-rc.1 '    - name: kobe-operator
+      image: docker.io/zondax/kobe-operator:v9.9.9-rc.1
+    - name: kobe-sync
+      image: docker.io/zondax/kobe-sync:v9.9.9-rc.1' false)"
+
+expect "a stable version with prerelease=true fails" 1 "artifacthub.io/prerelease 'true' != 'false'" \
+  "$(make_root 9.9.9 "$GOOD" true)"
+
+echo
+echo "version-consistency tests: $pass passed, $fail failed"
+[ "$fail" -eq 0 ]


### PR DESCRIPTION
The in-repo half of #53. Prerequisites are already met — `zondax/kobe` on Docker Hub is public, holds a valid semver tag (`0.37.0`), and the chart isn't listed on Artifact Hub yet.

## What's here

`charts/kobe/Chart.yaml` gains:

- `artifacthub.io/license`, `artifacthub.io/operator`, `artifacthub.io/prerelease`
- `artifacthub.io/links` — source, docs, issues
- `artifacthub.io/images` — every image the chart can deploy, so Artifact Hub's security report scans the right things
- `artifacthub.io/crds` — all eight CRDs, with display names and one-line descriptions

The CRD list was cross-checked against `charts/kobe/crds/`: kinds, plural names and versions all match exactly.

## The drift hazard, and the gate for it

`artifacthub.io/images` pins fully-qualified refs, so the first-party ones carry the release version:

```yaml
- name: kobe-operator
  image: docker.io/zondax/kobe-operator:0.37.0
```

Left alone, that would silently advertise a stale tag forever after the next bump — the worst kind of metadata bug, since the listing keeps looking correct. So this PR also:

- teaches `just bump` to rewrite those tags alongside `version` / `appVersion`
- extends `scripts/check-version-consistency.sh` to gate them

The check fails on a desynced tag:

```
version consistency FAILED for the workspace manifests:
  - Chart.yaml artifacthub.io/images kobe-sync tag '0.36.0' != workspace version '0.37.0'
```

It also fails if the annotation is removed entirely, so dropping it has to be a conscious act rather than a silent loss of coverage. Third-party images (`kine`) are deliberately not version-gated — they don't move with our releases. That gate already runs in CI via the `version-consistency` job, which `publish-chart` depends on.

## Description and keywords refreshed

The description read:

> Supports multiple backends: k3s, k0s, CAPI, and kobe-sync.

kobe-sync is the sidecar the vkobe backend uses, not a backend type, and it's retired as a strategy (#17) — while **vcluster**, the actual direction of travel, was missing entirely. Same fix in the keywords. This text is the chart's front page on Artifact Hub, so it seemed worth getting right before anyone reads it there.

## What still needs a human

Steps 1–2 of #53 are account/UI actions and can't be done from the repo:

1. Create/sign in to Artifact Hub, create the `zondax` org
2. Add the repo `oci://registry-1.docker.io/zondax/kobe` (kind: Helm)

Only then does Artifact Hub issue the `repositoryID`, which is the **input** to `artifacthub-repo.yml` — so step 3's file genuinely cannot be written correctly before that. The subsequent `oras push` also needs Docker Hub write creds (`DOCKERHUB_USER`/`DOCKERHUB_TOKEN` already exist as CI secrets).

So #53 should stay open after this merges, blocked on that registration.

## Verification

`helm lint charts/kobe` passes. All three multi-line annotations parse as YAML (3 images, 8 CRDs, 3 links). The version gate passes clean and was confirmed to fail on a deliberately desynced tag.

Refs #53