### PR TITLE
test(crd): pin the ClusterLease wire contract

### DIFF
--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -400,8 +400,16 @@ mod json_safety_tests {
     }
 
     /// A condition with no recorded transition omits the key rather than
-    /// writing null, so a Merge-Patch can't erase a timestamp another
-    /// writer set. Same rule as `message` and `conditions` above.
+    /// writing an explicit null, so a reader round-tripping the condition
+    /// does not turn "never transitioned" into a stored null.
+    ///
+    /// Note this is NOT the Merge-Patch protection that `message` and
+    /// `conditions` get. JSON Merge Patch replaces arrays wholesale, so a
+    /// patch carrying a `conditions` array at all replaces the stored list
+    /// entirely — omitting a property *inside* an emitted element protects
+    /// nothing. Omitting the whole `conditions` key is what protects the
+    /// list; that is pinned separately by
+    /// `empty_conditions_are_omitted_from_serialized_status`.
     #[test]
     fn condition_omits_last_transition_time_when_unset() {
         let c = ClusterLeaseCondition {
@@ -432,11 +440,18 @@ mod json_safety_tests {
         assert_eq!(st.cluster_name.as_deref(), Some("pool-x-0"));
     }
 
-    /// Serialize → deserialize → serialize is a fixed point, so a
-    /// controller that reads a status and writes it back unchanged does
-    /// not perturb it.
+    /// A fully-populated status survives serialize → deserialize →
+    /// serialize unchanged.
+    ///
+    /// Scoped deliberately to the populated case, which is what a bound
+    /// lease looks like. It is NOT a general fixed-point claim: an input
+    /// with `"conditions": []` comes back without the key, an explicit
+    /// null on a skipped field is likewise dropped, and unknown fields
+    /// from a newer operator are discarded on deserialize (by design —
+    /// see `status_from_a_newer_operator_still_deserializes`). Those are
+    /// intended asymmetries, not regressions this test would catch.
     #[test]
-    fn status_round_trip_is_a_fixed_point() {
+    fn a_populated_status_survives_a_serde_round_trip() {
         let original = ClusterLeaseStatus {
             phase: LeasePhase::Bound,
             cluster_name: Some("pool-x-0".into()),

--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -269,6 +269,233 @@ mod json_safety_tests {
         );
     }
 
+    /// The serialized form of `LeasePhase` is a WIRE CONTRACT, not an
+    /// implementation detail.
+    ///
+    /// `kobectl` reads the phase out of the API response as a *string*
+    /// and compares it against literals — `is_terminal_failure_phase`
+    /// matches "expired" / "released" / "recycling" case-insensitively to
+    /// decide whether to stop waiting on a lease. A `#[serde(rename)]` or
+    /// a renamed variant here would not fail to compile anywhere; the CLI
+    /// would just silently stop recognising terminal leases and wait out
+    /// its full timeout on a lease that was never going to bind.
+    #[test]
+    fn lease_phase_serializes_as_the_bare_variant_name() {
+        for (phase, wire) in [
+            (LeasePhase::Pending, "Pending"),
+            (LeasePhase::Bound, "Bound"),
+            (LeasePhase::Released, "Released"),
+            (LeasePhase::Expired, "Expired"),
+            (LeasePhase::Recycling, "Recycling"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(&phase).unwrap(),
+                serde_json::Value::String(wire.to_string()),
+                "{phase:?} must serialize as the bare name {wire:?} — kobectl \
+                 string-matches this"
+            );
+            let back: LeasePhase = serde_json::from_str(&format!("\"{wire}\"")).unwrap();
+            assert_eq!(back, phase, "{wire:?} must round-trip back to {phase:?}");
+        }
+    }
+
+    /// `Display` and the serde form must agree.
+    ///
+    /// Both reach users: the serde form goes over the API to the CLI's
+    /// phase comparison, and `Display` is what the CLI prints back
+    /// ("Lease {id} ended in phase {phase}"). If they diverged, an error
+    /// message would name a phase that the code matching on it would not
+    /// recognise — the most confusing possible failure.
+    #[test]
+    fn lease_phase_display_matches_the_serialized_form() {
+        for phase in [
+            LeasePhase::Pending,
+            LeasePhase::Bound,
+            LeasePhase::Released,
+            LeasePhase::Expired,
+            LeasePhase::Recycling,
+        ] {
+            let serialized = serde_json::to_value(&phase).unwrap();
+            assert_eq!(
+                serialized.as_str().unwrap(),
+                phase.to_string(),
+                "Display and serde disagree for {phase:?}"
+            );
+        }
+    }
+
+    /// Phase defaults to `Pending`: a status written without one describes
+    /// a lease that has not bound, which is the safe reading. Defaulting
+    /// to `Bound` would make an unbound lease look served.
+    #[test]
+    fn phase_defaults_to_pending() {
+        let st: ClusterLeaseStatus = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(st.phase, LeasePhase::Pending);
+        assert_eq!(LeasePhase::default(), LeasePhase::Pending);
+    }
+
+    /// The spec binds camelCase only. The API server writes these CRs, and
+    /// the CRD schema declares `poolRef` — a snake_case key would be
+    /// dropped as an unknown field rather than rejected, leaving a lease
+    /// with no pool.
+    #[test]
+    fn spec_binds_camel_case_keys_only() {
+        let ok: ClusterLeaseSpec = serde_json::from_value(serde_json::json!({
+            "poolRef": "ci-small",
+            "ttl": "1h",
+            "requester": { "type": "github-actions:ci", "identity": "repo:org/repo" }
+        }))
+        .expect("camelCase spec must bind");
+        assert_eq!(ok.pool_ref, "ci-small");
+
+        let snake = serde_json::from_value::<ClusterLeaseSpec>(serde_json::json!({
+            "pool_ref": "ci-small",
+            "ttl": "1h",
+            "requester": { "type": "github-actions:ci", "identity": "repo:org/repo" }
+        }));
+        assert!(
+            snake.is_err(),
+            "snake_case `pool_ref` must not bind — it would silently leave poolRef unset"
+        );
+    }
+
+    /// `priority` is optional and defaults to normal. The queue sorts on
+    /// it descending, so a wrong default would silently re-order every
+    /// lease that omits it.
+    #[test]
+    fn priority_defaults_to_normal_when_absent() {
+        let spec: ClusterLeaseSpec = serde_json::from_value(serde_json::json!({
+            "poolRef": "p", "ttl": "1h",
+            "requester": { "type": "t", "identity": "i" }
+        }))
+        .unwrap();
+        assert_eq!(spec.priority, 50);
+
+        let explicit: ClusterLeaseSpec = serde_json::from_value(serde_json::json!({
+            "poolRef": "p", "ttl": "1h", "priority": 99,
+            "requester": { "type": "t", "identity": "i" }
+        }))
+        .unwrap();
+        assert_eq!(explicit.priority, 99);
+    }
+
+    /// `Requester.requester_type` is spelled `type` on the wire — the
+    /// Rust field can't be, so this rename is the only thing keeping the
+    /// stored CR readable by every writer of it.
+    #[test]
+    fn requester_type_is_named_type_on_the_wire() {
+        let r = Requester {
+            requester_type: "github-actions:ci".into(),
+            identity: "repo:org/repo".into(),
+        };
+        let v = serde_json::to_value(&r).unwrap();
+        assert_eq!(
+            v.get("type").and_then(|x| x.as_str()),
+            Some("github-actions:ci")
+        );
+        assert!(
+            v.get("requesterType").is_none() && v.get("requester_type").is_none(),
+            "the Rust field name must not leak onto the wire, got: {v}"
+        );
+    }
+
+    /// A condition with no recorded transition omits the key rather than
+    /// writing null, so a Merge-Patch can't erase a timestamp another
+    /// writer set. Same rule as `message` and `conditions` above.
+    #[test]
+    fn condition_omits_last_transition_time_when_unset() {
+        let c = ClusterLeaseCondition {
+            condition_type: "Satisfiable".into(),
+            status: "False".into(),
+            reason: "Warming".into(),
+            message: "no Ready cluster".into(),
+            last_transition_time: None,
+        };
+        let v = serde_json::to_value(&c).unwrap();
+        assert!(
+            v.get("lastTransitionTime").is_none(),
+            "unset lastTransitionTime must be omitted, not null: {v}"
+        );
+    }
+
+    /// A status written by a NEWER operator must still deserialize, or a
+    /// rolling upgrade wedges the older replica on every lease it reads.
+    #[test]
+    fn status_from_a_newer_operator_still_deserializes() {
+        let st: ClusterLeaseStatus = serde_json::from_value(serde_json::json!({
+            "phase": "Bound",
+            "clusterName": "pool-x-0",
+            "someFieldFromTheFuture": { "nested": true }
+        }))
+        .expect("unknown fields must be ignored, not rejected");
+        assert_eq!(st.phase, LeasePhase::Bound);
+        assert_eq!(st.cluster_name.as_deref(), Some("pool-x-0"));
+    }
+
+    /// Serialize → deserialize → serialize is a fixed point, so a
+    /// controller that reads a status and writes it back unchanged does
+    /// not perturb it.
+    #[test]
+    fn status_round_trip_is_a_fixed_point() {
+        let original = ClusterLeaseStatus {
+            phase: LeasePhase::Bound,
+            cluster_name: Some("pool-x-0".into()),
+            bound_at: Some("2026-06-04T00:00:00Z".into()),
+            expires_at: Some("2026-06-04T01:00:00Z".into()),
+            queue_position: 0,
+            diagnostics_url: None,
+            extensions_count: 1,
+            max_extensions: 3,
+            message: Some("bound".into()),
+            conditions: vec![ClusterLeaseCondition {
+                condition_type: "Bound".into(),
+                status: "True".into(),
+                reason: "Bound".into(),
+                message: "bound".into(),
+                last_transition_time: Some("2026-06-04T00:00:00Z".into()),
+            }],
+        };
+        let once = serde_json::to_value(&original).unwrap();
+        let back: ClusterLeaseStatus = serde_json::from_value(once.clone()).unwrap();
+        assert_eq!(serde_json::to_value(&back).unwrap(), once);
+    }
+
+    /// The CRD's public identity. Changing any of these is a breaking
+    /// change for every `kubectl` invocation and manifest in the wild.
+    #[test]
+    fn crd_identity_is_stable() {
+        use kube::CustomResourceExt;
+        let crd = serde_json::to_value(ClusterLease::crd()).unwrap();
+
+        assert_eq!(crd["spec"]["group"], "kobe.kunobi.ninja");
+        assert_eq!(crd["spec"]["scope"], "Namespaced");
+        assert_eq!(crd["spec"]["names"]["kind"], "ClusterLease");
+        assert_eq!(crd["spec"]["names"]["plural"], "clusterleases");
+        assert_eq!(crd["spec"]["names"]["shortNames"][0], "cl");
+        assert_eq!(crd["metadata"]["name"], "clusterleases.kobe.kunobi.ninja");
+
+        let versions = crd["spec"]["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["name"], "v1alpha1");
+        assert_eq!(versions[0]["served"], true);
+        assert_eq!(versions[0]["storage"], true);
+    }
+
+    /// `status` must be a real subresource, or the apiserver silently
+    /// discards every `patch_status` the lease controller issues and no
+    /// lease ever leaves `Pending`.
+    #[test]
+    fn crd_declares_the_status_subresource() {
+        use kube::CustomResourceExt;
+        let crd = serde_json::to_value(ClusterLease::crd()).unwrap();
+        let versions = crd["spec"]["versions"].as_array().unwrap();
+        assert!(
+            versions[0]["subresources"].get("status").is_some(),
+            "status subresource missing: {}",
+            versions[0]["subresources"]
+        );
+    }
+
     #[test]
     fn legacy_status_without_conditions_deserializes() {
         // Back-compat: a ClusterLease persisted before the conditions field


### PR DESCRIPTION
`src/crd/lease.rs` had 3 tests, all about Merge-Patch erasure. This adds 11, covering the parts of the type that other components depend on **by string** — where a change compiles fine and breaks at runtime.

## The one that matters most

`LeasePhase`'s serialized form is a wire contract. `kobectl` reads the phase out of the API response as a string and compares it against literals:

```rust
fn is_terminal_failure_phase(phase: &str) -> bool {
    phase.eq_ignore_ascii_case("expired")
        || phase.eq_ignore_ascii_case("released")
        || phase.eq_ignore_ascii_case("recycling")
}
```

Adding a `#[serde(rename_all = ...)]` to the enum, or renaming a variant, would fail no compile anywhere in the workspace. The CLI would simply stop recognising terminal leases and wait out its full timeout on a lease that was never going to bind — which is exactly the confusing failure #59 has been chasing from the other end.

Pinned for all five variants in both directions, plus that **`Display` agrees with the serde form**. Both reach users: the serde form goes over the API to that comparison, and `Display` is what the CLI prints back (`"Lease {id} ended in phase {phase}"`). A divergence would print a phase name that the code matching on it doesn't recognise.

## Also pinned

- **camelCase-only spec binding** — a snake_case `pool_ref` is dropped as an unknown field rather than rejected, leaving a lease with no pool.
- **`priority` defaults to 50** — the queue sorts on it descending, so a wrong default silently re-orders every lease that omits it.
- **`Requester`'s `type` rename** — the Rust field can't be named `type`, so that rename is the only thing keeping the stored CR readable by every writer of it.
- **`lastTransitionTime` omitted, not null** when unset — same Merge-Patch rule as `message` and `conditions`.
- **Forward compat** — a status written by a newer operator still deserializes, so a rolling upgrade doesn't wedge the older replica.
- **Round-trip fixed point** — a controller that reads a status and writes it back unchanged doesn't perturb it.
- **CRD public identity** — group / kind / plural / `cl` shortname / single served+storage version, and that `status` is a real subresource (without it the apiserver silently drops every `patch_status` and no lease leaves `Pending`).

## Mutation-checked

| Mutation | Result |
|---|---|
| `#[serde(rename_all = "snake_case")]` on `LeasePhase` | both wire-contract tests fail |
| drop `rename_all = "camelCase"` from `ClusterLeaseSpec` | binding test fails |

## Verification

`cargo test --workspace` green (722 operator tests), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean. Spot-checked that a new test passes when run in isolation, so nothing here is order-dependent.