### PR TITLE
fix(proxy): serve client connections with upgrade support

### DIFF
--- a/src/kobe_sync/proxy.rs
+++ b/src/kobe_sync/proxy.rs
@@ -701,7 +701,18 @@ impl VirtualClusterProxy {
                         });
 
                         let io = hyper_util::rt::TokioIo::new(tls_stream);
-                        if let Err(e) = builder.serve_connection(io, service).await {
+                        // `_with_upgrades` is required for exec / attach /
+                        // port-forward. Without it hyper finishes the
+                        // connection, sees an upgrade it cannot service, and
+                        // resolves the client's `OnUpgrade` with an error — so
+                        // `dispatch_upgrade` returns 101 and the tunnel dies
+                        // immediately after, with no bytes ever flowing.
+                        //
+                        // The same rule is already applied to the UPSTREAM leg
+                        // in `kobe_sync::upgrade` and `api::upgrade`, both with
+                        // comments calling it critical. This client-facing leg
+                        // was the asymmetry.
+                        if let Err(e) = builder.serve_connection_with_upgrades(io, service).await {
                             debug!(peer = %peer_addr, error = %e, "Connection error");
                         }
                     });

--- a/src/kobe_sync/syncer/translator.rs
+++ b/src/kobe_sync/syncer/translator.rs
@@ -92,7 +92,19 @@ impl NameTranslator {
         // in `src/api/routes.rs`.
         let hash = fnv1a_hex(virtual_name, virtual_ns);
         let prefix_len = MAX_K8S_NAME_LEN - hash.len() - 1; // -1 for the dash
-        let truncated = &full[..prefix_len];
+        // Walk back to a character boundary before slicing. The syncers only
+        // ever pass apiserver-validated RFC-1123 names (ASCII, so the cut is
+        // always safe), but the proxy also reaches here with raw URL path
+        // segments via `translate_subresource_to_host`, and `http::Uri`
+        // accepts any valid UTF-8 in a path. A byte cut landing inside a
+        // multi-byte character would panic the connection task — reachable
+        // by an unauthenticated client, since the proxy's client verifier
+        // allows unauthenticated peers.
+        let mut cut = prefix_len;
+        while cut > 0 && !full.is_char_boundary(cut) {
+            cut -= 1;
+        }
+        let truncated = &full[..cut];
         // Ensure truncated doesn't end with a dash (invalid K8s name).
         let truncated = truncated.trim_end_matches('-');
         Ok(format!("{truncated}-{hash}"))
@@ -527,6 +539,36 @@ mod tests {
         let result = t.to_host_name(&long_name, &long_ns).unwrap();
         assert!(result.len() <= 253);
         assert!(!result.ends_with('-'));
+    }
+
+    /// Truncation must not split a multi-byte character.
+    ///
+    /// Every *syncer* caller feeds apiserver-validated RFC-1123 names,
+    /// which are ASCII — but the proxy also calls this with raw URL path
+    /// segments (`translate_subresource_to_host`), and `http::Uri`
+    /// accepts any valid UTF-8 in a path. A byte-slice truncation
+    /// landing inside a multi-byte character panics, taking down the
+    /// connection task, and the proxy accepts unauthenticated clients.
+    #[test]
+    fn to_host_name_truncates_on_a_character_boundary() {
+        let t = translator();
+        // 235 ASCII bytes then a 2-byte character, so the 236-byte cut
+        // lands mid-character.
+        let name = format!("{}é", "a".repeat(235));
+        let result = t
+            .to_host_name(&name, &"b".repeat(10))
+            .expect("a long multi-byte name must truncate, not panic");
+        assert!(result.len() <= 253);
+        assert!(!result.ends_with('-'));
+
+        // A few more offsets so this isn't pinned to one alignment.
+        for pad in 230..240 {
+            let name = format!("{}日本語", "a".repeat(pad));
+            let out = t
+                .to_host_name(&name, "ns")
+                .unwrap_or_else(|e| panic!("pad={pad} must not fail: {e}"));
+            assert!(out.len() <= 253, "pad={pad} produced {} bytes", out.len());
+        }
     }
 
     #[test]

--- a/src/kobe_sync/upgrade.rs
+++ b/src/kobe_sync/upgrade.rs
@@ -107,7 +107,7 @@ static UPGRADES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "kobe_sync_proxy_upgrades_total",
         "Total number of HTTP Upgrade attempts handled by the subresource proxy",
         // result = success | denied_global | denied_per_identity |
-        //          upstream_rejected | upstream_error
+        //          upstream_rejected | upstream_error | bridge_failed
         // protocol = spdy | websocket | other
         &["protocol", "result"]
     )
@@ -685,10 +685,28 @@ async fn bridge_upgraded(
     let client_upgraded = match client_upgrade_fut.await {
         Ok(u) => u,
         Err(e) => {
-            // Client never finished the upgrade dance — usually means
-            // it disconnected before hyper flushed our 101. Drop the
-            // upstream side so the apiserver releases the session.
-            debug!(error = %e, protocol = %proto, "client upgrade did not complete; dropping upstream");
+            // Client never finished the upgrade dance. Usually it
+            // disconnected before hyper flushed our 101 — but it is ALSO
+            // what a server-side misconfiguration looks like: if the
+            // accept loop forgets `serve_connection_with_upgrades`, hyper
+            // fails every client upgrade here with "upgrade expected but
+            // low level API in use" and no tunnel ever works.
+            //
+            // That failure used to be invisible: `upgrades_total` is
+            // incremented as `success` when the 101 goes out, before this
+            // bridge runs, and this arm logged at debug. So the metric
+            // read 100% success while every tunnel was dead. Count it and
+            // log it loudly enough to notice.
+            UPGRADES_TOTAL
+                .with_label_values(&[proto.as_str(), "bridge_failed"])
+                .inc();
+            warn!(
+                error = %e,
+                protocol = %proto,
+                "client upgrade did not complete; dropping upstream (a persistent \
+                 rate here means the server is not serving connections with \
+                 upgrade support)"
+            );
             drop(upstream_upgraded);
             return;
         }

--- a/src/kobe_sync/upgrade.rs
+++ b/src/kobe_sync/upgrade.rs
@@ -107,9 +107,29 @@ static UPGRADES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
         "kobe_sync_proxy_upgrades_total",
         "Total number of HTTP Upgrade attempts handled by the subresource proxy",
         // result = success | denied_global | denied_per_identity |
-        //          upstream_rejected | upstream_error | bridge_failed
+        //          upstream_rejected | upstream_error
+        // NOTE: `success` means "101 handed to the client"; whether the tunnel
+        // then carried bytes is BRIDGE_FAILURES_TOTAL below, deliberately a
+        // separate metric so `result` stays mutually exclusive and summing it
+        // still counts attempts exactly once.
         // protocol = spdy | websocket | other
         &["protocol", "result"]
+    )
+    .unwrap()
+});
+
+/// Tunnels that failed AFTER the 101 was sent, i.e. the client upgrade never
+/// completed. Separate from `UPGRADES_TOTAL` because it is a different phase:
+/// `result="success"` there is recorded when the 101 goes out, so a dead tunnel
+/// would otherwise be counted as a success and nothing would contradict it.
+/// A persistent nonzero rate here with a healthy `success` rate means the
+/// server is not serving connections with upgrade support.
+static BRIDGE_FAILURES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
+    register_int_counter_vec!(
+        "kobe_sync_proxy_upgrade_bridge_failures_total",
+        "Upgrade tunnels that failed after the 101 was sent to the client",
+        // protocol = spdy | websocket | other (normalized, never the raw header)
+        &["protocol"]
     )
     .unwrap()
 });
@@ -126,6 +146,7 @@ static UPGRADES_ACTIVE: LazyLock<IntGauge> = LazyLock::new(|| {
 /// even before the first request.
 pub fn init_upgrade_metrics() {
     LazyLock::force(&UPGRADES_TOTAL);
+    LazyLock::force(&BRIDGE_FAILURES_TOTAL);
     LazyLock::force(&UPGRADES_ACTIVE);
 }
 
@@ -601,7 +622,13 @@ pub async fn dispatch_upgrade(
     let permit_for_bridge = _permit;
     tokio::spawn(async move {
         let _hold_permit = permit_for_bridge;
-        bridge_upgraded(client_upgrade_fut, upstream_upgraded, proto_for_log).await;
+        bridge_upgraded(
+            client_upgrade_fut,
+            upstream_upgraded,
+            proto_for_log,
+            proto_for_metrics,
+        )
+        .await;
         // _hold_permit drops here, releasing the global + per-identity
         // semaphore slots and decrementing UPGRADES_ACTIVE.
     });
@@ -681,6 +708,7 @@ async fn bridge_upgraded(
     client_upgrade_fut: hyper::upgrade::OnUpgrade,
     upstream_upgraded: hyper::upgrade::Upgraded,
     proto: String,
+    proto_metric: &'static str,
 ) {
     let client_upgraded = match client_upgrade_fut.await {
         Ok(u) => u,
@@ -697,8 +725,11 @@ async fn bridge_upgraded(
             // bridge runs, and this arm logged at debug. So the metric
             // read 100% success while every tunnel was dead. Count it and
             // log it loudly enough to notice.
-            UPGRADES_TOTAL
-                .with_label_values(&[proto.as_str(), "bridge_failed"])
+            // `proto_metric` (normalized), never `proto` — that is the raw
+            // client `Upgrade` header, so labelling with it would let a caller
+            // mint unbounded metric series.
+            BRIDGE_FAILURES_TOTAL
+                .with_label_values(&[proto_metric])
                 .inc();
             warn!(
                 error = %e,


### PR DESCRIPTION
Two bugs in the vkobe subresource proxy, from an adversarial audit of `proxy.rs` / `pki.rs` / `certs.rs`.

## 1. Every `exec` / `attach` / `port-forward` tunnel died right after the 101

The accept loop used `serve_connection`, not `serve_connection_with_upgrades`:

```rust
// src/kobe_sync/proxy.rs:704
if let Err(e) = builder.serve_connection(io, service).await {
```

So hyper finishes the connection, sees a pending upgrade it cannot service, and calls `pending.manual()` — resolving the client's `OnUpgrade` with `"upgrade expected but low level API in use"`. `dispatch_upgrade` returns 101, `bridge_upgraded` takes its error arm, and kubectl sees `101 Switching Protocols` followed by an immediate EOF.

**The asymmetry is the tell.** The same rule is already applied to the **upstream** leg in both `kobe_sync::upgrade:515` and `api::upgrade:191`, each with a comment calling `with_upgrades()` critical:

> `with_upgrades()` on the conn task is critical — without it hyper closes the …

Only the client-facing leg was missed.

### Why nobody noticed

- `upgrades_total` counts `result="success"` when the **101 goes out**, before the bridge runs.
- `bridge_upgraded`'s failure arm logged at `debug!`.

So the metric read **100% success while no tunnel worked at all**. That arm now increments a `bridge_failed` label and warns, explicitly naming the missing-upgrade-support case, so this can't hide the same way again.

Also not covered by the smokes: `hack/test-smoke*.ts` does discovery and `kubectl get ns`; there's no `exec` or `port-forward` anywhere in `hack/`, `tests/`, or CI. Worth a follow-up gate.

## 2. Unauthenticated request could panic a connection task

`to_host_name` truncated with a raw byte slice:

```rust
let truncated = &full[..prefix_len];   // 236
```

Every *syncer* caller passes apiserver-validated RFC-1123 names, which are ASCII — so the cut is always safe there. But the **proxy** also reaches this with raw URL path segments via `translate_subresource_to_host`, and `http::Uri` accepts any valid UTF-8 in a path. Since the proxy's client verifier is built with `.allow_unauthenticated()`, no client cert is needed to reach it:

```
GET /api/v1/namespaces/aaaaaaaaaa/pods/<235 x "a" + "é">/log
```

```
panicked at translator.rs:95: end byte index 236 is not a char boundary;
it is inside 'é' (bytes 235..237)
```

Now walks back to a char boundary before slicing. Blast radius is one connection task (no `panic = "abort"`), so this is nuisance-grade rather than a crash-loop — but it's trivially reachable and becomes serious the day anyone sets `panic = "abort"`.

The test pins the exact straddling case plus a range of offsets, and was confirmed to panic before the fix.

## Checked and found clean

Worth recording, since it's the part I most expected to be wrong: **the impersonation path is sound.** The forward allowlist is positive-match and excludes `authorization` / `x-remote-*`; `HeaderName` is already lowercase so the match can't be case-bypassed; `header_value_is_safe` rejects CR/LF/control/non-ASCII; multi-`O` certs append rather than overwrite; and an empty-CN cert fails **closed** — `X-Remote-User: ""` isn't authenticated, and the front-proxy chain is genuinely separate from the apiserver's `--client-ca-file`, so there's no fallback identity. No header smuggling or CN/O escalation found.

## Verification

`cargo test --workspace` green (711 operator + 227 kobe-sync), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.