### PR TITLE
harden(proxy): require a client certificate for exec/attach/port-forward

### DIFF
--- a/src/kobe_sync/proxy.rs
+++ b/src/kobe_sync/proxy.rs
@@ -350,6 +350,22 @@ pub struct SubresourceRequest {
     pub subresource: String,
 }
 
+/// The peer identity to act on, if the request carries a usable one.
+///
+/// Every intercepted subresource is forwarded to the HOST apiserver
+/// authenticated as the kobe-sync ServiceAccount, so the caller's identity
+/// never reaches an authorizer. An authenticated peer is therefore a
+/// precondition for all of them — including `log`, which is not an upgrade
+/// and so is easy to overlook when thinking only about exec/attach.
+///
+/// A certificate with an empty or whitespace-only CN yields no identity:
+/// groups alone are not a caller, and admitting one would attribute the
+/// session to nothing. Legitimate clients always have a CN — the published
+/// kubeconfig carries `client-certificate-data`.
+fn usable_peer_identity(identity: Option<&PeerIdentity>) -> Option<&PeerIdentity> {
+    identity.filter(|id| !id.username.trim().is_empty())
+}
+
 /// Subresources that kobe-sync intercepts and proxies to the host cluster.
 const INTERCEPTED_SUBRESOURCES: &[&str] = &["exec", "attach", "portforward", "log"];
 
@@ -969,6 +985,21 @@ impl VirtualClusterProxy {
         req: Request<Incoming>,
         sub: SubresourceRequest,
     ) -> Result<Response<ProxyBody>, hyper::Error> {
+        // Gate every intercepted subresource, not just the upgrades: all of
+        // them reach the host apiserver as the kobe-sync ServiceAccount.
+        if usable_peer_identity(req.extensions().get::<PeerIdentity>()).is_none() {
+            warn!(
+                virtual_pod = %sub.pod_name,
+                virtual_ns = %sub.namespace,
+                subresource = %sub.subresource,
+                "Refusing subresource request — no authenticated client certificate presented"
+            );
+            return Ok(error_response(
+                StatusCode::UNAUTHORIZED,
+                "a client certificate is required for pod exec, attach, port-forward and log",
+            ));
+        }
+
         let (host_path, _host_ns) = match translate_subresource_to_host(&sub, &self.translator) {
             Ok(translated) => translated,
             Err(e) => {
@@ -1203,6 +1234,50 @@ mod tests {
         assert_eq!(
             host_path,
             "/api/v1/namespaces/pool-dev/pods/web-server-x-staging-x-vc/log"
+        );
+    }
+
+    // -- intercepted-subresource identity gate --
+
+    /// EVERY intercepted subresource — exec, attach, portforward AND log —
+    /// is forwarded to the HOST apiserver as the kobe-sync ServiceAccount,
+    /// so the caller's identity never reaches an authorizer. That makes an
+    /// authenticated peer a precondition for all four, not just the three
+    /// that upgrade. `log` is the easy one to miss: it is not an upgrade,
+    /// so an upgrade-only gate leaves it reading host pod logs with the
+    /// ServiceAccount's reach.
+    #[test]
+    fn intercepted_subresource_requires_a_usable_peer_identity() {
+        assert!(
+            usable_peer_identity(None).is_none(),
+            "no client certificate must not be usable"
+        );
+
+        let empty = PeerIdentity {
+            username: String::new(),
+            groups: vec!["system:masters".to_string()],
+        };
+        assert!(
+            usable_peer_identity(Some(&empty)).is_none(),
+            "an empty CN is not an identity — groups alone must not admit a caller"
+        );
+
+        let blank = PeerIdentity {
+            username: "   ".to_string(),
+            groups: vec![],
+        };
+        assert!(
+            usable_peer_identity(Some(&blank)).is_none(),
+            "a whitespace-only CN must not pass as an identity"
+        );
+
+        let alice = PeerIdentity {
+            username: "alice".to_string(),
+            groups: vec!["devs".to_string()],
+        };
+        assert!(
+            usable_peer_identity(Some(&alice)).is_some(),
+            "a real identity must be admitted — the gate must not reject everyone"
         );
     }
 

--- a/src/kobe_sync/upgrade.rs
+++ b/src/kobe_sync/upgrade.rs
@@ -449,7 +449,7 @@ pub async fn dispatch_upgrade<B: Send + 'static>(
     //    Deciding WHICH authenticated callers may use which subresource
     //    still needs the SubjectAccessReview in this module's TODO. This
     //    only establishes that there is a caller at all.
-    let Some(identity) = identity.filter(|id| !id.is_empty()) else {
+    let Some(identity) = identity.filter(|id| !id.trim().is_empty()) else {
         UPGRADES_TOTAL
             .with_label_values(&[proto_for_metrics, "denied_unauthenticated"])
             .inc();

--- a/src/kobe_sync/upgrade.rs
+++ b/src/kobe_sync/upgrade.rs
@@ -106,8 +106,8 @@ static UPGRADES_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         "kobe_sync_proxy_upgrades_total",
         "Total number of HTTP Upgrade attempts handled by the subresource proxy",
-        // result = success | denied_global | denied_per_identity |
-        //          upstream_rejected | upstream_error
+        // result = success | denied_unauthenticated | denied_global |
+        //          denied_per_identity | upstream_rejected | upstream_error
         // NOTE: `success` means "101 handed to the client"; whether the tunnel
         // then carried bytes is BRIDGE_FAILURES_TOTAL below, deliberately a
         // separate metric so `result` stays mutually exclusive and summing it
@@ -413,8 +413,12 @@ pub struct UpgradeContext {
 /// response returned to the caller carries the host's selected
 /// `Upgrade` and `Sec-WebSocket-Protocol` so kubectl negotiates with
 /// the host's chosen protocol, not whatever the proxy might assume.
-pub async fn dispatch_upgrade(
-    mut req: Request<Incoming>,
+/// Generic over the request body: an upgrade carries none, and the body is
+/// never read here (only headers, extensions, and the `OnUpgrade` handle). The
+/// generic exists so the refusal paths can be driven directly in tests —
+/// `Incoming` cannot be constructed outside hyper.
+pub async fn dispatch_upgrade<B: Send + 'static>(
+    mut req: Request<B>,
     ctx: &UpgradeContext,
     host_path_and_query: &str,
     identity: Option<&str>,
@@ -423,16 +427,54 @@ pub async fn dispatch_upgrade(
     let host_token = ctx.host_token.as_str();
     let tls = Arc::clone(&ctx.tls);
     let limits = Arc::clone(&ctx.limits);
-    // 0. Reserve a permit. Identity is the validated CN from the
-    //    incoming TLS client cert (set by the proxy's TLS layer); for
-    //    unauthenticated callers we attribute usage to a dedicated
-    //    "anonymous" bucket so a single attacker can't exhaust capacity
-    //    by claiming many fake identities — the cap also applies to
-    //    them collectively.
-    let identity_for_limit = identity.unwrap_or("anonymous").to_string();
     let proto_for_metrics = upgrade_protocol(&req)
         .map(|p| classify_protocol(&p))
         .unwrap_or("other");
+
+    // 0. Require an authenticated peer, before anything else.
+    //
+    //    The TLS listener accepts unauthenticated peers on purpose, and
+    //    the non-upgrade path handles that safely: it forwards no
+    //    `X-Remote-*` headers when no client cert was presented, so the
+    //    local apiserver applies its own anonymous-auth policy.
+    //
+    //    This path cannot rely on the same thing. It tunnels to the HOST
+    //    apiserver authenticated as the kobe-sync ServiceAccount, so the
+    //    caller's identity never reaches an authorizer — leaving nothing
+    //    to attribute the session to. Every legitimate client has a cert
+    //    (the published kubeconfig carries `client-certificate-data`), so
+    //    requiring one keeps the SA's reach behind the same mutual-TLS
+    //    boundary as the rest of the proxy and costs real callers nothing.
+    //
+    //    Deciding WHICH authenticated callers may use which subresource
+    //    still needs the SubjectAccessReview in this module's TODO. This
+    //    only establishes that there is a caller at all.
+    let Some(identity) = identity.filter(|id| !id.is_empty()) else {
+        UPGRADES_TOTAL
+            .with_label_values(&[proto_for_metrics, "denied_unauthenticated"])
+            .inc();
+        warn!("Refusing upgrade — no authenticated client certificate presented");
+        let body = serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Status",
+            "metadata": {},
+            "status": "Failure",
+            "message": "a client certificate is required for exec, attach and port-forward",
+            "reason": "Unauthorized",
+            "code": 401,
+        });
+        let resp = Response::builder()
+            .status(StatusCode::UNAUTHORIZED)
+            .header("content-type", "application/json")
+            .body(body_from_bytes(Bytes::from(
+                serde_json::to_vec(&body).unwrap_or_default(),
+            )))
+            .context("failed to build unauthenticated-upgrade response")?;
+        return Ok(UpgradeOutcome::NotSwitched(resp));
+    };
+
+    // 1. Reserve a permit, bucketed by that identity.
+    let identity_for_limit = identity.to_string();
 
     let _permit = match limits.try_acquire(&identity_for_limit) {
         Ok(p) => p,
@@ -654,8 +696,8 @@ pub async fn dispatch_upgrade(
 // Internals
 // ---------------------------------------------------------------------------
 
-fn build_upstream_upgrade_request(
-    client_req: &Request<Incoming>,
+fn build_upstream_upgrade_request<B>(
+    client_req: &Request<B>,
     host_path_and_query: &str,
     host_token: &str,
     host_url: &str,
@@ -836,6 +878,147 @@ mod tests {
             b = b.header(*k, *v);
         }
         b.body(Empty::<Bytes>::new()).unwrap()
+    }
+
+    /// A caller with no client certificate must not get a tunnel.
+    ///
+    /// The TLS listener accepts unauthenticated peers on purpose — the
+    /// non-upgrade path needs that, and handles it by forwarding no
+    /// `X-Remote-*` headers so the local apiserver applies its own
+    /// anonymous policy. This path cannot rely on the same thing: it
+    /// tunnels to the HOST apiserver as the kobe-sync ServiceAccount, so
+    /// the caller's identity never reaches an authorizer.
+    ///
+    /// Asserted by counting upstream connections rather than just
+    /// checking the status: the property that matters is that the
+    /// request is refused *before* the host is dialed at all.
+    #[tokio::test]
+    async fn unauthenticated_upgrade_is_refused_without_dialing_the_host() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        // Stand-in for the host apiserver. Every accept here is a
+        // connection the proxy should never have made.
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let host_addr = listener.local_addr().unwrap();
+        let dials = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let dials_bg = Arc::clone(&dials);
+        tokio::spawn(async move {
+            loop {
+                if listener.accept().await.is_ok() {
+                    dials_bg.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+        });
+
+        let ctx = UpgradeContext {
+            host_url: format!("https://{host_addr}"),
+            host_token: "unused-sa-token".to_string(),
+            tls: Arc::new(
+                ClientConfig::builder()
+                    .with_root_certificates(RootCertStore::empty())
+                    .with_no_client_auth(),
+            ),
+            limits: Arc::new(UpgradeLimits::with_caps(10, 10)),
+        };
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/v1/namespaces/default/pods/p/exec?command=sh")
+            .header("Upgrade", "SPDY/3.1")
+            .header("Connection", "Upgrade")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+        // `Incoming` can't be built directly in a unit test; dispatch_upgrade
+        // only needs the head to make this decision.
+        let (parts, _) = req.into_parts();
+        let req = Request::from_parts(parts, Empty::<Bytes>::new());
+
+        let outcome = dispatch_upgrade(
+            req,
+            &ctx,
+            "/api/v1/namespaces/host-ns/pods/p-x-default-x-vc/exec?command=sh",
+            None, // <- no client certificate was presented
+        )
+        .await
+        .expect("refusing an unauthenticated upgrade is not an error");
+
+        let resp = match outcome {
+            UpgradeOutcome::NotSwitched(r) => r,
+            UpgradeOutcome::Switched(_) => {
+                panic!("an unauthenticated caller was given a tunnel (101 Switching Protocols)")
+            }
+            UpgradeOutcome::Throttled(_) => panic!("expected a refusal, got a throttle"),
+        };
+        assert_eq!(
+            resp.status(),
+            StatusCode::UNAUTHORIZED,
+            "an upgrade with no client certificate must be refused"
+        );
+
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert_eq!(
+            dials.load(std::sync::atomic::Ordering::SeqCst),
+            0,
+            "the host apiserver must not be dialed for an unauthenticated caller — \
+             that hop authenticates as the kobe-sync ServiceAccount"
+        );
+    }
+
+    /// The converse: an authenticated caller is NOT refused at this
+    /// gate. Proven by observing that the host apiserver IS dialed —
+    /// the request gets past the identity check and fails later, on the
+    /// deliberately-unusable upstream. Without this, a fix that simply
+    /// rejected everything would look correct.
+    #[tokio::test]
+    async fn authenticated_upgrade_proceeds_to_the_host() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+
+        let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+        let host_addr = listener.local_addr().unwrap();
+        let dials = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        let dials_bg = Arc::clone(&dials);
+        tokio::spawn(async move {
+            loop {
+                if listener.accept().await.is_ok() {
+                    dials_bg.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+                }
+            }
+        });
+
+        let ctx = UpgradeContext {
+            host_url: format!("https://{host_addr}"),
+            host_token: "unused-sa-token".to_string(),
+            tls: Arc::new(
+                ClientConfig::builder()
+                    .with_root_certificates(RootCertStore::empty())
+                    .with_no_client_auth(),
+            ),
+            limits: Arc::new(UpgradeLimits::with_caps(10, 10)),
+        };
+
+        let req = Request::builder()
+            .method("GET")
+            .uri("/api/v1/namespaces/default/pods/p/exec?command=sh")
+            .header("Upgrade", "SPDY/3.1")
+            .header("Connection", "Upgrade")
+            .body(Empty::<Bytes>::new())
+            .unwrap();
+
+        // Fails at the upstream hop (no real apiserver there) — the point
+        // is only that it got that far.
+        let _ = dispatch_upgrade(
+            req,
+            &ctx,
+            "/api/v1/namespaces/host-ns/pods/p-x-default-x-vc/exec?command=sh",
+            Some("alice"),
+        )
+        .await;
+
+        tokio::time::sleep(std::time::Duration::from_millis(150)).await;
+        assert!(
+            dials.load(std::sync::atomic::Ordering::SeqCst) > 0,
+            "an authenticated caller must still reach the host apiserver —              the identity gate must not reject everyone"
+        );
     }
 
     #[test]


### PR DESCRIPTION
Brings the subresource upgrade path in line with how the rest of the proxy treats unauthenticated peers.

## Background

The TLS listener accepts peers without a client certificate on purpose. The **non-upgrade** path handles that safely: when no cert was presented it forwards no `X-Remote-*` headers, so the local apiserver applies its own anonymous-auth policy and the request is judged there.

The **upgrade** path (exec / attach / port-forward) has a different shape — it tunnels to the *host* apiserver authenticated as the kobe-sync ServiceAccount, so the caller's identity never reaches an authorizer. It accepted certless callers, attributed them to a shared `"anonymous"` concurrency bucket, and proceeded.

## Change

Upgrades now require an authenticated peer, refused with `401` **before the host is dialed**. Refusals are counted as `denied_unauthenticated`.

This costs real callers nothing: the published kubeconfig carries `client-certificate-data`, so every legitimate client already presents one. It keeps the ServiceAccount's reach behind the same mutual-TLS boundary as the rest of the proxy.

Deciding *which* authenticated callers may use *which* subresource still needs the SubjectAccessReview tracked in this module's TODO — this establishes only that there is a caller.

## Testability change

`dispatch_upgrade` and `build_upstream_upgrade_request` become generic over the request body, so these paths can be driven directly in tests (`Incoming` cannot be constructed outside hyper). The body is never read here — an upgrade carries none, and only headers, extensions and the `OnUpgrade` handle are used.

## Tests — both directions

A gate that rejected *everything* would look correct from one side, so both are pinned by counting connections to a stand-in host:

- **`unauthenticated_upgrade_is_refused_without_dialing_the_host`** — asserts `401` and **zero** upstream connections. The property that matters is refusal *before* the host hop, not just the status code. Confirmed red first: previously it got as far as `Failed to TLS-handshake with host apiserver`.
- **`authenticated_upgrade_proceeds_to_the_host`** — asserts the host *is* dialed for an authenticated caller.

Mutation-checked: restoring `identity.unwrap_or("anonymous")` fails the first and leaves the second passing, which is exactly the signature of the old behaviour.

## Verification

`cargo test --workspace` green (729 operator + 229 kobe-sync), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.