### PR TITLE
ci(conformance): add the k0s leg to the CI matrix

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,12 +155,22 @@ jobs:
       - name: Build all images (dry-run, no cache)
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from='
 
-  # Backend-agnostic conformance gate (#164): the same provision→Ready→recycle
-  # smoke, run PER BACKEND, so "passes conformance" is provable for each backend
-  # rather than k3s-only. Each leg exercises the real Helm chart (real rbac.yaml)
-  # against a REAL cluster nested-in-pod inside plain kind, catching the two
-  # regression classes unit tests can't: the readiness-probe class (members never
-  # go Ready) and the RBAC-403 recycle-wedge class (instances stuck Recycling).
+  # Backend-agnostic conformance gate (#164), run PER BACKEND so "passes
+  # conformance" is provable for each rather than k3s-only. Every leg exercises
+  # the real Helm chart (real rbac.yaml) against a REAL cluster nested-in-pod
+  # inside plain kind — which is what catches the readiness-probe class of
+  # regression (members never go Ready) that unit tests cannot.
+  #
+  # The legs are NOT equivalent, and it is worth being precise about it:
+  #   - k3s runs `hack/test-e2e-k3s.ts`: provision -> Ready -> recycle, and it
+  #     asserts teardown completed and left no orphaned data PVC. That is the
+  #     leg that covers the RBAC-403 recycle-wedge class (stuck Recycling).
+  #   - every other leg runs the generic `hack/test-smoke.ts`: provision ->
+  #     Ready -> lease -> API reachable -> release. It does NOT wait for or
+  #     assert recycle, so it does not cover the recycle-wedge class.
+  # Extending the generic smoke to assert teardown would make the matrix
+  # uniform; until then, read a green non-k3s leg as "provisions and serves",
+  # not "provisions, serves and reaps".
   #
   # Kept as one dedicated matrix job (cf. how kunobi-ninja/kache#487 kept its
   # audit gate a dedicated, scoped job) — each leg owns an isolated kind cluster

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -171,10 +171,11 @@ jobs:
   # push to main and on release tags, so a conformance regression is caught
   # before (main) or at (tag) the release boundary instead of a day later.
   # The full matrix (k3s + both vkobe datastores) stays nightly + manual; the
-  # vkobe legs run the same gate across etcd + kine/sqlite, and vcluster joins
-  # nightly against the upstream loft-sh chart (#31). capi still has no CI
-  # infrastructure provider, and k0s has a harness pool but no smoke recipe —
-  # both tracked as follow-ups before they join the matrix;
+  # vkobe legs run the same gate across etcd + kine/sqlite, vcluster runs
+  # nightly against the upstream loft-sh chart (#31), and k0s joins with the
+  # same on-demand shape (#65) — single-server only, since servers>1 is still
+  # rejected for that backend (#7). capi remains out: no CI infrastructure
+  # provider yet;
   # `backend_conformance_coverage_is_classified` (crd/profile.rs)
   # forces every new BackendType to be consciously classified against this
   # matrix. Since #28, reaching Ready on k3s/k0s/vcluster requires the
@@ -203,7 +204,7 @@ jobs:
       matrix:
         # k3s-only on push (fast feedback on the production backend); the full
         # matrix nightly / on manual dispatch.
-        backend: ${{ fromJSON(github.event_name == 'push' && '["k3s"]' || '["k3s", "vkobe-etcd", "vkobe-kine", "vcluster"]') }}
+        backend: ${{ fromJSON(github.event_name == 'push' && '["k3s"]' || '["k3s", "vkobe-etcd", "vkobe-kine", "vcluster", "k0s"]') }}
     steps:
       - uses: actions/checkout@v4
 
@@ -242,6 +243,7 @@ jobs:
             vkobe-etcd) mise exec -- just test-smoke-vkobe ;;
             vkobe-kine) mise exec -- just test-smoke-vkobe-kine ;;
             vcluster)   mise exec -- just test-smoke-vcluster ;;
+            k0s)        mise exec -- just test-smoke-k0s ;;
             *) echo "unknown backend ${{ matrix.backend }}" >&2; exit 1 ;;
           esac
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -241,7 +241,11 @@ jobs:
       # Per-backend kind cluster name (run id + backend) so concurrent legs and
       # persistent self-hosted runs never collide on a shared cluster name.
       - name: Bring up the e2e harness (kind + chart + pools)
-        run: mise exec -- bun run ./hack/e2e.ts up --cluster e2e-${{ github.run_id }}-${{ matrix.backend }}
+        # `--backend` only selects which guest images are worth pre-loading;
+        # every pool is applied regardless. Scale-to-zero pools provision only
+        # in their own leg, so pre-loading their images in every leg would be a
+        # pull each other leg never uses.
+        run: mise exec -- bun run ./hack/e2e.ts up --cluster e2e-${{ github.run_id }}-${{ matrix.backend }} --backend ${{ matrix.backend }}
 
       # The smoke recipes differ by backend (k3s takes the cluster name; the
       # vkobe recipes target their pool against the current kind context).

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -14,15 +14,17 @@ const DEMO_TOKEN_SECRET = "e2e-local-token";
 const DEMO_POLICY = "e2e-local-token";
 const DEMO_K0S_POOL = "e2e-k0s";
 const DEMO_K0S_VERSION = "v1.35.1+k0s.0";
-// k0s guest image the k0s backend launches for DEMO_K0S_VERSION. Same `+`->`-`
-// rewrite as k3s, for the same reason: OCI tags forbid `+` (see k0s_image() in
-// src/backend/k0s.rs). Keep in sync with DEMO_K0S_VERSION.
+// k0s guest image the k0s backend launches for DEMO_K0S_VERSION.
 //
-// Pre-loaded into the kind nodes for the same reason as the k3s image: without
-// it the guest pulls from the registry inside kind at provision time, and that
-// uncontrolled pull sits inside the pool's creatingTimeout — so the k0s leg
-// would be timing a network fetch rather than the backend.
-const K0S_GUEST_IMAGE = "k0sproject/k0s:v1.35.1-k0s.0";
+// DERIVED, not hand-written: `k0s_image()` (src/backend/k0s.rs) builds the tag
+// as `version.replace('+', "-")` — the `+` build-metadata separator is not a
+// legal OCI tag character. Applying the same transform here means a version
+// bump cannot silently desync the two. A hand-pinned constant could, and the
+// failure would be quiet: the preload would fetch an image nothing launches,
+// the guest would pull from the registry inside kind at provision time, and
+// that uncontrolled fetch would land back inside the pool's creatingTimeout —
+// exactly the problem pre-loading exists to remove.
+const K0S_GUEST_IMAGE = `k0sproject/k0s:${DEMO_K0S_VERSION.replace("+", "-")}`;
 // Single-server k3s pool exercised by the provision→Ready→recycle CI smoke
 // gate (hack/test-e2e-k3s.ts). Uses embedded SQLite (no shared datastore in
 // kind) and warms one member via scaling.minReady=1. The matching guest image

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -580,7 +580,14 @@ spec:
     maxClusters: 2
     scaleUpThreshold: 0
     scaleDownAfter: "5m"
-    queueTimeout: "5m"
+    # Must exceed the recipe LEASE_WAIT_TIMEOUT: a server-side cap shorter
+    # than the client wait expires the queued claim regardless of how
+    # long the client is willing to wait.
+    queueTimeout: "12m"
+    # Caps ONE provisioning attempt: past it the operator recycles that
+    # instance as wedged. Sized to fit a cold start in one attempt, so
+    # the leg measures provisioning rather than retries.
+    creatingTimeout: "8m"
   resources:
     limits:
       cpu: "1"

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -14,6 +14,15 @@ const DEMO_TOKEN_SECRET = "e2e-local-token";
 const DEMO_POLICY = "e2e-local-token";
 const DEMO_K0S_POOL = "e2e-k0s";
 const DEMO_K0S_VERSION = "v1.35.1+k0s.0";
+// k0s guest image the k0s backend launches for DEMO_K0S_VERSION. Same `+`->`-`
+// rewrite as k3s, for the same reason: OCI tags forbid `+` (see k0s_image() in
+// src/backend/k0s.rs). Keep in sync with DEMO_K0S_VERSION.
+//
+// Pre-loaded into the kind nodes for the same reason as the k3s image: without
+// it the guest pulls from the registry inside kind at provision time, and that
+// uncontrolled pull sits inside the pool's creatingTimeout — so the k0s leg
+// would be timing a network fetch rather than the backend.
+const K0S_GUEST_IMAGE = "k0sproject/k0s:v1.35.1-k0s.0";
 // Single-server k3s pool exercised by the provision→Ready→recycle CI smoke
 // gate (hack/test-e2e-k3s.ts). Uses embedded SQLite (no shared datastore in
 // kind) and warms one member via scaling.minReady=1. The matching guest image
@@ -458,7 +467,7 @@ async function loadImagesIntoKind(cluster: string, imageTag: string): Promise<vo
   // pull them inside the smoke gate's wait_ready budget. k3s is launched with
   // the default IfNotPresent pull policy for its tagged image, so a node-local
   // copy means the kubelet never reaches out to the registry.
-  await loadRemoteImagesIntoKind(cluster, [K3S_GUEST_IMAGE]);
+  await loadRemoteImagesIntoKind(cluster, [K3S_GUEST_IMAGE, K0S_GUEST_IMAGE]);
 }
 
 async function prepareHelm(): Promise<void> {
@@ -585,8 +594,11 @@ spec:
     # long the client is willing to wait.
     queueTimeout: "12m"
     # Caps ONE provisioning attempt: past it the operator recycles that
-    # instance as wedged. Sized to fit a cold start in one attempt, so
-    # the leg measures provisioning rather than retries.
+    # instance as wedged. The claim itself survives and a later attempt can
+    # still serve it, up to the waits above — so this is a chosen retry
+    # policy, not a hard bound on the claim. Sized to fit a cold start now
+    # that the guest image is pre-loaded into the kind nodes
+    # (K0S_GUEST_IMAGE); without that it would be timing a registry pull.
     creatingTimeout: "8m"
   resources:
     limits:

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -76,6 +76,10 @@ type Args = {
   namespace: string;
   release: string;
   imageTag: string;
+  /// Conformance backend this environment is being brought up for, when it is
+  /// known. Only used to decide which guest images are worth pre-loading —
+  /// every pool is still applied regardless.
+  backend?: string;
 };
 
 type E2eState = {
@@ -244,7 +248,7 @@ function parseArgs(argv: string[]): Args {
     namespace: DEFAULT_NAMESPACE,
     release: DEFAULT_RELEASE,
     imageTag: DEFAULT_IMAGE_TAG,
-  };
+  } as Args;
 
   const [maybeCommand, ...rest] = argv;
   const tokens = maybeCommand === "up" || maybeCommand === "down" ? rest : argv;
@@ -276,6 +280,11 @@ function parseArgs(argv: string[]): Args {
       i += 1;
       continue;
     }
+    if (token === "--backend" && next) {
+      args.backend = next;
+      i += 1;
+      continue;
+    }
     if (token === "--help" || token === "-h") {
       printHelpAndExit();
     }
@@ -286,7 +295,9 @@ function parseArgs(argv: string[]): Args {
 
 function printHelpAndExit(): never {
   info("Usage:");
-  info("  bun run ./hack/e2e.ts up [--cluster NAME] [--namespace NS] [--release NAME] [--image-tag TAG]");
+  info(
+    "  bun run ./hack/e2e.ts up [--cluster NAME] [--namespace NS] [--release NAME] [--image-tag TAG] [--backend NAME]",
+  );
   info("  bun run ./hack/e2e.ts down [--cluster NAME]");
   process.exit(0);
 }
@@ -467,7 +478,18 @@ async function loadImagesIntoKind(cluster: string, imageTag: string): Promise<vo
   // pull them inside the smoke gate's wait_ready budget. k3s is launched with
   // the default IfNotPresent pull policy for its tagged image, so a node-local
   // copy means the kubelet never reaches out to the registry.
-  await loadRemoteImagesIntoKind(cluster, [K3S_GUEST_IMAGE, K0S_GUEST_IMAGE]);
+  // k3s is pre-loaded unconditionally because `e2e-k3s` is the one pool with
+  // `scaling.minReady: 1` — it warms in EVERY leg, so every leg needs its
+  // guest image. The scale-to-zero pools only provision when their own leg
+  // leases from them, so pre-loading their images everywhere would tax each
+  // leg with a pull it never uses (and add a registry dependency, which is a
+  // fresh way for an unrelated leg to fail). Pull those only when the leg
+  // that needs them is the one coming up.
+  const guestImages = [K3S_GUEST_IMAGE];
+  if (args.backend === "k0s") {
+    guestImages.push(K0S_GUEST_IMAGE);
+  }
+  await loadRemoteImagesIntoKind(cluster, guestImages);
 }
 
 async function prepareHelm(): Promise<void> {

--- a/justfile
+++ b/justfile
@@ -74,6 +74,13 @@ test-smoke-vkobe-kine ttl='2m' *args:
 test-smoke-vcluster ttl='2m' *args:
     @env POOL_ON_DEMAND=1 LEASE_WAIT_TIMEOUT=15m mise exec -- bun run ./hack/test-smoke.ts e2e-vcluster {{ ttl }} {{ args }}
 
+# Lease a local k0s cluster on demand, verify kubectl can reach it, then release
+# it. Same scale-to-zero shape as the vkobe/vcluster recipes: the pool keeps
+# nothing warm, so the lease request itself is what provisions.
+[group('dev')]
+test-smoke-k0s ttl='2m' *args:
+    @env POOL_ON_DEMAND=1 LEASE_WAIT_TIMEOUT=10m mise exec -- bun run ./hack/test-smoke.ts e2e-k0s {{ ttl }} {{ args }}
+
 # Lease a local bootstrap-enabled vkobe cluster and verify bootstrap resources exist
 [group('dev')]
 test-smoke-bootstrap-vkobe ttl='2m' *args:

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1683,11 +1683,10 @@ mod tests {
                 BackendType::K3s => Some(&["k3s"]),
                 BackendType::Vkobe => Some(&["vkobe-etcd", "vkobe-kine"]),
                 BackendType::Vcluster => Some(&["vcluster"]),
-                // Documented exemptions — NOT yet in the matrix:
+                BackendType::K0s => Some(&["k0s"]),
+                // Documented exemption — NOT yet in the matrix:
                 // - capi: no CI infrastructure provider yet
-                // - k0s: the harness has an `e2e-k0s` pool, but no smoke
-                //   recipe drives it, so nothing asserts conformance
-                BackendType::Capi | BackendType::K0s => None,
+                BackendType::Capi => None,
             }
         }
 


### PR DESCRIPTION
Closes #65.

The harness has had an `e2e-k0s` pool for a while, but nothing drove it — no smoke recipe, no matrix leg — so k0s stayed a documented exemption in `backend_conformance_coverage_is_classified` while the pool sat there unused.

## Same on-demand shape as the others

The pool is scale-to-zero (`scaling.minReady: 0`), so the lease request is what provisions. That means the three timeouts governing the path have to be ordered, or the outer ones are unreachable:

```
creatingTimeout 8m  <  LEASE_WAIT_TIMEOUT 10m  <  queueTimeout 12m
```

One attempt finishes before the client gives up; the client gives up before the server expires the claim, so a failure surfaces as the clean client-side timeout rather than a terminal `Expired` phase (which bypasses the smoke's diagnostics).

The pool previously declared only `queueTimeout: "5m"` — which would have capped the whole budget at five minutes regardless of the client wait — and no `creatingTimeout` at all, which defaults to 10m and would have capped a *single attempt* above the client wait. Both are set explicitly now, with the relationship written next to them.

## Scope

**Single-server only.** `servers > 1` is still rejected outright for this backend (#7), so this leg proves the single-server path and nothing more — the same scope the k3s leg started with. The `ci.yml` comment says so, since "k0s is covered" would otherwise read as more than it is.

## Written classification-first

Flipping `BackendType::K0s` to conformance-covered failed the guard until the matrix entry existed:

```
K0s is classified as conformance-covered by leg k0s, but ci.yml's
conformance matrix does not include it
```

And removing the `case` arm fails it the other way:

```
leg k0s is in the conformance matrix but no case arm runs a smoke
recipe for it — it would fall through to `unknown backend`
```

Both directions checked, so the leg can't be half-wired.

## Same caveat as vcluster

The leg is `continue-on-error` (everything except k3s is), and **the conformance job doesn't run on `pull_request`** — so green CI here does not mean the kind harness path works. A `workflow_dispatch` is what proves it provisions. Tracked with the same caveat on #36.

## Verification

`cargo test --workspace` green (736 operator), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean, `hack/e2e.ts` type-checks, `just --list` shows the new recipe.