### PR TITLE
chore(release): bump workspace version to 0.38.0

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,16 +67,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Cache cargo registry & build
-        uses: actions/cache@v4
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: cargo-${{ runner.os }}-${{ hashFiles('Cargo.lock') }}
-          restore-keys: cargo-${{ runner.os }}-
-
       - name: Add Rust components
         run: rustup component add rustfmt clippy
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2717,7 +2717,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.37.0"
+version = "0.38.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.37.0"
+version = "0.38.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.37.0
-appVersion: "0.37.0"
+version: 0.38.0
+appVersion: "0.38.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.37.0
+      image: docker.io/zondax/kobe-operator:v0.38.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.37.0
+      image: docker.io/zondax/kobe-sync:v0.38.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
## Summary

- bump the Rust workspace packages to `0.38.0`
- bump the Helm chart version and appVersion to `0.38.0`
- update first-party Artifact Hub image references to `v0.38.0`
- remove the GitHub Actions Cargo cache step, whose release cache misses uploaded multi-gigabyte archives after every successful check

## Why

Prepare the v0.38.0 release, including the pool/lease lifecycle fixes merged since v0.37.0. This release is needed to move production off the v0.37.0 behavior that allowed overlapping leases on one cluster and recycled that cluster underneath an active lease.

The previous PR run spent 10m45s compressing and uploading a 5.2 GB Cargo cache after all substantive checks had already passed. Cold compilation is cheaper than that release-cache miss, so CI now runs without the GitHub-hosted Cargo cache.

## Validation

- `just check`
- `./scripts/check-version-consistency.sh`
- GitHub Actions Rust Checks without the Cargo cache
