### PR TITLE
test: cover the CRD types and CLI helpers that had no tests

### DIFF
--- a/crates/kobectl/src/commands/status.rs
+++ b/crates/kobectl/src/commands/status.rs
@@ -259,3 +259,37 @@ async fn enrich_leases(
 
     enriched
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The SSH hint fires on the one failure it can actually explain, and
+    /// stays quiet otherwise.
+    ///
+    /// "no key found in SSH agent" is the failure a user cannot diagnose from
+    /// the message alone — the fix is environmental (`SSH_AUTH_SOCK`,
+    /// `ssh-add -l`), not something they typed wrong. Attaching that hint to
+    /// unrelated auth failures would send people chasing their agent when the
+    /// real problem is an expired token or a bad issuer.
+    #[test]
+    fn the_ssh_hint_is_offered_only_for_the_failure_it_explains() {
+        assert!(
+            auth_error_hint("no matching key found in SSH agent").is_some(),
+            "the agent-lookup failure is the case this hint exists for"
+        );
+
+        for unrelated in [
+            "token expired",
+            "invalid issuer",
+            "connection refused",
+            "403 Forbidden",
+            "",
+        ] {
+            assert!(
+                auth_error_hint(unrelated).is_none(),
+                "must not offer an SSH-agent hint for: {unrelated:?}"
+            );
+        }
+    }
+}

--- a/crates/kobectl/src/commands/with_lease.rs
+++ b/crates/kobectl/src/commands/with_lease.rs
@@ -187,3 +187,53 @@ async fn wait_for_child_or_signal(child: &mut tokio::process::Child, verbose: bo
     let _ = child.wait().await;
     130
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `with-lease` wraps a user command and becomes its exit status. Anything
+    /// that is not a clean coded exit MUST map to non-zero.
+    ///
+    /// This is the whole contract of the wrapper in CI: `kobe with-lease -- <cmd>`
+    /// stands in for `<cmd>`, so mapping a signal death or a wait failure to 0
+    /// would turn a crashed test suite into a green pipeline — the one failure
+    /// mode a CI wrapper must never have.
+    #[test]
+    fn a_command_that_did_not_exit_cleanly_is_never_reported_as_success() {
+        #[cfg(unix)]
+        {
+            use std::os::unix::process::ExitStatusExt;
+
+            // Killed by SIGKILL: no exit code at all.
+            let signalled = std::process::ExitStatus::from_raw(9);
+            assert_eq!(
+                exit_code(Ok(signalled)),
+                1,
+                "a signal-killed child has no exit code and must not read as success"
+            );
+        }
+
+        // The wait itself failed — we never learned the outcome, so assume the
+        // worst rather than claiming success.
+        let failed_wait = Err(std::io::Error::other("wait failed"));
+        assert_eq!(exit_code(failed_wait), 1);
+    }
+
+    /// A clean exit is passed through verbatim, success and failure alike —
+    /// callers branch on the specific code, not just zero/non-zero.
+    #[cfg(unix)]
+    #[test]
+    fn a_clean_exit_code_is_propagated_verbatim() {
+        use std::os::unix::process::ExitStatusExt;
+
+        for code in [0, 1, 2, 42, 127] {
+            let status = std::process::ExitStatus::from_raw(code << 8);
+            assert_eq!(
+                exit_code(Ok(status)),
+                code,
+                "exit code {code} must survive the wrapper unchanged"
+            );
+        }
+    }
+}

--- a/src/crd/access_policy.rs
+++ b/src/crd/access_policy.rs
@@ -162,3 +162,199 @@ fn default_algorithms() -> Vec<String> {
 fn default_max_extensions() -> u32 {
     2
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn rule_json() -> serde_json::Value {
+        serde_json::json!({
+            "pools": ["ci-*"],
+            "maxTtl": "1h",
+            "maxConcurrentLeases": 5
+        })
+    }
+
+    /// `match_clause` is spelled `match` on the wire — it has to be, since
+    /// `match` is a Rust keyword.
+    ///
+    /// This is the whole multi-role OIDC mechanism. If the rename were lost,
+    /// a rule's match clause would deserialize as absent, and a rule scoped
+    /// to one role would start applying to every caller the policy
+    /// authenticates. That is an authorization widening, and nothing else in
+    /// the type would look wrong.
+    #[test]
+    fn match_clause_is_named_match_on_the_wire() {
+        let mut json = rule_json();
+        json["match"] = serde_json::json!({ "claim": "role", "value": "admin" });
+        let rule: AccessRule = serde_json::from_value(json).unwrap();
+        let m = rule
+            .match_clause
+            .as_ref()
+            .expect("`match` must bind to match_clause");
+        assert_eq!(m.claim, "role");
+        assert_eq!(m.value, "admin");
+
+        // And it round-trips back under the same key.
+        let v = serde_json::to_value(&rule).unwrap();
+        assert!(
+            v.get("match").is_some() && v.get("matchClause").is_none(),
+            "must serialize as `match`, got: {v}"
+        );
+    }
+
+    /// A rule written with the Rust field name must NOT silently become an
+    /// unscoped rule. `matchClause` is not the wire name, so it is ignored —
+    /// and an ignored match clause means the rule applies to everyone.
+    /// Pinned so the failure mode is visible if anyone "fixes" the rename.
+    #[test]
+    fn a_mis_spelled_match_clause_does_not_scope_the_rule() {
+        let mut json = rule_json();
+        json["matchClause"] = serde_json::json!({ "claim": "role", "value": "admin" });
+        let rule: AccessRule = serde_json::from_value(json).unwrap();
+        assert!(
+            rule.match_clause.is_none(),
+            "only `match` binds; if this ever starts binding, the rename changed"
+        );
+    }
+
+    /// The two ceilings are REQUIRED, deliberately. Giving either a default
+    /// would let a policy that forgot them be admitted with a silent value
+    /// instead of rejected — the difference between "no TTL cap configured"
+    /// and "some cap I never chose".
+    #[test]
+    fn the_lease_ceilings_have_no_default_and_must_be_declared() {
+        let missing_ttl = serde_json::json!({ "pools": ["*"], "maxConcurrentLeases": 1 });
+        assert!(
+            serde_json::from_value::<AccessRule>(missing_ttl).is_err(),
+            "maxTtl must be required"
+        );
+
+        let missing_quota = serde_json::json!({ "pools": ["*"], "maxTtl": "1h" });
+        assert!(
+            serde_json::from_value::<AccessRule>(missing_quota).is_err(),
+            "maxConcurrentLeases must be required"
+        );
+
+        let missing_pools = serde_json::json!({ "maxTtl": "1h", "maxConcurrentLeases": 1 });
+        assert!(
+            serde_json::from_value::<AccessRule>(missing_pools).is_err(),
+            "pools must be required — a rule with no pool scope is not a rule"
+        );
+    }
+
+    /// snake_case keys do not bind. The apiserver stores what the CRD schema
+    /// declares (camelCase), so a snake_case manifest field is dropped as
+    /// unknown — and for a required field that surfaces as a rejection rather
+    /// than a policy quietly missing its ceiling.
+    #[test]
+    fn rule_binds_camel_case_keys_only() {
+        let snake = serde_json::json!({
+            "pools": ["*"],
+            "max_ttl": "1h",
+            "max_concurrent_leases": 5
+        });
+        assert!(
+            serde_json::from_value::<AccessRule>(snake).is_err(),
+            "snake_case must not bind — it would drop the ceilings"
+        );
+    }
+
+    /// Defaults are load-bearing values, not formalities: `maxExtensions`
+    /// bounds how far a lease's TTL can be pushed past its original grant.
+    #[test]
+    fn max_extensions_defaults_to_two() {
+        let rule: AccessRule = serde_json::from_value(rule_json()).unwrap();
+        assert_eq!(rule.max_extensions, 2);
+
+        let mut explicit = rule_json();
+        explicit["maxExtensions"] = serde_json::json!(0);
+        let rule: AccessRule = serde_json::from_value(explicit).unwrap();
+        assert_eq!(rule.max_extensions, 0, "an explicit 0 must be honoured");
+    }
+
+    /// The identity template decides WHO a caller is taken to be. Defaulting
+    /// to anything other than the subject claim would silently re-map every
+    /// OIDC identity in a policy that omits it.
+    #[test]
+    fn identity_template_defaults_to_the_subject_claim() {
+        let spec: AccessPolicySpec = serde_json::from_value(serde_json::json!({
+            "auth": { "token": { "secretRef": "kobe-token" } },
+            "rules": [rule_json()]
+        }))
+        .unwrap();
+        assert_eq!(spec.identity, "{sub}");
+    }
+
+    /// JWT algorithms default to RS256 — asymmetric, never an HMAC family.
+    /// An empty or symmetric default is the classic algorithm-confusion
+    /// footgun, where a token signed with the public key as an HMAC secret
+    /// validates.
+    #[test]
+    fn oidc_algorithms_default_to_an_asymmetric_algorithm() {
+        let oidc: OidcAuth = serde_json::from_value(serde_json::json!({
+            "issuer": "https://issuer.example",
+            "audience": ["kobe"]
+        }))
+        .unwrap();
+        assert_eq!(oidc.algorithms, vec!["RS256".to_string()]);
+        assert!(
+            !oidc.algorithms.is_empty(),
+            "an empty algorithm list must never be the default"
+        );
+        for alg in &oidc.algorithms {
+            assert!(
+                !alg.starts_with("HS"),
+                "an HMAC algorithm must never be defaulted in: {alg}"
+            );
+        }
+    }
+
+    /// Every auth method is optional, so a policy naming none still parses.
+    /// That is deliberate — provider registration skips such a policy rather
+    /// than failing the whole reconcile — but it means the SKIP is what
+    /// enforces safety, so the parse must stay permissive on purpose.
+    #[test]
+    fn an_auth_block_naming_no_method_still_parses() {
+        let auth: AuthMethod = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert!(auth.oidc.is_none());
+        assert!(auth.token.is_none());
+        assert!(auth.service_account.is_none());
+        assert!(auth.ssh.is_none());
+    }
+
+    /// The CRD's public identity. Changing any of it breaks every manifest
+    /// and `kubectl` invocation in the wild.
+    #[test]
+    fn crd_identity_is_stable() {
+        use kube::CustomResourceExt;
+        let crd = serde_json::to_value(AccessPolicy::crd()).unwrap();
+
+        assert_eq!(crd["spec"]["group"], "kobe.kunobi.ninja");
+        assert_eq!(crd["spec"]["scope"], "Namespaced");
+        assert_eq!(crd["spec"]["names"]["kind"], "AccessPolicy");
+        assert_eq!(crd["spec"]["names"]["plural"], "accesspolicies");
+        assert_eq!(crd["spec"]["names"]["shortNames"][0], "ap");
+        assert_eq!(crd["metadata"]["name"], "accesspolicies.kobe.kunobi.ninja");
+
+        let versions = crd["spec"]["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["name"], "v1alpha1");
+        assert_eq!(versions[0]["served"], true);
+        assert_eq!(versions[0]["storage"], true);
+    }
+
+    /// A policy written by a newer operator must still deserialize, or a
+    /// rolling upgrade wedges the older replica on every policy it reads —
+    /// which for this type means it stops authenticating anyone.
+    #[test]
+    fn a_policy_from_a_newer_operator_still_deserializes() {
+        let spec: AccessPolicySpec = serde_json::from_value(serde_json::json!({
+            "auth": { "token": { "secretRef": "kobe-token" } },
+            "rules": [rule_json()],
+            "someFieldFromTheFuture": { "nested": true }
+        }))
+        .expect("unknown fields must be ignored, not rejected");
+        assert_eq!(spec.rules.len(), 1);
+    }
+}

--- a/src/crd/cidr.rs
+++ b/src/crd/cidr.rs
@@ -202,3 +202,144 @@ pub enum CIDRPoolPhase {
     /// See `message`.
     Invalid,
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The allocated CIDRs must be OMITTED when unset, never serialized as
+    /// null.
+    ///
+    /// This is the allocation record. A controller doing pass-through
+    /// preservation that momentarily reads them as `None` would, with an
+    /// explicit null, erase them via JSON Merge Patch (RFC 7396) — and the
+    /// allocator derives the in-use set by listing bound claims. A cleared
+    /// allocation is therefore not a display bug: the slot looks free and
+    /// gets re-issued to a second cluster, which is the CIDR-collision class
+    /// this type exists to prevent.
+    #[test]
+    fn an_unset_allocation_is_omitted_so_merge_patch_cannot_erase_it() {
+        let unbound = CIDRClaimStatus {
+            phase: CIDRClaimPhase::Pending,
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&unbound).unwrap();
+        for key in ["serviceCidr", "clusterCidr", "boundAt", "message"] {
+            assert!(
+                v.get(key).is_none(),
+                "{key} must be omitted when unset, not null: {v}"
+            );
+        }
+
+        let bound = CIDRClaimStatus {
+            phase: CIDRClaimPhase::Bound,
+            service_cidr: Some("10.240.0.0/20".into()),
+            cluster_cidr: Some("10.248.0.0/20".into()),
+            ..Default::default()
+        };
+        let v = serde_json::to_value(&bound).unwrap();
+        assert_eq!(
+            v.get("serviceCidr").and_then(|x| x.as_str()),
+            Some("10.240.0.0/20")
+        );
+        assert_eq!(
+            v.get("clusterCidr").and_then(|x| x.as_str()),
+            Some("10.248.0.0/20")
+        );
+    }
+
+    /// A claim with no status yet is `Pending`, never `Bound`. Defaulting to
+    /// `Bound` would make an unreconciled claim advertise an allocation it
+    /// does not have — and its `service_cidr` would be `None`, so it would
+    /// claim a slot of nothing.
+    #[test]
+    fn phase_defaults_to_pending() {
+        let st: CIDRClaimStatus = serde_json::from_value(serde_json::json!({})).unwrap();
+        assert_eq!(st.phase, CIDRClaimPhase::Pending);
+        assert_eq!(CIDRClaimPhase::default(), CIDRClaimPhase::Pending);
+    }
+
+    /// Phase round-trips as the bare variant name for every state. The IPAM
+    /// controller and the pool manager both branch on this value.
+    #[test]
+    fn phase_round_trips_as_the_bare_variant_name() {
+        for (phase, wire) in [
+            (CIDRClaimPhase::Pending, "Pending"),
+            (CIDRClaimPhase::Bound, "Bound"),
+            (CIDRClaimPhase::Conflict, "Conflict"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(&phase).unwrap(),
+                serde_json::Value::String(wire.to_string())
+            );
+            let back: CIDRClaimPhase = serde_json::from_str(&format!("\"{wire}\"")).unwrap();
+            assert_eq!(back, phase);
+        }
+    }
+
+    /// Static reservations are requested in camelCase. A snake_case key is
+    /// dropped as unknown, which for an optional field means the pin is
+    /// silently ignored and the allocator hands out a dynamic slot instead
+    /// of the one that was asked for.
+    #[test]
+    fn a_static_reservation_binds_camel_case_only() {
+        let camel: CIDRClaimSpec = serde_json::from_value(serde_json::json!({
+            "requestedServiceCidr": "10.240.0.0/20"
+        }))
+        .unwrap();
+        assert_eq!(
+            camel.requested_service_cidr.as_deref(),
+            Some("10.240.0.0/20")
+        );
+
+        let snake: CIDRClaimSpec = serde_json::from_value(serde_json::json!({
+            "requested_service_cidr": "10.240.0.0/20"
+        }))
+        .unwrap();
+        assert!(
+            snake.requested_service_cidr.is_none(),
+            "snake_case must not bind — pinning would be silently ignored"
+        );
+    }
+
+    /// A status written by a newer operator must still deserialize, or a
+    /// rolling upgrade wedges the older replica on every claim it reads.
+    #[test]
+    fn a_status_from_a_newer_operator_still_deserializes() {
+        let st: CIDRClaimStatus = serde_json::from_value(serde_json::json!({
+            "phase": "Bound",
+            "serviceCidr": "10.240.0.0/20",
+            "someFieldFromTheFuture": true
+        }))
+        .expect("unknown fields must be ignored");
+        assert_eq!(st.phase, CIDRClaimPhase::Bound);
+        assert_eq!(st.service_cidr.as_deref(), Some("10.240.0.0/20"));
+    }
+
+    /// Both IPAM CRDs' public identity, and that the claim carries a real
+    /// status subresource — without it the apiserver drops every allocation
+    /// the controller writes and no claim ever binds.
+    #[test]
+    fn crd_identities_are_stable() {
+        use kube::CustomResourceExt;
+
+        let claim = serde_json::to_value(CIDRClaim::crd()).unwrap();
+        assert_eq!(claim["spec"]["group"], "kobe.kunobi.ninja");
+        assert_eq!(claim["spec"]["names"]["kind"], "CIDRClaim");
+        assert_eq!(claim["spec"]["names"]["plural"], "cidrclaims");
+        assert_eq!(claim["spec"]["names"]["shortNames"][0], "cclaim");
+        assert_eq!(claim["metadata"]["name"], "cidrclaims.kobe.kunobi.ninja");
+        let versions = claim["spec"]["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["name"], "v1alpha1");
+        assert!(
+            versions[0]["subresources"].get("status").is_some(),
+            "CIDRClaim must have a status subresource or allocations are dropped"
+        );
+
+        let pool = serde_json::to_value(CIDRPool::crd()).unwrap();
+        assert_eq!(pool["spec"]["names"]["kind"], "CIDRPool");
+        assert_eq!(pool["spec"]["names"]["plural"], "cidrpools");
+        assert_eq!(pool["spec"]["names"]["shortNames"][0], "cpool");
+    }
+}

--- a/src/crd/datastore.rs
+++ b/src/crd/datastore.rs
@@ -168,3 +168,74 @@ impl KobeStoreStatus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The driver's wire values are kebab-case and explicitly renamed, which
+    /// `rename_all = "camelCase"` would NOT produce for `KineSqlite`.
+    ///
+    /// These strings are what every existing KobeStore has stored. Losing the
+    /// rename would make `kine-sqlite` fail to deserialize, and a KobeStore
+    /// that cannot be read is a datastore the operator stops reconciling —
+    /// while the guests depending on it keep running.
+    #[test]
+    fn driver_wire_values_are_the_kebab_case_names() {
+        for (driver, wire) in [
+            (KobeStoreDriver::Etcd, "etcd"),
+            (KobeStoreDriver::KineSqlite, "kine-sqlite"),
+        ] {
+            assert_eq!(
+                serde_json::to_value(&driver).unwrap(),
+                serde_json::Value::String(wire.to_string()),
+                "{driver:?} must serialize as {wire:?}"
+            );
+            let back: KobeStoreDriver = serde_json::from_str(&format!("\"{wire}\"")).unwrap();
+            assert_eq!(
+                serde_json::to_value(back).unwrap(),
+                serde_json::Value::String(wire.to_string()),
+                "{wire:?} must round-trip"
+            );
+        }
+
+        // The camelCase spelling is NOT accepted — asserted so that adding a
+        // rename_all here can't silently change the stored vocabulary.
+        assert!(
+            serde_json::from_str::<KobeStoreDriver>("\"kineSqlite\"").is_err(),
+            "camelCase must not be an accepted driver spelling"
+        );
+    }
+
+    /// The supported driver set, pinned. Adding one is a deliberate act with
+    /// backend work behind it (#18 tracks Postgres/MySQL/NATS), so it should
+    /// not be possible to widen this by accident.
+    #[test]
+    fn only_the_two_implemented_drivers_are_accepted() {
+        for unsupported in ["postgres", "postgresql", "mysql", "nats", "sqlite", ""] {
+            assert!(
+                serde_json::from_str::<KobeStoreDriver>(&format!("\"{unsupported}\"")).is_err(),
+                "{unsupported:?} must not deserialize as a driver — it has no backend"
+            );
+        }
+    }
+
+    /// The CRD's public identity.
+    #[test]
+    fn crd_identity_is_stable() {
+        use kube::CustomResourceExt;
+        let crd = serde_json::to_value(KobeStore::crd()).unwrap();
+
+        assert_eq!(crd["spec"]["group"], "kobe.kunobi.ninja");
+        assert_eq!(crd["spec"]["names"]["kind"], "KobeStore");
+        assert_eq!(crd["spec"]["names"]["plural"], "kobestores");
+        assert_eq!(crd["spec"]["names"]["shortNames"][0], "ks");
+        assert_eq!(crd["metadata"]["name"], "kobestores.kobe.kunobi.ninja");
+
+        let versions = crd["spec"]["versions"].as_array().unwrap();
+        assert_eq!(versions.len(), 1);
+        assert_eq!(versions[0]["name"], "v1alpha1");
+        assert_eq!(versions[0]["served"], true);
+        assert_eq!(versions[0]["storage"], true);
+    }
+}


### PR DESCRIPTION
`access_policy.rs`, `cidr.rs` and `datastore.rs` had **zero tests** between them. All three encode contracts that fail *silently* when broken — the type still compiles, the manifest still applies, and the behaviour changes.

## `access_policy.rs` — 10 tests

This is the authorization CRD, so the failure modes are the interesting ones:

- **`match_clause` must serialize as `match`.** The rename isn't cosmetic — `match` is a Rust keyword, so the field *has* to be renamed, and that rename is the entire multi-role OIDC mechanism. Lose it and a rule scoped to one role deserializes with **no match clause**, which means it applies to every caller the policy authenticates. An authorization widening, with nothing else in the type looking wrong.
- **`maxTtl`, `maxConcurrentLeases`, `pools` are required on purpose.** A default on any of them turns "this policy forgot its ceiling" from a rejection into a silent value nobody chose.
- **`identity` defaults to `{sub}`** — it decides who a caller is taken to be.
- **OIDC `algorithms` defaults to RS256**, asserted non-empty and never an `HS*` family. An empty or symmetric default is the classic algorithm-confusion footgun.

## `cidr.rs` — 6 tests

- **Allocated CIDRs must be omitted when unset, never null.** The allocator derives its in-use set by listing bound claims, so a Merge-Patch that erases one doesn't just lose a display value — the slot reads as *free* and gets re-issued to a second cluster. That's the collision class the module's own doc-comment warns about.
- **Phase defaults to `Pending`**, so an unreconciled claim can't advertise an allocation it doesn't have.

## `datastore.rs` — 3 tests

- **Driver wire values are kebab-case explicit renames** that `rename_all = "camelCase"` would not produce for `KineSqlite`. Losing the rename makes every stored `kine-sqlite` KobeStore unreadable — and an unreadable datastore stops being reconciled while the guests depending on it keep running.
- **The supported set is pinned** so it can't widen by accident; adding a driver is deliberate work (#18).

## Mutation-checked

Five seeded regressions, each caught:

| mutation | caught by |
|---|---|
| drop the `match` rename | `match_clause_is_named_match_on_the_wire` |
| give `maxTtl` a default | `the_lease_ceilings_have_no_default_and_must_be_declared` |
| default algorithms to `HS256` | `oidc_algorithms_default_to_an_asymmetric_algorithm` |
| serialize an unset CIDR as null | `an_unset_allocation_is_omitted_so_merge_patch_cannot_erase_it` |
| drop the `kine-sqlite` rename | `driver_wire_values_are_the_kebab_case_names` |

## Verification

`cargo test --workspace` green (755 operator, up from 736), `cargo fmt --check` and `cargo clippy --workspace --all-targets` clean.