### PR TITLE
fix(ci): pass backend into e2e image preload

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,6 +67,17 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Set up Bun for E2E harness tests
+        uses: jdx/mise-action@v2
+        with:
+          install_args: bun
+          cache: false
+
+      - name: Lint and test E2E harness
+        run: |
+          mise exec -- bunx @biomejs/biome@2.3.11 lint --only=correctness/noUndeclaredVariables hack/*.ts
+          mise exec -- bun test ./hack/e2e.test.ts
+
       - name: Add Rust components
         run: rustup component add rustfmt clippy
 

--- a/biome.json
+++ b/biome.json
@@ -1,0 +1,6 @@
+{
+  "$schema": "https://biomejs.dev/schemas/2.3.11/schema.json",
+  "javascript": {
+    "globals": ["Bun"]
+  }
+}

--- a/hack/e2e.test.ts
+++ b/hack/e2e.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+
+import { guestImagesForBackend, parseArgs } from "./e2e";
+
+test("k3s only preloads the always-warm k3s guest image", () => {
+  const args = parseArgs(["up", "--backend", "k3s"]);
+
+  expect(guestImagesForBackend(args.backend)).toEqual(["rancher/k3s:v1.31.3-k3s1"]);
+});
+
+test("k0s also preloads its on-demand guest image", () => {
+  const args = parseArgs(["up", "--backend", "k0s"]);
+
+  expect(guestImagesForBackend(args.backend)).toEqual([
+    "rancher/k3s:v1.31.3-k3s1",
+    "k0sproject/k0s:v1.35.1-k0s.0",
+  ]);
+});

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -243,7 +243,7 @@ function canReuseExistingEnvironment(args: Args, fingerprint: string): boolean {
   );
 }
 
-function parseArgs(argv: string[]): Args {
+export function parseArgs(argv: string[]): Args {
   const args = {
     command: "up" as const,
     cluster: DEFAULT_CLUSTER,
@@ -463,7 +463,19 @@ async function loadRemoteImagesIntoKind(cluster: string, images: string[]): Prom
   }
 }
 
-async function loadImagesIntoKind(cluster: string, imageTag: string): Promise<void> {
+export function guestImagesForBackend(backend?: string): string[] {
+  const images = [K3S_GUEST_IMAGE];
+  if (backend === "k0s") {
+    images.push(K0S_GUEST_IMAGE);
+  }
+  return images;
+}
+
+async function loadImagesIntoKind(
+  cluster: string,
+  imageTag: string,
+  backend?: string,
+): Promise<void> {
   step(`Loading images into kind cluster '${cluster}'`);
   await saveImages(imageTag);
 
@@ -487,11 +499,7 @@ async function loadImagesIntoKind(cluster: string, imageTag: string): Promise<vo
   // leg with a pull it never uses (and add a registry dependency, which is a
   // fresh way for an unrelated leg to fail). Pull those only when the leg
   // that needs them is the one coming up.
-  const guestImages = [K3S_GUEST_IMAGE];
-  if (args.backend === "k0s") {
-    guestImages.push(K0S_GUEST_IMAGE);
-  }
-  await loadRemoteImagesIntoKind(cluster, guestImages);
+  await loadRemoteImagesIntoKind(cluster, guestImagesForBackend(backend));
 }
 
 async function prepareHelm(): Promise<void> {
@@ -1190,7 +1198,7 @@ async function up(args: Args): Promise<void> {
 
   await ensureCluster(args.cluster);
   await buildImages(args.imageTag);
-  await loadImagesIntoKind(args.cluster, args.imageTag);
+  await loadImagesIntoKind(args.cluster, args.imageTag, args.backend);
   await prepareHelm();
   await runCommand(["/bin/sh", "-lc", `kubectl --context ${kubeContext(args.cluster)} create namespace ${args.namespace} --dry-run=client -o yaml | kubectl --context ${kubeContext(args.cluster)} apply -f -`], {
     step: `failed to ensure namespace '${args.namespace}'`,
@@ -1234,4 +1242,6 @@ async function main() {
   }
 }
 
-await main();
+if (import.meta.main) {
+  await main();
+}


### PR DESCRIPTION
Fixes the main conformance failure in run 31418572244 that blocked v0.38.0.

Root cause: loadImagesIntoKind referenced args.backend outside the args scope after the k0s matrix change. Pass the parsed backend explicitly and keep k0s image preloading scoped to the k0s leg.

Regression coverage:
- Pin k3s and k0s guest-image selection with Bun tests.
- Gate all hack TypeScript files with the pinned Biome undeclared-variable rule.
- Disable the mise cache for this small setup step.

Local validation:
- Biome undeclared-variable lint: clean across hack/*.ts
- Bun tests: 2 passed
- E2E harness help smoke: passed