### PR TITLE
fix(ci): avoid pipefail race in release gate tests

### DIFF
--- a/scripts/test-version-consistency.sh
+++ b/scripts/test-version-consistency.sh
@@ -58,7 +58,9 @@ expect() {
     echo "FAIL: $name — expected rc=$want_rc, got rc=$rc"
     echo "      output: $out"
     fail=$((fail + 1))
-  elif [ -n "$want_sub" ] && ! printf '%s' "$out" | grep -qF -- "$want_sub"; then
+  # Match in memory: with pipefail, `grep -q` can close the pipe after a match
+  # and turn printf's resulting SIGPIPE into a false test failure.
+  elif [ -n "$want_sub" ] && [[ "$out" != *"$want_sub"* ]]; then
     echo "FAIL: $name — output did not mention: $want_sub"
     echo "      output: $out"
     fail=$((fail + 1))


### PR DESCRIPTION
Unblocks the v0.38.0 release after main run 31422824397 produced false-negative version-consistency tests.

Root cause: with pipefail enabled, grep -q can exit as soon as it finds the expected substring; printf then receives SIGPIPE, making the pipeline nonzero even though the expected text was present.

Use Bash literal substring matching against the captured output instead. This has no pipeline and preserves the exact assertion semantics.

Validation:
- bash syntax check: passed
- version-consistency suite: 11/11 passed
- stress run: 20/20 full-suite iterations passed
- v0.38.0 manifest/tag consistency: passed