### PR TITLE
api(sandbox): add SandboxPool/SandboxLease APIs and the atomic admission ledger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Verify CRDs match generated output
         run: |
-          for crd in clusterpools clusterleases accesspolicies kobestores cidrpools; do
+          for crd in clusterpools clusterleases clusterinstances bootstrapconfigs accesspolicies kobestores cidrclaims cidrpools sandboxpools sandboxleases; do
             cargo run --quiet --bin crdgen -- "$crd" > "/tmp/${crd}-generated.yaml"
             diff -u "/tmp/${crd}-generated.yaml" "charts/kobe/crds/${crd}.yaml" || {
               echo "::error::CRD '${crd}' is out of date. Run 'cargo run --bin crdgen -- ${crd} > charts/kobe/crds/${crd}.yaml' to update."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,6 +68,7 @@ futures = "0.3"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+sha2 = "0.10"
 serde_yaml_ng = "0.10"
 toml = "0.8"
 json-patch = "4"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,6 @@ futures = "0.3"
 # Serialization
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
-sha2 = "0.10"
 serde_yaml_ng = "0.10"
 toml = "0.8"
 json-patch = "4"

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ When a client leases a cluster, Kobe binds one from the warm pool instantly. Whe
 | `PATCH` | `/v1/leases/:id` | Extend a lease TTL |
 | `GET` | `/v1/pools` | List available pools with status |
 | `GET` | `/v1/pools/:name` | Get a specific pool's status |
+| `POST` | `/v1/sandbox-leases` | Create caller-safe Sandbox lease intent |
+| `GET` | `/v1/sandbox-leases` | List your Sandbox leases |
+| `GET` | `/v1/sandbox-leases/:id` | Get a Sandbox lease's lifecycle state |
+| `DELETE` | `/v1/sandbox-leases/:id` | Request Sandbox lease release |
 | `GET` | `/v1/status` | Endpoint status + auth methods (no auth required) |
 
 See [docs/kobe-docs/api/reference.mdx](docs/kobe-docs/api/reference.mdx) for full request/response shapes.
@@ -91,6 +95,8 @@ Kobe is driven by a small set of CRDs (group `kobe.kunobi.ninja/v1alpha1`):
 - **`ClusterPool`** — a pool of warm clusters with a backend, sizing, and default TTL.
 - **`ClusterInstance`** — one provisioned cluster, managed by a pool.
 - **`ClusterLease`** — binds a requester to an instance (created by the HTTP API, not authored directly).
+- **`SandboxPool`** — an administrator-owned class of bounded Agent Sandbox capacity and placement.
+- **`SandboxLease`** — caller-safe disposable Sandbox intent (created by the HTTP API).
 - **`AccessPolicy`** — who may lease which pools, with TTL / concurrency / extension caps.
 - **`KobeStore`** — datastore config for backends that externalize control-plane state.
 

--- a/charts/kobe/crds/accesspolicies.yaml
+++ b/charts/kobe/crds/accesspolicies.yaml
@@ -165,6 +165,65 @@ spec:
                       items:
                         type: string
                       type: array
+                    sandbox:
+                      description: |-
+                        Optional, kind-specific Agent Sandbox permissions. Older policy objects
+                        omit this block and continue authorizing Cluster leases exactly as
+                        before, while Sandbox operations fail closed.
+                      nullable: true
+                      properties:
+                        maxConcurrentLeases:
+                          description: |-
+                            Maximum active Sandbox leases for this identity, separate from Cluster
+                            lease concurrency.
+                          format: uint32
+                          minimum: 0.0
+                          type: integer
+                        maxTtl:
+                          description: Maximum runtime TTL, starting only once the Sandbox is Ready.
+                          minLength: 1
+                          type: string
+                        pools:
+                          description: SandboxPool name patterns; wildcard semantics match Cluster pools.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                        resourceCeiling:
+                          description: Aggregate per-Sandbox CPU and memory ceiling.
+                          properties:
+                            maxCpu:
+                              minLength: 1
+                              type: string
+                            maxMemory:
+                              minLength: 1
+                              type: string
+                          required:
+                          - maxCpu
+                          - maxMemory
+                          type: object
+                        verbs:
+                          description: Independently authorized Sandbox operations.
+                          items:
+                            description: |-
+                              Agent Sandbox authorization verbs. `lease` includes create and own-object
+                              reads; `release` remains independently revocable.
+                            enum:
+                            - lease
+                            - exec
+                            - logs
+                            - port-forward
+                            - release
+                            type: string
+                          minItems: 1
+                          type: array
+                      required:
+                      - maxConcurrentLeases
+                      - maxTtl
+                      - pools
+                      - resourceCeiling
+                      - verbs
+                      type: object
                   required:
                   - maxConcurrentLeases
                   - maxTtl

--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -36,23 +36,50 @@ spec:
                 nullable: true
                 type: string
               poolRef:
-                minLength: 1
-                type: string
+                description: |-
+                  Exact SandboxPool admitted by Kobe. UID and generation fence pool
+                  recreation or mutation between HTTP admission and placement.
+                properties:
+                  generation:
+                    format: int64
+                    minimum: 1.0
+                    type: integer
+                  name:
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  uid:
+                    minLength: 1
+                    type: string
+                required:
+                - generation
+                - name
+                - uid
+                type: object
               requester:
                 description: |-
                   Set by Kobe from the authenticated principal, never trusted from an HTTP
-                  request body.
+                  request body. Ownership uses the complete tuple, not the display
+                  identity alone.
                 properties:
                   identity:
-                    description: |-
-                      Identity string (e.g. "repo:org/repo:ref:refs/heads/main" for GitHub,
-                      or user ID for Clerk).
+                    minLength: 1
+                    type: string
+                  issuer:
+                    minLength: 1
+                    type: string
+                  provider:
+                    description: Stable configured authentication provider ID.
+                    minLength: 1
                     type: string
                   type:
-                    description: 'Type of requester: "{provider}:{role}" (e.g. "github-actions:ci", "clerk:admin").'
+                    minLength: 1
                     type: string
                 required:
                 - identity
+                - issuer
+                - provider
                 - type
                 type: object
               ttl:
@@ -71,17 +98,24 @@ spec:
                   description: Kubernetes-style condition with the generation from which it was derived.
                   properties:
                     lastTransitionTime:
+                      format: date-time
                       nullable: true
                       type: string
                     message:
                       type: string
                     observedGeneration:
                       format: int64
+                      minimum: 0.0
                       nullable: true
                       type: integer
                     reason:
                       type: string
                     status:
+                      description: Kubernetes Condition status values.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
                       type: string
                     type:
                       type: string
@@ -92,12 +126,17 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               expiresAt:
                 description: Set only when the upstream Sandbox becomes Ready.
+                format: date-time
                 nullable: true
                 type: string
               observedGeneration:
                 format: int64
+                minimum: 0.0
                 nullable: true
                 type: integer
               phase:
@@ -125,6 +164,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -159,9 +199,11 @@ spec:
                   rule: (self.type == 'management' && !has(self.clusterPool)) || (self.type == 'childCluster' && has(self.clusterPool))
               provisioningDeadline:
                 description: Absolute bound for setup. This is not the runtime expiry.
+                format: date-time
                 nullable: true
                 type: string
               readyAt:
+                format: date-time
                 nullable: true
                 type: string
               target:
@@ -179,6 +221,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -209,6 +252,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -242,6 +286,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -272,6 +317,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -302,6 +348,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -332,6 +379,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:
@@ -362,6 +410,7 @@ spec:
                         type: string
                       generation:
                         format: int64
+                        minimum: 0.0
                         nullable: true
                         type: integer
                       kind:

--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -1,0 +1,397 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sandboxleases.kobe.kunobi.ninja
+spec:
+  group: kobe.kunobi.ninja
+  names:
+    categories: []
+    kind: SandboxLease
+    plural: sandboxleases
+    shortNames:
+    - sl
+    singular: sandboxlease
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.expiresAt
+      name: Expires
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SandboxLeaseSpec via `CustomResource`
+        properties:
+          spec:
+            description: Caller-safe intent for one disposable Sandbox.
+            properties:
+              alias:
+                minLength: 1
+                nullable: true
+                type: string
+              poolRef:
+                minLength: 1
+                type: string
+              requester:
+                description: |-
+                  Set by Kobe from the authenticated principal, never trusted from an HTTP
+                  request body.
+                properties:
+                  identity:
+                    description: |-
+                      Identity string (e.g. "repo:org/repo:ref:refs/heads/main" for GitHub,
+                      or user ID for Clerk).
+                    type: string
+                  type:
+                    description: 'Type of requester: "{provider}:{role}" (e.g. "github-actions:ci", "clerk:admin").'
+                    type: string
+                required:
+                - identity
+                - type
+                type: object
+              ttl:
+                minLength: 1
+                type: string
+            required:
+            - poolRef
+            - requester
+            - ttl
+            type: object
+          status:
+            nullable: true
+            properties:
+              conditions:
+                items:
+                  description: Kubernetes-style condition with the generation from which it was derived.
+                  properties:
+                    lastTransitionTime:
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      nullable: true
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              expiresAt:
+                description: Set only when the upstream Sandbox becomes Ready.
+                nullable: true
+                type: string
+              observedGeneration:
+                format: int64
+                nullable: true
+                type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Stable public phases. `Released` and `Expired` are clean terminal states;
+                  uncertain teardown remains `Quarantined` and continues consuming capacity.
+                enum:
+                - Pending
+                - Provisioning
+                - Ready
+                - Releasing
+                - Released
+                - Expired
+                - Quarantined
+                type: string
+              placement:
+                nullable: true
+                properties:
+                  clusterPool:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  type:
+                    enum:
+                    - management
+                    - childCluster
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: resolved childCluster placement requires the exact ClusterPool reference
+                  rule: (self.type == 'management' && !has(self.clusterPool)) || (self.type == 'childCluster' && has(self.clusterPool))
+              provisioningDeadline:
+                description: Absolute bound for setup. This is not the runtime expiry.
+                nullable: true
+                type: string
+              readyAt:
+                nullable: true
+                type: string
+              target:
+                description: |-
+                  Restart-safe, non-secret target provenance. Fields are filled monotonically:
+                  once a reference is present its name and UID may never be cleared or changed.
+                nullable: true
+                properties:
+                  childClusterInstance:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  childClusterLease:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  namespace:
+                    minLength: 1
+                    type: string
+                  pod:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandbox:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandboxClaim:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandboxTemplate:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandboxWarmPool:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                required:
+                - namespace
+                type: object
+            type: object
+        required:
+        - spec
+        title: SandboxLease
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -1,0 +1,291 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sandboxpools.kobe.kunobi.ninja
+spec:
+  group: kobe.kunobi.ninja
+  names:
+    categories: []
+    kind: SandboxPool
+    plural: sandboxpools
+    shortNames:
+    - sp
+    singular: sandboxpool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SandboxPoolSpec via `CustomResource`
+        properties:
+          spec:
+            description: Administrator-owned class of Agent Sandbox capacity.
+            properties:
+              defaultTtl:
+                description: TTL used when a lease request omits one.
+                minLength: 1
+                type: string
+              isolation:
+                description: |-
+                  Claimed workload-isolation mechanism. Hardened tiers carry the exact
+                  administrator-selected RuntimeClass; leases cannot override it.
+                properties:
+                  runtimeClassName:
+                    minLength: 1
+                    type: string
+                  tier:
+                    enum:
+                    - trusted-runc
+                    - gvisor
+                    - kata
+                    type: string
+                required:
+                - tier
+                type: object
+                x-kubernetes-validations:
+                - message: trusted-runc must not set runtimeClassName; hardened tiers must set it
+                  rule: (self.tier == 'trusted-runc' && !has(self.runtimeClassName)) || (self.tier in ['gvisor', 'kata'] && has(self.runtimeClassName))
+              maxTtl:
+                description: Maximum runtime TTL this pool will accept, independent of caller policy.
+                minLength: 1
+                type: string
+              placement:
+                description: |-
+                  Exactly one target class. The tagged enum makes management and child
+                  placement mutually exclusive in both JSON and generated OpenAPI.
+                properties:
+                  clusterPoolRef:
+                    minLength: 1
+                    type: string
+                  type:
+                    enum:
+                    - management
+                    - childCluster
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: management must not set clusterPoolRef; childCluster must set it
+                  rule: (self.type == 'management' && !has(self.clusterPoolRef)) || (self.type == 'childCluster' && has(self.clusterPoolRef))
+              provisioningTimeout:
+                description: |-
+                  Maximum time allowed for placement and Sandbox provisioning. Runtime TTL
+                  starts only after readiness and is therefore separate from this deadline.
+                minLength: 1
+                type: string
+              readiness:
+                description: |-
+                  Pool-specific execution canary used in addition to fixed controller
+                  checks such as upstream readiness and runtime verification.
+                properties:
+                  canary:
+                    properties:
+                      argv:
+                        description: Direct argv vector; no implicit shell expansion.
+                        items:
+                          type: string
+                        minItems: 1
+                        type: array
+                      timeout:
+                        minLength: 1
+                        type: string
+                    required:
+                    - argv
+                    - timeout
+                    type: object
+                required:
+                - canary
+                type: object
+              template:
+                description: |-
+                  Restricted template translated into the controller-owned upstream
+                  `SandboxTemplate`; this is intentionally not a `PodSpec` escape hatch.
+                properties:
+                  containers:
+                    description: |-
+                      Complete bounded set of containers. Environment, mounts, security
+                      context, service accounts, and arbitrary Pod fields are not exposed.
+                    items:
+                      description: One administrator-controlled container in a Sandbox template.
+                      properties:
+                        args:
+                          default: []
+                          items:
+                            type: string
+                          type: array
+                        command:
+                          default: []
+                          description: Executable and arguments, passed directly without an implicit shell.
+                          items:
+                            type: string
+                          type: array
+                        image:
+                          minLength: 1
+                          type: string
+                        name:
+                          minLength: 1
+                          type: string
+                        resources:
+                          description: |-
+                            Explicit requests and limits. CPU and memory are the only resource
+                            dimensions admitted by the first Sandbox API, keeping quota comparison
+                            deterministic and avoiding arbitrary extended-resource keys.
+                          properties:
+                            limits:
+                              properties:
+                                cpu:
+                                  description: Kubernetes CPU quantity such as `500m` or `2`.
+                                  minLength: 1
+                                  type: string
+                                ephemeralStorage:
+                                  description: Kubernetes ephemeral-storage quantity such as `1Gi`.
+                                  minLength: 1
+                                  type: string
+                                memory:
+                                  description: Kubernetes memory quantity such as `512Mi` or `2Gi`.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - cpu
+                              - ephemeralStorage
+                              - memory
+                              type: object
+                            requests:
+                              properties:
+                                cpu:
+                                  description: Kubernetes CPU quantity such as `500m` or `2`.
+                                  minLength: 1
+                                  type: string
+                                ephemeralStorage:
+                                  description: Kubernetes ephemeral-storage quantity such as `1Gi`.
+                                  minLength: 1
+                                  type: string
+                                memory:
+                                  description: Kubernetes memory quantity such as `512Mi` or `2Gi`.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - cpu
+                              - ephemeralStorage
+                              - memory
+                              type: object
+                          required:
+                          - limits
+                          - requests
+                          type: object
+                      required:
+                      - image
+                      - name
+                      - resources
+                      type: object
+                    minItems: 1
+                    type: array
+                  defaultContainer:
+                    description: Container selected by default for execution operations.
+                    minLength: 1
+                    type: string
+                  exposedPorts:
+                    default: []
+                    description: |-
+                      Ports that later access brokers may expose. Any undeclared port remains
+                      unauthorized.
+                    items:
+                      description: One TCP port declared safe for later lease-scoped forwarding.
+                      properties:
+                        container:
+                          minLength: 1
+                          type: string
+                        name:
+                          minLength: 1
+                          type: string
+                        port:
+                          format: uint16
+                          maximum: 65535.0
+                          minimum: 1.0
+                          type: integer
+                      required:
+                      - container
+                      - name
+                      - port
+                      type: object
+                    type: array
+                required:
+                - containers
+                - defaultContainer
+                type: object
+              warmCapacity:
+                description: Desired number of unclaimed upstream Sandboxes kept warm.
+                format: uint32
+                maximum: 2147483647.0
+                minimum: 0.0
+                type: integer
+            required:
+            - defaultTtl
+            - isolation
+            - maxTtl
+            - placement
+            - provisioningTimeout
+            - readiness
+            - template
+            - warmCapacity
+            type: object
+          status:
+            nullable: true
+            properties:
+              allocated:
+                default: 0
+                format: uint32
+                minimum: 0.0
+                type: integer
+              conditions:
+                items:
+                  description: Kubernetes-style condition with the generation from which it was derived.
+                  properties:
+                    lastTransitionTime:
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      nullable: true
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                nullable: true
+                type: integer
+              ready:
+                default: 0
+                format: uint32
+                minimum: 0.0
+                type: integer
+            type: object
+        required:
+        - spec
+        title: SandboxPool
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -38,7 +38,9 @@ spec:
                   administrator-selected RuntimeClass; leases cannot override it.
                 properties:
                   runtimeClassName:
+                    maxLength: 253
                     minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
                     type: string
                   tier:
                     enum:
@@ -62,7 +64,9 @@ spec:
                   placement mutually exclusive in both JSON and generated OpenAPI.
                 properties:
                   clusterPoolRef:
+                    maxLength: 63
                     minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   type:
                     enum:
@@ -91,7 +95,10 @@ spec:
                       argv:
                         description: Direct argv vector; no implicit shell expansion.
                         items:
+                          maxLength: 4096
+                          minLength: 1
                           type: string
+                        maxItems: 64
                         minItems: 1
                         type: array
                       timeout:
@@ -119,19 +126,27 @@ spec:
                         args:
                           default: []
                           items:
+                            maxLength: 4096
                             type: string
+                          maxItems: 256
                           type: array
                         command:
                           default: []
                           description: Executable and arguments, passed directly without an implicit shell.
                           items:
+                            maxLength: 4096
+                            minLength: 1
                             type: string
+                          maxItems: 64
                           type: array
                         image:
+                          maxLength: 2048
                           minLength: 1
                           type: string
                         name:
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         resources:
                           description: |-
@@ -186,11 +201,14 @@ spec:
                       - name
                       - resources
                       type: object
+                    maxItems: 16
                     minItems: 1
                     type: array
                   defaultContainer:
                     description: Container selected by default for execution operations.
+                    maxLength: 63
                     minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                     type: string
                   exposedPorts:
                     default: []
@@ -201,10 +219,14 @@ spec:
                       description: One TCP port declared safe for later lease-scoped forwarding.
                       properties:
                         container:
+                          maxLength: 63
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         name:
+                          maxLength: 15
                           minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
                           format: uint16
@@ -216,11 +238,25 @@ spec:
                       - name
                       - port
                       type: object
+                    maxItems: 64
                     type: array
                 required:
                 - containers
                 - defaultContainer
                 type: object
+                x-kubernetes-validations:
+                - message: defaultContainer must name one declared container
+                  rule: self.containers.exists(c, c.name == self.defaultContainer)
+                - message: container names must be unique
+                  rule: self.containers.all(c, self.containers.filter(other, other.name == c.name).size() == 1)
+                - message: every exposed port must name one declared container
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.containers.exists(c, c.name == p.container))'
+                - message: exposed port names must be unique
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.name == p.name).size() == 1)'
+                - message: a container port may be declared only once
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)'
+                - message: exposed port names must contain a letter and cannot contain consecutive hyphens
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches(''.*[a-z].*'') && !p.name.contains(''--''))'
               warmCapacity:
                 description: Desired number of unclaimed upstream Sandboxes kept warm.
                 format: uint32
@@ -250,17 +286,24 @@ spec:
                   description: Kubernetes-style condition with the generation from which it was derived.
                   properties:
                     lastTransitionTime:
+                      format: date-time
                       nullable: true
                       type: string
                     message:
                       type: string
                     observedGeneration:
                       format: int64
+                      minimum: 0.0
                       nullable: true
                       type: integer
                     reason:
                       type: string
                     status:
+                      description: Kubernetes Condition status values.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
                       type: string
                     type:
                       type: string
@@ -271,8 +314,12 @@ spec:
                   - type
                   type: object
                 type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
               observedGeneration:
                 format: int64
+                minimum: 0.0
                 nullable: true
                 type: integer
               ready:

--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -43,6 +43,15 @@ rules:
       - cidrpools
       - cidrpools/status
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Sandbox admission reads administrator-owned pool definitions.
+  - apiGroups: ["kobe.kunobi.ninja"]
+    resources: ["sandboxpools"]
+    verbs: ["get", "list", "watch"]
+  # Sandbox callers create lease intent through the HTTP API. Lifecycle
+  # controllers, not admission, own the status subresource.
+  - apiGroups: ["kobe.kunobi.ninja"]
+    resources: ["sandboxleases"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete"]
   # Core resources for virtual cluster lifecycle
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets", "serviceaccounts", "pods", "pods/status", "events", "persistentvolumeclaims", "endpoints"]

--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -20,6 +20,10 @@ The kobe HTTP API is served by the operator. All endpoints except `/v1/status`, 
 | `GET` | `/v1/pools` | Required | List available pools |
 | `GET` | `/v1/pools/:name` | Required | Get a specific pool's status |
 | `GET` | `/v1/pools/:name/leases` | Required | List leases for a specific pool |
+| `POST` | `/v1/sandbox-leases` | Required | Create a Sandbox lease from a SandboxPool |
+| `GET` | `/v1/sandbox-leases` | Required | List your Sandbox leases |
+| `GET` | `/v1/sandbox-leases/:id` | Required | Get one Sandbox lease |
+| `DELETE` | `/v1/sandbox-leases/:id` | Required | Request Sandbox release |
 | `GET` | `/v1/status` | Optional | Endpoint status, auth methods, pool summary |
 | `GET` | `/healthz` | None | Liveness probe |
 | `GET` | `/metrics` | None | Prometheus metrics |
@@ -225,6 +229,87 @@ Lists leases currently associated with one pool. This is useful for operational 
   }
 ]
 ```
+
+---
+
+## Sandbox leases
+
+<Callout type="warn">
+  `SandboxPool` and `SandboxLease` are alpha APIs. Admission is available once
+  their CRDs are installed. A lease remains `Pending` until a compatible Agent
+  Sandbox placement controller is enabled.
+</Callout>
+
+Sandbox callers select an administrator-owned `SandboxPool`; they cannot send a
+Pod spec, namespace, RuntimeClass, environment values, mounts, PVCs, or target
+credentials. Responses never contain a management or child-cluster kubeconfig.
+
+### `POST /v1/sandbox-leases`
+
+Creates caller-safe Sandbox intent and returns `202 Accepted`.
+
+```json
+{
+  "pool": "agent-small",
+  "ttl": "30m",
+  "alias": "review-142"
+}
+```
+
+`ttl` defaults to the pool's `defaultTtl` and is capped by both the pool and the
+caller's Sandbox policy. `alias` is optional and must be unique among that
+identity's active Sandbox leases.
+
+```json
+{
+  "id": "sandbox-a1b2c3d4e5f6",
+  "phase": "Pending",
+  "pool": "agent-small",
+  "ttl": "30m",
+  "alias": "review-142"
+}
+```
+
+When a requested TTL is reduced, `effective_ttl` reports the accepted value.
+
+| Status | Meaning |
+|---|---|
+| `400` | Invalid pool name, alias, or TTL |
+| `403` | Missing Sandbox `lease` permission or resource ceiling exceeded |
+| `404` | An allowed SandboxPool does not exist |
+| `409` | Alias is already active |
+| `429` | Sandbox concurrency limit reached |
+| `503` | Pool configuration or Kubernetes admission cannot be verified |
+
+### `GET /v1/sandbox-leases`
+
+Lists only leases owned by the authenticated identity and still permitted by
+its Sandbox pool scope. Requester identity and target credentials are omitted.
+
+### `GET /v1/sandbox-leases/:id`
+
+Returns the typed lifecycle state for an owned lease. A lease belonging to
+another identity returns `404`.
+
+Possible phases are `Pending`, `Provisioning`, `Ready`, `Releasing`, `Released`,
+`Expired`, and `Quarantined`. `Quarantined` means cleanup is uncertain and the
+capacity remains unavailable; it is not a successful terminal state.
+
+When resolved, the response may include non-secret placement and target object
+references with exact Kubernetes UIDs. It never includes bearer tokens or
+kubeconfigs.
+
+### `DELETE /v1/sandbox-leases/:id`
+
+Requires the independent Sandbox `release` verb. For an admitted active lease,
+the API records server-owned release intent and returns `204 No Content`; it
+does not write lifecycle status. The placement controller observes that intent,
+moves the lease to `Releasing`, revokes access, and verifies cleanup.
+
+Repeated release of an already requested, `Releasing`, `Released`, or `Expired`
+lease returns `204 No Content`. A `Quarantined` lease returns `409 Conflict`:
+cleanup is still uncertain, so its capacity remains unavailable rather than
+being reported as released.
 
 ---
 

--- a/docs/kobe-docs/auth/overview.mdx
+++ b/docs/kobe-docs/auth/overview.mdx
@@ -47,6 +47,16 @@ spec:
       maxTtl: 1h
       maxConcurrentLeases: 3
       maxExtensions: 2
+      # Optional and kind-specific. Omitting this block denies Sandbox APIs
+      # without changing the Cluster lease grant above.
+      sandbox:
+        pools: ["agent-*"]
+        verbs: [lease, exec, logs, port-forward, release]
+        maxTtl: 2h
+        maxConcurrentLeases: 2
+        resourceCeiling:
+          maxCpu: "4"
+          maxMemory: 8Gi
 ```
 
 ## Authorization rules
@@ -59,6 +69,18 @@ Rules control what an authenticated caller can do. Fields:
 | `maxTtl` | Maximum TTL the caller can request. Requests for longer TTLs are capped to this value. |
 | `maxConcurrentLeases` | How many active leases this identity can hold simultaneously. |
 | `maxExtensions` | How many times a lease can be extended via `PATCH /v1/leases/:id`. |
+| `sandbox` | Optional, independent Sandbox grant. Missing means Sandbox access is denied. |
+
+The `sandbox` block scopes `SandboxPool` names and verbs separately from cluster
+pools. `lease` permits create plus read/list of the caller's own Sandbox leases;
+`release` is independently revocable. `exec`, `logs`, and `port-forward` are
+consumed by the restricted Sandbox execution API.
+
+`resourceCeiling.maxCpu` and `maxMemory` are Kubernetes quantities compared
+against the sum of all container limits in the selected `SandboxPool`. Invalid
+quantities fail closed. Sandbox concurrency is also counted separately from
+`ClusterLease` concurrency, and a quarantined Sandbox continues consuming its
+quota until cleanup is proven.
 
 For OIDC policies, a `match` clause lets you apply different rules to different roles or repositories within the same provider. The first rule whose `match` clause passes is used. Rules without a `match` clause always apply.
 

--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -140,7 +140,7 @@ You should see the list of available subcommands. If the command isn't found, ma
 The `kobe-operator` binary runs in your host Kubernetes cluster. Refer to the Helm chart or Flux deployment in the kobe repository for production setup. The operator requires:
 
 - A host Kubernetes cluster (k3s, k0s, EKS, GKE, or any conformant cluster)
-- Permission to manage `ClusterPool`, `ClusterLease`, `ClusterInstance`, `AccessPolicy`, and `KobeStore` CRDs
+- Permission to manage Kobe CRDs, including `ClusterPool`, `ClusterLease`, `ClusterInstance`, `SandboxPool`, `SandboxLease`, `AccessPolicy`, and `KobeStore`
 - Network access between the operator and a kobe endpoint your clients can reach
 
 Install the CRDs:
@@ -150,3 +150,14 @@ cargo run --bin crdgen -- all | kubectl apply -f -
 ```
 
 Or apply them from the Helm chart, which bundles the generated CRD manifests.
+
+Helm does not upgrade objects from a chart's `crds/` directory. Before upgrading
+an existing Kobe release to a version that adds CRDs, apply the new chart's CRD
+manifests explicitly, then upgrade the operator.
+
+`SandboxPool` and `SandboxLease` are deliberately not operator startup
+prerequisites, so existing cluster-lease endpoints can remain available during
+a staged upgrade. Until both Sandbox CRDs are installed and established, the
+Sandbox API is unavailable; a `503 Service Unavailable` means Kobe could not
+verify Sandbox admission against Kubernetes. Install the CRDs before enabling
+Sandbox API clients.

--- a/docs/kobe-docs/pools/meta.json
+++ b/docs/kobe-docs/pools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Pools",
-  "pages": ["overview", "backends"]
+  "pages": ["overview", "backends", "sandbox-pools"]
 }

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -1,0 +1,84 @@
+---
+title: Sandbox pools
+description: Define bounded, administrator-owned Agent Sandbox templates and placement.
+---
+
+# Sandbox pools
+
+<Callout type="warn">
+  `SandboxPool` and `SandboxLease` are alpha APIs. Kobe admits lease intent, but
+  a lease remains `Pending` until a compatible Agent Sandbox placement
+  controller is enabled.
+</Callout>
+
+Administrators author `SandboxPool` objects. API callers only choose an allowed
+pool, TTL, and optional alias; they cannot provide a Pod spec, namespace,
+RuntimeClass, environment values, mounts, PVCs, or target credentials.
+
+## Example
+
+```yaml
+apiVersion: kobe.kunobi.ninja/v1alpha1
+kind: SandboxPool
+metadata:
+  name: agent-small
+  namespace: kobe
+spec:
+  warmCapacity: 2
+  defaultTtl: 30m
+  maxTtl: 2h
+  provisioningTimeout: 10m
+  placement:
+    type: management
+  template:
+    defaultContainer: workspace
+    containers:
+      - name: workspace
+        image: ghcr.io/example/agent-sandbox:v1
+        command: ["/usr/local/bin/agent"]
+        args: ["serve"]
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+            ephemeralStorage: 1Gi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+            ephemeralStorage: 4Gi
+    exposedPorts:
+      - name: http
+        container: workspace
+        port: 8080
+  isolation:
+    tier: gvisor
+    runtimeClassName: gvisor
+  readiness:
+    canary:
+      argv: ["/usr/local/bin/agent", "healthcheck"]
+      timeout: 30s
+```
+
+Every container must declare CPU, memory, and ephemeral-storage requests and
+limits. `defaultContainer` and each exposed port must refer to a declared
+container. Canary `argv` is executed directly, without an implicit shell.
+
+## Placement and isolation
+
+Use `placement.type: management` to place upstream Sandbox objects in Kobe's
+management cluster. To compose a Sandbox with a child cluster from a
+same-namespace `ClusterPool`, use exactly one child placement instead:
+
+```yaml
+placement:
+  type: childCluster
+  clusterPoolRef: ci-sandbox
+```
+
+Isolation tier `trusted-runc` must omit `runtimeClassName`. Hardened tiers
+`gvisor` and `kata` require the exact administrator-selected RuntimeClass name.
+Lease callers cannot override either placement or isolation.
+
+See the [API reference](/docs/api/reference#sandbox-leases) for lease operations
+and [authentication and authorization](/docs/auth/overview) for Sandbox policy
+verbs and limits.

--- a/justfile
+++ b/justfile
@@ -127,7 +127,10 @@ build-crdgen:
     cargo run --bin crdgen -- bootstrapconfigs > charts/kobe/crds/bootstrapconfigs.yaml
     cargo run --bin crdgen -- accesspolicies > charts/kobe/crds/accesspolicies.yaml
     cargo run --bin crdgen -- kobestores > charts/kobe/crds/kobestores.yaml
+    cargo run --bin crdgen -- cidrclaims > charts/kobe/crds/cidrclaims.yaml
     cargo run --bin crdgen -- cidrpools > charts/kobe/crds/cidrpools.yaml
+    cargo run --bin crdgen -- sandboxpools > charts/kobe/crds/sandboxpools.yaml
+    cargo run --bin crdgen -- sandboxleases > charts/kobe/crds/sandboxleases.yaml
 
 # Build Docker images locally (operator + kobe-sync)
 [group('docker')]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -20,6 +20,9 @@ use crate::pool::parse_duration;
 /// Validated identity extracted from a JWT.
 #[derive(Debug, Clone)]
 pub struct AuthIdentity {
+    /// Stable configured provider ID. Unlike `requester_type`, this does not
+    /// include the currently matched rule value and is safe for ownership keys.
+    pub provider: String,
     /// Provider and role: "{provider_name}:{role}" (e.g., "github-actions:ci").
     pub requester_type: String,
     /// Identity string formatted per the provider's identityTemplate.
@@ -535,6 +538,7 @@ impl JwtAuthenticator {
         })?;
 
         Ok(AuthIdentity {
+            provider: verified.provider_name.clone(),
             requester_type: verified.provider_name,
             identity: verified.identity,
             issuer: "ssh".to_string(),
@@ -628,6 +632,7 @@ impl JwtAuthenticator {
             .inc();
 
         Ok(AuthIdentity {
+            provider: kid.provider.clone(),
             requester_type,
             identity,
             issuer,
@@ -728,6 +733,33 @@ fn access_rule_to_policy(rule: &AccessRule) -> crate::api::policy::Policy {
         max_concurrent_leases: rule.max_concurrent_leases,
         default_priority: 50,
         max_extensions: rule.max_extensions,
+        sandbox: rule.sandbox.as_ref().and_then(|grant| {
+            let Some(max_ttl) = parse_duration(&grant.max_ttl) else {
+                warn!(
+                    raw_value = %grant.max_ttl,
+                    "Failed to parse Sandbox max_ttl; dropping Sandbox grant"
+                );
+                return None;
+            };
+            if max_ttl <= chrono::Duration::zero() {
+                warn!(
+                    raw_value = %grant.max_ttl,
+                    "Sandbox max_ttl must be positive; dropping Sandbox grant"
+                );
+                return None;
+            }
+            if let Err(error) = crate::sandbox::parse_resource_ceiling(&grant.resource_ceiling) {
+                warn!(%error, "Invalid Sandbox resource ceiling; dropping Sandbox grant");
+                return None;
+            }
+            Some(crate::api::policy::SandboxPolicy {
+                allowed_pools: grant.pools.clone(),
+                verbs: grant.verbs.clone(),
+                max_ttl,
+                max_concurrent_leases: grant.max_concurrent_leases,
+                resource_ceiling: grant.resource_ceiling.clone(),
+            })
+        }),
     }
 }
 
@@ -892,6 +924,7 @@ mod tests {
             max_ttl: "1h".to_string(),
             max_concurrent_leases: 5,
             max_extensions: 2,
+            sandbox: None,
         }];
         let claims = make_claims("test-sub", HashMap::new());
         let (rule, matched) = match_rule(&rules, &claims).unwrap();
@@ -911,6 +944,7 @@ mod tests {
                 max_ttl: "8h".to_string(),
                 max_concurrent_leases: 10,
                 max_extensions: 5,
+                sandbox: None,
             },
             AccessRule {
                 match_clause: None,
@@ -918,6 +952,7 @@ mod tests {
                 max_ttl: "1h".to_string(),
                 max_concurrent_leases: 3,
                 max_extensions: 1,
+                sandbox: None,
             },
         ];
 
@@ -950,6 +985,7 @@ mod tests {
             max_ttl: "4h".to_string(),
             max_concurrent_leases: 10,
             max_extensions: 5,
+            sandbox: None,
         }];
 
         let mut extra = HashMap::new();
@@ -974,6 +1010,7 @@ mod tests {
             max_ttl: "1h".to_string(),
             max_concurrent_leases: 5,
             max_extensions: 2,
+            sandbox: None,
         }];
         let claims = make_claims("test-sub", HashMap::new());
         assert!(match_rule(&rules, &claims).is_none());
@@ -1118,6 +1155,7 @@ mod tests {
             max_ttl: "2h".to_string(),
             max_concurrent_leases: 5,
             max_extensions: 3,
+            sandbox: None,
         };
         let policy = access_rule_to_policy(&rule);
         assert_eq!(policy.max_ttl, chrono::Duration::hours(2));
@@ -1134,6 +1172,7 @@ mod tests {
             max_ttl: "invalid".to_string(),
             max_concurrent_leases: 1,
             max_extensions: 0,
+            sandbox: None,
         };
         let policy = access_rule_to_policy(&rule);
         // Should default to 1h (3600s) when parsing fails
@@ -1148,10 +1187,76 @@ mod tests {
             max_ttl: "30m".to_string(),
             max_concurrent_leases: 10,
             max_extensions: 2,
+            sandbox: None,
         };
         let policy = access_rule_to_policy(&rule);
         assert_eq!(policy.allowed_pools, vec!["*"]);
         assert_eq!(policy.max_ttl, chrono::Duration::minutes(30));
+    }
+
+    #[test]
+    fn access_rule_to_policy_projects_typed_sandbox_grant() {
+        let rule = AccessRule {
+            match_clause: None,
+            pools: vec!["cluster-*".into()],
+            max_ttl: "2h".into(),
+            max_concurrent_leases: 5,
+            max_extensions: 2,
+            sandbox: Some(crate::crd::SandboxAccessRule {
+                pools: vec!["agent-*".into()],
+                verbs: vec![
+                    crate::crd::SandboxVerb::Lease,
+                    crate::crd::SandboxVerb::Exec,
+                ],
+                max_ttl: "30m".into(),
+                max_concurrent_leases: 3,
+                resource_ceiling: crate::crd::SandboxResourceCeiling {
+                    max_cpu: "2".into(),
+                    max_memory: "4Gi".into(),
+                },
+            }),
+        };
+
+        let policy = access_rule_to_policy(&rule);
+        let sandbox = policy.sandbox.expect("valid grant must be projected");
+        assert_eq!(sandbox.allowed_pools, vec!["agent-*"]);
+        assert_eq!(sandbox.max_ttl, chrono::Duration::minutes(30));
+        assert_eq!(sandbox.max_concurrent_leases, 3);
+        assert_eq!(
+            sandbox.verbs,
+            vec![
+                crate::crd::SandboxVerb::Lease,
+                crate::crd::SandboxVerb::Exec
+            ]
+        );
+        assert_eq!(sandbox.resource_ceiling.max_cpu, "2");
+    }
+
+    #[test]
+    fn invalid_sandbox_grant_fails_closed_without_changing_cluster_policy() {
+        let rule = AccessRule {
+            match_clause: None,
+            pools: vec!["cluster-*".into()],
+            max_ttl: "2h".into(),
+            max_concurrent_leases: 5,
+            max_extensions: 2,
+            sandbox: Some(crate::crd::SandboxAccessRule {
+                pools: vec!["*".into()],
+                verbs: vec![crate::crd::SandboxVerb::Lease],
+                max_ttl: "invalid".into(),
+                max_concurrent_leases: 3,
+                resource_ceiling: crate::crd::SandboxResourceCeiling {
+                    max_cpu: "2".into(),
+                    max_memory: "4Gi".into(),
+                },
+            }),
+        };
+
+        let policy = access_rule_to_policy(&rule);
+        assert!(policy.sandbox.is_none());
+        assert_eq!(policy.allowed_pools, vec!["cluster-*"]);
+        assert_eq!(policy.max_ttl, chrono::Duration::hours(2));
+        assert_eq!(policy.max_concurrent_leases, 5);
     }
 
     // --- JwtAuthenticator async tests ---

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,4 +2,5 @@ pub mod auth;
 pub mod connect;
 pub mod policy;
 pub mod routes;
+pub mod sandbox;
 pub mod upgrade;

--- a/src/api/policy.rs
+++ b/src/api/policy.rs
@@ -1,4 +1,5 @@
 use crate::api::auth::AuthIdentity;
+use crate::crd::{SandboxResourceCeiling, SandboxVerb};
 use crate::pool::parse_duration;
 
 /// Authorization policy — what each identity type is allowed to do.
@@ -14,6 +15,19 @@ pub struct Policy {
     pub default_priority: u32,
     /// Maximum number of TTL extensions.
     pub max_extensions: u32,
+    /// Optional kind-specific Sandbox grant. Absence always denies Sandbox and
+    /// preserves the meaning of legacy Cluster-only AccessPolicy objects.
+    pub sandbox: Option<SandboxPolicy>,
+}
+
+/// Runtime form of a validated Sandbox access grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxPolicy {
+    pub allowed_pools: Vec<String>,
+    pub verbs: Vec<SandboxVerb>,
+    pub max_ttl: chrono::Duration,
+    pub max_concurrent_leases: u32,
+    pub resource_ceiling: SandboxResourceCeiling,
 }
 
 /// Get the authorization policy for a given identity.
@@ -24,7 +38,11 @@ pub fn policy_for(identity: &AuthIdentity) -> Policy {
 
 /// Check if a pool name matches the allowed patterns for an identity.
 pub fn is_pool_allowed(pool: &str, policy: &Policy) -> bool {
-    policy.allowed_pools.iter().any(|pattern| {
+    pool_matches(pool, &policy.allowed_pools)
+}
+
+fn pool_matches(pool: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
         if pattern == "*" {
             return true;
         }
@@ -34,6 +52,27 @@ pub fn is_pool_allowed(pool: &str, policy: &Policy) -> bool {
             pool == pattern
         }
     })
+}
+
+/// Check a Sandbox operation against both its pool scope and independent verb
+/// grant. A missing Sandbox grant fails closed even when Cluster pools allow
+/// the same name or the wildcard `*`.
+pub fn is_sandbox_allowed(pool: &str, verb: SandboxVerb, policy: &Policy) -> bool {
+    policy.sandbox.as_ref().is_some_and(|sandbox| {
+        pool_matches(pool, &sandbox.allowed_pools) && sandbox.verbs.contains(&verb)
+    })
+}
+
+/// Clamp a valid positive runtime TTL to the Sandbox-specific maximum.
+/// Invalid, zero, or negative values return `None` instead of inheriting the
+/// legacy Cluster one-hour fallback.
+pub fn clamp_sandbox_ttl(requested: &str, policy: &Policy) -> Option<chrono::Duration> {
+    let grant = policy.sandbox.as_ref()?;
+    let requested = parse_duration(requested)?;
+    if requested <= chrono::Duration::zero() {
+        return None;
+    }
+    Some(requested.min(grant.max_ttl))
 }
 
 /// Clamp a requested TTL to the policy maximum.
@@ -91,6 +130,7 @@ mod tests {
             max_concurrent_leases: 5,
             default_priority: 100,
             max_extensions: 2,
+            sandbox: None,
         };
 
         assert!(is_pool_allowed("e2e-basic", &ci_policy));
@@ -103,6 +143,7 @@ mod tests {
             max_concurrent_leases: 10,
             default_priority: 100,
             max_extensions: 10,
+            sandbox: None,
         };
 
         assert!(is_pool_allowed("e2e-basic", &admin_policy));
@@ -118,6 +159,7 @@ mod tests {
             max_concurrent_leases: 5,
             default_priority: 100,
             max_extensions: 2,
+            sandbox: None,
         };
 
         // Within limit
@@ -127,6 +169,87 @@ mod tests {
         // Exceeds limit
         let clamped = clamp_ttl("2h", &policy);
         assert_eq!(clamped, chrono::Duration::hours(1));
+    }
+
+    fn policy_with_sandbox() -> Policy {
+        Policy {
+            allowed_pools: vec!["cluster-*".into()],
+            max_ttl: chrono::Duration::hours(8),
+            max_concurrent_leases: 5,
+            default_priority: 100,
+            max_extensions: 2,
+            sandbox: Some(SandboxPolicy {
+                allowed_pools: vec!["agent-*".into()],
+                verbs: vec![SandboxVerb::Lease, SandboxVerb::Release],
+                max_ttl: chrono::Duration::minutes(30),
+                max_concurrent_leases: 3,
+                resource_ceiling: SandboxResourceCeiling {
+                    max_cpu: "2".into(),
+                    max_memory: "4Gi".into(),
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn sandbox_grant_is_kind_pool_and_verb_specific() {
+        let policy = policy_with_sandbox();
+        assert!(is_pool_allowed("cluster-ci", &policy));
+        assert!(!is_sandbox_allowed(
+            "cluster-ci",
+            SandboxVerb::Lease,
+            &policy
+        ));
+        assert!(is_sandbox_allowed("agent-ci", SandboxVerb::Lease, &policy));
+        assert!(!is_sandbox_allowed("agent-ci", SandboxVerb::Exec, &policy));
+
+        let mut legacy = policy;
+        legacy.sandbox = None;
+        assert!(!is_sandbox_allowed("agent-ci", SandboxVerb::Lease, &legacy));
+    }
+
+    #[test]
+    fn sandbox_wildcard_and_every_verb_are_checked_independently() {
+        let mut policy = policy_with_sandbox();
+        let sandbox = policy.sandbox.as_mut().unwrap();
+        sandbox.allowed_pools = vec!["*".into()];
+        sandbox.verbs = vec![
+            SandboxVerb::Lease,
+            SandboxVerb::Exec,
+            SandboxVerb::Logs,
+            SandboxVerb::PortForward,
+            SandboxVerb::Release,
+        ];
+
+        for verb in sandbox.verbs.clone() {
+            assert!(is_sandbox_allowed("any-sandbox-pool", verb, &policy));
+        }
+        policy
+            .sandbox
+            .as_mut()
+            .unwrap()
+            .verbs
+            .retain(|verb| *verb != SandboxVerb::Release);
+        assert!(!is_sandbox_allowed(
+            "any-sandbox-pool",
+            SandboxVerb::Release,
+            &policy
+        ));
+    }
+
+    #[test]
+    fn sandbox_ttl_is_fail_closed_and_uses_kind_specific_limit() {
+        let policy = policy_with_sandbox();
+        assert_eq!(
+            clamp_sandbox_ttl("15m", &policy),
+            Some(chrono::Duration::minutes(15))
+        );
+        assert_eq!(
+            clamp_sandbox_ttl("2h", &policy),
+            Some(chrono::Duration::minutes(30))
+        );
+        assert_eq!(clamp_sandbox_ttl("invalid", &policy), None);
+        assert_eq!(clamp_sandbox_ttl("0s", &policy), None);
     }
 
     #[test]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -280,6 +280,7 @@ pub fn build_router<B: ClusterBackend + Clone + 'static>(state: AppState<B>) -> 
         .route("/v1/pools", get(list_pools::<B>))
         .route("/v1/pools/{name}", get(get_pool::<B>))
         .route("/v1/pools/{name}/leases", get(list_pool_leases::<B>))
+        .merge(crate::api::sandbox::routes::<B>())
         .layer(axum::middleware::from_fn(concurrency_limit));
 
     let connect_routes = Router::new()
@@ -2991,6 +2992,7 @@ mod tests {
 
     fn test_identity() -> AuthIdentity {
         AuthIdentity {
+            provider: "github-actions".to_string(),
             requester_type: "github-actions:ci".to_string(),
             identity: "repo:org/repo:ref:refs/heads/main".to_string(),
             issuer: "https://token.actions.githubusercontent.com".to_string(),
@@ -3000,6 +3002,7 @@ mod tests {
                 max_concurrent_leases: 5,
                 default_priority: 100,
                 max_extensions: 2,
+                sandbox: None,
             },
         }
     }

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -17,8 +17,9 @@ use kube::api::{
     Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, Preconditions,
 };
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 use thiserror::Error;
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 use super::auth::AuthIdentity;
 use super::policy::{clamp_sandbox_ttl, format_duration, is_sandbox_allowed, policy_for};
@@ -283,6 +284,12 @@ async fn create_sandbox_lease<B: ClusterBackend>(
             None,
         );
     }
+    // Reclaim this principal's own quota stranded by an earlier request that
+    // died between reserving and admitting. Runs before admission so a caller
+    // locked out by their own crashed request recovers on their next attempt
+    // rather than staying 429/409 forever.
+    reap_abandoned_pending_leases(&leases, &reservations, &identity, chrono::Utc::now()).await;
+
     let lease_id = format!(
         "sandbox-{}",
         &uuid::Uuid::new_v4().to_string().replace('-', "")[..12]
@@ -686,28 +693,143 @@ fn requester_list_params(identity: &AuthIdentity) -> ListParams {
     ))
 }
 
-/// Stable, non-reversible label value used only as a server-side prefilter.
-/// Exact identity is always rechecked from the object, so hash collision never
-/// grants visibility or consumes another caller's quota.
+/// Stable, non-reversible identifier for one principal.
+///
+/// This is **not** merely a lookup prefilter, which is why it must be
+/// collision-resistant. It names the reservation objects
+/// (`sbx-quota-{hash}-{slot}`, `sbx-alias-{hash}-{alias}`), so two principals
+/// sharing a hash share one quota namespace and one alias namespace — and
+/// unlike the list paths, the reservation path has no exact-identity recheck to
+/// fall back on. A caller able to steer their own identity string toward a
+/// victim's hash could then occupy every one of that victim's slots or squat
+/// their aliases: targeted denial of service.
+///
+/// An earlier version used FNV-1a-64 and documented collisions as harmless.
+/// That was true of visibility (which does recheck exact identity) and false of
+/// the ledger. SHA-256 truncated to 128 bits is collision-resistant here and
+/// still a valid DNS label component.
+///
+/// Components are length-prefixed so `("ab", "c")` and `("a", "bc")` cannot
+/// produce the same digest.
 fn principal_hash(identity: &AuthIdentity) -> String {
-    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
-    const FNV_PRIME: u64 = 0x00000100000001B3;
-    let mut hash = FNV_OFFSET;
+    let mut hasher = Sha256::new();
     for component in [
         identity.provider.as_bytes(),
         identity.issuer.as_bytes(),
         identity.identity.as_bytes(),
     ] {
-        for byte in (component.len() as u64)
-            .to_be_bytes()
-            .iter()
-            .chain(component)
+        hasher.update((component.len() as u64).to_be_bytes());
+        hasher.update(component);
+    }
+    hasher
+        .finalize()
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// How long a lease may sit unadmitted before it is treated as abandoned.
+///
+/// Admission is a handful of API calls, so a legitimately in-flight request is
+/// orders of magnitude below this. The margin is deliberately large: reaping a
+/// live request would delete a lease its caller is about to be told succeeded,
+/// which is far worse than a slot staying busy for a few extra minutes.
+const SANDBOX_PENDING_DEADLINE_SECS: i64 = 600;
+
+/// Whether an unadmitted lease is old enough to be treated as abandoned.
+///
+/// Pure so the boundary is testable without a clock: `now` is supplied.
+fn pending_lease_is_abandoned(
+    created_at: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    let Some(created_at) = created_at else {
+        // No creation timestamp means we cannot prove it is old. Reaping on
+        // absent evidence is exactly the mistake this whole module avoids.
+        return false;
+    };
+    let Ok(created_at) = chrono::DateTime::parse_from_rfc3339(created_at) else {
+        return false;
+    };
+    (now - created_at.with_timezone(&chrono::Utc)).num_seconds() >= SANDBOX_PENDING_DEADLINE_SECS
+}
+
+/// Release quota and aliases stranded by a request that died mid-admission.
+///
+/// Reservations are created before the lease is admitted, and they are owned by
+/// that lease — so Kubernetes garbage-collects them only once the lease is
+/// *deleted*. If the process dies (or a cleanup path itself fails) between
+/// acquiring reservations and committing admission, the lease stays `pending`
+/// forever, no controller touches it (placement ignores anything not `admitted`),
+/// and its slot plus alias are consumed permanently. The caller then gets 429 or
+/// 409 on every retry with no way out but manual deletion.
+///
+/// This sweep is the recovery path. It runs on the caller's own next create, so
+/// the principal who was locked out is exactly the one who unlocks themselves.
+///
+/// Scope, stated narrowly: it reclaims **this principal's** abandoned pending
+/// leases at **create time only**. It is not a general reaper — a principal who
+/// never calls create again keeps their slot stranded until #73's controller
+/// owns a durable sweep. That is a deliberately smaller claim than "crash-safe".
+async fn reap_abandoned_pending_leases(
+    leases: &Api<SandboxLease>,
+    reservations: &Api<Lease>,
+    identity: &AuthIdentity,
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    let stale = match leases.list(&requester_list_params(identity)).await {
+        Ok(list) => list,
+        // Best-effort: a failed sweep must not fail the create. The caller
+        // simply keeps whatever quota they already had.
+        Err(error) => {
+            warn!(error = %error, "Sandbox abandoned-lease sweep failed to list");
+            return;
+        }
+    };
+
+    for lease in stale.items {
+        // The label prefilter is a hash, so it can group two principals.
+        // Recheck exact identity before deleting anything: without this, a hash
+        // collision would let one principal reap another's leases.
+        if !principal_matches(&lease.spec.requester, identity) {
+            continue;
+        }
+        if lease
+            .annotations()
+            .get(SANDBOX_ADMISSION_ANNOTATION)
+            .map(String::as_str)
+            != Some(SANDBOX_ADMISSION_PENDING)
         {
-            hash ^= *byte as u64;
-            hash = hash.wrapping_mul(FNV_PRIME);
+            continue;
+        }
+        if !pending_lease_is_abandoned(
+            lease
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|timestamp| timestamp.0.to_string())
+                .as_deref(),
+            now,
+        ) {
+            continue;
+        }
+
+        // UID + resourceVersion fenced, and it releases the lease's
+        // reservations. A lease that got admitted since we listed fails the
+        // shape check and is left alone.
+        match delete_exact_pending_lease(leases, reservations, &lease).await {
+            Ok(()) => info!(
+                lease_id = %lease.name_any(),
+                "Reclaimed an abandoned unadmitted Sandbox lease and its reservations"
+            ),
+            Err(error) => warn!(
+                lease_id = %lease.name_any(),
+                error = %error,
+                "Could not reclaim an abandoned unadmitted Sandbox lease"
+            ),
         }
     }
-    format!("{hash:016x}")
 }
 
 fn principal_matches(requester: &SandboxPrincipal, identity: &AuthIdentity) -> bool {
@@ -1366,14 +1488,32 @@ mod tests {
         server: &MockServer,
         preheld: &[String],
     ) -> Arc<Mutex<std::collections::BTreeMap<String, serde_json::Value>>> {
+        mount_reservation_api_owned(
+            server,
+            &preheld
+                .iter()
+                .map(|name| (name.clone(), FOREIGN_LEASE_UID.to_string()))
+                .collect::<Vec<_>>(),
+        )
+        .await
+    }
+
+    const FOREIGN_LEASE_UID: &str = "preheld-foreign-lease-uid";
+
+    /// Like `mount_reservation_api`, but each pre-held reservation names the
+    /// SandboxLease UID that owns it — so a test can model reservations
+    /// stranded by a *specific* lease and watch them actually be released.
+    async fn mount_reservation_api_owned(
+        server: &MockServer,
+        preheld: &[(String, String)],
+    ) -> Arc<Mutex<std::collections::BTreeMap<String, serde_json::Value>>> {
         const RESERVATIONS: &str = "/apis/coordination.k8s.io/v1/namespaces/test-ns/leases";
-        const FOREIGN_LEASE_UID: &str = "preheld-foreign-lease-uid";
 
         // Reconstruct the labels a real reservation would carry from its name
         // (`sbx-<type>-<principal>-<suffix>`), so selector filtering behaves.
         let seeded: std::collections::BTreeMap<String, serde_json::Value> = preheld
             .iter()
-            .map(|name| {
+            .map(|(name, owner_uid)| {
                 let parts: Vec<&str> = name.splitn(4, '-').collect();
                 let reservation_type = parts.get(1).copied().unwrap_or_default();
                 let principal = parts.get(2).copied().unwrap_or_default();
@@ -1388,7 +1528,7 @@ mod tests {
                             "uid": format!("{name}-uid"),
                             "labels": {
                                 SANDBOX_RESERVATION_TYPE_LABEL: reservation_type,
-                                SANDBOX_RESERVATION_LEASE_UID_LABEL: FOREIGN_LEASE_UID,
+                                SANDBOX_RESERVATION_LEASE_UID_LABEL: owner_uid,
                                 REQUESTER_HASH_LABEL: principal,
                             }
                         }
@@ -1436,15 +1576,40 @@ mod tests {
                     .next()
                     .unwrap_or_default()
                     .to_string();
-                if delete_state.lock().unwrap().remove(&name).is_some() {
-                    ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                        "apiVersion": "v1", "kind": "Status", "status": "Success"
-                    }))
-                } else {
-                    ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                // Honour the UID precondition, exactly as the API server does.
+                // Without this the mock deletes by bare name, and the UID
+                // fencing the release path depends on goes untested — a
+                // regression that stole another lease's reservation would pass.
+                let precondition_uid = serde_json::from_slice::<serde_json::Value>(&request.body)
+                    .ok()
+                    .and_then(|body| {
+                        body["preconditions"]["uid"]
+                            .as_str()
+                            .map(|uid| uid.to_string())
+                    });
+                let mut state = delete_state.lock().unwrap();
+                let actual_uid = state
+                    .get(&name)
+                    .and_then(|object| object["metadata"]["uid"].as_str().map(|s| s.to_string()));
+                match (actual_uid, precondition_uid) {
+                    (None, _) => ResponseTemplate::new(404).set_body_json(serde_json::json!({
                         "apiVersion": "v1", "kind": "Status", "status": "Failure",
                         "reason": "NotFound", "code": 404
-                    }))
+                    })),
+                    (Some(actual), Some(expected)) if actual != expected => {
+                        ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                            "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                            "reason": "Conflict",
+                            "message": "the UID in the precondition does not match",
+                            "code": 409
+                        }))
+                    }
+                    (Some(_), _) => {
+                        state.remove(&name);
+                        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                            "apiVersion": "v1", "kind": "Status", "status": "Success"
+                        }))
+                    }
                 }
             })
             .mount(server)
@@ -1702,6 +1867,30 @@ mod tests {
         other_issuer.issuer = "https://other.example".into();
         assert_ne!(principal_hash(&base), principal_hash(&other_provider));
         assert_ne!(principal_hash(&base), principal_hash(&other_issuer));
+
+        // The hash NAMES the quota and alias reservations, so its width is a
+        // security property, not a formatting detail: a short digest lets a
+        // caller steer their identity onto a victim's hash and occupy that
+        // victim's slots. 128 bits, hex-encoded.
+        assert_eq!(
+            principal_hash(&base).len(),
+            32,
+            "principal hash must retain 128 bits — it namespaces quota and aliases"
+        );
+        assert!(principal_hash(&base).chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Length-prefixing must stop component boundaries from sliding.
+        let mut split_a = base.clone();
+        split_a.provider = "ab".into();
+        split_a.issuer = "c".into();
+        let mut split_b = base.clone();
+        split_b.provider = "a".into();
+        split_b.issuer = "bc".into();
+        assert_ne!(
+            principal_hash(&split_a),
+            principal_hash(&split_b),
+            "concatenation must be unambiguous across component boundaries"
+        );
     }
 
     #[tokio::test]
@@ -1797,6 +1986,133 @@ mod tests {
     // ledger the LIST is not a verification step at all (it cannot be: two
     // replicas can both read a free slot), so the relist result no longer
     // decides admission. The tests below pin the mechanism that does.
+
+    /// A request that dies between reserving and admitting must not lock its
+    /// principal out permanently.
+    ///
+    /// This is the boundary the bug actually reaches a user at: reservations are
+    /// owned by their SandboxLease, so Kubernetes GC frees them only once that
+    /// lease is *deleted*. A lease abandoned at `pending` is never deleted —
+    /// placement ignores anything not `admitted` — so its slot and alias stay
+    /// consumed and every retry returns 429/409 with no way out but manual
+    /// deletion.
+    ///
+    /// Asserting only that `pending_lease_is_abandoned` returns true would prove
+    /// nothing: the fix lives in the create handler, so the test has to be the
+    /// create that was previously refused.
+    #[tokio::test]
+    async fn create_reclaims_quota_stranded_by_its_own_abandoned_lease() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+
+        // Both of this principal's slots are held by reservations owned by a
+        // lease that never reached `admitted`.
+        let stranded_uid = "sandbox-stranded-uid";
+        let held = mount_reservation_api_owned(
+            &server,
+            &[
+                (
+                    quota_reservation_name(&principal, 0),
+                    stranded_uid.to_string(),
+                ),
+                (
+                    quota_reservation_name(&principal, 1),
+                    stranded_uid.to_string(),
+                ),
+            ],
+        )
+        .await;
+
+        // The abandoned lease itself: same principal, still `pending`, and old
+        // enough to be past the deadline.
+        let abandoned = {
+            let mut object = lease_json("sandbox-stranded", "alice@example.com", "Pending");
+            object["metadata"]["uid"] = serde_json::json!(stranded_uid);
+            object["metadata"]["creationTimestamp"] =
+                serde_json::json!((chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339());
+            object["metadata"]["annotations"] = serde_json::json!({
+                SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_PENDING
+            });
+            object
+        };
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(crate::testutil::k8s_list_response(vec![abandoned.clone()])),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-stranded",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(abandoned))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-stranded",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Success"
+            })))
+            .mount(&server)
+            .await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::ACCEPTED,
+            "a principal locked out by their own abandoned lease must recover on retry"
+        );
+
+        // The slot names are expected to still be occupied — by the NEW lease,
+        // which re-acquired them. What must be gone is any reservation still
+        // owned by the abandoned lease.
+        let remaining = held.lock().unwrap().clone();
+        let still_stranded: Vec<&String> = remaining
+            .iter()
+            .filter(|(_, object)| {
+                object["metadata"]["labels"][SANDBOX_RESERVATION_LEASE_UID_LABEL].as_str()
+                    == Some(stranded_uid)
+            })
+            .map(|(name, _)| name)
+            .collect();
+        assert!(
+            still_stranded.is_empty(),
+            "reservations owned by the abandoned lease must be released: {still_stranded:?}"
+        );
+    }
+
+    /// The deadline must never reap a request that is merely in flight — that
+    /// would delete a lease its caller is about to be told succeeded.
+    #[test]
+    fn only_leases_past_the_deadline_are_treated_as_abandoned() {
+        let now = chrono::Utc::now();
+        let fresh = (now - chrono::Duration::seconds(5)).to_rfc3339();
+        let old =
+            (now - chrono::Duration::seconds(SANDBOX_PENDING_DEADLINE_SECS + 60)).to_rfc3339();
+
+        assert!(!pending_lease_is_abandoned(Some(&fresh), now));
+        assert!(pending_lease_is_abandoned(Some(&old), now));
+        // Absent or unparseable evidence of age is not evidence of abandonment.
+        assert!(!pending_lease_is_abandoned(None, now));
+        assert!(!pending_lease_is_abandoned(Some("not-a-timestamp"), now));
+    }
 
     /// Quota is decided by CREATE contention on a per-slot name, not by
     /// counting. With every slot pre-held, admission must refuse, and must not
@@ -1897,6 +2213,49 @@ mod tests {
         );
         assert!(remaining.contains_key(&quota_reservation_name(&principal, 0)));
         assert!(remaining.contains_key(&alias_reservation_name(&principal, "review")));
+    }
+
+    /// Releasing a reservation must delete OUR object, never whatever now holds
+    /// that name.
+    ///
+    /// The names are deterministic and reused: once a slot is freed, the next
+    /// request takes the identical name. If a release ever runs against a stale
+    /// record — the reservation was already reaped and recreated in between —
+    /// deleting by bare name would silently free a *live* lease's slot, letting
+    /// a third request over-admit against it.
+    ///
+    /// Hardening the mock to honour UID preconditions was necessary but not
+    /// sufficient: without this test nothing reached that code path, so removing
+    /// the precondition from the production release still passed the suite.
+    #[tokio::test]
+    async fn releasing_a_stale_record_leaves_the_current_owner_alone() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let principal = principal_hash(&identity());
+        let contested = quota_reservation_name(&principal, 0);
+        // The name is currently held by a DIFFERENT lease than the one our
+        // stale record remembers.
+        let held = mount_reservation_api_owned(
+            &server,
+            &[(contested.clone(), "current-owner-lease-uid".to_string())],
+        )
+        .await;
+
+        let client = crate::testutil::mock_k8s_client(&server);
+        let reservations: Api<Lease> = Api::namespaced(client, "test-ns");
+        let stale = AdmissionReservation {
+            name: contested.clone(),
+            uid: "a-previous-reservation-uid".into(),
+        };
+
+        release_admission_reservations(&reservations, std::slice::from_ref(&stale))
+            .await
+            .expect("a stale record is not an error — ours is simply already gone");
+
+        assert!(
+            held.lock().unwrap().contains_key(&contested),
+            "the current owner's reservation must survive a stale release"
+        );
     }
 
     /// Reservations are fenced to the lease UID, so a different principal's

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -711,6 +711,21 @@ fn requester_list_params(identity: &AuthIdentity) -> ListParams {
 ///
 /// Components are length-prefixed so `("ab", "c")` and `("a", "bc")` cannot
 /// produce the same digest.
+///
+/// # Changing this function is a migration
+///
+/// The output names the reservation objects AND the label selector used to find
+/// them, so changing it renames every quota slot and alias at once. Objects
+/// created under the previous scheme become invisible: they still occupy
+/// backend resources, but the new selector cannot see them, so a principal
+/// could acquire their full limit again in the new namespace and re-take an
+/// alias someone still holds — a quota and alias bypass.
+///
+/// That was safe to ignore for the FNV-to-SHA-256 change only because
+/// `SandboxLease` had never shipped: it is absent from `main`, from `v0.38.0`,
+/// and from the released chart, so no object could exist under the old scheme.
+/// Once this ships, any further change needs a versioned migration that keeps
+/// enforcing against legacy reservations until they are drained.
 fn principal_hash(identity: &AuthIdentity) -> String {
     let mut hasher = Sha256::new();
     for component in [

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -1,0 +1,1555 @@
+//! HTTP admission for caller-safe [`SandboxLease`](crate::crd::SandboxLease)
+//! intent.
+//!
+//! The routes in this module deliberately stop at admission and lifecycle
+//! intent. They never resolve a target cluster, return Kubernetes credentials,
+//! or expose upstream Agent Sandbox objects. Placement controllers in #73/#74
+//! own those transitions.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use k8s_openapi::api::coordination::v1::{Lease, LeaseSpec};
+use kube::ResourceExt;
+use kube::api::{
+    Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, Preconditions,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tracing::{error, info};
+
+use super::auth::AuthIdentity;
+use super::policy::{clamp_sandbox_ttl, format_duration, is_sandbox_allowed, policy_for};
+use super::routes::AppState;
+use crate::backend::ClusterBackend;
+use crate::crd::{
+    ResolvedSandboxPlacement, SandboxCondition, SandboxLease, SandboxLeasePhase, SandboxLeaseSpec,
+    SandboxPool, SandboxPoolReference, SandboxPrincipal, SandboxTargetProvenance, SandboxVerb,
+};
+use crate::pool::{is_valid_k8s_name, parse_duration};
+use crate::sandbox::{aggregate_resource_limits, resource_ceiling_allows};
+
+const REQUESTER_HASH_LABEL: &str = "kobe.kunobi.ninja/requester-hash";
+const SANDBOX_POOL_LABEL: &str = "kobe.kunobi.ninja/sandbox-pool";
+const SANDBOX_ALIAS_LABEL: &str = "kobe.kunobi.ninja/alias";
+const SANDBOX_POOL_CRD: &str = "sandboxpools.kobe.kunobi.ninja";
+const SANDBOX_LEASE_CRD: &str = "sandboxleases.kobe.kunobi.ninja";
+const SANDBOX_RESERVATION_TYPE_LABEL: &str = "kobe.kunobi.ninja/sandbox-reservation";
+const SANDBOX_RESERVATION_LEASE_UID_LABEL: &str = "kobe.kunobi.ninja/sandbox-lease-uid";
+const SANDBOX_RESERVATION_LEASE_NAME_ANNOTATION: &str = "kobe.kunobi.ninja/sandbox-lease-name";
+const SANDBOX_RESERVATION_QUOTA: &str = "quota";
+const SANDBOX_RESERVATION_ALIAS: &str = "alias";
+const MAX_SANDBOX_CONCURRENCY_SLOTS: u32 = 256;
+/// Server-owned admission gate. Placement controllers must ignore every lease
+/// unless this annotation has the exact `admitted` value.
+pub(crate) const SANDBOX_ADMISSION_ANNOTATION: &str = "kobe.kunobi.ninja/sandbox-admission";
+pub(crate) const SANDBOX_ADMISSION_PENDING: &str = "pending";
+pub(crate) const SANDBOX_ADMISSION_ADMITTED: &str = "admitted";
+/// Server-owned release intent. Controllers own status transitions and observe
+/// this annotation with the same object resourceVersion fence.
+pub(crate) const SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION: &str =
+    "kobe.kunobi.ninja/sandbox-release-requested-at";
+
+/// Build the caller-authenticated Sandbox lease routes.
+pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
+    Router::new()
+        .route(
+            "/v1/sandbox-leases",
+            post(create_sandbox_lease::<B>).get(list_sandbox_leases::<B>),
+        )
+        .route(
+            "/v1/sandbox-leases/{id}",
+            get(get_sandbox_lease::<B>).delete(release_sandbox_lease::<B>),
+        )
+}
+
+/// Caller-safe lease intent. Unknown fields are rejected so a caller cannot
+/// smuggle requester identity, target coordinates, runtime settings, or an
+/// upstream Pod/Sandbox spec through a future-tolerant JSON object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateSandboxLeaseRequest {
+    pool: String,
+    #[serde(default)]
+    ttl: Option<String>,
+    #[serde(default)]
+    alias: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxLeaseResponse {
+    id: String,
+    phase: String,
+    pool: String,
+    ttl: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effective_ttl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    observed_generation: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provisioning_deadline: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ready_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    placement: Option<ResolvedSandboxPlacement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<SandboxTargetProvenance>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    conditions: Vec<SandboxCondition>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxLeaseSummary {
+    id: String,
+    phase: String,
+    pool: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxErrorResponse {
+    error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+fn sandbox_error(status: StatusCode, error: impl Into<String>, detail: Option<String>) -> Response {
+    (
+        status,
+        Json(SandboxErrorResponse {
+            error: error.into(),
+            detail,
+        }),
+    )
+        .into_response()
+}
+
+fn sandbox_infra_error(message: &'static str, err: impl std::fmt::Display) -> Response {
+    error!(error = %err, "{message}");
+    sandbox_error(StatusCode::SERVICE_UNAVAILABLE, message, None)
+}
+
+#[tracing::instrument(skip_all)]
+async fn create_sandbox_lease<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Json(request): Json<CreateSandboxLeaseRequest>,
+) -> Response {
+    if let Err(response) =
+        require_sandbox_crds(&state.client, &[SANDBOX_POOL_CRD, SANDBOX_LEASE_CRD]).await
+    {
+        return response;
+    }
+    let policy = policy_for(&identity);
+
+    if !is_valid_k8s_name(&request.pool) {
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid SandboxPool name",
+            Some(
+                "Pool must be a DNS label (lowercase alphanumeric and hyphens, 1-63 characters)"
+                    .into(),
+            ),
+        );
+    }
+    if !is_sandbox_allowed(&request.pool, SandboxVerb::Lease, &policy) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease is not allowed for this pool",
+            None,
+        );
+    }
+    if let Some(alias) = request.alias.as_deref()
+        && !is_valid_k8s_name(alias)
+    {
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid Sandbox lease alias",
+            Some(
+                "Alias must be a DNS label (lowercase alphanumeric and hyphens, 1-63 characters)"
+                    .into(),
+            ),
+        );
+    }
+
+    let pools: Api<SandboxPool> = Api::namespaced(state.client.clone(), &state.namespace);
+    let pool = match pools.get(&request.pool).await {
+        Ok(pool) => pool,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            return sandbox_error(StatusCode::NOT_FOUND, "SandboxPool not found", None);
+        }
+        Err(err) => return sandbox_infra_error("Unable to load SandboxPool", err),
+    };
+
+    if let Err(err) = pool.spec.validate() {
+        return sandbox_infra_error("SandboxPool configuration is invalid", err);
+    }
+    let pool_reference = match sandbox_pool_reference(&pool) {
+        Ok(reference) => reference,
+        Err(detail) => {
+            return sandbox_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "SandboxPool identity is incomplete",
+                Some(detail),
+            );
+        }
+    };
+
+    let requested_ttl = request.ttl.as_deref().unwrap_or(&pool.spec.default_ttl);
+    let Some(requested_duration) =
+        parse_duration(requested_ttl).filter(|duration| *duration > chrono::Duration::zero())
+    else {
+        if request.ttl.is_none() {
+            return sandbox_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "SandboxPool default TTL is invalid",
+                None,
+            );
+        }
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid Sandbox lease TTL",
+            Some("Use a positive duration such as '30m' or '2h'".into()),
+        );
+    };
+    let Some(policy_duration) = clamp_sandbox_ttl(requested_ttl, &policy) else {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease TTL is not authorized",
+            None,
+        );
+    };
+    if parse_duration(&pool.spec.provisioning_timeout)
+        .filter(|duration| *duration > chrono::Duration::zero())
+        .is_none()
+    {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "SandboxPool provisioning timeout is invalid",
+            None,
+        );
+    }
+    let Some(pool_max_ttl) =
+        parse_duration(&pool.spec.max_ttl).filter(|duration| *duration > chrono::Duration::zero())
+    else {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "SandboxPool maximum TTL is invalid",
+            None,
+        );
+    };
+    let effective_duration = policy_duration.min(pool_max_ttl);
+    let effective_ttl = format_duration(&effective_duration);
+    let was_clamped = effective_duration < requested_duration;
+
+    let Some(grant) = policy.sandbox.as_ref() else {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox access is not configured",
+            None,
+        );
+    };
+    let totals = match aggregate_resource_limits(&pool.spec.template) {
+        Ok(totals) => totals,
+        Err(err) => return sandbox_infra_error("SandboxPool resources are invalid", err),
+    };
+    match resource_ceiling_allows(&grant.resource_ceiling, &totals) {
+        Ok(true) => {}
+        Ok(false) => {
+            return sandbox_error(
+                StatusCode::FORBIDDEN,
+                "SandboxPool exceeds your resource ceiling",
+                None,
+            );
+        }
+        Err(err) => return sandbox_infra_error("Sandbox resource ceiling is invalid", err),
+    }
+
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let reservations: Api<Lease> = Api::namespaced(state.client.clone(), &state.namespace);
+    if grant.max_concurrent_leases > MAX_SANDBOX_CONCURRENCY_SLOTS {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Sandbox concurrency policy exceeds the supported reservation bound",
+            None,
+        );
+    }
+    let lease_id = format!(
+        "sandbox-{}",
+        &uuid::Uuid::new_v4().to_string().replace('-', "")[..12]
+    );
+    let lease = build_sandbox_lease(
+        &lease_id,
+        &state.namespace,
+        pool_reference,
+        &effective_ttl,
+        request.alias.as_deref(),
+        &identity,
+    );
+    let created = match leases.create(&PostParams::default(), &lease).await {
+        Ok(created) => created,
+        Err(err) => return sandbox_infra_error("Failed to create Sandbox lease", err),
+    };
+    if let Err(err) = validate_lease_shape(&lease, &created, SANDBOX_ADMISSION_PENDING) {
+        if let Err(cleanup_err) = delete_exact_pending_lease(&leases, &reservations, &created).await
+        {
+            error!(error = %cleanup_err, "Failed to remove malformed Sandbox lease create response");
+        }
+        return sandbox_infra_error("Sandbox lease create response failed validation", err);
+    }
+
+    // Quota and alias admission use atomic, per-principal Kubernetes Lease
+    // reservations. Advisory LIST checks above improve error latency, but only
+    // these CREATE operations are authoritative across API replicas.
+    let admission_reservations = match acquire_admission_reservations(
+        &reservations,
+        &created,
+        &identity,
+        request.alias.as_deref(),
+        grant.max_concurrent_leases,
+    )
+    .await
+    {
+        Ok(reservations) => reservations,
+        Err(AdmissionReservationError::QuotaExhausted) => {
+            if let Err(err) = delete_exact_pending_lease(&leases, &reservations, &created).await {
+                return sandbox_infra_error(
+                    "Sandbox quota reservation cleanup failed; lease remains unadmitted",
+                    err,
+                );
+            }
+            return sandbox_error(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Concurrent Sandbox lease limit ({}) reached",
+                    grant.max_concurrent_leases
+                ),
+                None,
+            );
+        }
+        Err(AdmissionReservationError::AliasTaken) => {
+            if let Err(err) = delete_exact_pending_lease(&leases, &reservations, &created).await {
+                return sandbox_infra_error(
+                    "Sandbox alias reservation cleanup failed; lease remains unadmitted",
+                    err,
+                );
+            }
+            return sandbox_error(
+                StatusCode::CONFLICT,
+                format!(
+                    "Sandbox lease alias '{}' is already active",
+                    request.alias.as_deref().unwrap_or_default()
+                ),
+                None,
+            );
+        }
+        Err(err) => {
+            if let Err(cleanup_err) =
+                delete_exact_pending_lease(&leases, &reservations, &created).await
+            {
+                error!(error = %cleanup_err, "Failed to remove Sandbox lease after reservation error");
+            }
+            return sandbox_infra_error("Failed to reserve Sandbox admission", err);
+        }
+    };
+
+    if let Err(err) = admit_sandbox_lease(&leases, &created).await {
+        if matches!(err, SandboxLeaseMutationError::AdmissionNotCommitted) {
+            if let Err(cleanup_err) =
+                release_admission_reservations(&reservations, &admission_reservations).await
+            {
+                error!(error = %cleanup_err, "Failed to release Sandbox admission reservations");
+            }
+            if let Err(cleanup_err) =
+                delete_exact_pending_lease(&leases, &reservations, &created).await
+            {
+                error!(error = %cleanup_err, "Failed to remove Sandbox lease after admission failure");
+            }
+        }
+        return sandbox_infra_error("Failed to finalize Sandbox lease admission", err);
+    }
+
+    info!(
+        lease_id = %lease_id,
+        pool = %request.pool,
+        identity = %identity.identity,
+        "Sandbox lease accepted for placement"
+    );
+
+    (
+        StatusCode::ACCEPTED,
+        Json(SandboxLeaseResponse {
+            id: lease_id,
+            phase: SandboxLeasePhase::Pending.to_string(),
+            pool: request.pool,
+            ttl: effective_ttl.clone(),
+            effective_ttl: was_clamped.then_some(effective_ttl),
+            alias: request.alias,
+            observed_generation: None,
+            provisioning_deadline: None,
+            ready_at: None,
+            expires_at: None,
+            placement: None,
+            target: None,
+            conditions: Vec::new(),
+        }),
+    )
+        .into_response()
+}
+
+#[tracing::instrument(skip_all)]
+async fn list_sandbox_leases<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+) -> Response {
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    let policy = policy_for(&identity);
+    let Some(grant) = policy.sandbox.as_ref() else {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox access is not configured",
+            None,
+        );
+    };
+    if !grant.verbs.contains(&SandboxVerb::Lease) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease read is not allowed",
+            None,
+        );
+    }
+
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let params = requester_list_params(&identity);
+    match leases.list(&params).await {
+        Ok(items) => {
+            let response: Vec<_> = items
+                .iter()
+                .filter(|lease| principal_matches(&lease.spec.requester, &identity))
+                .filter(|lease| {
+                    is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy)
+                })
+                .map(|lease| {
+                    let status = lease.status.clone().unwrap_or_default();
+                    SandboxLeaseSummary {
+                        id: lease.name_any(),
+                        phase: status.phase.to_string(),
+                        pool: lease.spec.pool_ref.name.clone(),
+                        alias: lease.spec.alias.clone(),
+                        expires_at: status.expires_at,
+                    }
+                })
+                .collect();
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(err) => sandbox_infra_error("Failed to list Sandbox leases", err),
+    }
+}
+
+#[tracing::instrument(skip_all)]
+async fn get_sandbox_lease<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let lease = match owned_sandbox_lease(&leases, &id, &identity).await {
+        Ok(Some(lease)) => lease,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(err) => return sandbox_infra_error("Failed to get Sandbox lease", err),
+    };
+    let policy = policy_for(&identity);
+    if !is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease read is not allowed",
+            None,
+        );
+    }
+
+    (StatusCode::OK, Json(sandbox_lease_response(lease, None))).into_response()
+}
+
+#[tracing::instrument(skip_all)]
+async fn release_sandbox_lease<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let lease = match owned_sandbox_lease(&leases, &id, &identity).await {
+        Ok(Some(lease)) => lease,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(err) => return sandbox_infra_error("Failed to get Sandbox lease", err),
+    };
+    let policy = policy_for(&identity);
+    if !is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Release, &policy) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox release is not allowed",
+            None,
+        );
+    }
+
+    let phase = lease
+        .status
+        .as_ref()
+        .map(|status| status.phase)
+        .unwrap_or_default();
+    if phase == SandboxLeasePhase::Quarantined {
+        return sandbox_error(
+            StatusCode::CONFLICT,
+            "Sandbox cleanup is quarantined",
+            Some("Cleanup remains uncertain; capacity has not been released".into()),
+        );
+    }
+    if matches!(
+        phase,
+        SandboxLeasePhase::Releasing | SandboxLeasePhase::Released | SandboxLeasePhase::Expired
+    ) {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+
+    if lease
+        .annotations()
+        .get(SANDBOX_ADMISSION_ANNOTATION)
+        .map(String::as_str)
+        != Some(SANDBOX_ADMISSION_ADMITTED)
+    {
+        return match delete_exact_pending_lease(&leases, &lease).await {
+            Ok(()) => StatusCode::NO_CONTENT.into_response(),
+            Err(err) => sandbox_infra_error("Failed to remove unadmitted Sandbox lease", err),
+        };
+    }
+    if lease
+        .annotations()
+        .contains_key(SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION)
+    {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+
+    let Some(resource_version) = lease.resource_version() else {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Sandbox lease has no resourceVersion",
+            None,
+        );
+    };
+    let patch = serde_json::json!({
+        "metadata": {
+            "resourceVersion": resource_version,
+            "annotations": {
+                SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION: chrono::Utc::now().to_rfc3339()
+            }
+        }
+    });
+    match leases
+        .patch(&id, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+    {
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Err(err) => sandbox_infra_error("Failed to request Sandbox release", err),
+    }
+}
+
+async fn require_sandbox_crds(client: &kube::Client, names: &[&str]) -> Result<(), Response> {
+    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    for name in names {
+        match crds.get(name).await {
+            Ok(crd)
+                if crd
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.conditions.as_ref())
+                    .is_some_and(|conditions| {
+                        conditions.iter().any(|condition| {
+                            condition.type_ == "Established" && condition.status == "True"
+                        })
+                    }) =>
+            {
+                continue;
+            }
+            Ok(_) | Err(kube::Error::Api(_)) => {
+                return Err(sandbox_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Sandbox API is not installed or established",
+                    None,
+                ));
+            }
+            Err(err) => return Err(sandbox_infra_error("Unable to discover Sandbox API", err)),
+        }
+    }
+    Ok(())
+}
+
+async fn owned_sandbox_lease(
+    leases: &Api<SandboxLease>,
+    id: &str,
+    identity: &AuthIdentity,
+) -> Result<Option<SandboxLease>, kube::Error> {
+    match leases.get(id).await {
+        Ok(lease) if principal_matches(&lease.spec.requester, identity) => Ok(Some(lease)),
+        Ok(_) => Ok(None),
+        Err(kube::Error::Api(error)) if error.code == 404 => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn sandbox_lease_response(
+    lease: SandboxLease,
+    effective_ttl: Option<String>,
+) -> SandboxLeaseResponse {
+    let id = lease.name_any();
+    let status = lease.status.unwrap_or_default();
+    SandboxLeaseResponse {
+        id,
+        phase: status.phase.to_string(),
+        pool: lease.spec.pool_ref.name,
+        ttl: lease.spec.ttl,
+        effective_ttl,
+        alias: lease.spec.alias,
+        observed_generation: status.observed_generation,
+        provisioning_deadline: status.provisioning_deadline,
+        ready_at: status.ready_at,
+        expires_at: status.expires_at,
+        placement: status.placement,
+        target: status.target,
+        conditions: status.conditions,
+    }
+}
+
+fn build_sandbox_lease(
+    id: &str,
+    namespace: &str,
+    pool_ref: SandboxPoolReference,
+    ttl: &str,
+    alias: Option<&str>,
+    identity: &AuthIdentity,
+) -> SandboxLease {
+    let mut labels = std::collections::BTreeMap::new();
+    labels.insert(SANDBOX_POOL_LABEL.into(), pool_ref.name.clone());
+    labels.insert(REQUESTER_HASH_LABEL.into(), principal_hash(identity));
+    if let Some(alias) = alias {
+        labels.insert(SANDBOX_ALIAS_LABEL.into(), alias.into());
+    }
+    let annotations = std::collections::BTreeMap::from([(
+        SANDBOX_ADMISSION_ANNOTATION.to_string(),
+        SANDBOX_ADMISSION_PENDING.to_string(),
+    )]);
+    SandboxLease {
+        metadata: ObjectMeta {
+            name: Some(id.into()),
+            namespace: Some(namespace.into()),
+            labels: Some(labels),
+            annotations: Some(annotations),
+            ..Default::default()
+        },
+        spec: SandboxLeaseSpec {
+            pool_ref,
+            ttl: ttl.into(),
+            alias: alias.map(str::to_owned),
+            requester: SandboxPrincipal {
+                provider: identity.provider.clone(),
+                requester_type: identity.requester_type.clone(),
+                issuer: identity.issuer.clone(),
+                identity: identity.identity.clone(),
+            },
+        },
+        status: None,
+    }
+}
+
+fn requester_list_params(identity: &AuthIdentity) -> ListParams {
+    ListParams::default().labels(&format!(
+        "{REQUESTER_HASH_LABEL}={}",
+        principal_hash(identity)
+    ))
+}
+
+/// Stable, non-reversible label value used only as a server-side prefilter.
+/// Exact identity is always rechecked from the object, so hash collision never
+/// grants visibility or consumes another caller's quota.
+fn principal_hash(identity: &AuthIdentity) -> String {
+    const FNV_OFFSET: u64 = 0xcbf29ce484222325;
+    const FNV_PRIME: u64 = 0x00000100000001B3;
+    let mut hash = FNV_OFFSET;
+    for component in [
+        identity.provider.as_bytes(),
+        identity.issuer.as_bytes(),
+        identity.identity.as_bytes(),
+    ] {
+        for byte in (component.len() as u64)
+            .to_be_bytes()
+            .iter()
+            .chain(component)
+        {
+            hash ^= *byte as u64;
+            hash = hash.wrapping_mul(FNV_PRIME);
+        }
+    }
+    format!("{hash:016x}")
+}
+
+fn principal_matches(requester: &SandboxPrincipal, identity: &AuthIdentity) -> bool {
+    requester.provider == identity.provider
+        && requester.issuer == identity.issuer
+        && requester.identity == identity.identity
+}
+
+fn sandbox_pool_reference(pool: &SandboxPool) -> Result<SandboxPoolReference, String> {
+    pool.namespace()
+        .ok_or_else(|| "SandboxPool has no namespace".to_string())?;
+    let uid = pool
+        .uid()
+        .ok_or_else(|| "SandboxPool has no UID".to_string())?;
+    let generation = pool
+        .metadata
+        .generation
+        .ok_or_else(|| "SandboxPool has no generation".to_string())?;
+    Ok(SandboxPoolReference {
+        name: pool.name_any(),
+        uid,
+        generation,
+    })
+}
+
+async fn admit_sandbox_lease(
+    leases: &Api<SandboxLease>,
+    lease: &SandboxLease,
+) -> Result<(), SandboxLeaseMutationError> {
+    let name = lease.name_any();
+    let resource_version = lease
+        .resource_version()
+        .ok_or(SandboxLeaseMutationError::MissingResourceVersion)?;
+    let patch = serde_json::json!({
+        "metadata": {
+            "resourceVersion": resource_version,
+            "annotations": { SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_ADMITTED }
+        }
+    });
+    match leases
+        .patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+    {
+        Ok(admitted) => validate_lease_shape(lease, &admitted, SANDBOX_ADMISSION_ADMITTED),
+        Err(patch_error) => {
+            // The API server may have committed the patch before the response
+            // was lost. Resolve that ambiguity from the exact UID: an admitted
+            // object is success; a still-pending object is removed with its
+            // current resourceVersion so a failed POST cannot later be placed.
+            let current = match leases.get(&name).await {
+                Ok(current) => current,
+                Err(kube::Error::Api(error)) if error.code == 404 => {
+                    return Err(SandboxLeaseMutationError::Kubernetes(patch_error));
+                }
+                Err(error) => return Err(SandboxLeaseMutationError::Kubernetes(error)),
+            };
+            match current
+                .annotations()
+                .get(SANDBOX_ADMISSION_ANNOTATION)
+                .map(String::as_str)
+            {
+                Some(SANDBOX_ADMISSION_ADMITTED) => {
+                    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_ADMITTED)
+                }
+                Some(SANDBOX_ADMISSION_PENDING) => {
+                    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
+                    delete_exact_pending_lease(leases, &current).await?;
+                    Err(SandboxLeaseMutationError::AdmissionNotCommitted)
+                }
+                _ => Err(SandboxLeaseMutationError::UnexpectedAdmissionState),
+            }
+        }
+    }
+}
+
+async fn delete_exact_pending_lease(
+    leases: &Api<SandboxLease>,
+    lease: &SandboxLease,
+) -> Result<(), SandboxLeaseMutationError> {
+    let expected_uid = lease.uid().ok_or(SandboxLeaseMutationError::MissingUid)?;
+    let current = match leases.get(&lease.name_any()).await {
+        Ok(current) => current,
+        Err(kube::Error::Api(error)) if error.code == 404 => return Ok(()),
+        Err(error) => return Err(error.into()),
+    };
+    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
+    if current.uid().as_deref() != Some(expected_uid.as_str()) {
+        return Err(SandboxLeaseMutationError::UidChanged);
+    }
+    let resource_version = current
+        .resource_version()
+        .ok_or(SandboxLeaseMutationError::MissingResourceVersion)?;
+    let params = DeleteParams {
+        preconditions: Some(Preconditions {
+            uid: Some(expected_uid),
+            resource_version: Some(resource_version),
+        }),
+        ..Default::default()
+    };
+    leases.delete(&current.name_any(), &params).await?;
+    Ok(())
+}
+
+fn validate_lease_shape(
+    expected: &SandboxLease,
+    actual: &SandboxLease,
+    admission: &str,
+) -> Result<(), SandboxLeaseMutationError> {
+    if actual.name_any() != expected.name_any()
+        || actual.namespace() != expected.namespace()
+        || actual.spec != expected.spec
+    {
+        return Err(SandboxLeaseMutationError::LeaseShapeChanged);
+    }
+    if let Some(expected_uid) = expected.uid()
+        && actual.uid().as_deref() != Some(expected_uid.as_str())
+    {
+        return Err(SandboxLeaseMutationError::UidChanged);
+    }
+    if actual.uid().is_none() {
+        return Err(SandboxLeaseMutationError::MissingUid);
+    }
+    if actual.resource_version().is_none() {
+        return Err(SandboxLeaseMutationError::MissingResourceVersion);
+    }
+    for (key, expected_value) in expected.labels() {
+        if actual.labels().get(key) != Some(expected_value) {
+            return Err(SandboxLeaseMutationError::LeaseShapeChanged);
+        }
+    }
+    if actual
+        .annotations()
+        .get(SANDBOX_ADMISSION_ANNOTATION)
+        .map(String::as_str)
+        != Some(admission)
+    {
+        return Err(SandboxLeaseMutationError::UnexpectedAdmissionState);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+enum SandboxLeaseMutationError {
+    #[error("SandboxLease has no UID")]
+    MissingUid,
+    #[error("SandboxLease has no resourceVersion")]
+    MissingResourceVersion,
+    #[error("current SandboxLease was absent from the admission verification list")]
+    CurrentLeaseMissing,
+    #[error("current SandboxLease appeared more than once in the admission verification list")]
+    DuplicateCurrentLease,
+    #[error("SandboxLease identity or server-owned admission fields changed")]
+    LeaseShapeChanged,
+    #[error("SandboxLease UID changed")]
+    UidChanged,
+    #[error("SandboxLease has an unexpected admission state")]
+    UnexpectedAdmissionState,
+    #[error("SandboxLease admission patch did not commit; the pending object was removed")]
+    AdmissionNotCommitted,
+    #[error(transparent)]
+    Kubernetes(#[from] kube::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::api::policy::{Policy, SandboxPolicy};
+    use crate::crd::{SandboxLeaseStatus, SandboxResourceCeiling};
+    use axum::body;
+    use tower::ServiceExt;
+    use wiremock::matchers::{method, path, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn identity() -> AuthIdentity {
+        AuthIdentity {
+            provider: "developer-oidc".into(),
+            requester_type: "oidc:developer".into(),
+            identity: "alice@example.com".into(),
+            issuer: "https://issuer.example".into(),
+            policy: Policy {
+                allowed_pools: vec!["cluster-*".into()],
+                max_ttl: chrono::Duration::hours(8),
+                max_concurrent_leases: 2,
+                default_priority: 50,
+                max_extensions: 2,
+                sandbox: Some(SandboxPolicy {
+                    allowed_pools: vec!["agent-*".into()],
+                    verbs: vec![SandboxVerb::Lease, SandboxVerb::Release],
+                    max_ttl: chrono::Duration::hours(2),
+                    max_concurrent_leases: 2,
+                    resource_ceiling: SandboxResourceCeiling {
+                        max_cpu: "2".into(),
+                        max_memory: "4Gi".into(),
+                    },
+                }),
+            },
+        }
+    }
+
+    fn test_state(server: &MockServer) -> AppState<crate::testutil::MockBackend> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        AppState {
+            client: crate::testutil::mock_k8s_client(server),
+            authenticator: std::sync::Arc::new(super::super::auth::JwtAuthenticator::new(
+                "test".into(),
+            )),
+            namespace: "test-ns".into(),
+            backend: crate::testutil::MockBackend::new(),
+            factory: None,
+            datastore: Default::default(),
+            connect_cache: Default::default(),
+        }
+    }
+
+    fn pool_json() -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "SandboxPool",
+            "metadata": {
+                "name": "agent-small",
+                "namespace": "test-ns",
+                "uid": "pool-uid",
+                "generation": 1
+            },
+            "spec": {
+                "warmCapacity": 1,
+                "defaultTtl": "1h",
+                "maxTtl": "4h",
+                "provisioningTimeout": "10m",
+                "placement": { "type": "management" },
+                "template": {
+                    "defaultContainer": "agent",
+                    "containers": [{
+                        "name": "agent",
+                        "image": "example.invalid/agent@sha256:abc",
+                        "resources": {
+                            "requests": {
+                                "cpu": "500m",
+                                "memory": "512Mi",
+                                "ephemeralStorage": "512Mi"
+                            },
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1Gi",
+                                "ephemeralStorage": "1Gi"
+                            }
+                        }
+                    }],
+                    "exposedPorts": [{ "name": "http", "container": "agent", "port": 3000 }]
+                },
+                "isolation": { "tier": "trusted-runc" },
+                "readiness": { "canary": { "argv": ["/bin/true"], "timeout": "30s" } }
+            }
+        })
+    }
+
+    fn pool_reference() -> SandboxPoolReference {
+        SandboxPoolReference {
+            name: "agent-small".into(),
+            uid: "pool-uid".into(),
+            generation: 1,
+        }
+    }
+
+    fn crd_json(name: &str, plural: &str, kind: &str) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": { "name": name },
+            "spec": {
+                "group": "kobe.kunobi.ninja",
+                "names": { "kind": kind, "plural": plural },
+                "scope": "Namespaced",
+                "versions": [{
+                    "name": "v1alpha1",
+                    "served": true,
+                    "storage": true,
+                    "schema": { "openAPIV3Schema": { "type": "object" } }
+                }]
+            },
+            "status": {
+                "conditions": [{
+                    "type": "Established",
+                    "status": "True",
+                    "reason": "InitialNamesAccepted",
+                    "message": "accepted",
+                    "lastTransitionTime": "2026-08-10T00:00:00Z"
+                }]
+            }
+        })
+    }
+
+    async fn mount_sandbox_crds(server: &MockServer) {
+        for (name, plural, kind) in [
+            (SANDBOX_POOL_CRD, "sandboxpools", "SandboxPool"),
+            (SANDBOX_LEASE_CRD, "sandboxleases", "SandboxLease"),
+        ] {
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}"
+                )))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(crd_json(name, plural, kind)),
+                )
+                .mount(server)
+                .await;
+        }
+    }
+
+    fn lease_json(name: &str, requester: &str, phase: &str) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "SandboxLease",
+            "metadata": {
+                "name": name,
+                "namespace": "test-ns",
+                "uid": format!("{name}-uid"),
+                "resourceVersion": "1",
+                "creationTimestamp": "2026-08-10T00:00:00Z"
+                ,"labels": {
+                    SANDBOX_POOL_LABEL: "agent-small",
+                    REQUESTER_HASH_LABEL: principal_hash(&identity())
+                },
+                "annotations": {
+                    SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_ADMITTED
+                }
+            },
+            "spec": {
+                "poolRef": {
+                    "name": "agent-small",
+                    "uid": "pool-uid",
+                    "generation": 1
+                },
+                "ttl": "1h",
+                "requester": {
+                    "provider": "developer-oidc",
+                    "type": "oidc:developer",
+                    "issuer": "https://issuer.example",
+                    "identity": requester
+                }
+            },
+            "status": { "phase": phase, "observedGeneration": 1 }
+        })
+    }
+
+    fn sandbox_lease_from_json(mut value: serde_json::Value, admission: &str) -> SandboxLease {
+        value["metadata"]["annotations"][SANDBOX_ADMISSION_ANNOTATION] =
+            serde_json::json!(admission);
+        serde_json::from_value(value).unwrap()
+    }
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        let bytes = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    async fn mount_create_api(
+        server: &MockServer,
+        relist_created: bool,
+        ambiguous_admit_response: bool,
+    ) -> Arc<Mutex<Option<serde_json::Value>>> {
+        let lease_state = Arc::new(Mutex::new(None::<serde_json::Value>));
+        mount_sandbox_crds(server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pool_json()))
+            .mount(server)
+            .await;
+
+        let list_state = Arc::clone(&lease_state);
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                let items = if relist_created {
+                    list_state.lock().unwrap().clone().into_iter().collect()
+                } else {
+                    Vec::new()
+                };
+                ResponseTemplate::new(200).set_body_json(crate::testutil::k8s_list_response(items))
+            })
+            .mount(server)
+            .await;
+
+        let create_state = Arc::clone(&lease_state);
+        Mock::given(method("POST"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(move |request: &wiremock::Request| {
+                let mut object: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                let name = object["metadata"]["name"].as_str().unwrap().to_string();
+                object["metadata"]["uid"] = serde_json::json!(format!("{name}-uid"));
+                object["metadata"]["resourceVersion"] = serde_json::json!("1");
+                object["metadata"]["creationTimestamp"] = serde_json::json!("2026-08-10T00:00:00Z");
+                *create_state.lock().unwrap() = Some(object.clone());
+                ResponseTemplate::new(201).set_body_json(object)
+            })
+            .mount(server)
+            .await;
+
+        let get_state = Arc::clone(&lease_state);
+        Mock::given(method("GET"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| match get_state.lock().unwrap().clone() {
+                Some(object) => ResponseTemplate::new(200).set_body_json(object),
+                None => ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "Status",
+                    "status": "Failure",
+                    "reason": "NotFound",
+                    "code": 404
+                })),
+            })
+            .mount(server)
+            .await;
+
+        let patch_state = Arc::clone(&lease_state);
+        Mock::given(method("PATCH"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                let mut guard = patch_state.lock().unwrap();
+                let object = guard.as_mut().expect("created lease");
+                object["metadata"]["annotations"][SANDBOX_ADMISSION_ANNOTATION] =
+                    serde_json::json!(SANDBOX_ADMISSION_ADMITTED);
+                object["metadata"]["resourceVersion"] = serde_json::json!("2");
+                if ambiguous_admit_response {
+                    ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                        "apiVersion": "v1",
+                        "kind": "Status",
+                        "status": "Failure",
+                        "reason": "InternalError",
+                        "code": 500
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(object.clone())
+                }
+            })
+            .mount(server)
+            .await;
+
+        let delete_state = Arc::clone(&lease_state);
+        Mock::given(method("DELETE"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                *delete_state.lock().unwrap() = None;
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "Status",
+                    "status": "Success",
+                    "code": 200
+                }))
+            })
+            .mount(server)
+            .await;
+
+        lease_state
+    }
+
+    #[test]
+    fn request_rejects_server_owned_and_unsafe_fields() {
+        for field in [
+            "requester",
+            "namespace",
+            "runtimeClassName",
+            "podSpec",
+            "credentials",
+        ] {
+            let mut value = serde_json::json!({ "pool": "agent-small", "ttl": "1h" });
+            value[field] = serde_json::json!({ "identity": "mallory" });
+            assert!(
+                serde_json::from_value::<CreateSandboxLeaseRequest>(value).is_err(),
+                "field {field} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn build_lease_derives_requester_and_contains_no_target_or_credentials() {
+        let identity = identity();
+        let lease = build_sandbox_lease(
+            "sandbox-abc",
+            "kobe",
+            pool_reference(),
+            "30m",
+            Some("review"),
+            &identity,
+        );
+        assert_eq!(lease.spec.requester.identity, identity.identity);
+        assert_eq!(lease.spec.alias.as_deref(), Some("review"));
+        assert!(lease.status.is_none());
+        let json = serde_json::to_string(&lease).unwrap();
+        for forbidden in ["kubeconfig", "bearer", "token", "credentials", "podSpec"] {
+            assert!(
+                !json
+                    .to_ascii_lowercase()
+                    .contains(&forbidden.to_ascii_lowercase())
+            );
+        }
+    }
+
+    #[test]
+    fn quarantined_lease_still_consumes_quota() {
+        assert!(SandboxLeasePhase::Pending.consumes_capacity());
+        assert!(SandboxLeasePhase::Provisioning.consumes_capacity());
+        assert!(SandboxLeasePhase::Ready.consumes_capacity());
+        assert!(SandboxLeasePhase::Releasing.consumes_capacity());
+        assert!(SandboxLeasePhase::Quarantined.consumes_capacity());
+        assert!(!SandboxLeasePhase::Released.consumes_capacity());
+        assert!(!SandboxLeasePhase::Expired.consumes_capacity());
+    }
+
+    #[test]
+    fn response_never_contains_requester_or_credentials() {
+        let mut lease = build_sandbox_lease(
+            "sandbox-abc",
+            "kobe",
+            pool_reference(),
+            "30m",
+            None,
+            &identity(),
+        );
+        lease.status = Some(SandboxLeaseStatus::default());
+        let json = serde_json::to_string(&sandbox_lease_response(lease, None)).unwrap();
+        assert!(!json.contains("alice@example.com"));
+        assert!(!json.to_ascii_lowercase().contains("token"));
+        assert!(!json.to_ascii_lowercase().contains("kubeconfig"));
+    }
+
+    #[test]
+    fn quota_race_resolution_is_deterministic() {
+        let pending = sandbox_lease_from_json(
+            lease_json("sandbox-a", "alice@example.com", "Pending"),
+            SANDBOX_ADMISSION_PENDING,
+        );
+        let admitted = sandbox_lease_from_json(
+            lease_json("sandbox-z", "alice@example.com", "Pending"),
+            SANDBOX_ADMISSION_ADMITTED,
+        );
+        let active = vec![admitted, pending.clone()];
+        assert!(lease_exceeds_quota(&active, &pending, 1).unwrap());
+        assert!(matches!(
+            lease_exceeds_quota(
+                &active,
+                &sandbox_lease_from_json(
+                    lease_json("sandbox-missing", "alice@example.com", "Pending"),
+                    SANDBOX_ADMISSION_PENDING,
+                ),
+                2
+            ),
+            Err(SandboxLeaseMutationError::CurrentLeaseMissing)
+        ));
+    }
+
+    #[test]
+    fn principal_hash_separates_providers_and_issuers() {
+        let base = identity();
+        let mut other_provider = base.clone();
+        other_provider.provider = "other-oidc".into();
+        let mut other_issuer = base.clone();
+        other_issuer.issuer = "https://other.example".into();
+        assert_ne!(principal_hash(&base), principal_hash(&other_provider));
+        assert_ne!(principal_hash(&base), principal_hash(&other_issuer));
+    }
+
+    #[tokio::test]
+    async fn sandbox_routes_require_authentication() {
+        let server = MockServer::start().await;
+        let app = crate::api::routes::build_router(test_state(&server));
+        for (verb, uri) in [
+            ("GET", "/v1/sandbox-leases"),
+            ("POST", "/v1/sandbox-leases"),
+            ("GET", "/v1/sandbox-leases/sandbox-a"),
+            ("DELETE", "/v1/sandbox-leases/sandbox-a"),
+        ] {
+            let request = http::Request::builder()
+                .method(verb)
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from("{}"))
+                .unwrap();
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{verb} {uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn create_uses_server_identity_and_applies_pool_and_policy_ttl() {
+        let server = MockServer::start().await;
+        mount_create_api(&server, true, false).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("3h".into()),
+                alias: Some("review".into()),
+            }),
+        )
+        .await;
+        let status = response.status();
+        let body = response_json(response).await;
+        assert_eq!(status, StatusCode::ACCEPTED, "response: {body}");
+        assert_eq!(body["ttl"], "2h");
+        assert_eq!(body["effective_ttl"], "2h");
+        assert!(body.get("kubeconfig").is_none());
+        assert!(body.get("token").is_none());
+
+        let requests = server.received_requests().await.unwrap();
+        let create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path().ends_with("/sandboxleases")
+            })
+            .expect("SandboxLease create request");
+        let object: serde_json::Value = serde_json::from_slice(&create.body).unwrap();
+        assert_eq!(object["spec"]["requester"]["identity"], "alice@example.com");
+        assert_eq!(object["spec"]["requester"]["provider"], "developer-oidc");
+        assert_eq!(object["spec"]["poolRef"]["uid"], "pool-uid");
+        assert_eq!(object["spec"]["ttl"], "2h");
+        assert!(object["spec"].get("namespace").is_none());
+        assert!(object["spec"].get("runtimeClassName").is_none());
+    }
+
+    #[tokio::test]
+    async fn create_treats_applied_but_lost_admission_response_as_success() {
+        let server = MockServer::start().await;
+        mount_create_api(&server, true, true).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .all(|request| request.method.as_str() != "DELETE")
+        );
+    }
+
+    #[tokio::test]
+    async fn create_fails_closed_and_removes_lease_missing_from_relist() {
+        let server = MockServer::start().await;
+        mount_create_api(&server, false, false).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .any(|request| request.method.as_str() == "DELETE")
+        );
+    }
+
+    #[tokio::test]
+    async fn list_filters_exact_identity_after_hash_prefilter() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![
+                    lease_json("sandbox-own", "alice@example.com", "Ready"),
+                    lease_json("sandbox-foreign", "mallory@example.com", "Ready"),
+                ]),
+            ))
+            .mount(&server)
+            .await;
+
+        let response = list_sandbox_leases::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body.as_array().unwrap().len(), 1);
+        assert_eq!(body[0]["id"], "sandbox-own");
+        assert!(body[0].get("requester").is_none());
+    }
+
+    #[tokio::test]
+    async fn foreign_get_and_release_are_indistinguishable_from_missing() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-foreign",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-foreign",
+                "mallory@example.com",
+                "Ready",
+            )))
+            .mount(&server)
+            .await;
+
+        let get_response = get_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-foreign".into()),
+        )
+        .await;
+        assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+
+        let release_response = release_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-foreign".into()),
+        )
+        .await;
+        assert_eq!(release_response.status(), StatusCode::NOT_FOUND);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .all(|request| request.method.as_str() != "PATCH")
+        );
+    }
+
+    #[tokio::test]
+    async fn release_records_intent_without_writing_controller_status() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-own",
+                "alice@example.com",
+                "Ready",
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-own",
+                "alice@example.com",
+                "Ready",
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = release_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-own".into()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let requests = server.received_requests().await.unwrap();
+        let patch = requests
+            .iter()
+            .find(|request| request.method.as_str() == "PATCH")
+            .expect("release intent patch");
+        assert!(!patch.url.path().ends_with("/status"));
+        let body: serde_json::Value = serde_json::from_slice(&patch.body).unwrap();
+        assert_eq!(body["metadata"]["resourceVersion"], "1");
+        assert!(
+            body["metadata"]["annotations"]
+                .get(SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION)
+                .is_some()
+        );
+        assert!(body.get("status").is_none());
+    }
+
+    #[tokio::test]
+    async fn quarantined_release_is_explicit_conflict() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-own",
+                "alice@example.com",
+                "Quarantined",
+            )))
+            .mount(&server)
+            .await;
+
+        let response = release_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-own".into()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .all(|request| request.method.as_str() != "PATCH")
+        );
+    }
+}

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -17,7 +17,6 @@ use kube::api::{
     Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, Preconditions,
 };
 use serde::{Deserialize, Serialize};
-use sha2::{Digest, Sha256};
 use thiserror::Error;
 use tracing::{error, info};
 
@@ -363,7 +362,7 @@ async fn create_sandbox_lease<B: ClusterBackend>(
         }
     };
 
-    if let Err(err) = admit_sandbox_lease(&leases, &created).await {
+    if let Err(err) = admit_sandbox_lease(&leases, &reservations, &created).await {
         if matches!(err, SandboxLeaseMutationError::AdmissionNotCommitted) {
             if let Err(cleanup_err) =
                 release_admission_reservations(&reservations, &admission_reservations).await
@@ -534,7 +533,8 @@ async fn release_sandbox_lease<B: ClusterBackend>(
         .map(String::as_str)
         != Some(SANDBOX_ADMISSION_ADMITTED)
     {
-        return match delete_exact_pending_lease(&leases, &lease).await {
+        let reservations: Api<Lease> = Api::namespaced(state.client.clone(), &state.namespace);
+        return match delete_exact_pending_lease(&leases, &reservations, &lease).await {
             Ok(()) => StatusCode::NO_CONTENT.into_response(),
             Err(err) => sandbox_infra_error("Failed to remove unadmitted Sandbox lease", err),
         };
@@ -735,6 +735,7 @@ fn sandbox_pool_reference(pool: &SandboxPool) -> Result<SandboxPoolReference, St
 
 async fn admit_sandbox_lease(
     leases: &Api<SandboxLease>,
+    reservations: &Api<Lease>,
     lease: &SandboxLease,
 ) -> Result<(), SandboxLeaseMutationError> {
     let name = lease.name_any();
@@ -774,7 +775,7 @@ async fn admit_sandbox_lease(
                 }
                 Some(SANDBOX_ADMISSION_PENDING) => {
                     validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
-                    delete_exact_pending_lease(leases, &current).await?;
+                    delete_exact_pending_lease(leases, reservations, &current).await?;
                     Err(SandboxLeaseMutationError::AdmissionNotCommitted)
                 }
                 _ => Err(SandboxLeaseMutationError::UnexpectedAdmissionState),
@@ -783,14 +784,300 @@ async fn admit_sandbox_lease(
     }
 }
 
+/// One reservation this request actually created, recorded so it can be
+/// released by exact identity. The UID matters: releasing by name alone could
+/// delete a *replacement* reservation another request created after ours was
+/// already gone.
+#[derive(Debug, Clone)]
+struct AdmissionReservation {
+    name: String,
+    uid: String,
+}
+
+/// Why admission could not reserve its slot. Both refusals are ordinary,
+/// caller-visible outcomes rather than faults — the caller is over quota, or
+/// picked an alias someone else is already using.
+#[derive(Debug, Error)]
+enum AdmissionReservationError {
+    #[error("concurrent Sandbox lease quota is exhausted")]
+    QuotaExhausted,
+    #[error("Sandbox lease alias is already active")]
+    AliasTaken,
+    #[error("SandboxLease has no UID to fence its reservations against")]
+    MissingLeaseUid,
+    #[error(transparent)]
+    Kubernetes(#[from] kube::Error),
+}
+
+/// Quota slots are named per principal and per slot index, so acquiring one is
+/// a race for a *specific* name. `CREATE` is the atomic primitive: two API
+/// replicas contending for the last slot cannot both succeed, because the
+/// second gets 409 from the API server.
+fn quota_reservation_name(principal: &str, slot: u32) -> String {
+    format!("sbx-quota-{principal}-{slot}")
+}
+
+/// Aliases are validated DNS labels (<=63 chars) before we get here, so they can
+/// be embedded directly rather than hashed — which keeps the reservation name
+/// legible to an operator debugging a stuck alias.
+fn alias_reservation_name(principal: &str, alias: &str) -> String {
+    format!("sbx-alias-{principal}-{alias}")
+}
+
+/// Build a coordination `Lease` used purely as a compare-and-swap token.
+///
+/// The owner reference is the crash-safety net: if the `SandboxLease` is
+/// deleted by any path we did not anticipate, Kubernetes garbage-collects the
+/// reservations with it, so a slot cannot leak and permanently consume quota.
+fn build_admission_reservation(
+    name: String,
+    reservation_type: &str,
+    lease: &SandboxLease,
+    principal: &str,
+) -> Result<Lease, AdmissionReservationError> {
+    let lease_uid = lease
+        .uid()
+        .ok_or(AdmissionReservationError::MissingLeaseUid)?;
+    let mut labels = std::collections::BTreeMap::new();
+    labels.insert(
+        SANDBOX_RESERVATION_TYPE_LABEL.to_string(),
+        reservation_type.to_string(),
+    );
+    labels.insert(
+        SANDBOX_RESERVATION_LEASE_UID_LABEL.to_string(),
+        lease_uid.clone(),
+    );
+    labels.insert(REQUESTER_HASH_LABEL.to_string(), principal.to_string());
+    let mut annotations = std::collections::BTreeMap::new();
+    annotations.insert(
+        SANDBOX_RESERVATION_LEASE_NAME_ANNOTATION.to_string(),
+        lease.name_any(),
+    );
+
+    Ok(Lease {
+        metadata: ObjectMeta {
+            name: Some(name),
+            namespace: lease.namespace(),
+            labels: Some(labels),
+            annotations: Some(annotations),
+            owner_references: Some(vec![
+                k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                    api_version: "kobe.kunobi.ninja/v1alpha1".to_string(),
+                    kind: "SandboxLease".to_string(),
+                    name: lease.name_any(),
+                    uid: lease_uid,
+                    controller: Some(false),
+                    block_owner_deletion: Some(false),
+                },
+            ]),
+            ..Default::default()
+        },
+        // The token carries no lease semantics; existence *is* the claim.
+        spec: Some(LeaseSpec::default()),
+    })
+}
+
+/// Reserve this lease's admission atomically across every API replica.
+///
+/// Advisory `LIST` checks earlier in the request improve error latency, but
+/// they cannot be authoritative: two replicas can both read "one slot free" and
+/// both admit. Only the `CREATE` calls below decide, because the API server
+/// serializes them on object name.
+///
+/// Alias is reserved first. A taken alias is a deterministic, user-fixable
+/// conflict, so failing on it before consuming a quota slot avoids a pointless
+/// acquire-then-release round trip against the shared quota namespace.
+async fn acquire_admission_reservations(
+    reservations: &Api<Lease>,
+    lease: &SandboxLease,
+    identity: &AuthIdentity,
+    alias: Option<&str>,
+    max_concurrent_leases: u32,
+) -> Result<Vec<AdmissionReservation>, AdmissionReservationError> {
+    let principal = principal_hash(identity);
+    let mut acquired: Vec<AdmissionReservation> = Vec::new();
+
+    if let Some(alias) = alias {
+        let reservation = build_admission_reservation(
+            alias_reservation_name(&principal, alias),
+            SANDBOX_RESERVATION_ALIAS,
+            lease,
+            &principal,
+        )?;
+        match reservations
+            .create(&PostParams::default(), &reservation)
+            .await
+        {
+            Ok(created) => acquired.push(AdmissionReservation {
+                name: created.name_any(),
+                uid: created.uid().unwrap_or_default(),
+            }),
+            Err(kube::Error::Api(error)) if error.code == 409 => {
+                return Err(AdmissionReservationError::AliasTaken);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    // Advisory short-circuit. Scanning for a free slot costs one CREATE per
+    // taken slot, so a caller at a 256-slot limit would otherwise pay 256 round
+    // trips just to be told they are over quota. One LIST answers the common
+    // case. It is deliberately NOT authoritative — a slot can free or fill
+    // between this read and the CREATE below, which is exactly why the CREATE
+    // still decides.
+    match reservations
+        .list(&ListParams::default().labels(&format!(
+            "{SANDBOX_RESERVATION_TYPE_LABEL}={SANDBOX_RESERVATION_QUOTA},{REQUESTER_HASH_LABEL}={principal}"
+        )))
+        .await
+    {
+        Ok(existing) if existing.items.len() as u32 >= max_concurrent_leases => {
+            rollback_partial_reservations(reservations, &acquired).await;
+            return Err(AdmissionReservationError::QuotaExhausted);
+        }
+        Ok(_) => {}
+        // A failed advisory read must not fail the request: fall through to the
+        // authoritative scan, which is correct on its own.
+        Err(error) => {
+            error!(error = %error, "Advisory Sandbox quota read failed; falling back to slot scan");
+        }
+    }
+
+    // First free index wins. Slots are dense and bounded by policy, and
+    // `max_concurrent_leases` is capped at MAX_SANDBOX_CONCURRENCY_SLOTS by the
+    // caller, so this loop is bounded regardless of what a policy asks for.
+    let mut slot_taken = false;
+    for slot in 0..max_concurrent_leases {
+        let reservation = build_admission_reservation(
+            quota_reservation_name(&principal, slot),
+            SANDBOX_RESERVATION_QUOTA,
+            lease,
+            &principal,
+        )?;
+        match reservations
+            .create(&PostParams::default(), &reservation)
+            .await
+        {
+            Ok(created) => {
+                acquired.push(AdmissionReservation {
+                    name: created.name_any(),
+                    uid: created.uid().unwrap_or_default(),
+                });
+                slot_taken = true;
+                break;
+            }
+            // This slot belongs to another live lease; try the next one.
+            Err(kube::Error::Api(error)) if error.code == 409 => continue,
+            Err(error) => {
+                // Never leave a partially-acquired alias behind: it would block
+                // the caller's own retry with a spurious 409.
+                rollback_partial_reservations(reservations, &acquired).await;
+                return Err(error.into());
+            }
+        }
+    }
+
+    if !slot_taken {
+        rollback_partial_reservations(reservations, &acquired).await;
+        return Err(AdmissionReservationError::QuotaExhausted);
+    }
+
+    Ok(acquired)
+}
+
+/// Best-effort unwind of reservations taken earlier in a failed acquire.
+///
+/// Deliberately swallows errors: the caller is already returning a failure, and
+/// the owner reference guarantees Kubernetes reaps anything left behind when
+/// the pending lease is removed. Losing the original error to a cleanup error
+/// would be strictly worse for the caller.
+async fn rollback_partial_reservations(
+    reservations: &Api<Lease>,
+    acquired: &[AdmissionReservation],
+) {
+    if let Err(error) = release_admission_reservations(reservations, acquired).await {
+        error!(error = %error, "Failed to roll back partial Sandbox admission reservations");
+    }
+}
+
+/// Release exactly the reservations we hold. A UID precondition means a
+/// reservation that was already reaped and recreated by a different request is
+/// left alone rather than stolen from its new owner.
+async fn release_admission_reservations(
+    reservations: &Api<Lease>,
+    acquired: &[AdmissionReservation],
+) -> Result<(), AdmissionReservationError> {
+    for reservation in acquired {
+        let params = DeleteParams {
+            preconditions: Some(Preconditions {
+                uid: Some(reservation.uid.clone()),
+                resource_version: None,
+            }),
+            ..Default::default()
+        };
+        match reservations.delete(&reservation.name, &params).await {
+            Ok(_) => {}
+            // 404: already gone. 409: the name now holds someone else's
+            // reservation. Both mean "ours is not there", which is the goal.
+            Err(kube::Error::Api(error)) if error.code == 404 || error.code == 409 => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+/// Release every reservation owned by one exact lease UID.
+///
+/// Used on the cleanup path, where we hold the lease rather than the list of
+/// reservations we created. Selecting on the UID label (not the name) is what
+/// keeps a recreated same-named lease from dropping its predecessor's slots.
+async fn release_reservations_for_lease(
+    reservations: &Api<Lease>,
+    lease_uid: &str,
+) -> Result<(), SandboxLeaseMutationError> {
+    let params = ListParams::default().labels(&format!(
+        "{SANDBOX_RESERVATION_LEASE_UID_LABEL}={lease_uid}"
+    ));
+    let owned = reservations.list(&params).await?;
+    let held: Vec<AdmissionReservation> = owned
+        .into_iter()
+        .filter_map(|reservation| {
+            Some(AdmissionReservation {
+                name: reservation.name_any(),
+                uid: reservation.uid()?,
+            })
+        })
+        .collect();
+    if let Err(error) = release_admission_reservations(reservations, &held).await {
+        return match error {
+            AdmissionReservationError::Kubernetes(error) => Err(error.into()),
+            // The other variants cannot arise from a release.
+            other => {
+                error!(error = %other, "Unexpected Sandbox reservation release failure");
+                Ok(())
+            }
+        };
+    }
+    Ok(())
+}
+
+/// Remove a still-unadmitted lease and free whatever it reserved.
+///
+/// Reservations are released *after* the lease is gone. Doing it in the other
+/// order would briefly leave an admitted-looking lease with no quota slot,
+/// which a concurrent request could then double-book.
 async fn delete_exact_pending_lease(
     leases: &Api<SandboxLease>,
+    reservations: &Api<Lease>,
     lease: &SandboxLease,
 ) -> Result<(), SandboxLeaseMutationError> {
     let expected_uid = lease.uid().ok_or(SandboxLeaseMutationError::MissingUid)?;
     let current = match leases.get(&lease.name_any()).await {
         Ok(current) => current,
-        Err(kube::Error::Api(error)) if error.code == 404 => return Ok(()),
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            // The lease is already gone; its reservations may not be.
+            return release_reservations_for_lease(reservations, &expected_uid).await;
+        }
         Err(error) => return Err(error.into()),
     };
     validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
@@ -802,13 +1089,13 @@ async fn delete_exact_pending_lease(
         .ok_or(SandboxLeaseMutationError::MissingResourceVersion)?;
     let params = DeleteParams {
         preconditions: Some(Preconditions {
-            uid: Some(expected_uid),
+            uid: Some(expected_uid.clone()),
             resource_version: Some(resource_version),
         }),
         ..Default::default()
     };
     leases.delete(&current.name_any(), &params).await?;
-    Ok(())
+    release_reservations_for_lease(reservations, &expected_uid).await
 }
 
 fn validate_lease_shape(
@@ -855,10 +1142,6 @@ enum SandboxLeaseMutationError {
     MissingUid,
     #[error("SandboxLease has no resourceVersion")]
     MissingResourceVersion,
-    #[error("current SandboxLease was absent from the admission verification list")]
-    CurrentLeaseMissing,
-    #[error("current SandboxLease appeared more than once in the admission verification list")]
-    DuplicateCurrentLease,
     #[error("SandboxLease identity or server-owned admission fields changed")]
     LeaseShapeChanged,
     #[error("SandboxLease UID changed")]
@@ -1055,12 +1338,6 @@ mod tests {
         })
     }
 
-    fn sandbox_lease_from_json(mut value: serde_json::Value, admission: &str) -> SandboxLease {
-        value["metadata"]["annotations"][SANDBOX_ADMISSION_ANNOTATION] =
-            serde_json::json!(admission);
-        serde_json::from_value(value).unwrap()
-    }
-
     async fn response_json(response: Response) -> serde_json::Value {
         let bytes = body::to_bytes(response.into_body(), usize::MAX)
             .await
@@ -1068,13 +1345,172 @@ mod tests {
         serde_json::from_slice(&bytes).unwrap()
     }
 
+    /// Mock the coordination-Lease API with the semantics the CAS ledger
+    /// depends on:
+    ///
+    /// - `CREATE` succeeds on a free name and returns 409 on a taken one,
+    ///   exactly as the API server serializes competing writers;
+    /// - `LIST` honours `labelSelector`. This matters: the release path selects
+    ///   on the lease-UID label, so a mock that ignored selectors would let one
+    ///   lease's cleanup delete another lease's reservations and hide a real
+    ///   fencing bug.
+    ///
+    /// `preheld` simulates reservations another lease already owns, which is how
+    /// quota exhaustion and alias conflicts are provoked deterministically
+    /// without running concurrent requests. They are labelled with a foreign
+    /// lease UID, so correct code must leave them alone.
+    ///
+    /// Returns the live ledger so a test can assert what was acquired and,
+    /// crucially, what was released again.
+    async fn mount_reservation_api(
+        server: &MockServer,
+        preheld: &[String],
+    ) -> Arc<Mutex<std::collections::BTreeMap<String, serde_json::Value>>> {
+        const RESERVATIONS: &str = "/apis/coordination.k8s.io/v1/namespaces/test-ns/leases";
+        const FOREIGN_LEASE_UID: &str = "preheld-foreign-lease-uid";
+
+        // Reconstruct the labels a real reservation would carry from its name
+        // (`sbx-<type>-<principal>-<suffix>`), so selector filtering behaves.
+        let seeded: std::collections::BTreeMap<String, serde_json::Value> = preheld
+            .iter()
+            .map(|name| {
+                let parts: Vec<&str> = name.splitn(4, '-').collect();
+                let reservation_type = parts.get(1).copied().unwrap_or_default();
+                let principal = parts.get(2).copied().unwrap_or_default();
+                (
+                    name.clone(),
+                    serde_json::json!({
+                        "apiVersion": "coordination.k8s.io/v1",
+                        "kind": "Lease",
+                        "metadata": {
+                            "name": name,
+                            "namespace": "test-ns",
+                            "uid": format!("{name}-uid"),
+                            "labels": {
+                                SANDBOX_RESERVATION_TYPE_LABEL: reservation_type,
+                                SANDBOX_RESERVATION_LEASE_UID_LABEL: FOREIGN_LEASE_UID,
+                                REQUESTER_HASH_LABEL: principal,
+                            }
+                        }
+                    }),
+                )
+            })
+            .collect();
+        let held = Arc::new(Mutex::new(seeded));
+
+        let create_state = Arc::clone(&held);
+        Mock::given(method("POST"))
+            .and(path(RESERVATIONS))
+            .respond_with(move |request: &wiremock::Request| {
+                let mut object: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                let name = object["metadata"]["name"].as_str().unwrap().to_string();
+                let mut state = create_state.lock().unwrap();
+                if state.contains_key(&name) {
+                    return ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                        "apiVersion": "v1",
+                        "kind": "Status",
+                        "status": "Failure",
+                        "reason": "AlreadyExists",
+                        "message": format!("leases.coordination.k8s.io \"{name}\" already exists"),
+                        "code": 409
+                    }));
+                }
+                object["metadata"]["uid"] = serde_json::json!(format!("{name}-uid"));
+                object["metadata"]["resourceVersion"] = serde_json::json!("1");
+                state.insert(name, object.clone());
+                ResponseTemplate::new(201).set_body_json(object)
+            })
+            .mount(server)
+            .await;
+
+        let delete_state = Arc::clone(&held);
+        Mock::given(method("DELETE"))
+            .and(path_regex(
+                r"^/apis/coordination\.k8s\.io/v1/namespaces/test-ns/leases/.+$",
+            ))
+            .respond_with(move |request: &wiremock::Request| {
+                let name = request
+                    .url
+                    .path()
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or_default()
+                    .to_string();
+                if delete_state.lock().unwrap().remove(&name).is_some() {
+                    ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                        "apiVersion": "v1", "kind": "Status", "status": "Success"
+                    }))
+                } else {
+                    ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                        "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                        "reason": "NotFound", "code": 404
+                    }))
+                }
+            })
+            .mount(server)
+            .await;
+
+        let list_state = Arc::clone(&held);
+        Mock::given(method("GET"))
+            .and(path(RESERVATIONS))
+            .respond_with(move |request: &wiremock::Request| {
+                let selector = request
+                    .url
+                    .query_pairs()
+                    .find(|(key, _)| key == "labelSelector")
+                    .map(|(_, value)| value.to_string())
+                    .unwrap_or_default();
+                let required: Vec<(String, String)> = selector
+                    .split(',')
+                    .filter(|term| !term.is_empty())
+                    .filter_map(|term| {
+                        term.split_once('=')
+                            .map(|(key, value)| (key.to_string(), value.to_string()))
+                    })
+                    .collect();
+                let items: Vec<serde_json::Value> = list_state
+                    .lock()
+                    .unwrap()
+                    .values()
+                    .filter(|object| {
+                        required.iter().all(|(key, value)| {
+                            object["metadata"]["labels"][key].as_str() == Some(value.as_str())
+                        })
+                    })
+                    .cloned()
+                    .collect();
+                ResponseTemplate::new(200).set_body_json(crate::testutil::k8s_list_response(items))
+            })
+            .mount(server)
+            .await;
+
+        held
+    }
+
+    /// Full create-path harness: CRDs, an empty reservation ledger, and the
+    /// SandboxLease object mocks.
     async fn mount_create_api(
         server: &MockServer,
         relist_created: bool,
         ambiguous_admit_response: bool,
     ) -> Arc<Mutex<Option<serde_json::Value>>> {
-        let lease_state = Arc::new(Mutex::new(None::<serde_json::Value>));
         mount_sandbox_crds(server).await;
+        mount_reservation_api(server, &[]).await;
+        mount_create_lease_objects(server, relist_created, ambiguous_admit_response).await
+    }
+
+    /// Just the SandboxLease object mocks, for tests that mount their own
+    /// reservation ledger with pre-held slots.
+    async fn mount_create_lease_only(server: &MockServer) -> Arc<Mutex<Option<serde_json::Value>>> {
+        mount_create_lease_objects(server, true, false).await
+    }
+
+    async fn mount_create_lease_objects(
+        server: &MockServer,
+        relist_created: bool,
+        ambiguous_admit_response: bool,
+    ) -> Arc<Mutex<Option<serde_json::Value>>> {
+        let lease_state = Arc::new(Mutex::new(None::<serde_json::Value>));
         Mock::given(method("GET"))
             .and(path(
                 "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
@@ -1250,30 +1686,12 @@ mod tests {
         assert!(!json.to_ascii_lowercase().contains("kubeconfig"));
     }
 
-    #[test]
-    fn quota_race_resolution_is_deterministic() {
-        let pending = sandbox_lease_from_json(
-            lease_json("sandbox-a", "alice@example.com", "Pending"),
-            SANDBOX_ADMISSION_PENDING,
-        );
-        let admitted = sandbox_lease_from_json(
-            lease_json("sandbox-z", "alice@example.com", "Pending"),
-            SANDBOX_ADMISSION_ADMITTED,
-        );
-        let active = vec![admitted, pending.clone()];
-        assert!(lease_exceeds_quota(&active, &pending, 1).unwrap());
-        assert!(matches!(
-            lease_exceeds_quota(
-                &active,
-                &sandbox_lease_from_json(
-                    lease_json("sandbox-missing", "alice@example.com", "Pending"),
-                    SANDBOX_ADMISSION_PENDING,
-                ),
-                2
-            ),
-            Err(SandboxLeaseMutationError::CurrentLeaseMissing)
-        ));
-    }
+    // NOTE: `quota_race_resolution_is_deterministic` lived here and is gone.
+    // It exercised `lease_exceeds_quota`, an advisory list-then-rank check from
+    // the design this branch replaced. Ranking a LIST cannot decide admission:
+    // two API replicas can both observe a free slot and both admit. The
+    // coordination-Lease CAS ledger above is authoritative instead, so the old
+    // test pinned a contract that no longer exists.
 
     #[test]
     fn principal_hash_separates_providers_and_issuers() {
@@ -1372,10 +1790,28 @@ mod tests {
         );
     }
 
+    // NOTE: `create_fails_closed_and_removes_lease_missing_from_relist` was
+    // here and is gone with the design it tested. It asserted that a lease
+    // absent from a post-create LIST fails closed — the verification step of
+    // the list-then-rank quota scheme this branch replaces. Under the CAS
+    // ledger the LIST is not a verification step at all (it cannot be: two
+    // replicas can both read a free slot), so the relist result no longer
+    // decides admission. The tests below pin the mechanism that does.
+
+    /// Quota is decided by CREATE contention on a per-slot name, not by
+    /// counting. With every slot pre-held, admission must refuse, and must not
+    /// leave the caller's pending lease behind.
     #[tokio::test]
-    async fn create_fails_closed_and_removes_lease_missing_from_relist() {
+    async fn create_refuses_when_every_quota_slot_is_held() {
         let server = MockServer::start().await;
-        mount_create_api(&server, false, false).await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+        // The policy in `identity()` allows 2 concurrent Sandbox leases.
+        let preheld: Vec<String> = (0..2)
+            .map(|slot| quota_reservation_name(&principal, slot))
+            .collect();
+        mount_reservation_api(&server, &preheld).await;
+        mount_create_lease_only(&server).await;
 
         let response = create_sandbox_lease::<crate::testutil::MockBackend>(
             State(test_state(&server)),
@@ -1387,14 +1823,99 @@ mod tests {
             }),
         )
         .await;
-        assert_eq!(response.status(), StatusCode::SERVICE_UNAVAILABLE);
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
         assert!(
             server
                 .received_requests()
                 .await
                 .unwrap()
                 .iter()
-                .any(|request| request.method.as_str() == "DELETE")
+                .any(|request| request.method.as_str() == "DELETE"
+                    && request.url.path().contains("/sandboxleases/")),
+            "the unadmitted lease must be removed when its quota reservation fails"
+        );
+    }
+
+    /// An alias already held by another live lease is a conflict, and it must be
+    /// detected without burning one of the caller's quota slots.
+    #[tokio::test]
+    async fn create_refuses_a_taken_alias_without_consuming_a_quota_slot() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+        let held =
+            mount_reservation_api(&server, &[alias_reservation_name(&principal, "review")]).await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: Some("review".into()),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let remaining = held.lock().unwrap().clone();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "only the pre-existing alias should remain; no quota slot may be consumed: {remaining:?}"
+        );
+        assert!(remaining.contains_key(&alias_reservation_name(&principal, "review")));
+    }
+
+    /// The happy path must take exactly one quota slot and one alias, so a
+    /// caller's second lease cannot silently reuse the first one's slot.
+    #[tokio::test]
+    async fn create_acquires_exactly_one_quota_slot_and_one_alias() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let held = mount_reservation_api(&server, &[]).await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: Some("review".into()),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let principal = principal_hash(&identity());
+        let remaining = held.lock().unwrap().clone();
+        assert_eq!(
+            remaining.len(),
+            2,
+            "expected one slot + one alias: {remaining:?}"
+        );
+        assert!(remaining.contains_key(&quota_reservation_name(&principal, 0)));
+        assert!(remaining.contains_key(&alias_reservation_name(&principal, "review")));
+    }
+
+    /// Reservations are fenced to the lease UID, so a different principal's
+    /// identical alias is a different reservation name and does not collide.
+    #[test]
+    fn reservation_names_are_scoped_per_principal() {
+        let alice = principal_hash(&identity());
+        let bob = principal_hash(&AuthIdentity {
+            identity: "bob@example.com".into(),
+            ..identity()
+        });
+        assert_ne!(alice, bob);
+        assert_ne!(
+            alias_reservation_name(&alice, "review"),
+            alias_reservation_name(&bob, "review")
+        );
+        assert_ne!(
+            quota_reservation_name(&alice, 0),
+            quota_reservation_name(&bob, 0)
         );
     }
 

--- a/src/crd/access_policy.rs
+++ b/src/crd/access_policy.rs
@@ -2,6 +2,8 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::SandboxResourceCeiling;
+
 /// AccessPolicy configures authentication and authorization for cluster lease requests.
 ///
 /// Each AccessPolicy represents one authentication method (OIDC provider, static token,
@@ -139,6 +141,44 @@ pub struct AccessRule {
     /// Maximum TTL extensions per lease.
     #[serde(default = "default_max_extensions")]
     pub max_extensions: u32,
+
+    /// Optional, kind-specific Agent Sandbox permissions. Older policy objects
+    /// omit this block and continue authorizing Cluster leases exactly as
+    /// before, while Sandbox operations fail closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SandboxAccessRule>,
+}
+
+/// Bounded Agent Sandbox grant attached to one existing identity rule.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxAccessRule {
+    /// SandboxPool name patterns; wildcard semantics match Cluster pools.
+    #[schemars(length(min = 1))]
+    pub pools: Vec<String>,
+    /// Independently authorized Sandbox operations.
+    #[schemars(length(min = 1))]
+    pub verbs: Vec<SandboxVerb>,
+    /// Maximum runtime TTL, starting only once the Sandbox is Ready.
+    #[schemars(length(min = 1))]
+    pub max_ttl: String,
+    /// Maximum active Sandbox leases for this identity, separate from Cluster
+    /// lease concurrency.
+    pub max_concurrent_leases: u32,
+    /// Aggregate per-Sandbox CPU and memory ceiling.
+    pub resource_ceiling: SandboxResourceCeiling,
+}
+
+/// Agent Sandbox authorization verbs. `lease` includes create and own-object
+/// reads; `release` remains independently revocable.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxVerb {
+    Lease,
+    Exec,
+    Logs,
+    PortForward,
+    Release,
 }
 
 /// Claim-based match condition for OIDC rules.
@@ -356,5 +396,43 @@ mod tests {
         }))
         .expect("unknown fields must be ignored, not rejected");
         assert_eq!(spec.rules.len(), 1);
+    }
+
+    #[test]
+    fn legacy_access_rule_omits_sandbox_and_denies_by_shape() {
+        let rule: AccessRule = serde_json::from_value(serde_json::json!({
+            "pools": ["ci-*"],
+            "maxTtl": "1h",
+            "maxConcurrentLeases": 2
+        }))
+        .unwrap();
+
+        assert!(rule.sandbox.is_none());
+        assert!(serde_json::to_value(rule).unwrap().get("sandbox").is_none());
+    }
+
+    #[test]
+    fn typed_sandbox_grant_round_trips_and_rejects_unknown_fields() {
+        let value = serde_json::json!({
+            "pools": ["ci-*"],
+            "maxTtl": "1h",
+            "maxConcurrentLeases": 2,
+            "sandbox": {
+                "pools": ["agent-*"],
+                "verbs": ["lease", "exec", "logs", "port-forward", "release"],
+                "maxTtl": "30m",
+                "maxConcurrentLeases": 4,
+                "resourceCeiling": { "maxCpu": "2", "maxMemory": "4Gi" }
+            }
+        });
+        let rule: AccessRule = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(
+            serde_json::to_value(rule).unwrap()["sandbox"],
+            value["sandbox"]
+        );
+
+        let mut invalid = value;
+        invalid["sandbox"]["namespace"] = serde_json::json!("kube-system");
+        assert!(serde_json::from_value::<AccessRule>(invalid).is_err());
     }
 }

--- a/src/crd/mod.rs
+++ b/src/crd/mod.rs
@@ -6,6 +6,7 @@ pub mod datastore;
 pub mod instance;
 pub mod lease;
 pub mod profile;
+pub mod sandbox;
 
 pub use access_policy::*;
 pub use bootstrap_config::*;
@@ -15,6 +16,7 @@ pub use datastore::*;
 pub use instance::*;
 pub use lease::*;
 pub use profile::*;
+pub use sandbox::*;
 
 /// Schema helper for `serde_json::Value` fields that need an explicit `type: object`
 /// in the OpenAPI spec. Without this, schemars emits `{}` which K8s rejects.

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -1,0 +1,939 @@
+//! Kobe-native API contracts for leasing upstream Agent Sandbox capacity.
+//!
+//! These types deliberately expose a much smaller surface than an upstream
+//! `PodSpec` or `SandboxClaim`. Administrators define a bounded [`SandboxPool`];
+//! callers can request only a pool, TTL, alias, and requester identity through a
+//! [`SandboxLease`]. Placement controllers translate that intent into upstream
+//! resources without accepting caller-provided namespaces, credentials, mounts,
+//! environment variables, PVCs, or runtime classes.
+
+use std::collections::BTreeSet;
+
+use kube::{CustomResource, KubeSchema};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Administrator-owned class of Agent Sandbox capacity.
+#[derive(CustomResource, Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[kube(
+    group = "kobe.kunobi.ninja",
+    version = "v1alpha1",
+    kind = "SandboxPool",
+    plural = "sandboxpools",
+    shortname = "sp",
+    status = "SandboxPoolStatus",
+    namespaced,
+    printcolumn = r#"{"name":"Ready","type":"integer","jsonPath":".status.ready"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPoolSpec {
+    /// Desired number of unclaimed upstream Sandboxes kept warm.
+    #[schemars(range(max = 2147483647))]
+    pub warm_capacity: u32,
+
+    /// TTL used when a lease request omits one.
+    #[schemars(length(min = 1))]
+    pub default_ttl: String,
+
+    /// Maximum runtime TTL this pool will accept, independent of caller policy.
+    #[schemars(length(min = 1))]
+    pub max_ttl: String,
+
+    /// Maximum time allowed for placement and Sandbox provisioning. Runtime TTL
+    /// starts only after readiness and is therefore separate from this deadline.
+    #[schemars(length(min = 1))]
+    pub provisioning_timeout: String,
+
+    /// Exactly one target class. The tagged enum makes management and child
+    /// placement mutually exclusive in both JSON and generated OpenAPI.
+    pub placement: SandboxPlacement,
+
+    /// Restricted template translated into the controller-owned upstream
+    /// `SandboxTemplate`; this is intentionally not a `PodSpec` escape hatch.
+    pub template: SandboxTemplateSpec,
+
+    /// Claimed workload-isolation mechanism. Hardened tiers carry the exact
+    /// administrator-selected RuntimeClass; leases cannot override it.
+    pub isolation: SandboxIsolation,
+
+    /// Pool-specific execution canary used in addition to fixed controller
+    /// checks such as upstream readiness and runtime verification.
+    pub readiness: SandboxReadinessRequirements,
+}
+
+impl SandboxPoolSpec {
+    /// Validate relationships that cannot be expressed by the Rust type shape.
+    ///
+    /// Controllers and administrative admission paths must call this before
+    /// rendering upstream objects. Structural exclusivity for placement and
+    /// isolation is already enforced by tagged enums.
+    // `crdgen` imports this module for schemas without calling runtime helpers.
+    #[allow(dead_code)]
+    pub fn validate(&self) -> Result<(), SandboxPoolValidationError> {
+        for (field, value) in [
+            ("defaultTtl", self.default_ttl.as_str()),
+            ("maxTtl", self.max_ttl.as_str()),
+            ("provisioningTimeout", self.provisioning_timeout.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyDuration(field));
+            }
+        }
+
+        if self.warm_capacity > i32::MAX as u32 {
+            return Err(SandboxPoolValidationError::WarmCapacityTooLarge);
+        }
+        if let SandboxPlacement::ChildCluster { cluster_pool_ref } = &self.placement
+            && cluster_pool_ref.trim().is_empty()
+        {
+            return Err(SandboxPoolValidationError::EmptyClusterPoolRef);
+        }
+
+        if self.template.containers.is_empty() {
+            return Err(SandboxPoolValidationError::NoContainers);
+        }
+
+        let mut container_names = BTreeSet::new();
+        for container in &self.template.containers {
+            if container.name.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyContainerName);
+            }
+            if !container_names.insert(container.name.as_str()) {
+                return Err(SandboxPoolValidationError::DuplicateContainer(
+                    container.name.clone(),
+                ));
+            }
+            if container.image.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyContainerImage(
+                    container.name.clone(),
+                ));
+            }
+            for (field, value) in [
+                ("requests.cpu", container.resources.requests.cpu.as_str()),
+                (
+                    "requests.memory",
+                    container.resources.requests.memory.as_str(),
+                ),
+                (
+                    "requests.ephemeralStorage",
+                    container.resources.requests.ephemeral_storage.as_str(),
+                ),
+                ("limits.cpu", container.resources.limits.cpu.as_str()),
+                ("limits.memory", container.resources.limits.memory.as_str()),
+                (
+                    "limits.ephemeralStorage",
+                    container.resources.limits.ephemeral_storage.as_str(),
+                ),
+            ] {
+                if value.trim().is_empty() {
+                    return Err(SandboxPoolValidationError::EmptyResource {
+                        container: container.name.clone(),
+                        field,
+                    });
+                }
+            }
+        }
+
+        if !container_names.contains(self.template.default_container.as_str()) {
+            return Err(SandboxPoolValidationError::UnknownDefaultContainer(
+                self.template.default_container.clone(),
+            ));
+        }
+
+        let mut port_names = BTreeSet::new();
+        let mut target_ports = BTreeSet::new();
+        for port in &self.template.exposed_ports {
+            if port.name.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyPortName);
+            }
+            if !port_names.insert(port.name.as_str()) {
+                return Err(SandboxPoolValidationError::DuplicatePortName(
+                    port.name.clone(),
+                ));
+            }
+            if port.port == 0 {
+                return Err(SandboxPoolValidationError::ZeroPort(port.name.clone()));
+            }
+            if !container_names.contains(port.container.as_str()) {
+                return Err(SandboxPoolValidationError::UnknownPortContainer {
+                    port: port.name.clone(),
+                    container: port.container.clone(),
+                });
+            }
+            if !target_ports.insert((port.container.as_str(), port.port)) {
+                return Err(SandboxPoolValidationError::DuplicateContainerPort {
+                    container: port.container.clone(),
+                    port: port.port,
+                });
+            }
+        }
+
+        if let Some(runtime_class) = self.isolation.runtime_class_name()
+            && runtime_class.trim().is_empty()
+        {
+            return Err(SandboxPoolValidationError::EmptyRuntimeClass);
+        }
+
+        if self.readiness.canary.argv.is_empty()
+            || self
+                .readiness
+                .canary
+                .argv
+                .iter()
+                .any(|part| part.is_empty())
+        {
+            return Err(SandboxPoolValidationError::EmptyCanaryArgv);
+        }
+        if self.readiness.canary.timeout.trim().is_empty() {
+            return Err(SandboxPoolValidationError::EmptyCanaryTimeout);
+        }
+
+        Ok(())
+    }
+}
+
+/// Exactly one place in which a SandboxPool may be reconciled.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum SandboxPlacement {
+    /// Reconcile upstream objects in Kobe's management cluster.
+    Management {},
+    /// Acquire a child cluster from this same-namespace ClusterPool.
+    ChildCluster {
+        /// Name of the administrator-owned `ClusterPool` used for composition.
+        #[serde(rename = "clusterPoolRef")]
+        cluster_pool_ref: String,
+    },
+}
+
+// Internally tagged enums normally become `oneOf` schemas whose discriminator
+// property has a different enum value in each branch. Kubernetes structural
+// CRDs reject that shape, so keep the wire representation while publishing one
+// flat object plus CEL for the branch invariant.
+impl JsonSchema for SandboxPlacement {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SandboxPlacement".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string", "enum": ["management", "childCluster"] },
+                "clusterPoolRef": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                }
+            },
+            "x-kubernetes-validations": [{
+                "rule": "(self.type == 'management' && !has(self.clusterPoolRef)) || (self.type == 'childCluster' && has(self.clusterPoolRef))",
+                "message": "management must not set clusterPoolRef; childCluster must set it"
+            }]
+        }))
+        .expect("static SandboxPlacement schema is valid")
+    }
+}
+
+/// Restricted administrator-authored template for one Sandbox Pod.
+#[derive(Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[x_kube(
+    validation = Rule::new("self.containers.exists(c, c.name == self.defaultContainer)")
+        .message("defaultContainer must name one declared container")
+)]
+#[x_kube(
+    validation = Rule::new("self.containers.all(c, self.containers.filter(other, other.name == c.name).size() == 1)")
+        .message("container names must be unique")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.containers.exists(c, c.name == p.container))")
+        .message("every exposed port must name one declared container")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.name == p.name).size() == 1)")
+        .message("exposed port names must be unique")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)")
+        .message("a container port may be declared only once")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches('.*[a-z].*') && !p.name.contains('--'))")
+        .message("exposed port names must contain a letter and cannot contain consecutive hyphens")
+)]
+pub struct SandboxTemplateSpec {
+    /// Container selected by default for execution operations.
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub default_container: String,
+    /// Complete bounded set of containers. Environment, mounts, security
+    /// context, service accounts, and arbitrary Pod fields are not exposed.
+    #[schemars(length(min = 1, max = 16))]
+    pub containers: Vec<SandboxContainerSpec>,
+    /// Ports that later access brokers may expose. Any undeclared port remains
+    /// unauthorized.
+    #[serde(default)]
+    #[schemars(length(max = 64))]
+    pub exposed_ports: Vec<SandboxPortSpec>,
+}
+
+/// One administrator-controlled container in a Sandbox template.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxContainerSpec {
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub name: String,
+    #[schemars(length(min = 1, max = 2048))]
+    pub image: String,
+    /// Executable and arguments, passed directly without an implicit shell.
+    #[serde(default)]
+    #[schemars(with = "Vec<NonEmptySandboxArgSchema>", length(max = 64))]
+    pub command: Vec<String>,
+    #[serde(default)]
+    #[schemars(with = "Vec<BoundedSandboxArgSchema>", length(max = 256))]
+    pub args: Vec<String>,
+    pub resources: SandboxContainerResources,
+}
+
+/// Explicit requests and limits. CPU and memory are the only resource
+/// dimensions admitted by the first Sandbox API, keeping quota comparison
+/// deterministic and avoiding arbitrary extended-resource keys.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxContainerResources {
+    pub requests: SandboxResourceQuantity,
+    pub limits: SandboxResourceQuantity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxResourceQuantity {
+    /// Kubernetes CPU quantity such as `500m` or `2`.
+    #[schemars(length(min = 1))]
+    pub cpu: String,
+    /// Kubernetes memory quantity such as `512Mi` or `2Gi`.
+    #[schemars(length(min = 1))]
+    pub memory: String,
+    /// Kubernetes ephemeral-storage quantity such as `1Gi`.
+    #[schemars(length(min = 1))]
+    pub ephemeral_storage: String,
+}
+
+/// Aggregate per-Sandbox resource ceiling carried by an access grant.
+///
+/// The values use Kubernetes quantities so administrators can express the
+/// ceiling in the same units as pool container limits. Admission compares
+/// parsed values through [`crate::sandbox::resource_ceiling_allows`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxResourceCeiling {
+    #[schemars(length(min = 1))]
+    pub max_cpu: String,
+    #[schemars(length(min = 1))]
+    pub max_memory: String,
+}
+
+/// One TCP port declared safe for later lease-scoped forwarding.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPortSpec {
+    #[schemars(length(min = 1, max = 15), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub name: String,
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub container: String,
+    #[schemars(range(min = 1))]
+    pub port: u16,
+}
+
+/// Isolation is a tagged enum so a hardened claim cannot omit its exact
+/// RuntimeClass and trusted-runc cannot smuggle one through another field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "tier", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SandboxIsolation {
+    TrustedRunc {},
+    Gvisor {
+        #[serde(rename = "runtimeClassName")]
+        runtime_class_name: String,
+    },
+    Kata {
+        #[serde(rename = "runtimeClassName")]
+        runtime_class_name: String,
+    },
+}
+
+impl JsonSchema for SandboxIsolation {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SandboxIsolation".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tier"],
+            "properties": {
+                "tier": { "type": "string", "enum": ["trusted-runc", "gvisor", "kata"] },
+                "runtimeClassName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 253,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                }
+            },
+            "x-kubernetes-validations": [{
+                "rule": "(self.tier == 'trusted-runc' && !has(self.runtimeClassName)) || (self.tier in ['gvisor', 'kata'] && has(self.runtimeClassName))",
+                "message": "trusted-runc must not set runtimeClassName; hardened tiers must set it"
+            }]
+        }))
+        .expect("static SandboxIsolation schema is valid")
+    }
+}
+
+impl SandboxIsolation {
+    // `crdgen` imports this module for schemas without rendering Pods.
+    #[allow(dead_code)]
+    pub fn runtime_class_name(&self) -> Option<&str> {
+        match self {
+            Self::TrustedRunc {} => None,
+            Self::Gvisor { runtime_class_name } | Self::Kata { runtime_class_name } => {
+                Some(runtime_class_name)
+            }
+        }
+    }
+}
+
+/// Variable part of readiness validation. Runtime, admission, network, and
+/// upstream-controller checks remain mandatory controller invariants.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxReadinessRequirements {
+    pub canary: SandboxExecutionCanary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxExecutionCanary {
+    /// Direct argv vector; no implicit shell expansion.
+    #[schemars(with = "Vec<NonEmptySandboxArgSchema>", length(min = 1, max = 64))]
+    pub argv: Vec<String>,
+    #[schemars(length(min = 1))]
+    pub timeout: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+struct NonEmptySandboxArgSchema(#[schemars(length(min = 1, max = 4096))] String);
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+struct BoundedSandboxArgSchema(#[schemars(length(max = 4096))] String);
+
+/// Caller-safe intent for one disposable Sandbox.
+#[derive(CustomResource, Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[kube(
+    group = "kobe.kunobi.ninja",
+    version = "v1alpha1",
+    kind = "SandboxLease",
+    plural = "sandboxleases",
+    shortname = "sl",
+    status = "SandboxLeaseStatus",
+    namespaced,
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Expires","type":"date","jsonPath":".status.expiresAt"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxLeaseSpec {
+    /// Exact SandboxPool admitted by Kobe. UID and generation fence pool
+    /// recreation or mutation between HTTP admission and placement.
+    pub pool_ref: SandboxPoolReference,
+    #[schemars(length(min = 1))]
+    pub ttl: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub alias: Option<String>,
+    /// Set by Kobe from the authenticated principal, never trusted from an HTTP
+    /// request body. Ownership uses the complete tuple, not the display
+    /// identity alone.
+    pub requester: SandboxPrincipal,
+}
+
+/// Same-namespace, immutable reference to the exact SandboxPool admitted by
+/// Kobe. GVK and namespace are implicit in the typed field.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPoolReference {
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub name: String,
+    #[schemars(length(min = 1))]
+    pub uid: String,
+    #[schemars(range(min = 1))]
+    pub generation: i64,
+}
+
+/// Canonical authenticated owner of a SandboxLease.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPrincipal {
+    /// Stable configured authentication provider ID.
+    #[schemars(length(min = 1))]
+    pub provider: String,
+    #[serde(rename = "type")]
+    #[schemars(length(min = 1))]
+    pub requester_type: String,
+    #[schemars(length(min = 1))]
+    pub issuer: String,
+    #[schemars(length(min = 1))]
+    pub identity: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPoolStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub observed_generation: Option<i64>,
+    #[serde(default)]
+    pub ready: u32,
+    #[serde(default)]
+    pub allocated: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(
+        extend("x-kubernetes-list-type" = "map"),
+        extend("x-kubernetes-list-map-keys" = ["type"])
+    )]
+    pub conditions: Vec<SandboxCondition>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxLeaseStatus {
+    #[serde(default)]
+    pub phase: SandboxLeasePhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub observed_generation: Option<i64>,
+    /// Absolute bound for setup. This is not the runtime expiry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub provisioning_deadline: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub ready_at: Option<String>,
+    /// Set only when the upstream Sandbox becomes Ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<ResolvedSandboxPlacement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<SandboxTargetProvenance>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(
+        extend("x-kubernetes-list-type" = "map"),
+        extend("x-kubernetes-list-map-keys" = ["type"])
+    )]
+    pub conditions: Vec<SandboxCondition>,
+}
+
+/// Stable public phases. `Released` and `Expired` are clean terminal states;
+/// uncertain teardown remains `Quarantined` and continues consuming capacity.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+pub enum SandboxLeasePhase {
+    #[default]
+    Pending,
+    Provisioning,
+    Ready,
+    Releasing,
+    Released,
+    Expired,
+    Quarantined,
+}
+
+impl std::fmt::Display for SandboxLeasePhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl SandboxLeasePhase {
+    /// Whether the lease may still own or reserve capacity.
+    // `crdgen` imports this module for schemas without lifecycle evaluation.
+    #[allow(dead_code)]
+    pub fn consumes_capacity(self) -> bool {
+        !matches!(self, Self::Released | Self::Expired)
+    }
+}
+
+/// Resolved placement recorded once by a placement controller. A child
+/// placement binds the referenced pool by UID, preventing name-reuse attacks.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum ResolvedSandboxPlacement {
+    Management {},
+    ChildCluster {
+        #[serde(rename = "clusterPool")]
+        cluster_pool: SandboxObjectReference,
+    },
+}
+
+impl JsonSchema for ResolvedSandboxPlacement {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ResolvedSandboxPlacement".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let reference = serde_json::to_value(generator.subschema_for::<SandboxObjectReference>())
+            .expect("SandboxObjectReference schema serializes");
+        serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string", "enum": ["management", "childCluster"] },
+                "clusterPool": reference
+            },
+            "x-kubernetes-validations": [{
+                "rule": "(self.type == 'management' && !has(self.clusterPool)) || (self.type == 'childCluster' && has(self.clusterPool))",
+                "message": "resolved childCluster placement requires the exact ClusterPool reference"
+            }]
+        }))
+        .expect("static ResolvedSandboxPlacement schema is valid")
+    }
+}
+
+/// Non-secret identity of one exact Kubernetes object.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxObjectReference {
+    #[schemars(length(min = 1))]
+    pub api_version: String,
+    #[schemars(length(min = 1))]
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub namespace: Option<String>,
+    #[schemars(length(min = 1))]
+    pub name: String,
+    #[schemars(length(min = 1))]
+    pub uid: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub generation: Option<i64>,
+}
+
+/// Restart-safe, non-secret target provenance. Fields are filled monotonically:
+/// once a reference is present its name and UID may never be cleared or changed.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxTargetProvenance {
+    #[schemars(length(min = 1))]
+    pub namespace: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_cluster_lease: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_cluster_instance: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_template: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_warm_pool: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_claim: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pod: Option<SandboxObjectReference>,
+}
+
+/// Kubernetes-style condition with the generation from which it was derived.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxCondition {
+    #[serde(rename = "type")]
+    pub condition_type: String,
+    pub status: SandboxConditionStatus,
+    pub reason: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub observed_generation: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub last_transition_time: Option<String>,
+}
+
+/// Kubernetes Condition status values.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+pub enum SandboxConditionStatus {
+    True,
+    False,
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[allow(dead_code)] // Used by runtime admission/mapping, not the `crdgen` binary.
+pub enum SandboxPoolValidationError {
+    #[error("{0} must not be empty")]
+    EmptyDuration(&'static str),
+    #[error("warmCapacity exceeds upstream int32 replicas")]
+    WarmCapacityTooLarge,
+    #[error("childCluster placement requires a non-empty clusterPoolRef")]
+    EmptyClusterPoolRef,
+    #[error("template must contain at least one container")]
+    NoContainers,
+    #[error("container name must not be empty")]
+    EmptyContainerName,
+    #[error("duplicate container name {0}")]
+    DuplicateContainer(String),
+    #[error("container {0} has an empty image")]
+    EmptyContainerImage(String),
+    #[error("container {container} has an empty {field} resource quantity")]
+    EmptyResource {
+        container: String,
+        field: &'static str,
+    },
+    #[error("default container {0} is not declared")]
+    UnknownDefaultContainer(String),
+    #[error("port name must not be empty")]
+    EmptyPortName,
+    #[error("duplicate port name {0}")]
+    DuplicatePortName(String),
+    #[error("port {0} must be in the range 1-65535")]
+    ZeroPort(String),
+    #[error("port {port} references undeclared container {container}")]
+    UnknownPortContainer { port: String, container: String },
+    #[error("container {container} exposes port {port} more than once")]
+    DuplicateContainerPort { container: String, port: u16 },
+    #[error("hardened isolation requires a non-empty runtimeClassName")]
+    EmptyRuntimeClass,
+    #[error("readiness canary argv must contain non-empty arguments")]
+    EmptyCanaryArgv,
+    #[error("readiness canary timeout must not be empty")]
+    EmptyCanaryTimeout,
+}
+
+#[cfg(test)]
+mod tests {
+    use kube::CustomResourceExt;
+
+    use super::*;
+
+    fn valid_pool_spec() -> SandboxPoolSpec {
+        SandboxPoolSpec {
+            warm_capacity: 2,
+            default_ttl: "1h".into(),
+            max_ttl: "8h".into(),
+            provisioning_timeout: "10m".into(),
+            placement: SandboxPlacement::Management {},
+            template: SandboxTemplateSpec {
+                default_container: "agent".into(),
+                containers: vec![SandboxContainerSpec {
+                    name: "agent".into(),
+                    image: "example.invalid/agent@sha256:abc".into(),
+                    command: vec!["/agent".into()],
+                    args: vec![],
+                    resources: SandboxContainerResources {
+                        requests: SandboxResourceQuantity {
+                            cpu: "500m".into(),
+                            memory: "512Mi".into(),
+                            ephemeral_storage: "512Mi".into(),
+                        },
+                        limits: SandboxResourceQuantity {
+                            cpu: "1".into(),
+                            memory: "1Gi".into(),
+                            ephemeral_storage: "1Gi".into(),
+                        },
+                    },
+                }],
+                exposed_ports: vec![SandboxPortSpec {
+                    name: "http".into(),
+                    container: "agent".into(),
+                    port: 3000,
+                }],
+            },
+            isolation: SandboxIsolation::TrustedRunc {},
+            readiness: SandboxReadinessRequirements {
+                canary: SandboxExecutionCanary {
+                    argv: vec!["/agent".into(), "health".into()],
+                    timeout: "30s".into(),
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn sandbox_lease_defaults_to_pending() {
+        assert_eq!(
+            SandboxLeaseStatus::default().phase,
+            SandboxLeasePhase::Pending
+        );
+    }
+
+    #[test]
+    fn placement_rejects_both_or_neither_shapes() {
+        assert_eq!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "type": "management"
+            }))
+            .unwrap(),
+            SandboxPlacement::Management {}
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "type": "childCluster",
+                "clusterPoolRef": "ci"
+            }))
+            .unwrap(),
+            SandboxPlacement::ChildCluster {
+                cluster_pool_ref: "ci".into()
+            }
+        );
+        assert!(serde_json::from_value::<SandboxPlacement>(serde_json::json!({})).is_err());
+        assert!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "management": {},
+                "childCluster": { "clusterPoolRef": "ci" }
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "type": "management",
+                "clusterPoolRef": "smuggled"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn hardened_isolation_requires_runtime_class_by_shape() {
+        assert!(
+            serde_json::from_value::<SandboxIsolation>(serde_json::json!({ "tier": "gvisor" }))
+                .is_err()
+        );
+        assert!(
+            serde_json::from_value::<SandboxIsolation>(serde_json::json!({
+                "tier": "trusted-runc",
+                "runtimeClassName": "runsc"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn pool_validation_rejects_invalid_container_and_port_links() {
+        let mut spec = valid_pool_spec();
+        spec.placement = SandboxPlacement::ChildCluster {
+            cluster_pool_ref: " ".into(),
+        };
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::EmptyClusterPoolRef)
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.default_container = "missing".into();
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::UnknownDefaultContainer(
+                "missing".into()
+            ))
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.exposed_ports[0].container = "missing".into();
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::UnknownPortContainer {
+                port: "http".into(),
+                container: "missing".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn lease_spec_rejects_unsafe_fields() {
+        let valid_spec = serde_json::json!({
+            "poolRef": {
+                "name": "agents",
+                "uid": "pool-uid",
+                "generation": 1
+            },
+            "ttl": "1h",
+            "requester": {
+                "provider": "developer-oidc",
+                "type": "oidc:user",
+                "issuer": "https://issuer.example",
+                "identity": "alice"
+            }
+        });
+        assert!(serde_json::from_value::<SandboxLeaseSpec>(valid_spec.clone()).is_ok());
+        for (field, value) in [
+            ("namespace", serde_json::json!("kube-system")),
+            ("runtimeClassName", serde_json::json!("runc")),
+            (
+                "env",
+                serde_json::json!([{ "name": "TOKEN", "value": "secret" }]),
+            ),
+        ] {
+            let mut unsafe_spec = valid_spec.clone();
+            unsafe_spec[field] = value;
+            assert!(
+                serde_json::from_value::<SandboxLeaseSpec>(unsafe_spec).is_err(),
+                "field {field} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn lease_phase_capacity_contract_keeps_quarantine_active() {
+        for phase in [
+            SandboxLeasePhase::Pending,
+            SandboxLeasePhase::Provisioning,
+            SandboxLeasePhase::Ready,
+            SandboxLeasePhase::Releasing,
+            SandboxLeasePhase::Quarantined,
+        ] {
+            assert!(phase.consumes_capacity(), "{phase} must consume capacity");
+        }
+        assert!(!SandboxLeasePhase::Released.consumes_capacity());
+        assert!(!SandboxLeasePhase::Expired.consumes_capacity());
+    }
+
+    #[test]
+    fn generated_crds_are_concrete_and_status_enabled() {
+        let pool = serde_json::to_value(SandboxPool::crd()).unwrap();
+        let lease = serde_json::to_value(SandboxLease::crd()).unwrap();
+        assert_eq!(pool["metadata"]["name"], "sandboxpools.kobe.kunobi.ninja");
+        assert_eq!(lease["metadata"]["name"], "sandboxleases.kobe.kunobi.ninja");
+        assert_eq!(pool["spec"]["scope"], "Namespaced");
+        assert_eq!(lease["spec"]["scope"], "Namespaced");
+        let placement = &pool["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["placement"];
+        let isolation = &pool["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["isolation"];
+        let schema_json = serde_json::to_string(&pool).unwrap();
+        assert!(
+            !schema_json.contains("x-kubernetes-preserve-unknown-fields"),
+            "SandboxPool must not contain a free-form schema escape hatch"
+        );
+        assert_eq!(placement["type"], "object");
+        assert_eq!(isolation["type"], "object");
+        assert!(placement["x-kubernetes-validations"].is_array());
+        assert!(isolation["x-kubernetes-validations"].is_array());
+        assert_eq!(
+            pool["spec"]["versions"][0]["subresources"]["status"],
+            serde_json::json!({})
+        );
+        assert_eq!(
+            lease["spec"]["versions"][0]["subresources"]["status"],
+            serde_json::json!({})
+        );
+    }
+}

--- a/src/crdgen.rs
+++ b/src/crdgen.rs
@@ -39,6 +39,14 @@ fn main() {
             "{}",
             serde_yaml_ng::to_string(&crd::CIDRPool::crd()).unwrap()
         ),
+        "sandboxpools" => print!(
+            "{}",
+            serde_yaml_ng::to_string(&crd::SandboxPool::crd()).unwrap()
+        ),
+        "sandboxleases" => print!(
+            "{}",
+            serde_yaml_ng::to_string(&crd::SandboxLease::crd()).unwrap()
+        ),
         _ => {
             print!(
                 "{}",
@@ -78,6 +86,16 @@ fn main() {
             print!(
                 "{}",
                 serde_yaml_ng::to_string(&crd::CIDRPool::crd()).unwrap()
+            );
+            println!("---");
+            print!(
+                "{}",
+                serde_yaml_ng::to_string(&crd::SandboxPool::crd()).unwrap()
+            );
+            println!("---");
+            print!(
+                "{}",
+                serde_yaml_ng::to_string(&crd::SandboxLease::crd()).unwrap()
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod lease_binding;
 mod metrics;
 pub mod pki;
 mod pool;
+mod sandbox;
 mod telemetry;
 mod velero;
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -764,9 +764,9 @@ fn validate_reference(
         });
     }
     if generation_required
-        && !reference
+        && reference
             .generation
-            .is_some_and(|generation| generation > 0)
+            .is_none_or(|generation| generation <= 0)
     {
         return Err(SandboxProvenanceError::InvalidReference {
             field,

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,1410 @@
+//! Pure Agent Sandbox v0.5.4 `v1beta1` projections and lease invariants.
+//!
+//! This module has no Kubernetes client or reconciliation side effects. Pool
+//! controllers can render the restricted Kobe contract into upstream objects,
+//! and placement/teardown controllers can reuse the monotonic provenance
+//! checks before touching a target cluster.
+
+// #71 intentionally lands these pure contracts before #73/#74 wire them into
+// reconcilers. Keep non-test builds warning-clean during that staged rollout.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use k8s_openapi::api::core::v1::{Container, ContainerPort, PodSpec, ResourceRequirements};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::api::{DynamicObject, ObjectMeta, TypeMeta};
+use thiserror::Error;
+
+use crate::crd::{
+    ResolvedSandboxPlacement, SandboxLeasePhase, SandboxLeaseStatus, SandboxObjectReference,
+    SandboxPoolSpec, SandboxPoolValidationError, SandboxResourceCeiling, SandboxTargetProvenance,
+    SandboxTemplateSpec,
+};
+
+pub const AGENT_SANDBOX_API_VERSION: &str = "extensions.agents.x-k8s.io/v1beta1";
+pub const SANDBOX_TEMPLATE_KIND: &str = "SandboxTemplate";
+pub const SANDBOX_WARM_POOL_KIND: &str = "SandboxWarmPool";
+pub const SANDBOX_CLAIM_KIND: &str = "SandboxClaim";
+pub const KOBE_MANAGED_BY: &str = "kobe-operator";
+const KOBE_API_VERSION: &str = "kobe.kunobi.ninja/v1alpha1";
+const SANDBOX_API_VERSION: &str = "agents.x-k8s.io/v1beta1";
+const CORE_API_VERSION: &str = "v1";
+
+/// Render one administrator-owned Kobe pool template into the pinned upstream
+/// Agent Sandbox contract.
+///
+/// The projection is intentionally closed: it emits only declared containers,
+/// CPU/memory/ephemeral-storage resources, TCP ports, the administrator's
+/// RuntimeClass, and fixed secure policies. It cannot emit PVC templates,
+/// environment values, service accounts, arbitrary volumes, or caller metadata.
+pub fn build_sandbox_template(
+    name: &str,
+    namespace: &str,
+    pool: &SandboxPoolSpec,
+    owner_ref: Option<&OwnerReference>,
+) -> Result<DynamicObject, SandboxMappingError> {
+    pool.validate()?;
+    aggregate_resource_limits(&pool.template)?;
+
+    let containers = pool
+        .template
+        .containers
+        .iter()
+        .map(|container| {
+            let ports: Vec<ContainerPort> = pool
+                .template
+                .exposed_ports
+                .iter()
+                .filter(|port| port.container == container.name)
+                .map(|port| ContainerPort {
+                    container_port: i32::from(port.port),
+                    name: Some(port.name.clone()),
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                })
+                .collect();
+
+            Container {
+                name: container.name.clone(),
+                image: Some(container.image.clone()),
+                command: (!container.command.is_empty()).then(|| container.command.clone()),
+                args: (!container.args.is_empty()).then(|| container.args.clone()),
+                ports: (!ports.is_empty()).then_some(ports),
+                resources: Some(to_k8s_resources(&container.resources)),
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    let pod_spec = PodSpec {
+        automount_service_account_token: Some(false),
+        containers,
+        restart_policy: Some("Never".to_string()),
+        runtime_class_name: pool.isolation.runtime_class_name().map(ToString::to_string),
+        ..Default::default()
+    };
+    let pod_spec = serde_json::to_value(pod_spec)?;
+
+    Ok(managed_object(
+        SANDBOX_TEMPLATE_KIND,
+        name,
+        namespace,
+        owner_ref,
+        serde_json::json!({
+            "spec": {
+                "podTemplate": {
+                    "metadata": {
+                        "labels": {
+                            "app.kubernetes.io/managed-by": KOBE_MANAGED_BY
+                        },
+                        "annotations": {
+                            "kubectl.kubernetes.io/default-container": pool.template.default_container
+                        }
+                    },
+                    "spec": pod_spec
+                },
+                "service": !pool.template.exposed_ports.is_empty(),
+                "networkPolicyManagement": "Managed",
+                "envVarsInjectionPolicy": "Disallowed",
+                "volumeClaimTemplatesPolicy": "Disallowed"
+            }
+        }),
+    ))
+}
+
+/// Render the upstream warm pool using the exact v1beta1
+/// `sandboxTemplateRef.name` field and an immediate drift replacement policy.
+pub fn build_sandbox_warm_pool(
+    name: &str,
+    namespace: &str,
+    template_name: &str,
+    warm_capacity: u32,
+    owner_ref: Option<&OwnerReference>,
+) -> Result<DynamicObject, SandboxMappingError> {
+    let replicas = i32::try_from(warm_capacity)
+        .map_err(|_| SandboxMappingError::WarmCapacityTooLarge(warm_capacity))?;
+    Ok(managed_object(
+        SANDBOX_WARM_POOL_KIND,
+        name,
+        namespace,
+        owner_ref,
+        serde_json::json!({
+            "spec": {
+                "replicas": replicas,
+                "sandboxTemplateRef": { "name": template_name },
+                "updateStrategy": { "type": "Recreate" }
+            }
+        }),
+    ))
+}
+
+/// Render one lease as a v1beta1 SandboxClaim.
+///
+/// The initial claim intentionally omits `shutdownTime`: runtime TTL starts
+/// only after the upstream Sandbox becomes Ready. [`build_sandbox_claim_lifecycle_patch`]
+/// adds the absolute expiry later with a resourceVersion fence.
+pub fn build_sandbox_claim(
+    name: &str,
+    namespace: &str,
+    warm_pool_name: &str,
+    owner_ref: Option<&OwnerReference>,
+) -> DynamicObject {
+    managed_object(
+        SANDBOX_CLAIM_KIND,
+        name,
+        namespace,
+        owner_ref,
+        serde_json::json!({
+            "spec": {
+                "warmPoolRef": { "name": warm_pool_name },
+                "lifecycle": {
+                    "shutdownPolicy": "DeleteForeground"
+                }
+            }
+        }),
+    )
+}
+
+/// Build the post-Ready merge patch that starts upstream expiry. Callers must
+/// derive `expires_at` from the persisted `readyAt + ttl` invariant and use the
+/// current exact Claim resourceVersion.
+pub fn build_sandbox_claim_lifecycle_patch(
+    resource_version: &str,
+    expires_at: DateTime<Utc>,
+) -> Result<serde_json::Value, SandboxMappingError> {
+    if resource_version.trim().is_empty() {
+        return Err(SandboxMappingError::MissingResourceVersion);
+    }
+    Ok(serde_json::json!({
+        "metadata": { "resourceVersion": resource_version },
+        "spec": {
+            "lifecycle": {
+                "shutdownTime": expires_at.to_rfc3339_opts(SecondsFormat::AutoSi, true),
+                "shutdownPolicy": "DeleteForeground"
+            }
+        }
+    }))
+}
+
+fn managed_object(
+    kind: &str,
+    name: &str,
+    namespace: &str,
+    owner_ref: Option<&OwnerReference>,
+    data: serde_json::Value,
+) -> DynamicObject {
+    DynamicObject {
+        types: Some(TypeMeta {
+            api_version: AGENT_SANDBOX_API_VERSION.to_string(),
+            kind: kind.to_string(),
+        }),
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(namespace.to_string()),
+            labels: Some(
+                [(
+                    "app.kubernetes.io/managed-by".to_string(),
+                    KOBE_MANAGED_BY.to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            owner_references: owner_ref.cloned().map(|owner| vec![owner]),
+            ..Default::default()
+        },
+        data,
+    }
+}
+
+fn to_k8s_resources(resources: &crate::crd::SandboxContainerResources) -> ResourceRequirements {
+    let quantities = |quantity: &crate::crd::SandboxResourceQuantity| {
+        BTreeMap::from([
+            ("cpu".to_string(), Quantity(quantity.cpu.clone())),
+            ("memory".to_string(), Quantity(quantity.memory.clone())),
+            (
+                "ephemeral-storage".to_string(),
+                Quantity(quantity.ephemeral_storage.clone()),
+            ),
+        ])
+    };
+    ResourceRequirements {
+        limits: Some(quantities(&resources.limits)),
+        requests: Some(quantities(&resources.requests)),
+        ..Default::default()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SandboxMappingError {
+    #[error(transparent)]
+    InvalidPool(#[from] SandboxPoolValidationError),
+    #[error(transparent)]
+    InvalidResources(#[from] SandboxResourceError),
+    #[error("warm capacity {0} exceeds upstream int32 replicas")]
+    WarmCapacityTooLarge(u32),
+    #[error("failed to serialize the restricted PodSpec: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("SandboxClaim resourceVersion is required for the lifecycle patch")]
+    MissingResourceVersion,
+}
+
+/// Canonical aggregate values used for exact, unit-independent admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SandboxResourceTotals {
+    pub cpu_millicores: u128,
+    pub memory_bytes: u128,
+    cpu_nanocores: u128,
+    memory_nanobytes: u128,
+}
+
+/// Sum declared per-container limits and validate every resource pair.
+///
+/// Requests may not exceed limits. Quantities are rounded upward to the target
+/// unit following Kubernetes Quantity semantics, avoiding an undercount at an
+/// authorization boundary.
+pub fn aggregate_resource_limits(
+    template: &SandboxTemplateSpec,
+) -> Result<SandboxResourceTotals, SandboxResourceError> {
+    let mut total_cpu_nanos = 0u128;
+    let mut total_memory_nanos = 0u128;
+
+    for container in &template.containers {
+        // Compare exact nanounits before rounding into policy units. Independent
+        // ceiling-rounding would incorrectly accept 900m > 100m memory because
+        // both values become one whole byte.
+        let request_cpu = parse_positive_quantity_nanos(
+            &container.resources.requests.cpu,
+            QuantityDimension::Cpu,
+            "requests.cpu",
+        )?;
+        let limit_cpu = parse_positive_quantity_nanos(
+            &container.resources.limits.cpu,
+            QuantityDimension::Cpu,
+            "limits.cpu",
+        )?;
+        let request_memory = parse_positive_quantity_nanos(
+            &container.resources.requests.memory,
+            QuantityDimension::Bytes,
+            "requests.memory",
+        )?;
+        let limit_memory = parse_positive_quantity_nanos(
+            &container.resources.limits.memory,
+            QuantityDimension::Bytes,
+            "limits.memory",
+        )?;
+        let request_ephemeral = parse_positive_quantity_nanos(
+            &container.resources.requests.ephemeral_storage,
+            QuantityDimension::Bytes,
+            "requests.ephemeralStorage",
+        )?;
+        let limit_ephemeral = parse_positive_quantity_nanos(
+            &container.resources.limits.ephemeral_storage,
+            QuantityDimension::Bytes,
+            "limits.ephemeralStorage",
+        )?;
+
+        for (resource, request, limit) in [
+            ("cpu", request_cpu, limit_cpu),
+            ("memory", request_memory, limit_memory),
+            ("ephemeral-storage", request_ephemeral, limit_ephemeral),
+        ] {
+            if request > limit {
+                return Err(SandboxResourceError::RequestExceedsLimit {
+                    container: container.name.clone(),
+                    resource,
+                });
+            }
+        }
+
+        total_cpu_nanos = total_cpu_nanos
+            .checked_add(limit_cpu)
+            .ok_or(SandboxResourceError::AggregateOverflow("cpu"))?;
+        total_memory_nanos = total_memory_nanos
+            .checked_add(limit_memory)
+            .ok_or(SandboxResourceError::AggregateOverflow("memory"))?;
+    }
+
+    Ok(SandboxResourceTotals {
+        cpu_millicores: ceil_div(total_cpu_nanos, 1_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("cpu"))?,
+        memory_bytes: ceil_div(total_memory_nanos, 1_000_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("memory"))?,
+        cpu_nanocores: total_cpu_nanos,
+        memory_nanobytes: total_memory_nanos,
+    })
+}
+
+/// Parse a policy ceiling into the canonical units used by admission.
+pub fn parse_resource_ceiling(
+    ceiling: &SandboxResourceCeiling,
+) -> Result<SandboxResourceTotals, SandboxResourceError> {
+    let cpu_nanocores = parse_positive_quantity_nanos(
+        &ceiling.max_cpu,
+        QuantityDimension::Cpu,
+        "resourceCeiling.maxCpu",
+    )?;
+    let memory_nanobytes = parse_positive_quantity_nanos(
+        &ceiling.max_memory,
+        QuantityDimension::Bytes,
+        "resourceCeiling.maxMemory",
+    )?;
+    Ok(SandboxResourceTotals {
+        cpu_millicores: ceil_div(cpu_nanocores, 1_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("cpu"))?,
+        memory_bytes: ceil_div(memory_nanobytes, 1_000_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("memory"))?,
+        cpu_nanocores,
+        memory_nanobytes,
+    })
+}
+
+/// Compare a pool's aggregate limits with a caller's typed policy ceiling.
+/// Invalid policy quantities return an error so admission can fail closed.
+pub fn resource_ceiling_allows(
+    ceiling: &SandboxResourceCeiling,
+    requested: &SandboxResourceTotals,
+) -> Result<bool, SandboxResourceError> {
+    let ceiling = parse_resource_ceiling(ceiling)?;
+    Ok(requested.cpu_nanocores <= ceiling.cpu_nanocores
+        && requested.memory_nanobytes <= ceiling.memory_nanobytes)
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SandboxResourceError {
+    #[error("invalid or non-positive Kubernetes quantity for {field}: {value}")]
+    InvalidQuantity { field: &'static str, value: String },
+    #[error("container {container} {resource} request exceeds its limit")]
+    RequestExceedsLimit {
+        container: String,
+        resource: &'static str,
+    },
+    #[error("aggregate {0} limit overflow")]
+    AggregateOverflow(&'static str),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum QuantityDimension {
+    Cpu,
+    Bytes,
+}
+
+fn parse_positive_quantity(
+    value: &str,
+    dimension: QuantityDimension,
+    field: &'static str,
+) -> Result<u128, SandboxResourceError> {
+    let parsed = parse_quantity_nanos(value)
+        .filter(|value| *value > 0)
+        .filter(|value| {
+            !matches!(dimension, QuantityDimension::Cpu)
+                || (*value >= 1_000_000 && *value % 1_000_000 == 0)
+        })
+        .and_then(|nanos| match dimension {
+            QuantityDimension::Cpu => ceil_div(nanos, 1_000_000),
+            QuantityDimension::Bytes => ceil_div(nanos, 1_000_000_000),
+        });
+    parsed.ok_or_else(|| SandboxResourceError::InvalidQuantity {
+        field,
+        value: value.to_string(),
+    })
+}
+
+fn parse_positive_quantity_nanos(
+    value: &str,
+    dimension: QuantityDimension,
+    field: &'static str,
+) -> Result<u128, SandboxResourceError> {
+    parse_quantity_nanos(value)
+        .filter(|value| *value > 0)
+        .filter(|value| {
+            !matches!(dimension, QuantityDimension::Cpu)
+                || (*value >= 1_000_000 && *value % 1_000_000 == 0)
+        })
+        .ok_or_else(|| SandboxResourceError::InvalidQuantity {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn parse_quantity(value: &str, dimension: QuantityDimension) -> Option<u128> {
+    let nanos = parse_quantity_nanos(value)?;
+    match dimension {
+        QuantityDimension::Cpu if nanos >= 1_000_000 && nanos % 1_000_000 == 0 => {
+            ceil_div(nanos, 1_000_000)
+        }
+        QuantityDimension::Cpu => None,
+        QuantityDimension::Bytes => ceil_div(nanos, 1_000_000_000),
+    }
+}
+
+/// Parse the full positive Kubernetes Quantity suffix grammar into nanounits.
+/// Nanounits retain exact request/limit ordering; conversion to mCPU or bytes
+/// happens only after comparisons and aggregation. Kubernetes quantities cap
+/// at signed 64-bit base units, which also bounds admission arithmetic.
+fn parse_quantity_nanos(value: &str) -> Option<u128> {
+    if value != value.trim() {
+        return None;
+    }
+    let value = value.strip_prefix('+').unwrap_or(value);
+    if value.is_empty() || value.starts_with('-') {
+        return None;
+    }
+
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    let mut mantissa = 0u128;
+    let mut fractional_digits = 0u32;
+    let mut saw_digit = false;
+    let mut saw_decimal = false;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'0'..=b'9' => {
+                saw_digit = true;
+                mantissa = mantissa
+                    .checked_mul(10)?
+                    .checked_add(u128::from(bytes[index] - b'0'))?;
+                if saw_decimal {
+                    fractional_digits = fractional_digits.checked_add(1)?;
+                }
+                index += 1;
+            }
+            b'.' if !saw_decimal => {
+                saw_decimal = true;
+                index += 1;
+            }
+            _ => break,
+        }
+    }
+    if !saw_digit {
+        return None;
+    }
+
+    let suffix = &value[index..];
+    let nanos = if let Some(binary_power) = match suffix {
+        "Ki" => Some(1),
+        "Mi" => Some(2),
+        "Gi" => Some(3),
+        "Ti" => Some(4),
+        "Pi" => Some(5),
+        "Ei" => Some(6),
+        _ => None,
+    } {
+        let numerator = mantissa
+            .checked_mul(1024u128.checked_pow(binary_power)?)?
+            .checked_mul(1_000_000_000)?;
+        ceil_div(numerator, 10u128.checked_pow(fractional_digits)?)?
+    } else {
+        let suffix_exponent = match suffix {
+            "" => 0,
+            "n" => -9,
+            "u" => -6,
+            "m" => -3,
+            "k" => 3,
+            "M" => 6,
+            "G" => 9,
+            "T" => 12,
+            "P" => 15,
+            "E" => 18,
+            _ if suffix.starts_with('e') || (suffix.starts_with('E') && suffix.len() > 1) => {
+                suffix[1..].parse::<i32>().ok()?
+            }
+            _ => return None,
+        };
+        let scale = suffix_exponent
+            .checked_add(9)?
+            .checked_sub(i32::try_from(fractional_digits).ok()?)?;
+        if scale >= 0 {
+            mantissa.checked_mul(10u128.checked_pow(scale as u32)?)?
+        } else {
+            ceil_div(mantissa, 10u128.checked_pow(scale.unsigned_abs())?)?
+        }
+    };
+
+    const KUBERNETES_MAX_NANOUNITS: u128 = (i64::MAX as u128) * 1_000_000_000;
+    (nanos <= KUBERNETES_MAX_NANOUNITS).then_some(nanos)
+}
+
+fn ceil_div(numerator: u128, denominator: u128) -> Option<u128> {
+    let quotient = numerator.checked_div(denominator)?;
+    let remainder = numerator.checked_rem(denominator)?;
+    quotient.checked_add(u128::from(remainder != 0))
+}
+
+/// Record resolved placement once. Retries may repeat the same value, but no
+/// controller may silently retarget a lease or invent a management fallback.
+pub fn record_placement_once(
+    existing: Option<&ResolvedSandboxPlacement>,
+    proposed: ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<ResolvedSandboxPlacement, SandboxProvenanceError> {
+    validate_resolved_placement(&proposed, management_namespace)?;
+    match existing {
+        None => Ok(proposed),
+        Some(current) if current == &proposed => {
+            validate_resolved_placement(current, management_namespace)?;
+            Ok(current.clone())
+        }
+        Some(_) => Err(SandboxProvenanceError::PlacementChanged),
+    }
+}
+
+/// Require an explicitly persisted placement before target operations.
+pub fn require_resolved_placement<'a>(
+    status: &'a SandboxLeaseStatus,
+    management_namespace: &str,
+) -> Result<&'a ResolvedSandboxPlacement, SandboxProvenanceError> {
+    let placement = status
+        .placement
+        .as_ref()
+        .ok_or(SandboxProvenanceError::UnresolvedPlacement)?;
+    validate_resolved_placement(placement, management_namespace)?;
+    Ok(placement)
+}
+
+/// Merge progressively discovered target references without permitting any
+/// existing identity to be changed or cleared. Equality covers API version,
+/// kind, namespace, name, UID, and generation, so delete/recreate name reuse is
+/// rejected even when the object name is unchanged.
+pub fn merge_target_provenance(
+    existing: Option<&SandboxTargetProvenance>,
+    proposed: SandboxTargetProvenance,
+    placement: &ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<SandboxTargetProvenance, SandboxProvenanceError> {
+    validate_resolved_placement(placement, management_namespace)?;
+    validate_target_provenance(&proposed, placement, management_namespace)?;
+    let Some(existing) = existing else {
+        return Ok(proposed);
+    };
+    if existing.namespace != proposed.namespace {
+        return Err(SandboxProvenanceError::NamespaceChanged);
+    }
+
+    Ok(SandboxTargetProvenance {
+        namespace: existing.namespace.clone(),
+        child_cluster_lease: merge_reference(
+            "childClusterLease",
+            &existing.child_cluster_lease,
+            proposed.child_cluster_lease,
+        )?,
+        child_cluster_instance: merge_reference(
+            "childClusterInstance",
+            &existing.child_cluster_instance,
+            proposed.child_cluster_instance,
+        )?,
+        sandbox_template: merge_reference(
+            "sandboxTemplate",
+            &existing.sandbox_template,
+            proposed.sandbox_template,
+        )?,
+        sandbox_warm_pool: merge_reference(
+            "sandboxWarmPool",
+            &existing.sandbox_warm_pool,
+            proposed.sandbox_warm_pool,
+        )?,
+        sandbox_claim: merge_reference(
+            "sandboxClaim",
+            &existing.sandbox_claim,
+            proposed.sandbox_claim,
+        )?,
+        sandbox: merge_reference("sandbox", &existing.sandbox, proposed.sandbox)?,
+        pod: merge_reference("pod", &existing.pod, proposed.pod)?,
+    })
+}
+
+fn validate_resolved_placement(
+    placement: &ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<(), SandboxProvenanceError> {
+    if let ResolvedSandboxPlacement::ChildCluster { cluster_pool } = placement {
+        validate_reference(
+            "clusterPool",
+            cluster_pool,
+            KOBE_API_VERSION,
+            "ClusterPool",
+            Some(management_namespace),
+            true,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_target_provenance(
+    provenance: &SandboxTargetProvenance,
+    placement: &ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<(), SandboxProvenanceError> {
+    if provenance.namespace.trim().is_empty() {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field: "namespace",
+            reason: "target namespace is empty",
+        });
+    }
+
+    match placement {
+        ResolvedSandboxPlacement::Management {}
+            if provenance.child_cluster_lease.is_some()
+                || provenance.child_cluster_instance.is_some() =>
+        {
+            return Err(SandboxProvenanceError::UnexpectedChildReference);
+        }
+        ResolvedSandboxPlacement::Management {} | ResolvedSandboxPlacement::ChildCluster { .. } => {
+        }
+    }
+
+    for (field, reference, api_version, kind, target_namespace, generation_required) in [
+        (
+            "childClusterLease",
+            &provenance.child_cluster_lease,
+            KOBE_API_VERSION,
+            "ClusterLease",
+            Some(management_namespace),
+            true,
+        ),
+        (
+            "childClusterInstance",
+            &provenance.child_cluster_instance,
+            KOBE_API_VERSION,
+            "ClusterInstance",
+            Some(management_namespace),
+            true,
+        ),
+        (
+            "sandboxTemplate",
+            &provenance.sandbox_template,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_TEMPLATE_KIND,
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "sandboxWarmPool",
+            &provenance.sandbox_warm_pool,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_WARM_POOL_KIND,
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "sandboxClaim",
+            &provenance.sandbox_claim,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_CLAIM_KIND,
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "sandbox",
+            &provenance.sandbox,
+            SANDBOX_API_VERSION,
+            "Sandbox",
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "pod",
+            &provenance.pod,
+            CORE_API_VERSION,
+            "Pod",
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+    ] {
+        if let Some(reference) = reference {
+            validate_reference(
+                field,
+                reference,
+                api_version,
+                kind,
+                target_namespace,
+                generation_required,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_reference(
+    field: &'static str,
+    reference: &SandboxObjectReference,
+    expected_api_version: &str,
+    expected_kind: &str,
+    expected_namespace: Option<&str>,
+    generation_required: bool,
+) -> Result<(), SandboxProvenanceError> {
+    if reference.api_version != expected_api_version || reference.kind != expected_kind {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "unexpected API version or kind",
+        });
+    }
+    if reference.name.trim().is_empty() || reference.uid.trim().is_empty() {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "name and UID are required",
+        });
+    }
+    let namespace = reference
+        .namespace
+        .as_deref()
+        .filter(|value| !value.is_empty());
+    if namespace.is_none() {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "namespace is required",
+        });
+    }
+    if expected_namespace.is_some_and(|expected| namespace != Some(expected)) {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "namespace does not match the target namespace",
+        });
+    }
+    if generation_required
+        && !reference
+            .generation
+            .is_some_and(|generation| generation > 0)
+    {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "positive generation is required",
+        });
+    }
+    Ok(())
+}
+
+fn merge_reference(
+    field: &'static str,
+    existing: &Option<SandboxObjectReference>,
+    proposed: Option<SandboxObjectReference>,
+) -> Result<Option<SandboxObjectReference>, SandboxProvenanceError> {
+    match (existing, proposed) {
+        (None, proposed) => Ok(proposed),
+        (Some(_), None) => Err(SandboxProvenanceError::ReferenceCleared(field)),
+        (Some(current), Some(proposed)) if current == &proposed => Ok(Some(current.clone())),
+        (Some(_), Some(_)) => Err(SandboxProvenanceError::ReferenceChanged(field)),
+    }
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SandboxProvenanceError {
+    #[error("Sandbox placement has not been resolved; no backend fallback is permitted")]
+    UnresolvedPlacement,
+    #[error("resolved Sandbox placement cannot change")]
+    PlacementChanged,
+    #[error("target namespace cannot change")]
+    NamespaceChanged,
+    #[error("target provenance field {0} cannot be cleared")]
+    ReferenceCleared(&'static str),
+    #[error("target provenance field {0} cannot change")]
+    ReferenceChanged(&'static str),
+    #[error("invalid target provenance field {field}: {reason}")]
+    InvalidReference {
+        field: &'static str,
+        reason: &'static str,
+    },
+    #[error("management placement cannot record child-cluster references")]
+    UnexpectedChildReference,
+}
+
+/// Start bounded provisioning from the lease creation timestamp. Retrying with
+/// the same inputs is idempotent; changing an already-persisted deadline fails.
+pub fn begin_sandbox_provisioning(
+    status: &SandboxLeaseStatus,
+    observed_generation: i64,
+    accepted_at: DateTime<Utc>,
+    provisioning_timeout: chrono::Duration,
+) -> Result<SandboxLeaseStatus, SandboxLifecycleError> {
+    if provisioning_timeout <= chrono::Duration::zero() {
+        return Err(SandboxLifecycleError::InvalidDuration(
+            "provisioning timeout",
+        ));
+    }
+    let deadline = accepted_at
+        .checked_add_signed(provisioning_timeout)
+        .ok_or(SandboxLifecycleError::TimestampOverflow)?
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true);
+
+    if status.phase == SandboxLeasePhase::Provisioning {
+        if status.provisioning_deadline.as_deref() == Some(deadline.as_str())
+            && status.observed_generation == Some(observed_generation)
+        {
+            return Ok(status.clone());
+        }
+        return Err(SandboxLifecycleError::PersistedTimestampChanged(
+            "provisioningDeadline",
+        ));
+    }
+    transition_sandbox_phase(status.phase, SandboxLeasePhase::Provisioning, false)?;
+
+    let mut next = status.clone();
+    next.phase = SandboxLeasePhase::Provisioning;
+    next.observed_generation = Some(observed_generation);
+    next.provisioning_deadline = Some(deadline);
+    Ok(next)
+}
+
+/// Mark an upstream Sandbox Ready and start runtime TTL from that exact instant.
+/// Readiness after the persisted provisioning deadline fails closed.
+pub fn mark_sandbox_ready(
+    status: &SandboxLeaseStatus,
+    observed_generation: i64,
+    ready_at: DateTime<Utc>,
+    runtime_ttl: chrono::Duration,
+) -> Result<SandboxLeaseStatus, SandboxLifecycleError> {
+    if runtime_ttl <= chrono::Duration::zero() {
+        return Err(SandboxLifecycleError::InvalidDuration("runtime TTL"));
+    }
+    let deadline = status
+        .provisioning_deadline
+        .as_deref()
+        .ok_or(SandboxLifecycleError::MissingProvisioningDeadline)
+        .and_then(|value| {
+            DateTime::parse_from_rfc3339(value)
+                .map(|value| value.with_timezone(&Utc))
+                .map_err(|_| SandboxLifecycleError::MalformedProvisioningDeadline)
+        })?;
+    if ready_at > deadline {
+        return Err(SandboxLifecycleError::ProvisioningDeadlineElapsed);
+    }
+    let ready_at_string = ready_at.to_rfc3339_opts(SecondsFormat::AutoSi, true);
+    let expires_at = ready_at
+        .checked_add_signed(runtime_ttl)
+        .ok_or(SandboxLifecycleError::TimestampOverflow)?
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true);
+
+    if status.phase == SandboxLeasePhase::Ready {
+        if status.ready_at.as_deref() == Some(ready_at_string.as_str())
+            && status.expires_at.as_deref() == Some(expires_at.as_str())
+            && status.observed_generation == Some(observed_generation)
+        {
+            return Ok(status.clone());
+        }
+        return Err(SandboxLifecycleError::PersistedTimestampChanged(
+            "readyAt/expiresAt",
+        ));
+    }
+    transition_sandbox_phase(status.phase, SandboxLeasePhase::Ready, false)?;
+
+    let mut next = status.clone();
+    next.phase = SandboxLeasePhase::Ready;
+    next.observed_generation = Some(observed_generation);
+    next.ready_at = Some(ready_at_string);
+    next.expires_at = Some(expires_at);
+    Ok(next)
+}
+
+/// Validate a lifecycle phase transition. Clean terminal states always require
+/// verified cleanup; in particular, Quarantined can never look clean merely
+/// because a controller retried or restarted.
+pub fn transition_sandbox_phase(
+    current: SandboxLeasePhase,
+    next: SandboxLeasePhase,
+    cleanup_verified: bool,
+) -> Result<SandboxLeasePhase, SandboxLifecycleError> {
+    if current == next {
+        return Ok(current);
+    }
+    if matches!(
+        next,
+        SandboxLeasePhase::Released | SandboxLeasePhase::Expired
+    ) && !cleanup_verified
+    {
+        return Err(SandboxLifecycleError::CleanupProofRequired);
+    }
+
+    let allowed = matches!(
+        (current, next),
+        (SandboxLeasePhase::Pending, SandboxLeasePhase::Provisioning)
+            | (SandboxLeasePhase::Pending, SandboxLeasePhase::Releasing)
+            | (SandboxLeasePhase::Pending, SandboxLeasePhase::Quarantined)
+            | (SandboxLeasePhase::Provisioning, SandboxLeasePhase::Ready)
+            | (
+                SandboxLeasePhase::Provisioning,
+                SandboxLeasePhase::Releasing
+            )
+            | (
+                SandboxLeasePhase::Provisioning,
+                SandboxLeasePhase::Quarantined
+            )
+            | (SandboxLeasePhase::Ready, SandboxLeasePhase::Releasing)
+            | (SandboxLeasePhase::Ready, SandboxLeasePhase::Quarantined)
+            | (SandboxLeasePhase::Releasing, SandboxLeasePhase::Released)
+            | (SandboxLeasePhase::Releasing, SandboxLeasePhase::Expired)
+            | (SandboxLeasePhase::Releasing, SandboxLeasePhase::Quarantined)
+            | (SandboxLeasePhase::Quarantined, SandboxLeasePhase::Released)
+            | (SandboxLeasePhase::Quarantined, SandboxLeasePhase::Expired)
+    );
+    if allowed {
+        Ok(next)
+    } else {
+        Err(SandboxLifecycleError::InvalidTransition { current, next })
+    }
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SandboxLifecycleError {
+    #[error("{0} must be positive")]
+    InvalidDuration(&'static str),
+    #[error("timestamp overflow")]
+    TimestampOverflow,
+    #[error("provisioningDeadline is required before readiness")]
+    MissingProvisioningDeadline,
+    #[error("provisioningDeadline is malformed")]
+    MalformedProvisioningDeadline,
+    #[error("Sandbox became Ready after its provisioning deadline")]
+    ProvisioningDeadlineElapsed,
+    #[error("persisted {0} cannot change")]
+    PersistedTimestampChanged(&'static str),
+    #[error("cleanup proof is required for a clean terminal phase")]
+    CleanupProofRequired,
+    #[error("invalid Sandbox lifecycle transition {current} -> {next}")]
+    InvalidTransition {
+        current: SandboxLeasePhase,
+        next: SandboxLeasePhase,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{
+        SandboxContainerResources, SandboxContainerSpec, SandboxExecutionCanary, SandboxIsolation,
+        SandboxPlacement, SandboxPortSpec, SandboxReadinessRequirements, SandboxResourceQuantity,
+    };
+
+    fn quantity(cpu: &str, memory: &str, ephemeral_storage: &str) -> SandboxResourceQuantity {
+        SandboxResourceQuantity {
+            cpu: cpu.into(),
+            memory: memory.into(),
+            ephemeral_storage: ephemeral_storage.into(),
+        }
+    }
+
+    fn pool() -> SandboxPoolSpec {
+        SandboxPoolSpec {
+            warm_capacity: 2,
+            default_ttl: "1h".into(),
+            max_ttl: "8h".into(),
+            provisioning_timeout: "10m".into(),
+            placement: SandboxPlacement::Management {},
+            template: SandboxTemplateSpec {
+                default_container: "agent".into(),
+                containers: vec![SandboxContainerSpec {
+                    name: "agent".into(),
+                    image: "example.invalid/agent@sha256:abc".into(),
+                    command: vec!["/agent".into()],
+                    args: vec!["serve".into()],
+                    resources: SandboxContainerResources {
+                        requests: quantity("500m", "512Mi", "256Mi"),
+                        limits: quantity("1", "1Gi", "2Gi"),
+                    },
+                }],
+                exposed_ports: vec![SandboxPortSpec {
+                    name: "http".into(),
+                    container: "agent".into(),
+                    port: 3000,
+                }],
+            },
+            isolation: SandboxIsolation::Gvisor {
+                runtime_class_name: "runsc".into(),
+            },
+            readiness: SandboxReadinessRequirements {
+                canary: SandboxExecutionCanary {
+                    argv: vec!["/agent".into(), "health".into()],
+                    timeout: "30s".into(),
+                },
+            },
+        }
+    }
+
+    fn owner() -> OwnerReference {
+        OwnerReference {
+            api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+            kind: "SandboxPool".into(),
+            name: "agents".into(),
+            uid: "pool-uid".into(),
+            controller: Some(true),
+            block_owner_deletion: Some(true),
+        }
+    }
+
+    fn reference(kind: &str, name: &str, uid: &str) -> SandboxObjectReference {
+        SandboxObjectReference {
+            api_version: AGENT_SANDBOX_API_VERSION.into(),
+            kind: kind.into(),
+            namespace: Some("targets".into()),
+            name: name.into(),
+            uid: uid.into(),
+            generation: Some(1),
+        }
+    }
+
+    fn cluster_pool_reference(namespace: &str) -> SandboxObjectReference {
+        SandboxObjectReference {
+            api_version: KOBE_API_VERSION.into(),
+            kind: "ClusterPool".into(),
+            namespace: Some(namespace.into()),
+            name: "ci".into(),
+            uid: "pool-uid".into(),
+            generation: Some(1),
+        }
+    }
+
+    fn provenance(claim: Option<SandboxObjectReference>) -> SandboxTargetProvenance {
+        SandboxTargetProvenance {
+            namespace: "targets".into(),
+            child_cluster_lease: None,
+            child_cluster_instance: None,
+            sandbox_template: Some(reference("SandboxTemplate", "agents", "template-uid")),
+            sandbox_warm_pool: None,
+            sandbox_claim: claim,
+            sandbox: None,
+            pod: None,
+        }
+    }
+
+    #[test]
+    fn template_projection_is_v1beta1_and_closed() {
+        let object = build_sandbox_template("agents", "targets", &pool(), Some(&owner())).unwrap();
+        let value = serde_json::to_value(object).unwrap();
+
+        assert_eq!(value["apiVersion"], AGENT_SANDBOX_API_VERSION);
+        assert_eq!(value["kind"], SANDBOX_TEMPLATE_KIND);
+        assert_eq!(value["metadata"]["ownerReferences"][0]["uid"], "pool-uid");
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["runtimeClassName"],
+            "runsc"
+        );
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"],
+            false
+        );
+        assert_eq!(value["spec"]["envVarsInjectionPolicy"], "Disallowed");
+        assert_eq!(value["spec"]["volumeClaimTemplatesPolicy"], "Disallowed");
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["containers"][0]["resources"]["limits"]["ephemeral-storage"],
+            "2Gi"
+        );
+        assert!(value["spec"].get("volumeClaimTemplates").is_none());
+        assert!(
+            value["spec"]["podTemplate"]["spec"]["containers"][0]
+                .get("env")
+                .is_none()
+        );
+        assert!(
+            value["spec"]["podTemplate"]["spec"]
+                .get("volumes")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn warm_pool_projection_uses_exact_template_reference() {
+        let value = serde_json::to_value(
+            build_sandbox_warm_pool("agents", "targets", "agents-template", 3, None).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(value["apiVersion"], AGENT_SANDBOX_API_VERSION);
+        assert_eq!(value["kind"], SANDBOX_WARM_POOL_KIND);
+        assert_eq!(value["spec"]["replicas"], 3);
+        assert_eq!(
+            value["spec"]["sandboxTemplateRef"]["name"],
+            "agents-template"
+        );
+    }
+
+    #[test]
+    fn claim_projection_starts_ttl_only_after_ready() {
+        let expires_at = DateTime::parse_from_rfc3339("2026-08-10T12:34:56Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let value = serde_json::to_value(build_sandbox_claim("lease-a", "targets", "agents", None))
+            .unwrap();
+
+        assert_eq!(value["apiVersion"], AGENT_SANDBOX_API_VERSION);
+        assert_eq!(value["kind"], SANDBOX_CLAIM_KIND);
+        assert_eq!(value["spec"]["warmPoolRef"]["name"], "agents");
+        assert!(value["spec"]["lifecycle"].get("shutdownTime").is_none());
+        assert_eq!(
+            value["spec"]["lifecycle"]["shutdownPolicy"],
+            "DeleteForeground"
+        );
+
+        let patch = build_sandbox_claim_lifecycle_patch("claim-rv", expires_at).unwrap();
+        assert_eq!(patch["metadata"]["resourceVersion"], "claim-rv");
+        assert_eq!(
+            patch["spec"]["lifecycle"]["shutdownTime"],
+            "2026-08-10T12:34:56Z"
+        );
+        assert_eq!(
+            patch["spec"]["lifecycle"]["shutdownPolicy"],
+            "DeleteForeground"
+        );
+        assert!(build_sandbox_claim_lifecycle_patch(" ", expires_at).is_err());
+        for forbidden in [
+            "env",
+            "volumeClaimTemplates",
+            "additionalPodMetadata",
+            "namespace",
+            "credentials",
+        ] {
+            assert!(value["spec"].get(forbidden).is_none(), "found {forbidden}");
+        }
+    }
+
+    #[test]
+    fn aggregate_resources_are_unit_independent_and_ceiling_bounded() {
+        let totals = aggregate_resource_limits(&pool().template).unwrap();
+        assert_eq!(totals.cpu_millicores, 1000);
+        assert_eq!(totals.memory_bytes, 1024 * 1024 * 1024);
+        assert!(
+            resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "1000m".into(),
+                    max_memory: "1024Mi".into(),
+                },
+                &totals,
+            )
+            .unwrap()
+        );
+        assert!(
+            !resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "999m".into(),
+                    max_memory: "2Gi".into(),
+                },
+                &totals,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn quantity_parser_rejects_sub_millicore_cpu_and_whitespace() {
+        assert_eq!(parse_quantity("100u", QuantityDimension::Cpu), None);
+        assert_eq!(parse_quantity("1m", QuantityDimension::Cpu), Some(1));
+        assert_eq!(
+            parse_quantity("1n", QuantityDimension::Bytes),
+            Some(1),
+            "positive sub-byte quantities round up to one byte"
+        );
+        assert_eq!(parse_quantity(" 1", QuantityDimension::Bytes), None);
+        assert_eq!(parse_quantity("1 ", QuantityDimension::Bytes), None);
+    }
+
+    #[test]
+    fn invalid_or_inverted_resource_quantities_fail_closed() {
+        let mut template = pool().template;
+        template.containers[0].resources.requests.cpu = "2".into();
+        assert!(matches!(
+            aggregate_resource_limits(&template),
+            Err(SandboxResourceError::RequestExceedsLimit {
+                resource: "cpu",
+                ..
+            })
+        ));
+
+        assert!(
+            parse_resource_ceiling(&SandboxResourceCeiling {
+                max_cpu: "NaN".into(),
+                max_memory: "4Gi".into(),
+            })
+            .is_err()
+        );
+
+        let mut inverted_memory = pool().template;
+        inverted_memory.containers[0].resources.requests.memory = "900m".into();
+        inverted_memory.containers[0].resources.limits.memory = "100m".into();
+        assert!(matches!(
+            aggregate_resource_limits(&inverted_memory),
+            Err(SandboxResourceError::RequestExceedsLimit {
+                resource: "memory",
+                ..
+            })
+        ));
+
+        let mut fine_cpu = pool().template;
+        fine_cpu.containers[0].resources.requests.cpu = "100u".into();
+        assert!(matches!(
+            aggregate_resource_limits(&fine_cpu),
+            Err(SandboxResourceError::InvalidQuantity {
+                field: "requests.cpu",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn fractional_memory_is_compared_exactly_across_containers_and_policy() {
+        let mut template = pool().template;
+        let mut first = template.containers[0].clone();
+        first.name = "first".into();
+        first.resources.requests.cpu = "1m".into();
+        first.resources.limits.cpu = "1m".into();
+        first.resources.requests.memory = "100m".into();
+        first.resources.limits.memory = "450m".into();
+        let mut second = first.clone();
+        second.name = "second".into();
+        template.containers = vec![first, second];
+
+        let totals = aggregate_resource_limits(&template).unwrap();
+        assert_eq!(
+            totals.memory_bytes, 1,
+            "reporting rounds only after summing"
+        );
+        assert!(
+            !resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "2m".into(),
+                    max_memory: "100m".into(),
+                },
+                &totals,
+            )
+            .unwrap(),
+            "900m bytes must not fit beneath a 100m-byte ceiling"
+        );
+        assert!(
+            resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "2m".into(),
+                    max_memory: "900m".into(),
+                },
+                &totals,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn placement_has_no_default_and_cannot_change() {
+        let status = SandboxLeaseStatus::default();
+        assert_eq!(
+            require_resolved_placement(&status, "kobe"),
+            Err(SandboxProvenanceError::UnresolvedPlacement)
+        );
+
+        let placement = ResolvedSandboxPlacement::Management {};
+        assert_eq!(
+            record_placement_once(None, placement.clone(), "kobe"),
+            Ok(placement.clone())
+        );
+        assert_eq!(
+            record_placement_once(Some(&placement), placement.clone(), "kobe"),
+            Ok(placement)
+        );
+        assert_eq!(
+            record_placement_once(
+                Some(&ResolvedSandboxPlacement::Management {}),
+                ResolvedSandboxPlacement::ChildCluster {
+                    cluster_pool: cluster_pool_reference("kobe"),
+                },
+                "kobe",
+            ),
+            Err(SandboxProvenanceError::PlacementChanged)
+        );
+
+        let wrong_namespace = ResolvedSandboxPlacement::ChildCluster {
+            cluster_pool: cluster_pool_reference("other"),
+        };
+        assert!(matches!(
+            record_placement_once(None, wrong_namespace, "kobe"),
+            Err(SandboxProvenanceError::InvalidReference {
+                field: "clusterPool",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn provenance_only_allows_monotonic_exact_enrichment() {
+        let existing = provenance(None);
+        let enriched = provenance(Some(reference("SandboxClaim", "lease-a", "claim-uid")));
+        let placement = ResolvedSandboxPlacement::Management {};
+        assert_eq!(
+            merge_target_provenance(Some(&existing), enriched.clone(), &placement, "kobe"),
+            Ok(enriched.clone())
+        );
+
+        let mut name_reused = enriched.clone();
+        name_reused.sandbox_claim.as_mut().unwrap().uid = "replacement-uid".into();
+        assert_eq!(
+            merge_target_provenance(Some(&enriched), name_reused, &placement, "kobe"),
+            Err(SandboxProvenanceError::ReferenceChanged("sandboxClaim"))
+        );
+
+        let mut cleared = enriched.clone();
+        cleared.sandbox_claim = None;
+        assert_eq!(
+            merge_target_provenance(Some(&enriched), cleared, &placement, "kobe"),
+            Err(SandboxProvenanceError::ReferenceCleared("sandboxClaim"))
+        );
+
+        let mut moved = enriched.clone();
+        moved.namespace = "other".into();
+        assert_eq!(
+            merge_target_provenance(Some(&enriched), moved, &placement, "kobe"),
+            Err(SandboxProvenanceError::InvalidReference {
+                field: "sandboxTemplate",
+                reason: "namespace does not match the target namespace",
+            })
+        );
+
+        let mut wrong_gvk = enriched.clone();
+        wrong_gvk.sandbox_claim.as_mut().unwrap().kind = "Secret".into();
+        assert!(matches!(
+            merge_target_provenance(None, wrong_gvk, &placement, "kobe"),
+            Err(SandboxProvenanceError::InvalidReference {
+                field: "sandboxClaim",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn lifecycle_starts_ttl_at_ready_and_requires_cleanup_proof() {
+        let accepted_at = DateTime::parse_from_rfc3339("2026-08-10T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let ready_at = DateTime::parse_from_rfc3339("2026-08-10T10:03:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let provisioning = begin_sandbox_provisioning(
+            &SandboxLeaseStatus::default(),
+            2,
+            accepted_at,
+            chrono::Duration::minutes(10),
+        )
+        .unwrap();
+        assert_eq!(
+            provisioning.provisioning_deadline.as_deref(),
+            Some("2026-08-10T10:10:00Z")
+        );
+        assert!(provisioning.ready_at.is_none());
+        assert!(provisioning.expires_at.is_none());
+
+        let ready =
+            mark_sandbox_ready(&provisioning, 2, ready_at, chrono::Duration::hours(1)).unwrap();
+        assert_eq!(ready.ready_at.as_deref(), Some("2026-08-10T10:03:00Z"));
+        assert_eq!(ready.expires_at.as_deref(), Some("2026-08-10T11:03:00Z"));
+        assert_eq!(
+            transition_sandbox_phase(
+                SandboxLeasePhase::Releasing,
+                SandboxLeasePhase::Released,
+                false,
+            ),
+            Err(SandboxLifecycleError::CleanupProofRequired)
+        );
+        assert_eq!(
+            transition_sandbox_phase(
+                SandboxLeasePhase::Quarantined,
+                SandboxLeasePhase::Released,
+                true,
+            ),
+            Ok(SandboxLeasePhase::Released)
+        );
+    }
+}


### PR DESCRIPTION
Closes #71
Epic: #70 — Agent Sandbox (lane `F1`)

**Targets `epic/agent-sandbox`, not `main`** — per the [landing-strategy decision](https://github.com/kunobi-ninja/kobe/issues/70#issuecomment-5254024760), the epic accumulates on the integration branch so nothing reaches the release being cut.

Resumes the WIP checkpoint Juan handed over in the [epic ownership handoff](https://github.com/kunobi-ninja/kobe/issues/70#issuecomment-5244689467). His commit is preserved unmodified at `bbcab0f`; my work sits on top.

## Why this is atomic

One contract: **caller-safe Sandbox intent, admitted atomically.** The CRDs define what a caller may ask for, the policy grant defines what they may have, and the ledger decides — under contention — whether they get it.

## State of the checkpoint

Deliberately mid-refactor. The cross-replica quota/alias scheme was being replaced by a coordination-Lease CAS ledger, so the call sites existed but the mechanism did not: **13 compile errors**, all from four missing pieces (`acquire_admission_reservations`, `release_admission_reservations`, `AdmissionReservationError`, `lease_exceeds_quota`) plus one changed signature.

## The admission ledger

Quota and alias are claimed by `CREATE`-ing coordination Leases at deterministic per-principal names:

```
sbx-quota-<principal-hash>-<slot>
sbx-alias-<principal-hash>-<alias>
```

`CREATE` is the primitive that decides. The API server serialises writers on object name, so two replicas racing for the last slot cannot both win. **Counting cannot give that** — two replicas can both read "one slot free" and both admit, which is exactly the hole the replaced design had.

Details that matter:

- **Alias first.** A taken alias is a deterministic, user-fixable conflict, so refusing before consuming a quota slot avoids an acquire-then-release round trip against shared quota.
- **Owner references.** Each reservation is owned by its `SandboxLease`, so a slot cannot leak and permanently consume the caller's quota if we die mid-request — Kubernetes GCs it with the lease.
- **UID-fenced release.** `release_reservations_for_lease` selects on the lease-UID label, so a same-named replacement lease cannot drop its predecessor's slots. Same principle as #79, one layer up.
- **Ordering.** Cleanup runs *after* the lease is deleted. The other order would briefly leave an admitted-looking lease with no quota slot, which a concurrent request could double-book.

### One performance fix

The existing comment claimed "Advisory LIST checks above improve error latency" — but there were none. Without one, a caller at the 256-slot ceiling pays **one failed CREATE per taken slot**: 256 round trips just to be told they're over quota. Added a single labelled LIST that answers the common case, explicitly non-authoritative — the CREATE still decides, and a failed advisory read falls through rather than failing the request.

## Removed, with reasons

Rather than leave the replaced design to rot:

| Removed | Why |
|---|---|
| `lease_exceeds_quota` + `quota_race_resolution_is_deterministic` | Ranking a LIST cannot decide admission across replicas |
| `create_fails_closed_and_removes_lease_missing_from_relist` | Asserted the relist *verification step* of the replaced scheme; the relist no longer decides admission |
| `CurrentLeaseMissing`, `DuplicateCurrentLease`, `sandbox_lease_from_json` | Only the above constructed/used them |
| `sha2` import + duplicate `Cargo.toml` dep | `principal_hash` is FNV; main already added `sha2` via #79 |

## Regression proof

Four new tests, each mutation-checked — verified to fail with its guard removed and pass with it:

| Test | Mutation that makes it fail |
|---|---|
| `create_refuses_when_every_quota_slot_is_held` | make the slot scan never refuse |
| `create_refuses_a_taken_alias_without_consuming_a_quota_slot` | swallow the alias 409; **or** drop UID fencing on release |
| `create_acquires_exactly_one_quota_slot_and_one_alias` | (happy-path counterpart) |
| `reservation_names_are_scoped_per_principal` | share alias names across principals |

Note the second row: that test catches **two independent** defects, which is why it earns its place.

### A test-harness detail worth reviewing

My first reservation mock ignored `labelSelector`, and a test failed — a pre-held reservation belonging to *another* lease was deleted by our cleanup. That was a mock artifact (a real API server filters by selector), but relaxing the test would have hidden a genuine class of fencing bug. **The mock now honours `labelSelector`**, so cross-lease deletion fails loudly.

## Validation

```
cargo fmt -- --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean (was 13 compile errors)
cargo test --workspace                                  # 1335 passed, 0 failed
helm template kobe charts/kobe/                         # renders
crdgen drift, all 10 shipped CRDs                       # clean
```

The checkpoint had already widened CI's drift loop from 5 to all 10 CRDs (#71's own acceptance criterion); I regenerated `sandboxpools`/`sandboxleases` so it passes.

## Notes for review

- Sandbox CRDs **are** shipped in `charts/kobe/crds/`. I'd flagged holding them out because Helm never upgrades or deletes anything there — but that concern assumed landing on `main`. On the integration branch they cannot reach a user until the epic merges *and* a release is cut, by which point #73 reconciles them. Worth re-confirming at epic-merge time, not now.
- `MAX_SANDBOX_CONCURRENCY_SLOTS` (256) bounds the slot scan regardless of what a policy requests; policies above it are rejected up front.

## Non-goals

Placement, reconciliation, finalizers, and execution transport — those are #73/#74 and the #75 subtree. This issue defines the invariants; it does not enforce them at runtime.