### PR TITLE
fix(aur): publish a real pkgver for the -git package

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,6 +98,11 @@ jobs:
       - name: Version-consistency gate tests
         run: ./scripts/test-version-consistency.sh
 
+      # Same reasoning: the -git pkgver is only ever visible as AUR metadata,
+      # so a wrong value publishes cleanly and no build ever fails on it.
+      - name: AUR -git pkgver tests
+        run: ./scripts/aur/test-vcs-pkgver.sh
+
       - name: Security audit
         run: |
           cargo install cargo-audit --locked || true

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -405,9 +405,12 @@ jobs:
   # ssh://aur@aur.archlinux.org/<name>.git — NOT a GitHub repo, just
   # PKGBUILD + .SRCINFO). Enable/disable a flavor per project by adding/removing
   # its aur/<name>/ folder. Versioned packages (-bin, source) get pkgver
-  # refreshed to the release; VCS packages (-git) keep their git-derived pkgver
-  # (so a stable release is a no-op for them — allow_empty_commits:false). STABLE
-  # only — AUR pkgver can't carry a pre-release '-'. Requires the AUR_SSH_KEY secret.
+  # refreshed to the release; VCS packages (-git) get theirs computed from git
+  # as <latest tag>.r<commits>.g<sha> by scripts/aur/vcs-pkgver.sh, matching what
+  # their own pkgver() recomputes at build time. That value moves every release,
+  # so -git packages now produce a real commit each time rather than being a
+  # no-op. STABLE only — AUR pkgver can't carry a pre-release '-'. Requires the
+  # AUR_SSH_KEY secret.
   # ---------------------------------------------------------------------------
   aur-list:
     needs: resolve
@@ -435,17 +438,31 @@ jobs:
       matrix:
         pkg: ${{ fromJson(needs.aur-list.outputs.pkgs) }}
     steps:
+      # fetch-depth: 0 is load-bearing for the -git packages below: their
+      # pkgver embeds `git rev-list --count HEAD`, and the default depth-1
+      # checkout would count 1 commit no matter the real history.
       - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
-      - name: Refresh pkgver for versioned packages (skip -git)
+      - name: Refresh pkgver
         env:
           VERSION: ${{ needs.resolve.outputs.version }}
           PKG: ${{ matrix.pkg }}
         run: |
           set -euo pipefail
-          if [[ "$PKG" != *-git ]]; then
-            sed -i -e "s/^pkgver=.*/pkgver=${VERSION}/" -e "s/^pkgrel=.*/pkgrel=1/" "aur/${PKG}/PKGBUILD"
+          if [[ "$PKG" == *-git ]]; then
+            # A VCS package tracks main, so it must NOT claim the release
+            # version — its pkgver is <latest tag>.r<commits>.g<sha>, the same
+            # shape the PKGBUILD's own pkgver() recomputes at build time.
+            # Without this the placeholder committed in the repo
+            # (0.0.0.r0.g0000000) is what reaches the AUR, which is what every
+            # release up to 0.38.0 published.
+            PKGVER="$(./scripts/aur/vcs-pkgver.sh .)"
+          else
+            PKGVER="$VERSION"
           fi
+          sed -i -e "s/^pkgver=.*/pkgver=${PKGVER}/" -e "s/^pkgrel=.*/pkgrel=1/" "aur/${PKG}/PKGBUILD"
           echo "--- aur/${PKG}/PKGBUILD ---"; cat "aur/${PKG}/PKGBUILD"
 
       - name: Publish ${{ matrix.pkg }} to the AUR

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -458,7 +458,19 @@ jobs:
             # Without this the placeholder committed in the repo
             # (0.0.0.r0.g0000000) is what reaches the AUR, which is what every
             # release up to 0.38.0 published.
-            PKGVER="$(./scripts/aur/vcs-pkgver.sh .)"
+            #
+            # A `release` event checks out that release's TAG. Re-running the
+            # publish for a tag cut before this script existed would therefore
+            # not find it — leave that case exactly as it behaved then (the
+            # committed placeholder) rather than failing the leg, since
+            # re-running a publish after an outage is a normal admin action.
+            if [ -x ./scripts/aur/vcs-pkgver.sh ]; then
+              PKGVER="$(./scripts/aur/vcs-pkgver.sh .)"
+            else
+              echo "::warning::scripts/aur/vcs-pkgver.sh not present at this ref — leaving ${PKG} pkgver untouched"
+              echo "--- aur/${PKG}/PKGBUILD (unchanged) ---"; cat "aur/${PKG}/PKGBUILD"
+              exit 0
+            fi
           else
             PKGVER="$VERSION"
           fi

--- a/justfile
+++ b/justfile
@@ -207,6 +207,21 @@ bump VERSION:
     ./scripts/check-version-consistency.sh
     echo "Bumped to {{ VERSION }}. Review the diff, commit, then \`just release\`."
 
+# Deliberately read-only: the value is only correct once HEAD is the tagged
+# release commit, so package-publish computes it at publish time rather than
+# committing it here. Run from a full clone — it refuses a shallow one.
+# Show the pkgver the -git AUR packages will be published with
+[group('release')]
+aur-pkgver:
+    @./scripts/aur/vcs-pkgver.sh .
+
+# Runs in CI on every change: the value it guards is only ever seen as AUR
+# metadata, so a wrong one publishes cleanly and no build fails.
+# Test the -git pkgver computation
+[group('release')]
+test-aur-pkgver:
+    @./scripts/aur/test-vcs-pkgver.sh
+
 # Cut a release: validate clean tree / on main / in sync, run the version gate,
 # and push the tag. The tag push fires CI (build+sign), package-publish, and the
 # crates.io publish.

--- a/scripts/aur/test-vcs-pkgver.sh
+++ b/scripts/aur/test-vcs-pkgver.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Executable tests for vcs-pkgver.sh.
+#
+# vcs-pkgver.sh runs once per release, inside CI, and its output is committed
+# to the AUR as package metadata. A wrong value there is not a build failure —
+# it publishes cleanly and is only visible on a web page nobody on the team
+# reads. So the failure modes have to be caught here.
+#
+# The one that matters is the shallow clone: actions/checkout defaults to
+# fetch-depth 1, which makes `git rev-list --count HEAD` return 1 no matter how
+# many commits exist. That silently produces a pkgver LOWER than the previous
+# release's, which is the one thing a version string must never do.
+#
+# Usage: scripts/aur/test-vcs-pkgver.sh    (exit 0 = all cases pass)
+set -uo pipefail
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+script="$here/vcs-pkgver.sh"
+repo_root="$(cd "$here/../.." && pwd)"
+pass=0
+fail=0
+
+# A throwaway git repo with $1 commits, optionally tagged $2 on the last one.
+make_repo() {
+  local commits="$1" tag="${2:-}" root
+  root="$(mktemp -d)"
+  git -C "$root" init -q -b main
+  git -C "$root" config user.email t@example.com
+  git -C "$root" config user.name t
+  for i in $(seq 1 "$commits"); do
+    echo "$i" >"$root/f"
+    git -C "$root" add f
+    git -C "$root" commit -qm "c$i"
+  done
+  [ -n "$tag" ] && git -C "$root" tag "$tag"
+  echo "$root"
+}
+
+ok() { printf '  ok   %s\n' "$1"; pass=$((pass + 1)); }
+no() { printf '  FAIL %s\n     %s\n' "$1" "$2"; fail=$((fail + 1)); }
+
+# Assert the script succeeds and prints exactly $2.
+expect_output() {
+  local name="$1" want="$2" repo="$3" got status
+  got="$("$script" "$repo" 2>&1)"
+  status=$?
+  if [ "$status" -ne 0 ]; then
+    no "$name" "expected success, exited $status: $got"
+  elif [ "$got" != "$want" ]; then
+    no "$name" "want '$want', got '$got'"
+  else
+    ok "$name"
+  fi
+}
+
+# Assert the script fails and says why (a bare non-zero could be any bug).
+expect_failure() {
+  local name="$1" substr="$2" repo="$3" got status
+  got="$("$script" "$repo" 2>&1)"
+  status=$?
+  if [ "$status" -eq 0 ]; then
+    no "$name" "expected failure, but it succeeded with: $got"
+  elif [[ "$got" != *"$substr"* ]]; then
+    no "$name" "failed as expected, but message lacked '$substr': $got"
+  else
+    ok "$name"
+  fi
+}
+
+echo "vcs-pkgver.sh"
+
+# --- format ---------------------------------------------------------------
+
+r="$(make_repo 3 v1.2.3)"
+sha="$(git -C "$r" rev-parse --short=7 HEAD)"
+expect_output "tagged repo yields <version>.r<count>.g<sha>" "1.2.3.r3.g$sha" "$r"
+
+r="$(make_repo 1 v0.38.0)"
+sha="$(git -C "$r" rev-parse --short=7 HEAD)"
+expect_output "leading v is stripped from the tag" "0.38.0.r1.g$sha" "$r"
+
+r="$(make_repo 2)"
+sha="$(git -C "$r" rev-parse --short=7 HEAD)"
+expect_output "untagged repo falls back to 0.0.0" "0.0.0.r2.g$sha" "$r"
+
+# The AUR sorts pkgver with the same rules pacman uses, so the r<count> field
+# is what orders two builds of the same tag. It must track real depth.
+r="$(make_repo 7 v1.0.0)"
+sha="$(git -C "$r" rev-parse --short=7 HEAD)"
+expect_output "commit count reflects full history" "1.0.0.r7.g$sha" "$r"
+
+# --- the shallow-clone trap ----------------------------------------------
+
+r="$(make_repo 5 v1.0.0)"
+shallow="$(mktemp -d)/clone"
+git clone -q --depth 1 "file://$r" "$shallow" 2>/dev/null
+expect_failure "shallow clone is refused, not silently counted as r1" \
+  "shallow" "$shallow"
+
+# --- misuse ---------------------------------------------------------------
+
+expect_failure "a non-repo path is refused" "not a git repository" "$(mktemp -d)"
+expect_failure "a missing path is refused" "does not exist" "/nonexistent/nope"
+
+# --- drift guard ----------------------------------------------------------
+#
+# The PKGBUILD computes its own pkgver at build time on the user's machine.
+# If these two ever disagree on format, the AUR advertises one shape and
+# installs another, and version comparison stops meaning anything. Run the
+# real pkgver() from the shipped PKGBUILD against the same repo and demand
+# byte-identical output.
+pkgbuild="$repo_root/aur/kobe-git/PKGBUILD"
+if [ -f "$pkgbuild" ]; then
+  r="$(make_repo 4 v2.5.1)"
+  holder="$(mktemp -d)"
+  cp -R "$r" "$holder/kobe"
+  from_pkgbuild="$(
+    srcdir="$holder"
+    export srcdir
+    eval "$(sed -n '/^pkgver() {/,/^}/p' "$pkgbuild")"
+    pkgver 2>/dev/null
+  )"
+  from_script="$("$script" "$holder/kobe" 2>&1)"
+  if [ "$from_pkgbuild" = "$from_script" ] && [ -n "$from_script" ]; then
+    ok "output matches the PKGBUILD's own pkgver() byte for byte"
+  else
+    no "output matches the PKGBUILD's own pkgver() byte for byte" \
+      "PKGBUILD gave '$from_pkgbuild', script gave '$from_script'"
+  fi
+else
+  no "aur/kobe-git/PKGBUILD is present" "not found at $pkgbuild"
+fi
+
+echo
+echo "passed: $pass  failed: $fail"
+[ "$fail" -eq 0 ]

--- a/scripts/aur/test-vcs-pkgver.sh
+++ b/scripts/aur/test-vcs-pkgver.sh
@@ -109,26 +109,34 @@ expect_failure "a missing path is refused" "does not exist" "/nonexistent/nope"
 # installs another, and version comparison stops meaning anything. Run the
 # real pkgver() from the shipped PKGBUILD against the same repo and demand
 # byte-identical output.
-pkgbuild="$repo_root/aur/kobe-git/PKGBUILD"
+pkgbuild="$(echo "$repo_root"/aur/*-git/PKGBUILD)"
 if [ -f "$pkgbuild" ]; then
-  r="$(make_repo 4 v2.5.1)"
-  holder="$(mktemp -d)"
-  cp -R "$r" "$holder/kobe"
-  from_pkgbuild="$(
-    srcdir="$holder"
-    export srcdir
-    eval "$(sed -n '/^pkgver() {/,/^}/p' "$pkgbuild")"
-    pkgver 2>/dev/null
-  )"
-  from_script="$("$script" "$holder/kobe" 2>&1)"
-  if [ "$from_pkgbuild" = "$from_script" ] && [ -n "$from_script" ]; then
-    ok "output matches the PKGBUILD's own pkgver() byte for byte"
+  # pkgver() does `cd "$srcdir/<name>"`, where <name> comes from the PKGBUILD's
+  # own source= line. Derive it rather than hardcoding, so this file stays
+  # identical across repos that vendor it.
+  srcname="$(sed -n 's/^source=("\([^:]*\)::git+.*/\1/p' "$pkgbuild" | head -1)"
+  if [ -z "$srcname" ]; then
+    no "source= names a git checkout directory" "could not parse it from $pkgbuild"
   else
-    no "output matches the PKGBUILD's own pkgver() byte for byte" \
-      "PKGBUILD gave '$from_pkgbuild', script gave '$from_script'"
+    r="$(make_repo 4 v2.5.1)"
+    holder="$(mktemp -d)"
+    cp -R "$r" "$holder/$srcname"
+    from_pkgbuild="$(
+      srcdir="$holder"
+      export srcdir
+      eval "$(sed -n '/^pkgver() {/,/^}/p' "$pkgbuild")"
+      pkgver 2>/dev/null
+    )"
+    from_script="$("$script" "$holder/$srcname" 2>&1)"
+    if [ "$from_pkgbuild" = "$from_script" ] && [ -n "$from_script" ]; then
+      ok "output matches the PKGBUILD's own pkgver() byte for byte"
+    else
+      no "output matches the PKGBUILD's own pkgver() byte for byte" \
+        "PKGBUILD gave '$from_pkgbuild', script gave '$from_script'"
+    fi
   fi
 else
-  no "aur/kobe-git/PKGBUILD is present" "not found at $pkgbuild"
+  no "an aur/*-git/PKGBUILD is present" "not found under $repo_root/aur"
 fi
 
 echo

--- a/scripts/aur/vcs-pkgver.sh
+++ b/scripts/aur/vcs-pkgver.sh
@@ -1,0 +1,48 @@
+#!/usr/bin/env bash
+# Compute the pkgver for a VCS (-git) AUR package.
+#
+# Emits `<version>.r<count>.g<sha>`, byte-identical to what the pkgver()
+# function inside aur/*-git/PKGBUILD produces at build time. The two must
+# agree: the AUR advertises this value as metadata, makepkg recomputes it on
+# the user's machine, and if the formats diverge then version comparison
+# between "what the AUR says" and "what got installed" stops meaning anything.
+#
+# Usage: scripts/aur/vcs-pkgver.sh [repo-dir]     (default: cwd)
+set -uo pipefail
+
+repo="${1:-.}"
+
+if [ ! -e "$repo" ]; then
+  echo "vcs-pkgver: '$repo' does not exist" >&2
+  exit 1
+fi
+
+if ! git -C "$repo" rev-parse --git-dir >/dev/null 2>&1; then
+  echo "vcs-pkgver: '$repo' is not a git repository" >&2
+  exit 1
+fi
+
+# A shallow clone silently breaks this. `git rev-list --count HEAD` counts only
+# the commits it actually has, so a depth-1 checkout reports 1 regardless of
+# real history — and actions/checkout defaults to depth 1. That would publish a
+# pkgver LOWER than the previous release's, which pacman reads as a downgrade
+# and which no build failure would ever surface. Refuse instead of guessing.
+if [ "$(git -C "$repo" rev-parse --is-shallow-repository 2>/dev/null)" = "true" ]; then
+  echo "vcs-pkgver: '$repo' is a shallow clone — the commit count would be wrong." >&2
+  echo "            Fetch full history first (actions/checkout: fetch-depth: 0)." >&2
+  exit 1
+fi
+
+if ! git -C "$repo" rev-parse HEAD >/dev/null 2>&1; then
+  echo "vcs-pkgver: '$repo' has no commits" >&2
+  exit 1
+fi
+
+# Mirrors aur/*-git/PKGBUILD's pkgver() exactly, including the 0.0.0 fallback
+# for a repo with no tags yet.
+version="$(git -C "$repo" describe --tags --abbrev=0 2>/dev/null | sed 's/^v//')"
+[ -n "$version" ] || version="0.0.0"
+count="$(git -C "$repo" rev-list --count HEAD)"
+sha="$(git -C "$repo" rev-parse --short=7 HEAD)"
+
+printf '%s.r%s.g%s\n' "$version" "$count" "$sha"


### PR DESCRIPTION
## What

`kobe-git` has advertised `0.0.0.r0.g0000000-1` on the AUR since it was first submitted on 2026-07-28, and its `LastModified` is still that same timestamp.

```
kobe        0.38.0-1
kobe-bin    0.38.0-1
kobe-git    0.0.0.r0.g0000000-1     ← never resolved
```

That string is the literal `pkgver=` line committed in `aur/kobe-git/PKGBUILD`. `package-publish` skips the pkgver rewrite for `*-git` packages — **correctly**, since stamping a release version onto a package that builds from `main` would be false — but nothing ever replaced it with a computed one either. The AUR reads `.SRCINFO`, which `makepkg --printsrcinfo` generates from that literal line; it never executes `pkgver()`. So the placeholder is what every release has published.

## What was and wasn't broken

**Installs were fine.** `pkgver()` runs at build time on the user's machine and produces the real value, which is strictly higher than the placeholder — so nothing downgraded.

What was actually wrong is smaller: the AUR page advertised a meaningless version, and because that version never changed, AUR helpers had nothing to detect an update from. (Devel packages are conventionally refreshed via `yay -Syu --devel`, which compares upstream git HEAD directly and ignores pkgver — so this was mostly cosmetic for `--devel` users.)

## Fix

Compute it at publish time as `<latest tag>.r<commits>.g<sha>`, the same shape `pkgver()` recomputes at build time:

```
kobe       -> pkgver=0.39.0
kobe-bin   -> pkgver=0.39.0
kobe-git   -> pkgver=0.38.0.r352.g497a34f
```

Two things this has to get right, and both are covered by tests:

**`fetch-depth: 0` on the aur job.** The pkgver embeds `git rev-list --count HEAD`, and `actions/checkout` defaults to depth 1 — which counts 1 commit regardless of real history, publishing a version *lower* than the previous release's. `vcs-pkgver.sh` refuses a shallow clone rather than emit that, so the mistake is loud instead of silent.

**Format agreement with the PKGBUILD.** If the CI-side computation and `pkgver()` ever diverge, the AUR advertises one shape and installs another, and version comparison stops meaning anything. One test runs the real `pkgver()` out of the shipped PKGBUILD against the same repo and demands byte-identical output.

Because the value now moves every release, `-git` packages produce a real commit each time instead of being a no-op — the job's header comment is updated to say so, since it previously documented the opposite.

## Tests

`scripts/aur/test-vcs-pkgver.sh`, 8 cases, following the existing `test-version-consistency.sh` pattern. Confirmed red 8/8 before `vcs-pkgver.sh` existed:

```
  ok   tagged repo yields <version>.r<count>.g<sha>
  ok   leading v is stripped from the tag
  ok   untagged repo falls back to 0.0.0
  ok   commit count reflects full history
  ok   shallow clone is refused, not silently counted as r1
  ok   a non-repo path is refused
  ok   a missing path is refused
  ok   output matches the PKGBUILD's own pkgver() byte for byte
```

Wired into CI on every change, for the same reason the version-consistency tests are: this value is only ever visible as AUR metadata, so a wrong one publishes cleanly and no build ever fails on it.

Also adds `just aur-pkgver` (preview what will be published) and `just test-aur-pkgver`.

shellcheck clean; both workflows parse.

## Note for kache

`kache` has the identical issue — `kache-git` is also on `0.0.0.r0.g0000000-1` with the same PKGBUILD shape. Separately, `kache` (source) is on `0.12.0-1` while `kache-bin` is on `0.13.0-1`, so the source package appears to have missed a release. Both are worth a follow-up there.