### PR TITLE
fix(kobectl): purge must not abandon the batch on one unremovable file

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2732,6 +2732,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_yaml_ng",
+ "tempfile",
  "tokio",
  "toml",
  "url",

--- a/crates/kobectl/Cargo.toml
+++ b/crates/kobectl/Cargo.toml
@@ -42,6 +42,9 @@ url = "2"
 # v0.10.0 is on crates.io, the git key can be dropped.
 kunobi-auth = { git = "https://github.com/kunobi-ninja/kunobi-auth.git", tag = "v0.10.0", version = "0.10.0" }
 
+[dev-dependencies]
+tempfile = "3"
+
 [package.metadata.binstall]
 # Asset stem is `kobe-<target>` (named after the binary, NOT the crate) — do NOT
 # use `{ name }` here, which would resolve to `kobectl-<target>`.

--- a/crates/kobectl/src/commands/purge.rs
+++ b/crates/kobectl/src/commands/purge.rs
@@ -79,13 +79,14 @@ pub async fn purge(
         }
     }
 
-    forget_endpoint_kubeconfigs(endpoint)?;
-    let mut removed_paths = Vec::new();
-    for path in dedupe_paths(removable_files) {
-        if path.exists() {
-            std::fs::remove_file(&path)?;
-            removed_paths.push(path);
-        }
+    let (removed_paths, failures) = remove_kubeconfig_files(dedupe_paths(removable_files));
+
+    // Drop the tracking entries only once the files are actually gone. Wiping
+    // them up front means a failed removal leaves a file on disk that nothing
+    // points at any more — the same silent leak `purge_orphans_only` was fixed
+    // for. Leaving them lets the next run re-detect the stragglers.
+    if failures.is_empty() {
+        forget_endpoint_kubeconfigs(endpoint)?;
     }
 
     match output {
@@ -102,6 +103,12 @@ pub async fn purge(
                     println!("  {}", path.display());
                 }
             }
+            if !failures.is_empty() {
+                eprintln!("Failed to remove {} file(s):", failures.len());
+                for (path, err) in &failures {
+                    eprintln!("  {}: {err}", path.display());
+                }
+            }
         }
         OutputFormat::Json => print_json(&PurgeOutput {
             released_leases: released,
@@ -110,6 +117,10 @@ pub async fn purge(
                 .map(|path| path.display().to_string())
                 .collect(),
         })?,
+    }
+
+    if !failures.is_empty() {
+        anyhow::bail!("Failed to remove {} kubeconfig file(s)", failures.len());
     }
 
     Ok(())
@@ -233,6 +244,28 @@ pub(crate) fn live_lease_ids(leases: &[LeaseSummary]) -> BTreeSet<String> {
         .collect()
 }
 
+/// Remove each file, collecting failures instead of aborting on the first.
+///
+/// Same policy as `purge_orphans_only`: one unremovable file must not abandon
+/// every file after it. Returns the paths actually removed and the ones that
+/// could not be.
+fn remove_kubeconfig_files(paths: Vec<PathBuf>) -> (Vec<PathBuf>, Vec<(PathBuf, std::io::Error)>) {
+    let mut removed_paths = Vec::new();
+    let mut failures = Vec::new();
+    for path in paths {
+        if !path.exists() {
+            continue;
+        }
+        match std::fs::remove_file(&path) {
+            Ok(()) => removed_paths.push(path),
+            // Vanished between the check and the removal — the desired state.
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
+            Err(err) => failures.push((path, err)),
+        }
+    }
+    (removed_paths, failures)
+}
+
 fn dedupe_paths(paths: impl IntoIterator<Item = PathBuf>) -> Vec<PathBuf> {
     let mut seen = BTreeSet::new();
     let mut deduped = Vec::new();
@@ -260,6 +293,80 @@ fn confirm_purge(active_leases: usize, kubeconfigs: usize) -> Result<()> {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A batch of paths where the middle entry cannot be removed.
+    ///
+    /// `remove_file` on a *directory* fails on every supported platform and
+    /// needs no permission games, so it stays correct when the suite runs as
+    /// root (a chmod-based fixture would silently stop failing there).
+    fn batch_with_an_unremovable_middle() -> (tempfile::TempDir, Vec<PathBuf>) {
+        let dir = tempfile::tempdir().unwrap();
+        let first = dir.path().join("kobe-lease-first.yaml");
+        let blocked = dir.path().join("kobe-lease-blocked.yaml");
+        let last = dir.path().join("kobe-lease-last.yaml");
+        std::fs::write(&first, "a").unwrap();
+        std::fs::create_dir(&blocked).unwrap();
+        std::fs::write(&last, "c").unwrap();
+        (dir, vec![first, blocked, last])
+    }
+
+    /// The regression this fixes.
+    ///
+    /// `purge_orphans_only` collects per-file failures and keeps going,
+    /// deliberately — its comment records that aborting "turned a single I/O
+    /// error into a permanent silent leak". The full-purge path had never
+    /// adopted that policy: it propagated with `?`, so one unremovable file
+    /// abandoned every file after it, while `forget_endpoint_kubeconfigs` had
+    /// already dropped the tracking entries for all of them.
+    #[test]
+    fn one_unremovable_file_does_not_abandon_the_rest_of_the_batch() {
+        let (dir, paths) = batch_with_an_unremovable_middle();
+        let (first, blocked, last) = (paths[0].clone(), paths[1].clone(), paths[2].clone());
+
+        let (removed, failures) = remove_kubeconfig_files(paths);
+
+        assert_eq!(removed, vec![first.clone(), last.clone()]);
+        assert!(!first.exists());
+        assert!(!last.exists(), "the file after the failure must still go");
+        assert_eq!(failures.len(), 1);
+        assert_eq!(failures[0].0, blocked);
+        drop(dir);
+    }
+
+    #[test]
+    fn missing_paths_are_skipped_without_being_reported_as_failures() {
+        let dir = tempfile::tempdir().unwrap();
+        let present = dir.path().join("kobe-lease-here.yaml");
+        std::fs::write(&present, "x").unwrap();
+        let absent = dir.path().join("kobe-lease-gone.yaml");
+
+        let (removed, failures) = remove_kubeconfig_files(vec![absent, present.clone()]);
+
+        assert_eq!(removed, vec![present]);
+        assert!(
+            failures.is_empty(),
+            "an already-absent file is the goal state"
+        );
+    }
+
+    #[test]
+    fn an_empty_batch_is_not_a_failure() {
+        let (removed, failures) = remove_kubeconfig_files(Vec::new());
+        assert!(removed.is_empty());
+        assert!(failures.is_empty());
+    }
+
+    /// `purge` chains state-tracked paths with the ~/.kube glob, so the same
+    /// file arrives twice whenever a tracked kubeconfig also matches the
+    /// naming pattern. Deduping is what stops the second pass reporting a
+    /// spurious failure for a file the first pass already removed.
+    #[test]
+    fn dedupe_paths_keeps_first_occurrence_order() {
+        let a = PathBuf::from("/tmp/kobe-a.yaml");
+        let b = PathBuf::from("/tmp/kobe-b.yaml");
+        let deduped = dedupe_paths(vec![a.clone(), b.clone(), a.clone(), b.clone()]);
+        assert_eq!(deduped, vec![a, b]);
+    }
 
     #[test]
     fn active_lease_filter_rejects_terminal_phases() {


### PR DESCRIPTION
## The bug

`purge.rs` contains two removal paths with **opposite** error-handling policies, and the one that was never fixed is the destructive one.

`purge_orphans_only` collects per-file failures and keeps going. Its comment says exactly why:

> the previous ordering (forget then remove) turned a single I/O error into a permanent silent leak — the state entry was gone so subsequent runs would not re-detect the file [...] errors are collected and reported at the end so one bad file does not abort the whole batch

The full-purge path in the same file never adopted that policy:

```rust
forget_endpoint_kubeconfigs(endpoint)?;          // wipes tracking for the WHOLE endpoint
for path in dedupe_paths(removable_files) {
    if path.exists() {
        std::fs::remove_file(&path)?;            // aborts the batch
```

So a single unremovable file:

- **abandons every file after it** in the batch, and
- leaves all of them **untracked**, because the endpoint-wide state wipe already ran.

That is the precise leak the sibling function carries a comment about.

## Fix

Adopt the sibling's policy — collect failures, remove everything removable, report the rest, exit non-zero at the end. And drop the tracking entries only once the files are actually gone, so a failure leaves them for the next run to re-detect rather than orphaning them.

## Proving it first

Per the TDD ask, the defect was demonstrated against unchanged logic before anything was fixed. The loop was extracted verbatim, then a test asserting the *broken* behaviour was written and confirmed passing:

```
test full_purge_currently_aborts_the_batch_on_the_first_failure ... ok
```

— i.e. the batch did abort and the trailing file was left on disk. That test was then inverted to assert the corrected behaviour. Seeding a `break` back into the failure arm fails it again:

```
test one_unremovable_file_does_not_abandon_the_rest_of_the_batch ... FAILED
```

## A note on the fixture

The unremovable entry is a **directory**, not a chmod'd file. `remove_file` on a directory fails on every supported platform, whereas a permission-based fixture silently stops failing when the suite runs as root — which would turn this into a test that passes for the wrong reason in a container.

## Scope

`purge.rs`: 2 → 6 tests. Also covers the already-absent case (goal state, not a failure), the empty batch, and `dedupe_paths` ordering — which matters because `purge` chains state-tracked paths with the `~/.kube` glob, so the same file legitimately arrives twice.

Adds `tempfile` as a `kobectl` dev-dependency. It is already a workspace dev-dep, so no new third-party code enters the tree.

Workspace green (1289 tests), clippy `-D warnings` clean.