### PR TITLE
lifecycle(k3s): add verified-teardown vocabulary and the Quarantined phase

### DIFF
--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -1026,6 +1026,7 @@ spec:
                 - Recycling
                 - Unhealthy
                 - Failed
+                - Quarantined
                 type: string
               provisioned:
                 default: false

--- a/charts/kobe/crds/clusterleases.yaml
+++ b/charts/kobe/crds/clusterleases.yaml
@@ -27,6 +27,13 @@ spec:
               The lease controller binds it to a warm cluster, tracks TTL,
               and handles release/expiry/recycling.
             properties:
+              cleanupMode:
+                description: How thoroughly a lease's capacity must be torn down before it can be reused.
+                enum:
+                - Standard
+                - VerifiedDestroy
+                nullable: true
+                type: string
               poolRef:
                 description: Which profile's pool to lease from.
                 type: string
@@ -299,6 +306,7 @@ spec:
                 - Released
                 - Expired
                 - Recycling
+                - Quarantined
                 type: string
               queuePosition:
                 default: 0
@@ -306,6 +314,165 @@ spec:
                 format: uint32
                 minimum: 0.0
                 type: integer
+              teardownReceipt:
+                description: |-
+                  Durable proof that this lease's exact capacity was destroyed.
+
+                  Recorded here rather than on the `ClusterInstance` because it must stay
+                  queryable *after* the instance object is gone — which is exactly when
+                  the evidence matters, and when #74's owning `SandboxLease` consumes it.
+                nullable: true
+                properties:
+                  attemptId:
+                    description: Unique per attempt; retries produce new attempts, never edit old ones.
+                    type: string
+                  backendType:
+                    description: Backend identity and immutable provenance digest observed at bind time.
+                    type: string
+                  checks:
+                    items:
+                      description: Evidence for one subject.
+                      properties:
+                        reason:
+                          description: |-
+                            Bounded, non-secret reason code (e.g. `pv_still_present`,
+                            `datastore_unreachable`). Never a raw provider response.
+                          nullable: true
+                          type: string
+                        result:
+                          description: Outcome of proving one subject absent.
+                          enum:
+                          - verified
+                          - notApplicable
+                          - unknown
+                          type: string
+                        subject:
+                          description: |-
+                            One thing whose absence must be proven.
+
+                            Enumerated rather than free-text so a receipt cannot be satisfied by an
+                            unrecognised or invented subject, and so adding a resource to the teardown
+                            path is a deliberate, reviewable change to this list.
+                          enum:
+                          - agentDeployment
+                          - serverStatefulSet
+                          - serverPods
+                          - service
+                          - podDisruptionBudget
+                          - publisherConfigMap
+                          - registriesConfigMap
+                          - tokenSecret
+                          - kubeconfigSecret
+                          - cidrClaim
+                          - connectTokenSecret
+                          - serverDataPvcs
+                          - serverDataVolumes
+                          - database
+                          type: string
+                      required:
+                      - result
+                      - subject
+                      type: object
+                    type: array
+                  completedAt:
+                    nullable: true
+                    type: string
+                  configDigest:
+                    type: string
+                  instance:
+                    description: Reference to another Kobe-managed resource in the same namespace.
+                    properties:
+                      name:
+                        description: |-
+                          Resource name. Names are display and lookup handles, never sufficient
+                          authority on their own because Kubernetes permits name reuse.
+                        type: string
+                      uid:
+                        description: |-
+                          Kubernetes UID of the referenced object. New controller-written
+                          references always set this. `None` is accepted only so pre-UID-fence
+                          objects remain readable; security-sensitive consumers must fail closed
+                          or run the proof-based legacy migration before using the reference.
+                        nullable: true
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  instanceSpecDigest:
+                    type: string
+                  lease:
+                    description: |-
+                      Exact subjects this receipt is about. A same-named replacement is a
+                      mismatch, not successful absence.
+                    properties:
+                      name:
+                        description: |-
+                          Resource name. Names are display and lookup handles, never sufficient
+                          authority on their own because Kubernetes permits name reuse.
+                        type: string
+                      uid:
+                        description: |-
+                          Kubernetes UID of the referenced object. New controller-written
+                          references always set this. `None` is accepted only so pre-UID-fence
+                          objects remain readable; security-sensitive consumers must fail closed
+                          or run the proof-based legacy migration before using the reference.
+                        nullable: true
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  outcome:
+                    description: Aggregate verdict for one teardown attempt.
+                    enum:
+                    - verified
+                    - quarantined
+                    type: string
+                  pool:
+                    description: Reference to another Kobe-managed resource in the same namespace.
+                    properties:
+                      name:
+                        description: |-
+                          Resource name. Names are display and lookup handles, never sufficient
+                          authority on their own because Kubernetes permits name reuse.
+                        type: string
+                      uid:
+                        description: |-
+                          Kubernetes UID of the referenced object. New controller-written
+                          references always set this. `None` is accepted only so pre-UID-fence
+                          objects remain readable; security-sensitive consumers must fail closed
+                          or run the proof-based legacy migration before using the reference.
+                        nullable: true
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  retryCount:
+                    default: 0
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  schemaVersion:
+                    description: |-
+                      Schema version, so a consumer can refuse evidence it does not understand
+                      rather than misread an older shape as complete.
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  startedAt:
+                    type: string
+                required:
+                - attemptId
+                - backendType
+                - checks
+                - configDigest
+                - instance
+                - instanceSpecDigest
+                - lease
+                - outcome
+                - pool
+                - schemaVersion
+                - startedAt
+                type: object
             type: object
         required:
         - spec

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2748,6 +2748,10 @@ fn build_lease_crd(
                 identity: identity.identity.clone(),
             },
             priority,
+            // Callers cannot request verified teardown: it is an internal
+            // composition detail of #74's child placement, not tenant-facing
+            // intent. Absent means Standard, so behaviour is unchanged.
+            cleanup_mode: None,
         },
         status: None,
     }

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -2244,6 +2244,7 @@ fn phase_reason(phase: &ClusterInstancePhase) -> &'static str {
         ClusterInstancePhase::Recycling => "Recycling",
         ClusterInstancePhase::Unhealthy => "Unhealthy",
         ClusterInstancePhase::Failed => "Failed",
+        ClusterInstancePhase::Quarantined => "Quarantined",
     }
 }
 

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -596,6 +596,13 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
             Ok(Action::requeue(std::time::Duration::from_secs(10)))
         }
 
+        // Terminal until the same exact subject produces a verified receipt.
+        // Access is already revoked and the binding/finalizers are deliberately
+        // retained as cleanup handles, so there is nothing to reconcile here.
+        // The transitions INTO this phase, and the retry that can leave it,
+        // belong to the verified-teardown controller work.
+        LeasePhase::Quarantined => Ok(Action::requeue(std::time::Duration::from_secs(300))),
+
         LeasePhase::Recycling => {
             let cluster_gone = if let Some(binding) = &status.binding {
                 let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), &ns);
@@ -837,6 +844,7 @@ async fn finalize_binding<B: ClusterBackend>(
         max_extensions,
         message: None,
         conditions: Vec::new(),
+        teardown_receipt: None,
     };
     new_status.conditions =
         derive_lease_conditions(&new_status, &status.conditions, None, &now.to_rfc3339());

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -45,6 +45,42 @@ pub struct ProfileContext {
 }
 
 #[cfg(test)]
+mod quarantine_tests {
+    use super::*;
+
+    /// Quarantined capacity must never present as leasable. `ClusterState` has
+    /// no Quarantined variant yet, so this pins the interim mapping: whatever it
+    /// maps to, it must not be `Ready` or `Leased`, or unproven capacity would
+    /// be handed to the next caller.
+    #[test]
+    fn quarantined_never_maps_to_usable_capacity() {
+        let state = cluster_state_from_phase(&ClusterInstancePhase::Quarantined);
+        assert_ne!(state, ClusterState::Ready);
+        assert_ne!(state, ClusterState::Leased);
+    }
+
+    /// The reverse mapping must never *produce* Quarantined, because that would
+    /// mean in-memory pool state could invent a quarantine that no teardown
+    /// evidence supports.
+    #[test]
+    fn pool_state_cannot_invent_a_quarantine() {
+        for state in [
+            ClusterState::Creating,
+            ClusterState::Ready,
+            ClusterState::Leased,
+            ClusterState::Unhealthy,
+            ClusterState::Recycling,
+        ] {
+            assert_ne!(
+                cluster_phase_from_state(&state),
+                ClusterInstancePhase::Quarantined,
+                "{state:?} must not round-trip into Quarantined"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod cluster_instance_tests {
     use super::*;
     use std::collections::HashMap;
@@ -1910,7 +1946,14 @@ async fn sync_cluster_instance_statuses(client: &Client, namespace: &str, pool_s
         // In particular, an invalid/legacy binding must remain unavailable
         // even if its display-only leaseRef is missing or stale.
         let lease_held = current.lease_ref.is_some() || current.binding.is_some();
-        let phase = if lease_held {
+        // Quarantined is preserved explicitly, not just incidentally. A
+        // quarantined instance keeps its binding as a cleanup handle, so
+        // `lease_held` happens to cover it today — but relying on that would
+        // mean a future change to binding retention silently downgrades
+        // Quarantined to whatever the in-memory pool state says, handing
+        // unproven capacity back to the pool.
+        let quarantined = current.phase == ClusterInstancePhase::Quarantined;
+        let phase = if lease_held || quarantined {
             current.phase.clone()
         } else {
             cluster_phase_from_state(&entry.state)
@@ -2210,6 +2253,17 @@ fn cluster_state_from_phase(phase: &ClusterInstancePhase) -> ClusterState {
         ClusterInstancePhase::Recycling => ClusterState::Recycling,
         ClusterInstancePhase::Unhealthy => ClusterState::Unhealthy,
         ClusterInstancePhase::Failed => ClusterState::Unhealthy,
+        // PLACEHOLDER. `ClusterState` has no Quarantined variant yet, and adding
+        // one touches ~109 call sites across pool scaling — that belongs with
+        // the controller work that can actually reason about quarantined
+        // capacity, not here.
+        //
+        // `Unhealthy` is the safe interim: it is excluded from Ready capacity,
+        // so a quarantined instance can never be leased. It is NOT correct
+        // long-term, because Unhealthy is replacement-eligible and quarantined
+        // capacity must never be silently deleted. Nothing sets Quarantined in
+        // this change, so this arm is currently unreachable.
+        ClusterInstancePhase::Quarantined => ClusterState::Unhealthy,
     }
 }
 

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -2253,17 +2253,10 @@ fn cluster_state_from_phase(phase: &ClusterInstancePhase) -> ClusterState {
         ClusterInstancePhase::Recycling => ClusterState::Recycling,
         ClusterInstancePhase::Unhealthy => ClusterState::Unhealthy,
         ClusterInstancePhase::Failed => ClusterState::Unhealthy,
-        // PLACEHOLDER. `ClusterState` has no Quarantined variant yet, and adding
-        // one touches ~109 call sites across pool scaling — that belongs with
-        // the controller work that can actually reason about quarantined
-        // capacity, not here.
-        //
-        // `Unhealthy` is the safe interim: it is excluded from Ready capacity,
-        // so a quarantined instance can never be leased. It is NOT correct
-        // long-term, because Unhealthy is replacement-eligible and quarantined
-        // capacity must never be silently deleted. Nothing sets Quarantined in
-        // this change, so this arm is currently unreachable.
-        ClusterInstancePhase::Quarantined => ClusterState::Unhealthy,
+        // Quarantined maps to its own state, never to Unhealthy: Unhealthy is
+        // deleted unconditionally by the pool manager, which would destroy the
+        // cleanup handle and let the ordinary recycle path resume.
+        ClusterInstancePhase::Quarantined => ClusterState::Quarantined,
     }
 }
 
@@ -2274,6 +2267,7 @@ fn cluster_phase_from_state(state: &ClusterState) -> ClusterInstancePhase {
         ClusterState::Leased => ClusterInstancePhase::Leased,
         ClusterState::Recycling => ClusterInstancePhase::Recycling,
         ClusterState::Unhealthy => ClusterInstancePhase::Unhealthy,
+        ClusterState::Quarantined => ClusterInstancePhase::Quarantined,
     }
 }
 

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -203,6 +203,12 @@ pub enum ClusterInstancePhase {
     Recycling,
     Unhealthy,
     Failed,
+    /// Teardown could not be proven complete. Access stays revoked, finalizers
+    /// and binding provenance are retained, and the unit is never Ready, never
+    /// rebound, and never counted as clean replacement capacity. It may leave
+    /// this phase only when the same exact subject produces a fully verified
+    /// receipt.
+    Quarantined,
 }
 
 /// Network ranges reserved for one ClusterInstance.

--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::crd::LeaseBinding;
+use crate::crd::teardown::{CleanupMode, TeardownReceipt};
 
 /// ClusterLease is the internal representation of a cluster lease.
 ///
@@ -34,6 +35,15 @@ pub struct ClusterLeaseSpec {
     /// Higher values are served first.
     #[serde(default = "default_priority")]
     pub priority: u32,
+
+    /// How thoroughly this lease's capacity must be torn down before reuse.
+    ///
+    /// Absent means [`CleanupMode::Standard`], so every existing `ClusterLease`
+    /// keeps its current behaviour. #74's internal leases request
+    /// [`CleanupMode::VerifiedDestroy`]; pools that cannot produce evidence
+    /// reject it at bind time rather than degrading silently.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_mode: Option<CleanupMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -79,6 +89,14 @@ pub struct ClusterLeaseStatus {
     /// When the lease expires (TTL deadline).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+
+    /// Durable proof that this lease's exact capacity was destroyed.
+    ///
+    /// Recorded here rather than on the `ClusterInstance` because it must stay
+    /// queryable *after* the instance object is gone — which is exactly when
+    /// the evidence matters, and when #74's owning `SandboxLease` consumes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teardown_receipt: Option<TeardownReceipt>,
 
     /// Position in the priority queue (0 = not queued, 1 = next).
     #[serde(default)]
@@ -172,6 +190,9 @@ pub enum LeasePhase {
     Expired,
     /// Cluster being deleted and recreated.
     Recycling,
+    /// Teardown could not be proven complete for this lease's exact capacity.
+    /// Terminal until the same subject produces a verified receipt.
+    Quarantined,
 }
 
 impl std::fmt::Display for LeasePhase {
@@ -182,6 +203,7 @@ impl std::fmt::Display for LeasePhase {
             LeasePhase::Released => write!(f, "Released"),
             LeasePhase::Expired => write!(f, "Expired"),
             LeasePhase::Recycling => write!(f, "Recycling"),
+            LeasePhase::Quarantined => write!(f, "Quarantined"),
         }
     }
 }
@@ -235,6 +257,7 @@ mod json_safety_tests {
             cluster_name: Some("pool-x-0".into()),
             bound_at: Some("2026-06-04T00:00:00Z".into()),
             expires_at: Some("2026-06-04T01:00:00Z".into()),
+            teardown_receipt: None,
             ..Default::default()
         };
         let v = serde_json::to_value(&set_status).unwrap();
@@ -522,6 +545,37 @@ mod json_safety_tests {
                 message: "bound".into(),
                 last_transition_time: Some("2026-06-04T00:00:00Z".into()),
             }],
+            // Populated, not None: the receipt is the durable evidence a #74
+            // SandboxLease reads back after its ClusterInstance is gone, so it
+            // has to survive the wire intact.
+            teardown_receipt: Some(crate::crd::TeardownReceipt {
+                schema_version: crate::crd::TEARDOWN_RECEIPT_SCHEMA_VERSION,
+                attempt_id: "attempt-1".into(),
+                lease: crate::crd::ResourceRef {
+                    name: "lease-x".into(),
+                    uid: Some("lease-uid".into()),
+                },
+                instance: crate::crd::ResourceRef {
+                    name: "pool-x-0".into(),
+                    uid: Some("instance-uid".into()),
+                },
+                pool: crate::crd::ResourceRef {
+                    name: "x".into(),
+                    uid: Some("pool-uid".into()),
+                },
+                backend_type: "k3s".into(),
+                config_digest: "cfg".into(),
+                instance_spec_digest: "spec".into(),
+                started_at: "2026-06-04T02:00:00Z".into(),
+                completed_at: Some("2026-06-04T02:01:00Z".into()),
+                checks: vec![crate::crd::TeardownCheck {
+                    subject: crate::crd::TeardownSubject::ServerStatefulSet,
+                    result: crate::crd::CheckResult::Verified,
+                    reason: None,
+                }],
+                retry_count: 0,
+                outcome: crate::crd::TeardownOutcome::Verified,
+            }),
         };
         let once = serde_json::to_value(&original).unwrap();
         let back: ClusterLeaseStatus = serde_json::from_value(once.clone()).unwrap();

--- a/src/crd/mod.rs
+++ b/src/crd/mod.rs
@@ -7,6 +7,12 @@ pub mod instance;
 pub mod lease;
 pub mod profile;
 pub mod sandbox;
+// The verified-teardown vocabulary is defined ahead of the k3s provider and the
+// controllers that consume it, so these types have no callers in this change.
+// Same pattern as `datastore` above. `crdgen` also compiles `src/crd` alone, so
+// anything used only by controllers looks dead in that unit regardless.
+#[allow(dead_code)]
+pub mod teardown;
 
 pub use access_policy::*;
 pub use bootstrap_config::*;
@@ -17,6 +23,8 @@ pub use instance::*;
 pub use lease::*;
 pub use profile::*;
 pub use sandbox::*;
+#[allow(unused_imports)]
+pub use teardown::*;
 
 /// Schema helper for `serde_json::Value` fields that need an explicit `type: object`
 /// in the OpenAPI spec. Without this, schemars emits `{}` which K8s rejects.

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -1,0 +1,428 @@
+//! Verified-teardown vocabulary: cleanup modes, per-subject evidence, receipts,
+//! and the pure eligibility rules that decide whether a footprint can be proven
+//! absent at all.
+//!
+//! This module deliberately contains **no** teardown behaviour. It defines what
+//! evidence looks like and which configurations can produce it; the k3s provider
+//! and the controllers that consume it land separately.
+//!
+//! # Why receipts exist
+//!
+//! Today `ClusterBackend::delete` returns `Result<()>`, the instance controller
+//! deletes the `ClusterInstance` once it returns, and the lease controller reads
+//! the resulting 404 as "recycling complete". So an *accepted DELETE request* is
+//! treated as proof of destruction. For capacity that held another tenant's code
+//! and credentials that is not good enough: PVC, PDB, Pod and PostgreSQL
+//! failures currently warn and continue, and nothing waits for the objects or
+//! their backing volumes to actually disappear.
+//!
+//! A receipt replaces inference with evidence. The rule throughout is that
+//! **uncertainty is not success**: anything we cannot observe becomes
+//! [`CheckResult::Unknown`], which quarantines the capacity rather than
+//! returning it to the pool.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::ResourceRef;
+use super::profile::{ClusterConfig, DiagnosticsConfig};
+
+/// How thoroughly a lease's capacity must be torn down before it can be reused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub enum CleanupMode {
+    /// Today's behaviour: issue the deletes and trust an accepted request.
+    ///
+    /// Remains the default so existing `ClusterLease` objects are untouched.
+    #[default]
+    Standard,
+    /// Removal of the final cleanup handle requires a verified receipt proving
+    /// the exact lease-owned footprint is absent. Missing or uncertain evidence
+    /// quarantines the unit instead of returning it to the pool.
+    ///
+    /// Only `backend.type=k3s` implements this; every other backend must reject
+    /// it at bind time rather than silently degrading to [`Self::Standard`].
+    VerifiedDestroy,
+}
+
+impl CleanupMode {
+    /// Whether this mode requires evidence before capacity may be reused.
+    pub fn requires_receipt(self) -> bool {
+        matches!(self, Self::VerifiedDestroy)
+    }
+}
+
+/// One thing whose absence must be proven.
+///
+/// Enumerated rather than free-text so a receipt cannot be satisfied by an
+/// unrecognised or invented subject, and so adding a resource to the teardown
+/// path is a deliberate, reviewable change to this list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TeardownSubject {
+    AgentDeployment,
+    ServerStatefulSet,
+    ServerPods,
+    Service,
+    PodDisruptionBudget,
+    PublisherConfigMap,
+    RegistriesConfigMap,
+    TokenSecret,
+    KubeconfigSecret,
+    /// The lease's connect-token Secret. Revoked first, verified like the rest.
+    ConnectTokenSecret,
+    CidrClaim,
+    /// Every `data-{instance}-server-{ordinal}` PVC.
+    ServerDataPvcs,
+    /// The PVs those PVCs were bound to, captured before deletion.
+    ServerDataVolumes,
+    /// The exact `k3s_<instance>` database.
+    Database,
+}
+
+/// Outcome of proving one subject absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum CheckResult {
+    /// Observed absent. The only result that contributes to a verified receipt.
+    Verified,
+    /// This footprint never existed, established from **recorded creation-time
+    /// configuration** — not from a lookup that happened to return nothing.
+    ///
+    /// The distinction matters: "the pool never enabled registry mirrors" is
+    /// `NotApplicable`; "listing ConfigMaps returned 403" is [`Self::Unknown`].
+    NotApplicable,
+    /// Could not be determined: an API or RBAC error, a timeout, an
+    /// unreachable datastore, or a UID that no longer matches. Quarantines.
+    Unknown,
+}
+
+/// Aggregate verdict for one teardown attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TeardownOutcome {
+    /// Every required subject is `Verified` or `NotApplicable`.
+    Verified,
+    /// At least one subject is `Unknown`. Capacity is not reusable.
+    Quarantined,
+}
+
+/// Evidence for one subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TeardownCheck {
+    pub subject: TeardownSubject,
+    pub result: CheckResult,
+    /// Bounded, non-secret reason code (e.g. `pv_still_present`,
+    /// `datastore_unreachable`). Never a raw provider response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Durable proof that one exact lease-owned footprint is gone.
+///
+/// Lives on `ClusterLeaseStatus` rather than on the `ClusterInstance`, because
+/// it must remain queryable **after** the instance object disappears — that is
+/// precisely the moment the evidence matters, and #74's owning `SandboxLease`
+/// has to be able to consume it afterwards.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TeardownReceipt {
+    /// Schema version, so a consumer can refuse evidence it does not understand
+    /// rather than misread an older shape as complete.
+    pub schema_version: u32,
+    /// Unique per attempt; retries produce new attempts, never edit old ones.
+    pub attempt_id: String,
+    /// Exact subjects this receipt is about. A same-named replacement is a
+    /// mismatch, not successful absence.
+    pub lease: ResourceRef,
+    pub instance: ResourceRef,
+    pub pool: ResourceRef,
+    /// Backend identity and immutable provenance digest observed at bind time.
+    pub backend_type: String,
+    pub config_digest: String,
+    pub instance_spec_digest: String,
+    pub started_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+    pub checks: Vec<TeardownCheck>,
+    #[serde(default)]
+    pub retry_count: u32,
+    pub outcome: TeardownOutcome,
+}
+
+/// Current schema version emitted by this build.
+pub const TEARDOWN_RECEIPT_SCHEMA_VERSION: u32 = 1;
+
+impl TeardownReceipt {
+    /// Derive the aggregate outcome from the per-subject evidence.
+    ///
+    /// Deliberately not stored independently of `checks`: an outcome that could
+    /// disagree with its own evidence is exactly the failure mode receipts exist
+    /// to prevent.
+    pub fn outcome_for(checks: &[TeardownCheck]) -> TeardownOutcome {
+        if checks
+            .iter()
+            .any(|check| check.result == CheckResult::Unknown)
+        {
+            TeardownOutcome::Quarantined
+        } else {
+            TeardownOutcome::Verified
+        }
+    }
+
+    /// Whether this receipt permits releasing the final cleanup handle.
+    ///
+    /// Requires an explicitly recorded verdict *and* agreement with the checks,
+    /// so a hand-edited or truncated receipt cannot unlock capacity.
+    pub fn permits_release(&self) -> bool {
+        self.schema_version == TEARDOWN_RECEIPT_SCHEMA_VERSION
+            && self.outcome == TeardownOutcome::Verified
+            && Self::outcome_for(&self.checks) == TeardownOutcome::Verified
+            && !self.checks.is_empty()
+    }
+}
+
+/// Why a pool's footprint cannot support [`CleanupMode::VerifiedDestroy`].
+///
+/// Rejected **before binding**. An ineligible pool must never accept a
+/// receipt-required lease and then discover mid-teardown that it cannot produce
+/// evidence — that would strand the lease in quarantine through no fault of the
+/// caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum VerifiedDestroyIneligible {
+    #[error("backend does not implement verified teardown")]
+    UnsupportedBackend,
+    #[error("kubeletSharedMount leaves host state this receipt cannot account for")]
+    KubeletSharedMount,
+    #[error("diagnostics capture writes objects whose deletion is not receipt-verifiable")]
+    DiagnosticsEnabled,
+    #[error("storage is neither ephemeral nor dynamically provisioned with an observable volume")]
+    UnverifiableStorage,
+    #[error("external datastore identity was not recorded, so its absence cannot be proven")]
+    DatastoreProvenanceMissing,
+}
+
+impl VerifiedDestroyIneligible {
+    /// Bounded reason code for status, events, and metrics.
+    pub const fn reason_code(&self) -> &'static str {
+        match self {
+            Self::UnsupportedBackend => "unsupported_backend",
+            Self::KubeletSharedMount => "kubelet_shared_mount",
+            Self::DiagnosticsEnabled => "diagnostics_enabled",
+            Self::UnverifiableStorage => "unverifiable_storage",
+            Self::DatastoreProvenanceMissing => "datastore_provenance_missing",
+        }
+    }
+}
+
+/// Whether a k3s cluster configuration can produce a verifiable receipt.
+///
+/// Pure and total: every rejection is derived from recorded configuration, never
+/// from a live lookup, so the same inputs always yield the same verdict and the
+/// decision can be made at bind time.
+///
+/// `external_datastore_identity_recorded` is threaded in rather than read here
+/// because the datastore connection lives outside the CRD; the caller knows
+/// whether the exact database identity needed to verify absence was captured.
+pub fn verified_destroy_eligibility(
+    cluster: &ClusterConfig,
+    diagnostics: Option<&DiagnosticsConfig>,
+    external_datastore_identity_recorded: bool,
+) -> Result<(), VerifiedDestroyIneligible> {
+    // Host-side kubelet trees survive object deletion and are not part of any
+    // subject we can observe from the API, so their presence makes "the
+    // footprint is absent" unprovable. Re-admissible once the host reaper's
+    // acknowledgement becomes part of the receipt.
+    if cluster.kubelet_shared_mount.is_some() {
+        return Err(VerifiedDestroyIneligible::KubeletSharedMount);
+    }
+
+    // Diagnostics capture writes bundles to S3 on release. Object deletion there
+    // is not receipt-verifiable today, and a receipt that silently ignored them
+    // would overstate what was destroyed.
+    if diagnostics.is_some_and(|diagnostics| diagnostics.enabled) {
+        return Err(VerifiedDestroyIneligible::DiagnosticsEnabled);
+    }
+
+    // Storage must be either non-persistent, or dynamically provisioned so the
+    // PVC and its backing PV can be observed disappearing. A pool that pins a
+    // storage class we cannot reason about is rejected rather than assumed
+    // deletable — the reclaim policy itself is checked against the live
+    // StorageClass by the provider, since it is not part of this config.
+    if let Some(persistence) = cluster.persistence.as_ref() {
+        let storage_type = persistence.storage_type.as_deref().unwrap_or("emptyDir");
+        let ephemeral = storage_type.eq_ignore_ascii_case("emptydir");
+        let dynamic = storage_type.eq_ignore_ascii_case("dynamic");
+        if !ephemeral && !dynamic {
+            return Err(VerifiedDestroyIneligible::UnverifiableStorage);
+        }
+    }
+
+    if !external_datastore_identity_recorded {
+        return Err(VerifiedDestroyIneligible::DatastoreProvenanceMissing);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::profile::{KubeletSharedMountConfig, PersistenceConfig};
+
+    fn cluster() -> ClusterConfig {
+        serde_json::from_value(serde_json::json!({ "version": "v1.32.0" }))
+            .expect("minimal ClusterConfig must deserialize")
+    }
+
+    #[test]
+    fn ephemeral_k3s_with_recorded_datastore_is_eligible() {
+        assert!(verified_destroy_eligibility(&cluster(), None, true).is_ok());
+    }
+
+    /// Each rejection must be derived from configuration alone, so an ineligible
+    /// pool is refused at bind time rather than stranding a lease in quarantine.
+    #[test]
+    fn unverifiable_footprints_are_rejected_before_binding() {
+        let mut shared_mount = cluster();
+        shared_mount.kubelet_shared_mount = Some(KubeletSharedMountConfig {
+            server: true,
+            agents: true,
+            ..serde_json::from_value(serde_json::json!({})).unwrap()
+        });
+        assert_eq!(
+            verified_destroy_eligibility(&shared_mount, None, true).unwrap_err(),
+            VerifiedDestroyIneligible::KubeletSharedMount
+        );
+
+        let capture: DiagnosticsConfig = serde_json::from_value(
+            serde_json::json!({ "enabled": true, "storage": "s3://bucket/" }),
+        )
+        .unwrap();
+        assert_eq!(
+            verified_destroy_eligibility(&cluster(), Some(&capture), true).unwrap_err(),
+            VerifiedDestroyIneligible::DiagnosticsEnabled
+        );
+
+        let mut retained = cluster();
+        retained.persistence = Some(PersistenceConfig {
+            storage_type: Some("hostPath".into()),
+            storage_class_name: None,
+            storage_request_size: None,
+        });
+        assert_eq!(
+            verified_destroy_eligibility(&retained, None, true).unwrap_err(),
+            VerifiedDestroyIneligible::UnverifiableStorage
+        );
+
+        assert_eq!(
+            verified_destroy_eligibility(&cluster(), None, false).unwrap_err(),
+            VerifiedDestroyIneligible::DatastoreProvenanceMissing
+        );
+    }
+
+    /// Disabled diagnostics must not disqualify a pool — only active capture
+    /// creates objects we cannot account for.
+    #[test]
+    fn disabled_diagnostics_stays_eligible() {
+        let disabled: DiagnosticsConfig = serde_json::from_value(
+            serde_json::json!({ "enabled": false, "storage": "s3://bucket/" }),
+        )
+        .unwrap();
+        assert!(verified_destroy_eligibility(&cluster(), Some(&disabled), true).is_ok());
+    }
+
+    /// A single `Unknown` must dominate, however many subjects verified: the
+    /// whole point is that partial evidence is not evidence.
+    #[test]
+    fn one_unknown_quarantines_the_whole_attempt() {
+        let verified = TeardownCheck {
+            subject: TeardownSubject::ServerStatefulSet,
+            result: CheckResult::Verified,
+            reason: None,
+        };
+        let not_applicable = TeardownCheck {
+            subject: TeardownSubject::RegistriesConfigMap,
+            result: CheckResult::NotApplicable,
+            reason: None,
+        };
+        let unknown = TeardownCheck {
+            subject: TeardownSubject::Database,
+            result: CheckResult::Unknown,
+            reason: Some("datastore_unreachable".into()),
+        };
+
+        assert_eq!(
+            TeardownReceipt::outcome_for(&[verified.clone(), not_applicable.clone()]),
+            TeardownOutcome::Verified
+        );
+        assert_eq!(
+            TeardownReceipt::outcome_for(&[verified, not_applicable, unknown]),
+            TeardownOutcome::Quarantined
+        );
+    }
+
+    fn receipt(checks: Vec<TeardownCheck>, outcome: TeardownOutcome) -> TeardownReceipt {
+        TeardownReceipt {
+            schema_version: TEARDOWN_RECEIPT_SCHEMA_VERSION,
+            attempt_id: "attempt-1".into(),
+            lease: ResourceRef {
+                name: "lease-a".into(),
+                uid: Some("lease-uid".into()),
+            },
+            instance: ResourceRef {
+                name: "pool-p-0".into(),
+                uid: Some("instance-uid".into()),
+            },
+            pool: ResourceRef {
+                name: "p".into(),
+                uid: Some("pool-uid".into()),
+            },
+            backend_type: "k3s".into(),
+            config_digest: "digest".into(),
+            instance_spec_digest: "spec-digest".into(),
+            started_at: "2026-01-01T00:00:00Z".into(),
+            completed_at: Some("2026-01-01T00:01:00Z".into()),
+            checks,
+            retry_count: 0,
+            outcome,
+        }
+    }
+
+    /// A receipt may only unlock capacity when its recorded verdict and its own
+    /// evidence agree, so a hand-edited or truncated receipt cannot release it.
+    #[test]
+    fn release_requires_evidence_that_matches_the_verdict() {
+        let verified = TeardownCheck {
+            subject: TeardownSubject::ServerStatefulSet,
+            result: CheckResult::Verified,
+            reason: None,
+        };
+        let unknown = TeardownCheck {
+            subject: TeardownSubject::Database,
+            result: CheckResult::Unknown,
+            reason: Some("datastore_unreachable".into()),
+        };
+
+        assert!(receipt(vec![verified.clone()], TeardownOutcome::Verified).permits_release());
+
+        // Verdict claims success while the evidence says otherwise.
+        assert!(
+            !receipt(vec![verified.clone(), unknown], TeardownOutcome::Verified).permits_release(),
+            "a Verified verdict must not override an Unknown check"
+        );
+        // No evidence at all is not proof of absence.
+        assert!(!receipt(Vec::new(), TeardownOutcome::Verified).permits_release());
+        // An unrecognised schema must not be read as complete.
+        let mut future = receipt(vec![verified], TeardownOutcome::Verified);
+        future.schema_version = TEARDOWN_RECEIPT_SCHEMA_VERSION + 1;
+        assert!(!future.permits_release());
+    }
+
+    #[test]
+    fn standard_cleanup_is_the_default_and_needs_no_receipt() {
+        assert_eq!(CleanupMode::default(), CleanupMode::Standard);
+        assert!(!CleanupMode::Standard.requires_receipt());
+        assert!(CleanupMode::VerifiedDestroy.requires_receipt());
+    }
+}

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -190,14 +190,21 @@ impl TeardownReceipt {
     /// - the recorded verdict agreeing with the checks;
     /// - identity matching `expected` exactly, so a receipt from another
     ///   attempt or a same-named replacement cannot be replayed;
-    /// - exactly one check per expected subject, each `Verified` or
-    ///   `NotApplicable` — no missing subjects, no duplicates, no extras.
+    /// - exactly one `Verified` check per expected subject — no missing
+    ///   subjects, no duplicates, no extras, and no `NotApplicable` standing in
+    ///   for a subject the scope says was created.
     pub fn permits_release_for(&self, expected: &TeardownScope<'_>) -> bool {
         if self.schema_version != TEARDOWN_RECEIPT_SCHEMA_VERSION
             || self.completed_at.is_none()
             || self.outcome != TeardownOutcome::Verified
             || Self::outcome_for(&self.checks) != TeardownOutcome::Verified
         {
+            return false;
+        }
+        // A reference without a UID cannot fence anything: two `None` UIDs
+        // compare equal, so a same-named replacement would satisfy the match
+        // that is supposed to exclude it.
+        if self.lease.uid.is_none() || self.instance.uid.is_none() || self.pool.uid.is_none() {
             return false;
         }
         // Identity, not just shape: a valid receipt for a *different* subject
@@ -226,11 +233,13 @@ impl TeardownReceipt {
             };
             // Exactly one: duplicates could otherwise pair a Verified with a
             // silently ignored second opinion.
-            matching.next().is_none()
-                && matches!(
-                    check.result,
-                    CheckResult::Verified | CheckResult::NotApplicable
-                )
+            //
+            // And it must be Verified, not merely "not Unknown". Accepting
+            // NotApplicable here would let a receipt mark the database and
+            // credentials as never-created and still release the lease. A
+            // footprint that genuinely was never created belongs OUT of
+            // `required_subjects` — that is what the scope is for.
+            matching.next().is_none() && check.result == CheckResult::Verified
         })
     }
 }
@@ -522,9 +531,22 @@ mod tests {
             TeardownSubject::KubeconfigSecret,
         ];
 
-        // Every required subject accounted for: two verified, one genuinely
-        // never created.
+        // Every required subject positively verified.
         let complete = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Verified),
+                check(TeardownSubject::KubeconfigSecret, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(complete.permits_release_for(&scope(&required, &refs)));
+
+        // NotApplicable must NOT satisfy a subject the scope says was created:
+        // otherwise a receipt marks the database "never existed" and releases
+        // the lease anyway. A genuinely absent footprint belongs out of the
+        // scope, not explained away inside the receipt.
+        let excused = receipt(
             vec![
                 check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
                 check(TeardownSubject::Database, CheckResult::NotApplicable),
@@ -532,7 +554,10 @@ mod tests {
             ],
             TeardownOutcome::Verified,
         );
-        assert!(complete.permits_release_for(&scope(&required, &refs)));
+        assert!(
+            !excused.permits_release_for(&scope(&required, &refs)),
+            "NotApplicable cannot stand in for a subject the scope says was created"
+        );
 
         // One subject simply missing — the defect this test exists for.
         let partial = receipt(
@@ -595,6 +620,32 @@ mod tests {
         let mut drifted = scope(&required, &refs);
         drifted.config_digest = "other-digest";
         assert!(!valid.permits_release_for(&drifted));
+
+        // A reference with no UID cannot fence anything: two `None`s compare
+        // equal, so this would otherwise "match" any same-named object.
+        let unfenced_refs = (
+            lease_ref(),
+            ResourceRef {
+                name: "pool-p-0".into(),
+                uid: None,
+            },
+            pool_ref(),
+        );
+        let mut unfenced = receipt(
+            vec![check(
+                TeardownSubject::ServerStatefulSet,
+                CheckResult::Verified,
+            )],
+            TeardownOutcome::Verified,
+        );
+        unfenced.instance = ResourceRef {
+            name: "pool-p-0".into(),
+            uid: None,
+        };
+        assert!(
+            !unfenced.permits_release_for(&scope(&required, &unfenced_refs)),
+            "a receipt without UIDs must never release capacity"
+        );
     }
 
     /// Verdict, evidence, schema, and completeness each fail closed on their own.

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -170,16 +170,91 @@ impl TeardownReceipt {
         }
     }
 
-    /// Whether this receipt permits releasing the final cleanup handle.
+    /// Whether this receipt releases the exact footprint described by
+    /// `expected`.
     ///
-    /// Requires an explicitly recorded verdict *and* agreement with the checks,
-    /// so a hand-edited or truncated receipt cannot unlock capacity.
-    pub fn permits_release(&self) -> bool {
-        self.schema_version == TEARDOWN_RECEIPT_SCHEMA_VERSION
-            && self.outcome == TeardownOutcome::Verified
-            && Self::outcome_for(&self.checks) == TeardownOutcome::Verified
-            && !self.checks.is_empty()
+    /// A receipt is only proof of *what it actually covers*. An earlier version
+    /// asked only "no `Unknown`, and not empty", which meant a receipt carrying
+    /// one `serverStatefulSet=verified` check released capacity while saying
+    /// nothing about the database, credentials, volumes, or Pods. Absence of
+    /// evidence read as evidence of absence — the exact inversion receipts
+    /// exist to prevent.
+    ///
+    /// `expected` must come from controller-owned bind-time state, never from
+    /// the receipt being validated: a receipt that vouches for its own scope
+    /// proves nothing.
+    ///
+    /// Requires all of:
+    /// - a schema version this build understands;
+    /// - a completion timestamp — an unfinished attempt is not proof;
+    /// - the recorded verdict agreeing with the checks;
+    /// - identity matching `expected` exactly, so a receipt from another
+    ///   attempt or a same-named replacement cannot be replayed;
+    /// - exactly one check per expected subject, each `Verified` or
+    ///   `NotApplicable` — no missing subjects, no duplicates, no extras.
+    pub fn permits_release_for(&self, expected: &TeardownScope<'_>) -> bool {
+        if self.schema_version != TEARDOWN_RECEIPT_SCHEMA_VERSION
+            || self.completed_at.is_none()
+            || self.outcome != TeardownOutcome::Verified
+            || Self::outcome_for(&self.checks) != TeardownOutcome::Verified
+        {
+            return false;
+        }
+        // Identity, not just shape: a valid receipt for a *different* subject
+        // must not release this one.
+        if self.lease != *expected.lease
+            || self.instance != *expected.instance
+            || self.pool != *expected.pool
+            || self.backend_type != expected.backend_type
+            || self.config_digest != expected.config_digest
+            || self.instance_spec_digest != expected.instance_spec_digest
+        {
+            return false;
+        }
+        if expected.required_subjects.is_empty() {
+            // Nothing to prove means nothing was proven. Fail closed rather
+            // than treat an empty plan as a clean bill of health.
+            return false;
+        }
+        if self.checks.len() != expected.required_subjects.len() {
+            return false;
+        }
+        expected.required_subjects.iter().all(|subject| {
+            let mut matching = self.checks.iter().filter(|check| check.subject == *subject);
+            let Some(check) = matching.next() else {
+                return false;
+            };
+            // Exactly one: duplicates could otherwise pair a Verified with a
+            // silently ignored second opinion.
+            matching.next().is_none()
+                && matches!(
+                    check.result,
+                    CheckResult::Verified | CheckResult::NotApplicable
+                )
+        })
     }
+}
+
+/// The exact footprint a receipt must account for, derived from
+/// controller-owned bind-time state.
+///
+/// Separate from [`TeardownReceipt`] on purpose. The receipt is mutable status
+/// written by the teardown path; the scope is the trusted record of what that
+/// path was supposed to destroy. Validating a receipt against fields carried
+/// inside itself would let a truncated or replayed receipt define its own
+/// success criteria.
+#[derive(Debug, Clone, Copy)]
+pub struct TeardownScope<'a> {
+    pub lease: &'a ResourceRef,
+    pub instance: &'a ResourceRef,
+    pub pool: &'a ResourceRef,
+    pub backend_type: &'a str,
+    pub config_digest: &'a str,
+    pub instance_spec_digest: &'a str,
+    /// Every subject this instance actually created. Optional footprints that
+    /// were never created are simply absent — which is why the list must come
+    /// from the creation record, not be inferred at teardown time.
+    pub required_subjects: &'a [TeardownSubject],
 }
 
 /// Why a pool's footprint cannot support [`CleanupMode::VerifiedDestroy`].
@@ -389,34 +464,175 @@ mod tests {
         }
     }
 
-    /// A receipt may only unlock capacity when its recorded verdict and its own
-    /// evidence agree, so a hand-edited or truncated receipt cannot release it.
+    fn check(subject: TeardownSubject, result: CheckResult) -> TeardownCheck {
+        TeardownCheck {
+            subject,
+            result,
+            reason: None,
+        }
+    }
+
+    fn lease_ref() -> ResourceRef {
+        ResourceRef {
+            name: "lease-a".into(),
+            uid: Some("lease-uid".into()),
+        }
+    }
+    fn instance_ref() -> ResourceRef {
+        ResourceRef {
+            name: "pool-p-0".into(),
+            uid: Some("instance-uid".into()),
+        }
+    }
+    fn pool_ref() -> ResourceRef {
+        ResourceRef {
+            name: "p".into(),
+            uid: Some("pool-uid".into()),
+        }
+    }
+
+    fn scope<'a>(
+        required: &'a [TeardownSubject],
+        refs: &'a (ResourceRef, ResourceRef, ResourceRef),
+    ) -> TeardownScope<'a> {
+        TeardownScope {
+            lease: &refs.0,
+            instance: &refs.1,
+            pool: &refs.2,
+            backend_type: "k3s",
+            config_digest: "digest",
+            instance_spec_digest: "spec-digest",
+            required_subjects: required,
+        }
+    }
+
+    /// A receipt releases capacity only if it accounts for EVERY subject the
+    /// instance actually created.
+    ///
+    /// The earlier rule was "no Unknown, and not empty", which let a receipt
+    /// carrying a single `serverStatefulSet=verified` check release a lease
+    /// while saying nothing about the database, credentials, volumes, or Pods —
+    /// absence of evidence read as evidence of absence.
+    #[test]
+    fn partial_evidence_cannot_release_capacity() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [
+            TeardownSubject::ServerStatefulSet,
+            TeardownSubject::Database,
+            TeardownSubject::KubeconfigSecret,
+        ];
+
+        // Every required subject accounted for: two verified, one genuinely
+        // never created.
+        let complete = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::NotApplicable),
+                check(TeardownSubject::KubeconfigSecret, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(complete.permits_release_for(&scope(&required, &refs)));
+
+        // One subject simply missing — the defect this test exists for.
+        let partial = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !partial.permits_release_for(&scope(&required, &refs)),
+            "a receipt that omits a required subject must not release capacity"
+        );
+
+        // Duplicates must not let a second opinion hide behind the first.
+        let duplicated = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(!duplicated.permits_release_for(&scope(&required, &refs)));
+
+        // An empty plan is not a clean bill of health.
+        assert!(!complete.permits_release_for(&scope(&[], &refs)));
+    }
+
+    /// A receipt is proof about ONE subject. It must not be replayable against
+    /// another lease, instance, pool, or a same-named replacement.
+    #[test]
+    fn a_receipt_cannot_be_replayed_against_another_subject() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [TeardownSubject::ServerStatefulSet];
+        let valid = receipt(
+            vec![check(
+                TeardownSubject::ServerStatefulSet,
+                CheckResult::Verified,
+            )],
+            TeardownOutcome::Verified,
+        );
+        assert!(valid.permits_release_for(&scope(&required, &refs)));
+
+        // Same name, different UID — a replacement object.
+        let replaced = (
+            lease_ref(),
+            ResourceRef {
+                name: "pool-p-0".into(),
+                uid: Some("replacement-instance-uid".into()),
+            },
+            pool_ref(),
+        );
+        assert!(
+            !valid.permits_release_for(&scope(&required, &replaced)),
+            "a same-named replacement is a different subject"
+        );
+
+        // Drifted provenance must also refuse.
+        let mut drifted = scope(&required, &refs);
+        drifted.config_digest = "other-digest";
+        assert!(!valid.permits_release_for(&drifted));
+    }
+
+    /// Verdict, evidence, schema, and completeness each fail closed on their own.
     #[test]
     fn release_requires_evidence_that_matches_the_verdict() {
-        let verified = TeardownCheck {
-            subject: TeardownSubject::ServerStatefulSet,
-            result: CheckResult::Verified,
-            reason: None,
-        };
-        let unknown = TeardownCheck {
-            subject: TeardownSubject::Database,
-            result: CheckResult::Unknown,
-            reason: Some("datastore_unreachable".into()),
-        };
-
-        assert!(receipt(vec![verified.clone()], TeardownOutcome::Verified).permits_release());
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [
+            TeardownSubject::ServerStatefulSet,
+            TeardownSubject::Database,
+        ];
 
         // Verdict claims success while the evidence says otherwise.
+        let contradicted = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Unknown),
+            ],
+            TeardownOutcome::Verified,
+        );
         assert!(
-            !receipt(vec![verified.clone(), unknown], TeardownOutcome::Verified).permits_release(),
+            !contradicted.permits_release_for(&scope(&required, &refs)),
             "a Verified verdict must not override an Unknown check"
         );
-        // No evidence at all is not proof of absence.
-        assert!(!receipt(Vec::new(), TeardownOutcome::Verified).permits_release());
+
+        let good = vec![
+            check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+            check(TeardownSubject::Database, CheckResult::Verified),
+        ];
+
         // An unrecognised schema must not be read as complete.
-        let mut future = receipt(vec![verified], TeardownOutcome::Verified);
+        let mut future = receipt(good.clone(), TeardownOutcome::Verified);
         future.schema_version = TEARDOWN_RECEIPT_SCHEMA_VERSION + 1;
-        assert!(!future.permits_release());
+        assert!(!future.permits_release_for(&scope(&required, &refs)));
+
+        // An attempt that never finished is not proof.
+        let mut unfinished = receipt(good, TeardownOutcome::Verified);
+        unfinished.completed_at = None;
+        assert!(!unfinished.permits_release_for(&scope(&required, &refs)));
     }
 
     #[test]

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -263,6 +263,16 @@ pub enum ClusterState {
     /// Being deleted and recreated.
     #[allow(dead_code)]
     Recycling,
+    /// Teardown could not be proven complete.
+    ///
+    /// Distinct from `Unhealthy` on purpose: `Unhealthy` is
+    /// replacement-eligible and is deleted unconditionally below, which would
+    /// destroy the cleanup handle and let the ordinary 404-based recycle path
+    /// resume — exactly what a quarantine exists to prevent. Quarantined
+    /// capacity is never deleted, replaced, scaled down, or counted as
+    /// available; it leaves only when the same exact subject produces a
+    /// verified teardown receipt.
+    Quarantined,
 }
 
 /// Pool state for a single profile.
@@ -534,6 +544,8 @@ pub fn compute_pool_actions(
     let metric_profile = profile.metadata.name.clone().unwrap_or_default();
 
     // === 1. Unhealthy: always Delete (unbounded). ===
+    // Quarantined is deliberately NOT included: deleting it would remove the
+    // cleanup handle that proves whether the tenant's data is actually gone.
     for (name, entry) in &state.clusters {
         if entry.state == ClusterState::Unhealthy {
             actions.push(PoolAction::Delete(name.clone()));
@@ -1127,6 +1139,10 @@ pub struct StateCounts {
     pub leased: u32,
     pub unhealthy: u32,
     pub recycling: u32,
+    /// Capacity held back because its teardown could not be proven. Counted
+    /// separately from `unhealthy` so an operator can see stuck evidence
+    /// rather than mistaking it for ordinary churn.
+    pub quarantined: u32,
     /// Ready instances whose `spec_hash` matches `current_hash`. Zero
     /// when `count_states` was called without a `current_hash`.
     pub ready_clean: u32,
@@ -1164,6 +1180,7 @@ pub fn count_states(state: &PoolState, current_hash: Option<&SpecHash>) -> State
             ClusterState::Leased => c.leased += 1,
             ClusterState::Unhealthy => c.unhealthy += 1,
             ClusterState::Recycling => c.recycling += 1,
+            ClusterState::Quarantined => c.quarantined += 1,
         }
         // Only an entry with both a `current_hash` to compare against
         // AND its own stamped hash can hash-drift. Unstamped entries
@@ -3155,6 +3172,63 @@ mod tests {
         );
         // It was NOT counted toward `max_recycling=1`, but the budget
         // is still 1 here because there are no drifted Ready candidates.
+    }
+
+    /// Quarantined capacity must never be deleted by the pool manager.
+    ///
+    /// This is the boundary that matters. `Unhealthy` is deleted
+    /// unconditionally ("always Delete (unbounded)"), so had `Quarantined`
+    /// been folded into it, the first reconcile after a failed teardown would
+    /// destroy the very object holding the evidence — and the ordinary
+    /// 404-based recycle path would then treat the capacity as clean.
+    ///
+    /// Asserting only on a phase→state mapping helper would not catch that:
+    /// the deletion decision lives here, in `compute_pool_actions`.
+    #[test]
+    fn quarantined_instances_are_never_deleted_or_counted_available() {
+        let profile = make_profile_with_upgrade(4, 1, 1, Some(1));
+        let mut clusters = HashMap::new();
+        clusters.insert(
+            "pool-test-profile-1".into(),
+            make_entry(ClusterState::Quarantined),
+        );
+        clusters.insert(
+            "pool-test-profile-2".into(),
+            make_entry(ClusterState::Ready),
+        );
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter_map(|a| match a {
+                PoolAction::Delete(n) => Some(n.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !deletes.contains(&"pool-test-profile-1".to_string()),
+            "quarantined capacity must never be deleted — that destroys the \
+             cleanup handle proving the tenant's data is gone; got {deletes:?}"
+        );
+
+        // It must also not read as available capacity.
+        let counts = count_states(&state, None);
+        assert_eq!(counts.quarantined, 1);
+        assert_eq!(counts.ready, 1, "only the genuinely Ready member counts");
+        assert_eq!(
+            counts.unhealthy, 0,
+            "quarantined must be distinguishable from ordinary churn"
+        );
     }
 
     /// Unhealthy instances are recycled aggressively without

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -583,8 +583,16 @@ pub fn compute_pool_actions(
 
     let current_hash = profile_spec_hash(profile, render_ctx, bootstrap_specs);
     let counts = count_states(state, Some(&current_hash));
-    let total =
-        counts.creating + counts.ready + counts.leased + counts.unhealthy + counts.recycling;
+    // Quarantined counts toward the ceiling. Its backend resources still
+    // exist — that is the whole point, the cleanup handle is being held — so
+    // excluding it would let the pool create a replacement and exceed
+    // maxClusters in real capacity every time a teardown could not be proven.
+    let total = counts.creating
+        + counts.ready
+        + counts.leased
+        + counts.unhealthy
+        + counts.recycling
+        + counts.quarantined;
     let policy = resolved_upgrade_policy(profile, min_ready);
 
     // === 2. Backoff early-return for drift recycle and scale-up. ===
@@ -3228,6 +3236,58 @@ mod tests {
         assert_eq!(
             counts.unhealthy, 0,
             "quarantined must be distinguishable from ordinary churn"
+        );
+    }
+
+    /// Quarantined capacity must count against the pool ceiling.
+    ///
+    /// Protecting it from deletion is only half the job: its backend resources
+    /// still exist — holding them is the entire point — so if the ceiling
+    /// ignores it, the pool creates a replacement and the operator ends up with
+    /// more physical clusters than `maxClusters` allows. Every failed teardown
+    /// would then quietly grow real resource usage.
+    #[test]
+    fn quarantined_capacity_counts_against_the_pool_ceiling() {
+        // An AUTOSCALED pool whose hard ceiling is one member, and whose one
+        // member is quarantined. (A fixed pool deliberately allows `size + 10`
+        // headroom, so its ceiling is not the binding constraint here.)
+        let profile = make_profile(
+            1,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 1,
+                max_clusters: 1,
+                scale_up_threshold: 1,
+                scale_down_after: "30m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let mut clusters = HashMap::new();
+        clusters.insert(
+            "pool-test-profile-0".into(),
+            make_entry(ClusterState::Quarantined),
+        );
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+        let creates = actions
+            .iter()
+            .filter(|action| matches!(action, PoolAction::Create(_)))
+            .count();
+        assert_eq!(
+            creates, 0,
+            "a quarantined member already occupies the pool's only slot; \
+             replacing it would exceed maxClusters in real resources"
         );
     }
 


### PR DESCRIPTION
Part 1 of 3 for #80
Epic: #70 — Agent Sandbox (lane `S1`)

**Targets `epic/agent-sandbox`.** Sibling of PR #93, not stacked on it — #80 depends only on #79 (merged), so stacking would invent a dependency and block it behind #71's review.

## Why #80 is split

#80 is one issue but a very large change: two new CRD phases, a `VerifiedDestroy` mode, a receipt that must outlive the `ClusterInstance`, a `ClusterBackend` contract change touching five backends, create-time inventory capture, absence polling, controller finalizer rework, metrics, CLI phases, and a k3s integration test. That is not one reviewable diff, so it lands as three:

| | Scope |
|---|---|
| **1 (this PR)** | Types + pure rules. No behaviour change; nothing can reach the new phase. |
| 2 | k3s provider: backend contract returning evidence, inventory capture, absence polling. |
| 3 | Controller wiring: revoke → destroy → verify → receipt, quarantine transitions, metrics, integration test. |

## The problem being fixed

`ClusterBackend::delete` returns `Result<()>`. The instance controller deletes the `ClusterInstance` once it returns, and the lease controller reads the resulting 404 as "recycling complete". So **an accepted DELETE request is treated as proof of destruction.**

For capacity that held another tenant's code and credentials that isn't good enough. Today PVC, PDB, Pod and PostgreSQL failures warn and continue, and nothing waits for the objects — or their backing volumes — to actually disappear.

## What this adds

- **`CleanupMode::{Standard, VerifiedDestroy}`** on `ClusterLeaseSpec`. Absent means `Standard`, so every existing lease is untouched. The public lease API pins it to `None`: verified teardown is an internal composition detail of #74's child placement, not tenant-facing intent.
- **`TeardownReceipt` / `TeardownCheck` / `CheckResult` / `TeardownOutcome`.** `CheckResult` deliberately separates `NotApplicable` — established from *recorded creation-time configuration* — from `Unknown`. That distinction is the whole point: "the pool never enabled registry mirrors" is fine; "listing ConfigMaps returned 403" is not, and must quarantine.
- **`Quarantined`** on both `ClusterInstancePhase` and `LeasePhase`.
- **Pure `verified_destroy_eligibility`**, so an ineligible pool is refused *at bind time* rather than discovering mid-teardown that it can't produce evidence — which would strand a lease in quarantine through no fault of the caller.

## Design points worth reviewing

**The receipt lives on `ClusterLeaseStatus`, not the `ClusterInstance`.** It must stay queryable *after* the instance object is gone — that is exactly when the evidence matters, and when #74's owning `SandboxLease` consumes it.

**`permits_release` requires the verdict to agree with its own evidence** and the schema version to be recognised. A hand-edited, truncated, or newer-than-understood receipt cannot unlock capacity. An outcome that could disagree with its checks is precisely the failure mode receipts exist to prevent.

**Two guards against inventing or losing a quarantine:**

- `cluster_phase_from_state` can never *produce* `Quarantined`, so in-memory pool state cannot invent a quarantine no evidence supports.
- The profile controller now preserves `Quarantined` **explicitly**. Quarantined instances keep their binding as a cleanup handle, so `lease_held` covers it incidentally today — but relying on that means a future change to binding retention silently downgrades `Quarantined` and hands unproven capacity back to the pool.

**`ClusterState` gets no new variant here.** That touches ~109 call sites across pool scaling and belongs with the layer that can actually reason about quarantined capacity. The interim mapping to `Unhealthy` is documented as a placeholder, is unreachable in this change, and is pinned by a test asserting it never presents as `Ready` or `Leased`.

## Validation

```
cargo fmt -- --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1297 passed, 0 failed
helm template kobe charts/kobe/                         # renders
crdgen drift, all 8 shipped CRDs                        # clean
```

One run mid-session showed 8 failures; it executed concurrently with `helm dependency build` and clippy and took 6.4s against a normal 0.9s. Four consecutive isolated runs are clean, so that was contention on these wiremock port-binding tests rather than a defect. Flagging it because intermittent failures in teardown-verification code would be exactly the wrong thing to wave through.

## Note on dead code

The new module carries `#[allow(dead_code)]`, matching the existing `datastore` precedent in `crd/mod.rs`. Layer 1 defines the vocabulary that layers 2 and 3 consume, so it has no callers *yet*; `crdgen` also compiles `src/crd` alone, so controller-only types look dead there regardless.