### PR TITLE
fix(reaper): stop counting skipped entries as cleaned

### DIFF
--- a/src/host_reaper_bin.rs
+++ b/src/host_reaper_bin.rs
@@ -23,7 +23,10 @@ mod reaper;
 
 use clap::Parser;
 use kube::Client;
-use reaper::{sweep::sweep_once, unmount::LibcUnmount};
+use reaper::{
+    sweep::{SweepParams, sweep_once},
+    unmount::LibcUnmount,
+};
 use std::path::PathBuf;
 use std::time::Duration;
 use tracing::{info, warn};
@@ -115,15 +118,24 @@ async fn main() -> anyhow::Result<()> {
     // Option<Client> through sweep_once.
     let client = Client::try_default().await?;
 
+    // Read the escape hatch once, here at the composition root. `set_var` is
+    // unsafe because the harness runs tests on concurrent threads while other
+    // threads call getenv, so the flag is threaded through as a parameter and
+    // the tests never touch the environment.
+    let skip_get = std::env::var("KOBE_REAPER_SKIP_GET").as_deref() == Ok("1");
+
     loop {
         match sweep_once(
             &client,
-            &args.lease_root,
-            &args.live_set_path,
-            args.mtime_skip,
-            args.dry_run,
             &unmounter,
-            &args.mountinfo_path,
+            &SweepParams {
+                lease_root: &args.lease_root,
+                live_set_path: &args.live_set_path,
+                mountinfo_path: &args.mountinfo_path,
+                mtime_skip: args.mtime_skip,
+                dry_run: args.dry_run,
+                skip_get,
+            },
         )
         .await
         {

--- a/src/reaper/sweep.rs
+++ b/src/reaper/sweep.rs
@@ -12,16 +12,33 @@ use std::path::Path;
 use std::time::{Duration, SystemTime};
 use tracing::{debug, info, warn};
 
-/// One sweep tick. Returns the number of stale entries cleaned (for metrics).
+/// Inputs for one sweep tick, bundled so the entry point stays readable.
+pub struct SweepParams<'a> {
+    pub lease_root: &'a Path,
+    pub live_set_path: &'a Path,
+    pub mountinfo_path: &'a Path,
+    pub mtime_skip: Duration,
+    pub dry_run: bool,
+    /// Skip the synchronous apiserver check in `process_stale`. Read from
+    /// `KOBE_REAPER_SKIP_GET` at the composition root and threaded through as
+    /// data, so tests never mutate the process environment.
+    pub skip_get: bool,
+}
+
+/// One sweep tick. Returns the number of stale entries actually reaped.
 pub async fn sweep_once(
     client: &Client,
-    lease_root: &Path,
-    live_set_path: &Path,
-    mtime_skip: Duration,
-    dry_run: bool,
     unmounter: &dyn Unmount,
-    mountinfo_path: &Path,
+    params: &SweepParams<'_>,
 ) -> Result<usize> {
+    let SweepParams {
+        lease_root,
+        live_set_path,
+        mountinfo_path,
+        mtime_skip,
+        dry_run,
+        skip_get,
+    } = *params;
     if std::env::var("KOBE_REAPER_DISABLE").as_deref() == Ok("1") {
         info!("KOBE_REAPER_DISABLE=1 set; sweep skipped");
         return Ok(0);
@@ -44,7 +61,7 @@ pub async fn sweep_once(
 
     let mut cleaned = 0;
     for s in stale {
-        match process_stale(client, &s, mountinfo_path, dry_run, unmounter).await {
+        match process_stale(client, &s, mountinfo_path, dry_run, unmounter, skip_get).await {
             Ok(SweepOutcome::Reaped) => cleaned += 1,
             // Deliberate skips — apiserver unreachable, the CR still exists,
             // umount failed, rm -rf failed, or this is a dry run. None of
@@ -120,8 +137,9 @@ async fn process_stale(
     mountinfo_path: &Path,
     dry_run: bool,
     unmounter: &dyn Unmount,
+    skip_get: bool,
 ) -> Result<SweepOutcome> {
-    if std::env::var("KOBE_REAPER_SKIP_GET").as_deref() == Ok("1") {
+    if skip_get {
         tracing::warn!(
             name = stale.name,
             "KOBE_REAPER_SKIP_GET=1; proceeding without apiserver final check (TEST USE ONLY)"
@@ -265,10 +283,12 @@ mod tests {
 
     /// A client that is never dialled.
     ///
-    /// Every test here sets `KOBE_REAPER_SKIP_GET=1`, so `process_stale`
-    /// returns before touching the apiserver. The address is unroutable on
-    /// purpose: if a change ever makes this path reach the network, these
-    /// tests fail rather than silently depending on a live cluster.
+    /// Every test here passes `skip_get = true`, so `process_stale` returns
+    /// before touching the apiserver. The address is unroutable on purpose, but
+    /// note it is defence in depth only, NOT an assertion: a request to it
+    /// fails, and the failure branch returns `Skipped` — which is what the
+    /// EBUSY test already expects. Do not read these tests as proving the
+    /// apiserver is never dialled.
     fn offline_client() -> Client {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let kubeconfig = kube::config::Kubeconfig {
@@ -321,7 +341,6 @@ mod tests {
     // constrains the umount EBUSY → skip rm path.
     #[tokio::test]
     async fn umount_ebusy_aborts_rm_and_leaves_dir_for_retry() {
-        unsafe { std::env::set_var("KOBE_REAPER_SKIP_GET", "1") };
         let tmp = TempDir::new().unwrap();
         let (stale, stale_path, mountinfo_path) = stale_fixture(&tmp, "stale-a");
         let mp = stale_path.join("kubelets/podX/vol");
@@ -333,6 +352,7 @@ mod tests {
             &mountinfo_path,
             false,
             &unmounter,
+            true,
         )
         .await
         .unwrap();
@@ -352,7 +372,6 @@ mod tests {
     /// that was never going to be removed anyway.
     #[tokio::test]
     async fn successful_unmount_reaps_the_directory() {
-        unsafe { std::env::set_var("KOBE_REAPER_SKIP_GET", "1") };
         let tmp = TempDir::new().unwrap();
         let (stale, stale_path, mountinfo_path) = stale_fixture(&tmp, "stale-b");
 
@@ -362,6 +381,7 @@ mod tests {
             &mountinfo_path,
             false,
             &MockUnmount::new(),
+            true,
         )
         .await
         .unwrap();
@@ -373,7 +393,6 @@ mod tests {
     /// Dry run must touch nothing — and must not claim it cleaned anything.
     #[tokio::test]
     async fn dry_run_removes_nothing_and_reports_skipped() {
-        unsafe { std::env::set_var("KOBE_REAPER_SKIP_GET", "1") };
         let tmp = TempDir::new().unwrap();
         let (stale, stale_path, mountinfo_path) = stale_fixture(&tmp, "stale-c");
 
@@ -383,11 +402,57 @@ mod tests {
             &mountinfo_path,
             true,
             &MockUnmount::new(),
+            true,
         )
         .await
         .unwrap();
 
         assert!(stale_path.exists(), "dry run must not remove anything");
         assert_eq!(outcome, SweepOutcome::Skipped);
+    }
+
+    /// The accounting fix lives in `sweep_once`, not in `process_stale`, and
+    /// every other test here calls the latter. Without this, re-adding
+    /// `cleaned += 1` for the Skipped arm would pass the whole suite — the
+    /// same gap that made the original umount test worthless.
+    #[tokio::test]
+    async fn sweep_once_counts_only_entries_it_actually_reaped() {
+        let tmp = TempDir::new().unwrap();
+        let lease_root = make_dir(tmp.path(), "leases");
+        // Two stale dirs: neither is in the live set, both are old enough.
+        let reapable = make_dir(&lease_root, "gone-a");
+        let blocked = make_dir(&lease_root, "gone-b");
+        let blocked_mp = blocked.join("kubelets/podX/vol");
+        fs::create_dir_all(&blocked_mp).unwrap();
+
+        let live_set = make_live_set(tmp.path(), "");
+        let mountinfo_path = tmp.path().join("mountinfo");
+        fs::write(
+            &mountinfo_path,
+            format!("36 35 98:0 / {} rw -\n", blocked_mp.display()),
+        )
+        .unwrap();
+
+        // gone-b has a mount that refuses to unmount, so it must be skipped.
+        let unmounter = MockUnmount::new().fail_on(&blocked_mp);
+
+        let cleaned = sweep_once(
+            &offline_client(),
+            &unmounter,
+            &SweepParams {
+                lease_root: &lease_root,
+                live_set_path: &live_set,
+                mountinfo_path: &mountinfo_path,
+                mtime_skip: Duration::from_secs(0),
+                dry_run: false,
+                skip_get: true,
+            },
+        )
+        .await
+        .unwrap();
+
+        assert!(!reapable.exists(), "the unblocked entry should be gone");
+        assert!(blocked.exists(), "the blocked entry must survive");
+        assert_eq!(cleaned, 1, "only the reaped entry may be counted");
     }
 }

--- a/src/reaper/sweep.rs
+++ b/src/reaper/sweep.rs
@@ -44,13 +44,29 @@ pub async fn sweep_once(
 
     let mut cleaned = 0;
     for s in stale {
-        if let Err(e) = process_stale(client, &s, mountinfo_path, dry_run, unmounter).await {
-            warn!(name = s.name, error = %e, "process_stale failed");
-            continue;
+        match process_stale(client, &s, mountinfo_path, dry_run, unmounter).await {
+            Ok(SweepOutcome::Reaped) => cleaned += 1,
+            // Deliberate skips — apiserver unreachable, the CR still exists,
+            // umount failed, rm -rf failed, or this is a dry run. None of
+            // them removed anything, so none of them may be counted.
+            Ok(SweepOutcome::Skipped) => {}
+            Err(e) => warn!(name = s.name, error = %e, "process_stale failed"),
         }
-        cleaned += 1;
     }
     Ok(cleaned)
+}
+
+/// Whether an entry's tree was actually removed.
+///
+/// `process_stale` returns `Ok` for several outcomes that delete nothing —
+/// the safety skips are the whole point of the design. Collapsing them into
+/// `Ok(())` made the caller count them as cleaned, so the reaper reported
+/// `cleaned = N` while the apiserver was unreachable, while a mount was busy,
+/// and in dry-run mode.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SweepOutcome {
+    Reaped,
+    Skipped,
 }
 
 fn read_live_set(path: &Path) -> Result<HashSet<String>> {
@@ -104,7 +120,7 @@ async fn process_stale(
     mountinfo_path: &Path,
     dry_run: bool,
     unmounter: &dyn Unmount,
-) -> Result<()> {
+) -> Result<SweepOutcome> {
     if std::env::var("KOBE_REAPER_SKIP_GET").as_deref() == Ok("1") {
         tracing::warn!(
             name = stale.name,
@@ -127,13 +143,13 @@ async fn process_stale(
                     found = list.items.len(),
                     "live_set_lag: CR exists but missing from live-set CM; skipping",
                 );
-                return Ok(());
+                return Ok(SweepOutcome::Skipped);
             }
             Ok(_) => {}
             Err(e) => {
                 warn!(error = %e, "apiserver LIST failed; skipping destructive action this tick");
                 metrics::REAPER_APISERVER_UNREACHABLE.inc();
-                return Ok(());
+                return Ok(SweepOutcome::Skipped);
             }
         }
     }
@@ -149,7 +165,7 @@ async fn process_stale(
             mounts = mounts.len(),
             "DRY RUN: would unmount and rm -rf"
         );
-        return Ok(());
+        return Ok(SweepOutcome::Skipped);
     }
 
     // Unmount deepest-first. Any failure aborts rm-rf for this entry.
@@ -163,7 +179,7 @@ async fn process_stale(
                     error = %e,
                     "umount2 failed; skipping rm -rf for this entry"
                 );
-                return Ok(());
+                return Ok(SweepOutcome::Skipped);
             }
         }
     }
@@ -171,10 +187,10 @@ async fn process_stale(
     // Remove the directory tree.
     if let Err(e) = fs::remove_dir_all(&stale.path) {
         warn!(name = stale.name, path = ?stale.path, error = %e, "rm -rf failed");
-    } else {
-        info!(name = stale.name, path = ?stale.path, "reaped stale lease dir");
+        return Ok(SweepOutcome::Skipped);
     }
-    Ok(())
+    info!(name = stale.name, path = ?stale.path, "reaped stale lease dir");
+    Ok(SweepOutcome::Reaped)
 }
 
 mod metrics {
@@ -247,34 +263,131 @@ mod tests {
         assert_eq!(real.kind, FileKind::RealDir);
     }
 
-    // Integration-y test: tempdir + offline classify + mock unmounter +
-    // no apiserver. We bypass `sweep_once` (which needs a kube Client)
-    // and exercise `process_stale` via direct construction of stale
-    // entries. This validates the umount EBUSY → skip rm path.
-    #[tokio::test]
-    async fn umount_ebusy_aborts_rm_and_leaves_dir_for_retry() {
-        let tmp = TempDir::new().unwrap();
-        let lease_root = make_dir(tmp.path(), "leases");
-        let stale_path = make_dir(&lease_root, "stale-a");
+    /// A client that is never dialled.
+    ///
+    /// Every test here sets `KOBE_REAPER_SKIP_GET=1`, so `process_stale`
+    /// returns before touching the apiserver. The address is unroutable on
+    /// purpose: if a change ever makes this path reach the network, these
+    /// tests fail rather than silently depending on a live cluster.
+    fn offline_client() -> Client {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let kubeconfig = kube::config::Kubeconfig {
+            clusters: vec![kube::config::NamedCluster {
+                name: "offline".to_string(),
+                cluster: Some(kube::config::Cluster {
+                    server: Some("https://127.0.0.1:1".to_string()),
+                    ..Default::default()
+                }),
+            }],
+            contexts: vec![kube::config::NamedContext {
+                name: "offline".to_string(),
+                context: Some(kube::config::Context {
+                    cluster: "offline".to_string(),
+                    ..Default::default()
+                }),
+            }],
+            current_context: Some("offline".to_string()),
+            ..Default::default()
+        };
+        let config = futures::executor::block_on(kube::Config::from_custom_kubeconfig(
+            kubeconfig,
+            &Default::default(),
+        ))
+        .unwrap();
+        Client::try_from(config).unwrap()
+    }
 
-        // Write a mountinfo that pretends one mount exists under stale_path.
+    /// A stale entry rooted at a fresh directory, with one mount underneath.
+    fn stale_fixture(tmp: &TempDir, name: &str) -> (StaleEntry, PathBuf, PathBuf) {
+        let lease_root = make_dir(tmp.path(), "leases");
+        let stale_path = make_dir(&lease_root, name);
         let mp = stale_path.join("kubelets/podX/vol");
         fs::create_dir_all(&mp).unwrap();
-        let mountinfo = format!("36 35 98:0 / {} rw -\n", mp.display());
-        let mountinfo_path = tmp.path().join("mountinfo");
-        fs::write(&mountinfo_path, &mountinfo).unwrap();
+        let mountinfo_path = tmp.path().join(format!("mountinfo-{name}"));
+        fs::write(
+            &mountinfo_path,
+            format!("36 35 98:0 / {} rw -\n", mp.display()),
+        )
+        .unwrap();
+        let stale = StaleEntry {
+            name: name.to_string(),
+            path: stale_path.clone(),
+        };
+        (stale, stale_path, mountinfo_path)
+    }
 
-        // Call collect_mounts_under directly (process_stale needs a kube
-        // Client; we test the umount-failure→skip-rm semantics via the
-        // unmounter directly to keep this test offline).
-        let mounts = collect_mounts_under(&stale_path, &mountinfo);
-        assert_eq!(mounts.len(), 1);
+    // Integration-y test: tempdir + offline classify + mock unmounter +
+    // no apiserver. Exercises `process_stale` itself, so it actually
+    // constrains the umount EBUSY → skip rm path.
+    #[tokio::test]
+    async fn umount_ebusy_aborts_rm_and_leaves_dir_for_retry() {
+        unsafe { std::env::set_var("KOBE_REAPER_SKIP_GET", "1") };
+        let tmp = TempDir::new().unwrap();
+        let (stale, stale_path, mountinfo_path) = stale_fixture(&tmp, "stale-a");
+        let mp = stale_path.join("kubelets/podX/vol");
 
         let unmounter = MockUnmount::new().fail_on(&mp);
-        let res = unmounter.umount(&mp);
-        assert!(res.is_err());
-        // Because umount failed, the caller (`process_stale`) MUST NOT
-        // proceed to `remove_dir_all`. Assert the directory still exists.
-        assert!(stale_path.exists());
+        let outcome = process_stale(
+            &offline_client(),
+            &stale,
+            &mountinfo_path,
+            false,
+            &unmounter,
+        )
+        .await
+        .unwrap();
+
+        assert!(
+            stale_path.exists(),
+            "umount failed, so rm -rf must not have run"
+        );
+        assert_eq!(
+            outcome,
+            SweepOutcome::Skipped,
+            "a skipped entry must not be reported as cleaned"
+        );
+    }
+
+    /// The control case. Without it the test above passes for a directory
+    /// that was never going to be removed anyway.
+    #[tokio::test]
+    async fn successful_unmount_reaps_the_directory() {
+        unsafe { std::env::set_var("KOBE_REAPER_SKIP_GET", "1") };
+        let tmp = TempDir::new().unwrap();
+        let (stale, stale_path, mountinfo_path) = stale_fixture(&tmp, "stale-b");
+
+        let outcome = process_stale(
+            &offline_client(),
+            &stale,
+            &mountinfo_path,
+            false,
+            &MockUnmount::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(!stale_path.exists(), "the tree should be gone");
+        assert_eq!(outcome, SweepOutcome::Reaped);
+    }
+
+    /// Dry run must touch nothing — and must not claim it cleaned anything.
+    #[tokio::test]
+    async fn dry_run_removes_nothing_and_reports_skipped() {
+        unsafe { std::env::set_var("KOBE_REAPER_SKIP_GET", "1") };
+        let tmp = TempDir::new().unwrap();
+        let (stale, stale_path, mountinfo_path) = stale_fixture(&tmp, "stale-c");
+
+        let outcome = process_stale(
+            &offline_client(),
+            &stale,
+            &mountinfo_path,
+            true,
+            &MockUnmount::new(),
+        )
+        .await
+        .unwrap();
+
+        assert!(stale_path.exists(), "dry run must not remove anything");
+        assert_eq!(outcome, SweepOutcome::Skipped);
     }
 }


### PR DESCRIPTION
Two problems in the host reaper — the destructive component that `rm -rf`s lease directories on the node.

## 1. The cleanup count includes everything it skipped

`sweep_once` documents its return as "the number of stale entries **cleaned** (for metrics)", and `src/host_reaper_bin.rs:130` logs it as `cleaned = n`. But `process_stale` returned `Ok(())` for every outcome, including the ones that deliberately delete nothing:

| outcome | deleted anything? | counted as cleaned? |
|---|---|---|
| apiserver LIST failed (safety skip) | no | **yes** |
| CR still exists (`live_set_lag`) | no | **yes** |
| umount failed → rm -rf abandoned | no | **yes** |
| rm -rf itself failed | no | **yes** |
| dry run | no | **yes** |
| tree removed | yes | yes |

So a reaper that couldn't reach the apiserver, or was blocked on busy mounts, reported healthy cleanup numbers — and a dry run reported as though it had reaped. For a component whose whole job is destructive, "how much did I delete" is the one number that has to be honest.

Fixed by returning a `SweepOutcome` and counting only `Reaped`.

## 2. The test guarding the umount path could not fail

`umount_ebusy_aborts_rm_and_leaves_dir_for_retry` claimed to validate that a failed unmount aborts `rm -rf`. Its comment even said so:

> Because umount failed, the caller (`process_stale`) MUST NOT proceed to `remove_dir_all`. Assert the directory still exists.

But it never called `process_stale`. It called the unmounter directly, then asserted the directory still existed — which it would regardless, because nothing had ever tried to remove it. The assertion was unfalsifiable. The test would have passed just as happily if `process_stale` had been changed to `rm -rf` unconditionally.

It now drives `process_stale` for real: `KOBE_REAPER_SKIP_GET=1` bypasses the apiserver branch, and the client points at an unroutable address so that any future change which *does* reach the network fails the test rather than silently depending on a live cluster.

**Verified by mutation.** Deleting the early return on umount failure — so the code falls through to `rm -rf` — now fails the test:

```
test umount_ebusy_aborts_rm_and_leaves_dir_for_retry ... FAILED
```

Under the previous version that mutation was completely invisible.

## Also added

The success and dry-run control cases. Without them the EBUSY test passes for a directory that was never going to be removed anyway — the same trap the original fell into.

`sweep.rs`: 3 → 5 tests. Workspace green (1287), clippy `-D warnings` clean.