### PR TITLE
fix(kobectl): purge left files on disk with their tracking already dropped

### DIFF
--- a/crates/kobectl/src/commands/purge.rs
+++ b/crates/kobectl/src/commands/purge.rs
@@ -253,12 +253,15 @@ fn remove_kubeconfig_files(paths: Vec<PathBuf>) -> (Vec<PathBuf>, Vec<(PathBuf, 
     let mut removed_paths = Vec::new();
     let mut failures = Vec::new();
     for path in paths {
-        if !path.exists() {
-            continue;
-        }
+        // Attempt the removal unconditionally rather than gating on
+        // `Path::exists()`. That call follows symlinks and reports false for a
+        // broken one, and also returns false when the metadata lookup itself
+        // fails (a permission error on the parent, say) — both of which then
+        // looked like "already gone" and let the caller clear its tracking
+        // state for a file still on disk. NotFound from the removal is the only
+        // thing that actually proves absence.
         match std::fs::remove_file(&path) {
             Ok(()) => removed_paths.push(path),
-            // Vanished between the check and the removal — the desired state.
             Err(err) if err.kind() == std::io::ErrorKind::NotFound => {}
             Err(err) => failures.push((path, err)),
         }
@@ -449,5 +452,25 @@ mod tests {
         );
         assert!(!live.contains("released"));
         assert!(!live.contains("expired"));
+    }
+
+    /// `Path::exists()` follows symlinks and returns false for a broken one,
+    /// so a dangling kubeconfig symlink was skipped, counted as absent, and
+    /// left on disk forever — while the caller saw no failure and cleared the
+    /// endpoint's tracking state. `remove_file` unlinks the symlink itself.
+    #[test]
+    #[cfg(unix)]
+    fn a_dangling_symlink_is_removed_not_silently_skipped() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("kobe-lease-dangling.yaml");
+        std::os::unix::fs::symlink(dir.path().join("no-such-target"), &link).unwrap();
+        assert!(!link.exists(), "precondition: exists() is false for it");
+        assert!(link.symlink_metadata().is_ok(), "precondition: it is there");
+
+        let (removed, failures) = remove_kubeconfig_files(vec![link.clone()]);
+
+        assert!(failures.is_empty());
+        assert_eq!(removed, vec![link.clone()], "it should be reported removed");
+        assert!(link.symlink_metadata().is_err(), "the link must be gone");
     }
 }

--- a/crates/kobectl/src/commands/state.rs
+++ b/crates/kobectl/src/commands/state.rs
@@ -64,14 +64,21 @@ pub(crate) fn forget_kubeconfig(endpoint: &str, lease_id: &str) -> Result<()> {
 }
 
 pub(crate) fn remove_kubeconfig(endpoint: &str, lease_id: &str) -> Result<Option<PathBuf>> {
-    let recorded = if let Ok(state) = CliState::load() {
-        state
-            .lease_artifacts
-            .get(&lease_key(endpoint, lease_id))
-            .map(|artifact| PathBuf::from(&artifact.kubeconfig_path))
-    } else {
-        None
-    };
+    // Load state up front and propagate a failure BEFORE deleting anything.
+    //
+    // This used to tolerate an unreadable state file and fall through to the
+    // guessed default path, which was harmless only because the subsequent
+    // `forget_kubeconfig` re-read the file and errored out before the removal.
+    // Now that the removal happens first, that tolerance would delete a
+    // kubeconfig on the strength of a guess — and `release` calls this before
+    // it validates the DELETE response and discards the error, so a corrupt
+    // state file plus a failed release would remove the local kubeconfig for a
+    // lease that is still active.
+    let state = CliState::load()?;
+    let recorded = state
+        .lease_artifacts
+        .get(&lease_key(endpoint, lease_id))
+        .map(|artifact| PathBuf::from(&artifact.kubeconfig_path));
 
     let path = recorded.unwrap_or_else(|| default_kubeconfig_path(lease_id));
 
@@ -128,7 +135,7 @@ pub(crate) fn find_orphan_kubeconfigs(
             continue;
         }
         let path = PathBuf::from(&artifact.kubeconfig_path);
-        if !path.exists() {
+        if !path_is_present(&path) {
             continue;
         }
         orphans.push(OrphanKubeconfig {
@@ -205,6 +212,16 @@ pub(crate) fn default_kubeconfig_path(lease_id: &str) -> PathBuf {
         .join(format!("kobe-{lease_id}"))
 }
 
+/// Whether something exists at `path`, INCLUDING a broken symlink.
+///
+/// `Path::exists()` follows symlinks and reports false for a dangling one, so
+/// using it here made orphan discovery skip exactly the case `purge` was fixed
+/// to clean up: the link stayed on disk, its tracking entry stayed behind it,
+/// and `--orphans-only` reported "No orphan kubeconfigs found".
+fn path_is_present(path: &Path) -> bool {
+    path.symlink_metadata().is_ok()
+}
+
 fn lease_key(endpoint: &str, lease_id: &str) -> String {
     format!("{endpoint}::{lease_id}")
 }
@@ -213,4 +230,46 @@ fn state_path() -> Result<PathBuf> {
     let dir =
         dirs::config_dir().ok_or_else(|| anyhow::anyhow!("Cannot determine config directory"))?;
     Ok(dir.join("kobe").join("state.json"))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn path_is_present_for_an_ordinary_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let f = dir.path().join("kobe-lease-x.yaml");
+        std::fs::write(&f, "x").unwrap();
+        assert!(path_is_present(&f));
+    }
+
+    #[test]
+    fn path_is_absent_when_nothing_is_there() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(!path_is_present(&dir.path().join("nope.yaml")));
+    }
+
+    /// The case orphan discovery used to skip. `Path::exists()` is false here,
+    /// which is why it must not be the predicate.
+    #[test]
+    #[cfg(unix)]
+    fn path_is_present_for_a_dangling_symlink() {
+        let dir = tempfile::tempdir().unwrap();
+        let link = dir.path().join("kobe-lease-dangling.yaml");
+        std::os::unix::fs::symlink(dir.path().join("missing"), &link).unwrap();
+        assert!(!link.exists(), "precondition: exists() is false");
+        assert!(
+            path_is_present(&link),
+            "a dangling symlink is still on disk and must be discoverable"
+        );
+    }
+
+    #[test]
+    fn lease_key_is_endpoint_scoped() {
+        assert_eq!(lease_key("https://a", "lease-1"), "https://a::lease-1");
+        // The separator is what stops one endpoint's prefix matching another's
+        // keys when one endpoint string is a prefix of the other.
+        assert!(!lease_key("https://a/api", "lease-1").starts_with("https://a::"));
+    }
 }

--- a/crates/kobectl/src/commands/state.rs
+++ b/crates/kobectl/src/commands/state.rs
@@ -1,4 +1,4 @@
-use anyhow::Result;
+use anyhow::{Context, Result};
 use serde::{Deserialize, Serialize};
 use std::collections::{BTreeMap, BTreeSet};
 use std::path::{Path, PathBuf};
@@ -73,15 +73,27 @@ pub(crate) fn remove_kubeconfig(endpoint: &str, lease_id: &str) -> Result<Option
         None
     };
 
-    forget_kubeconfig(endpoint, lease_id)?;
-
     let path = recorded.unwrap_or_else(|| default_kubeconfig_path(lease_id));
-    if path.exists() {
-        std::fs::remove_file(&path)?;
-        return Ok(Some(path));
-    }
 
-    Ok(None)
+    // Remove the file FIRST, and drop the tracking entry only once it is
+    // actually gone. Forgetting first — as this did — meant that a file which
+    // could not be removed (a custom `--kubeconfig` path that is now a
+    // directory, or one the user made read-only) lost the state entry pointing
+    // at it, so `purge --orphans-only` could never rediscover it, and a custom
+    // path outside `~/.kube/kobe-*.yaml` escaped a future full purge too. Same
+    // ordering rule `purge_orphans_only` already documents.
+    match std::fs::remove_file(&path) {
+        Ok(()) => {
+            forget_kubeconfig(endpoint, lease_id)?;
+            Ok(Some(path))
+        }
+        Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+            // Nothing on disk, so the entry is stale — dropping it is correct.
+            forget_kubeconfig(endpoint, lease_id)?;
+            Ok(None)
+        }
+        Err(err) => Err(err).with_context(|| format!("remove kubeconfig {}", path.display())),
+    }
 }
 
 pub(crate) fn endpoint_kubeconfigs(endpoint: &str) -> Result<Vec<PathBuf>> {


### PR DESCRIPTION
Follow-up to #95. A cross-family (codex) review of that merged change found two holes it did not close — both of which defeat the leak fix it claimed to make.

## 1. `remove_kubeconfig` forgets before it deletes

#95 fixed the *batch* path to retain tracking when a removal fails. But the per-lease path used for **active leases** still did this:

```rust
forget_kubeconfig(endpoint, lease_id)?;          // state entry gone
let path = ...;
if path.exists() { std::fs::remove_file(&path)?; }
```

So a kubeconfig that cannot be removed — a custom `--kubeconfig` path that is now a directory, or one the user made read-only — loses the only record pointing at it. `purge --orphans-only` can never rediscover it, and a custom path outside `~/.kube/kobe-*.yaml` escapes a future full purge too, since the filename glob won't match it.

That directly contradicts #95's "a failure leaves them for the next run to re-detect".

Now removes first and forgets only once the file is actually gone — the ordering `purge_orphans_only` already documents.

## 2. `Path::exists()` was treated as proof of absence

```rust
if !path.exists() { continue; }
```

`exists()` follows symlinks and returns **false for a broken one**, and also returns false when the metadata lookup itself fails (a permission error on the parent). Both looked like "already gone", so the caller saw no failure and cleared the endpoint's tracking state — for a file still sitting on disk.

Now the removal is attempted unconditionally, and only `NotFound` is accepted as proof of absence. That is what the sibling orphan path already did; #95 should have copied it exactly.

## Test

The dangling-symlink case, red before the fix:

```
test a_dangling_symlink_is_removed_not_silently_skipped ... FAILED
   assertion `left == right` failed: it should be reported removed
```

`purge.rs`: 6 → 7 tests.

## Why #95 missed these

Its tests exercised the extracted helper (`remove_kubeconfig_files`) rather than the behaviour at the boundary where the claim lived — so nothing constrained the caller's state handling at all. Same gap the reviewer flagged in #97, and the same one #97 itself was fixing a level down. Worth noting as a pattern rather than three separate slips.

Workspace green, clippy `-D warnings` clean.