### PR TITLE
fix(vcluster): carry helm's stderr into the provisioning error

### DIFF
--- a/src/backend/vcluster.rs
+++ b/src/backend/vcluster.rs
@@ -190,6 +190,45 @@ const DEFAULT_CHART_VERSION: &str = "0.34.0";
 /// Helm repository alias the operator uses internally.
 const HELM_REPO_ALIAS: &str = "kobe-loft-sh";
 
+/// Cap on how much helm stderr is carried into an error.
+///
+/// The message reaches ClusterInstance status and the pool's
+/// `lastFailureReason`, which is surfaced to lease clients — so an unbounded
+/// helm dump would bloat those objects on every failed attempt.
+const HELM_STDERR_LIMIT: usize = 800;
+
+/// Build the error for a failed helm invocation, including what helm wrote to
+/// stderr.
+///
+/// Previously both helm calls sent stderr to `Stdio::null()` and reported only
+/// "returned non-zero status". That made provisioning failures undiagnosable
+/// from the operator log: a DNS failure, a TLS error and a 404 were
+/// indistinguishable, which is exactly what happened in #92.
+fn helm_command_error(what: &str, output: &std::process::Output) -> anyhow::Error {
+    let code = output
+        .status
+        .code()
+        .map(|c| c.to_string())
+        .unwrap_or_else(|| "signal".to_string());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let stderr = stderr.trim();
+    if stderr.is_empty() {
+        return anyhow!("{what} returned non-zero status (exit {code}), with no stderr");
+    }
+    if stderr.len() > HELM_STDERR_LIMIT {
+        // Cut on a char boundary — helm output can carry non-ASCII.
+        let mut end = HELM_STDERR_LIMIT;
+        while end > 0 && !stderr.is_char_boundary(end) {
+            end -= 1;
+        }
+        return anyhow!(
+            "{what} returned non-zero status (exit {code}): {} […truncated]",
+            &stderr[..end]
+        );
+    }
+    anyhow!("{what} returned non-zero status (exit {code}): {stderr}")
+}
+
 /// Helm repository URL for upstream vcluster charts.
 const HELM_REPO_URL: &str = "https://charts.loft.sh";
 
@@ -302,29 +341,33 @@ impl VclusterBackend {
 
     /// Ensure the Helm repo is registered locally. Idempotent.
     async fn ensure_helm_repo(&self) -> Result<()> {
-        let status = Command::new("helm")
+        let output = Command::new("helm")
             .args(["repo", "add", HELM_REPO_ALIAS, HELM_REPO_URL])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
+            .stderr(Stdio::piped())
+            .output()
             .await
             .context("failed to spawn `helm repo add`")?;
-        // Non-zero is normal if the repo is already registered. We don't
-        // distinguish that case from real errors here because `helm repo
-        // update` will fail downstream with a clearer message.
-        if !status.success() {
-            debug!("helm repo add returned non-zero (likely already registered); continuing");
+        // Non-zero is normal if the repo is already registered, so this is not
+        // fatal — but log what helm said rather than discarding it, since a
+        // genuine failure here is otherwise invisible until `update` fails.
+        if !output.status.success() {
+            debug!(
+                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                "helm repo add returned non-zero (likely already registered); continuing"
+            );
         }
-        let status = Command::new("helm")
+        let output = Command::new("helm")
             .args(["repo", "update", HELM_REPO_ALIAS])
             .stdout(Stdio::null())
-            .stderr(Stdio::null())
-            .status()
+            .stderr(Stdio::piped())
+            .output()
             .await
             .context("failed to spawn `helm repo update`")?;
-        if !status.success() {
-            return Err(anyhow!(
-                "helm repo update for {HELM_REPO_ALIAS} returned non-zero status"
+        if !output.status.success() {
+            return Err(helm_command_error(
+                &format!("helm repo update for {HELM_REPO_ALIAS}"),
+                &output,
             ));
         }
         Ok(())
@@ -1500,5 +1543,61 @@ mod tests {
             format!("{err:#}").contains("kubeconfig Secret get failed"),
             "unexpected error: {err:#}"
         );
+    }
+
+    // --- helm stderr capture -------------------------------------------
+
+    fn output_with(stderr: &[u8], code: i32) -> std::process::Output {
+        use std::os::unix::process::ExitStatusExt;
+        std::process::Output {
+            status: std::process::ExitStatus::from_raw(code << 8),
+            stdout: Vec::new(),
+            stderr: stderr.to_vec(),
+        }
+    }
+
+    #[test]
+    fn helm_error_includes_what_helm_actually_said() {
+        let err = helm_command_error(
+            "helm repo update for kobe-loft-sh",
+            &output_with(
+                b"Error: looks like \"https://charts.loft.sh\" is not a valid chart repository",
+                1,
+            ),
+        );
+        let msg = err.to_string();
+        assert!(msg.contains("helm repo update for kobe-loft-sh"), "{msg}");
+        assert!(msg.contains("not a valid chart repository"), "{msg}");
+    }
+
+    #[test]
+    fn helm_error_trims_surrounding_whitespace() {
+        let err = helm_command_error("helm repo add", &output_with(b"\n\n  boom  \n\n", 1));
+        assert!(err.to_string().ends_with("boom"), "{err}");
+    }
+
+    /// The message lands in ClusterInstance status and in the pool's
+    /// lastFailureReason, which is surfaced to lease clients. An unbounded
+    /// helm dump there bloats the object on every failed attempt.
+    #[test]
+    fn helm_error_truncates_a_very_long_stderr() {
+        let long = vec![b'x'; 10_000];
+        let msg = helm_command_error("helm repo update", &output_with(&long, 1)).to_string();
+        assert!(msg.len() < 1_200, "message was {} bytes", msg.len());
+        assert!(msg.contains("truncated"), "{msg}");
+    }
+
+    #[test]
+    fn helm_error_without_stderr_still_reports_the_exit_code() {
+        let msg = helm_command_error("helm repo update", &output_with(b"", 3)).to_string();
+        assert!(msg.contains("helm repo update"), "{msg}");
+        assert!(msg.contains('3'), "expected the exit code in: {msg}");
+    }
+
+    #[test]
+    fn helm_error_survives_non_utf8_stderr() {
+        let msg = helm_command_error("helm repo add", &output_with(&[0xff, 0xfe, b'h', b'i'], 1))
+            .to_string();
+        assert!(msg.contains("hi"), "{msg}");
     }
 }

--- a/src/backend/vcluster.rs
+++ b/src/backend/vcluster.rs
@@ -190,12 +190,37 @@ const DEFAULT_CHART_VERSION: &str = "0.34.0";
 /// Helm repository alias the operator uses internally.
 const HELM_REPO_ALIAS: &str = "kobe-loft-sh";
 
-/// Cap on how much helm stderr is carried into an error.
+/// Cap on how much helm stderr is carried into an error message.
 ///
-/// The message reaches ClusterInstance status and the pool's
-/// `lastFailureReason`, which is surfaced to lease clients — so an unbounded
-/// helm dump would bloat those objects on every failed attempt.
+/// The message reaches `ClusterInstance.status.message`, which is rewritten on
+/// every failed attempt, so an unbounded helm dump would bloat that object.
+///
+/// It does NOT reach the pool's `lastFailureReason`: `reconcile_profile` builds
+/// that string from pool-level counters and only cites a member's message when
+/// the instance controller stamped a `crash_message`, which a provisioning
+/// failure never sets. Lease clients therefore still see the generic
+/// "N instance(s) not reaching Ready" text — improving that is a separate
+/// change to the pool controller, not something this cap implies.
+///
+/// The cap bounds what is STORED and LOGGED, not what is buffered: `.output()`
+/// reads helm's stderr in full before this applies. That is acceptable here
+/// because helm is a trusted local binary whose diagnostics are small; it is
+/// not a defence against a hostile subprocess.
 const HELM_STDERR_LIMIT: usize = 800;
+
+/// Trim and cap helm stderr for embedding in a message, on a char boundary.
+fn clip_helm_stderr(raw: &[u8]) -> String {
+    let text = String::from_utf8_lossy(raw);
+    let text = text.trim();
+    if text.len() <= HELM_STDERR_LIMIT {
+        return text.to_string();
+    }
+    let mut end = HELM_STDERR_LIMIT;
+    while end > 0 && !text.is_char_boundary(end) {
+        end -= 1;
+    }
+    format!("{} […truncated]", &text[..end])
+}
 
 /// Build the error for a failed helm invocation, including what helm wrote to
 /// stderr.
@@ -210,21 +235,9 @@ fn helm_command_error(what: &str, output: &std::process::Output) -> anyhow::Erro
         .code()
         .map(|c| c.to_string())
         .unwrap_or_else(|| "signal".to_string());
-    let stderr = String::from_utf8_lossy(&output.stderr);
-    let stderr = stderr.trim();
+    let stderr = clip_helm_stderr(&output.stderr);
     if stderr.is_empty() {
         return anyhow!("{what} returned non-zero status (exit {code}), with no stderr");
-    }
-    if stderr.len() > HELM_STDERR_LIMIT {
-        // Cut on a char boundary — helm output can carry non-ASCII.
-        let mut end = HELM_STDERR_LIMIT;
-        while end > 0 && !stderr.is_char_boundary(end) {
-            end -= 1;
-        }
-        return anyhow!(
-            "{what} returned non-zero status (exit {code}): {} […truncated]",
-            &stderr[..end]
-        );
     }
     anyhow!("{what} returned non-zero status (exit {code}): {stderr}")
 }
@@ -353,7 +366,7 @@ impl VclusterBackend {
         // genuine failure here is otherwise invisible until `update` fails.
         if !output.status.success() {
             debug!(
-                stderr = %String::from_utf8_lossy(&output.stderr).trim(),
+                stderr = %clip_helm_stderr(&output.stderr),
                 "helm repo add returned non-zero (likely already registered); continuing"
             );
         }

--- a/src/backend/vcluster.rs
+++ b/src/backend/vcluster.rs
@@ -208,6 +208,18 @@ const HELM_REPO_ALIAS: &str = "kobe-loft-sh";
 /// not a defence against a hostile subprocess.
 const HELM_STDERR_LIMIT: usize = 800;
 
+/// Describe how a process ended, without asserting an exit code it may not have.
+///
+/// A signalled process has no `code()`, so calling that case "exit signal" — or
+/// worse, folding it into "returned non-zero status" — states something untrue
+/// about how helm terminated.
+fn exit_description(status: &std::process::ExitStatus) -> String {
+    match status.code() {
+        Some(code) => format!("exited with status {code}"),
+        None => "terminated by signal".to_string(),
+    }
+}
+
 /// Trim and cap helm stderr for embedding in a message, on a char boundary.
 fn clip_helm_stderr(raw: &[u8]) -> String {
     let text = String::from_utf8_lossy(raw);
@@ -230,16 +242,12 @@ fn clip_helm_stderr(raw: &[u8]) -> String {
 /// from the operator log: a DNS failure, a TLS error and a 404 were
 /// indistinguishable, which is exactly what happened in #92.
 fn helm_command_error(what: &str, output: &std::process::Output) -> anyhow::Error {
-    let code = output
-        .status
-        .code()
-        .map(|c| c.to_string())
-        .unwrap_or_else(|| "signal".to_string());
+    let how = exit_description(&output.status);
     let stderr = clip_helm_stderr(&output.stderr);
     if stderr.is_empty() {
-        return anyhow!("{what} returned non-zero status (exit {code}), with no stderr");
+        return anyhow!("{what} failed ({how}), with no stderr");
     }
-    anyhow!("{what} returned non-zero status (exit {code}): {stderr}")
+    anyhow!("{what} failed ({how}): {stderr}")
 }
 
 /// Helm repository URL for upstream vcluster charts.
@@ -502,11 +510,14 @@ impl ClusterBackend for VclusterBackend {
         // Temp files are removed by `temp_files`' Drop on return (all paths).
 
         if !output.status.success() {
-            let stderr = String::from_utf8_lossy(&output.stderr);
-            let stdout = String::from_utf8_lossy(&output.stdout);
+            // Clip both streams: `helm upgrade --install --wait` can emit a
+            // great deal on failure, and this error is written verbatim to
+            // ClusterInstance.status.message on every failed attempt.
+            let stderr = clip_helm_stderr(&output.stderr);
+            let stdout = clip_helm_stderr(&output.stdout);
             return Err(anyhow!(
-                "helm install for vcluster `{name}` failed: status={:?}\nstdout: {stdout}\nstderr: {stderr}",
-                output.status.code()
+                "helm install for vcluster `{name}` failed ({})\nstdout: {stdout}\nstderr: {stderr}",
+                exit_description(&output.status)
             ));
         }
         info!(cluster = name, "Helm install completed");
@@ -1589,14 +1600,23 @@ mod tests {
         assert!(err.to_string().ends_with("boom"), "{err}");
     }
 
-    /// The message lands in ClusterInstance status and in the pool's
-    /// lastFailureReason, which is surfaced to lease clients. An unbounded
-    /// helm dump there bloats the object on every failed attempt.
+    /// The message is written to ClusterInstance.status.message on every
+    /// failed attempt, so it must not carry an unbounded helm dump. (It does
+    /// NOT reach the pool's lastFailureReason — see HELM_STDERR_LIMIT.)
     #[test]
     fn helm_error_truncates_a_very_long_stderr() {
-        let long = vec![b'x'; 10_000];
+        // Fill with a character that cannot appear in the surrounding message
+        // — 'x' collides with "exited", which made an earlier version of this
+        // assertion count 801.
+        let long = vec![b'Q'; 10_000];
         let msg = helm_command_error("helm repo update", &output_with(&long, 1)).to_string();
-        assert!(msg.len() < 1_200, "message was {} bytes", msg.len());
+        // Pin the actual cap: a `< 1200` bound would still pass if the limit
+        // silently became 1100.
+        assert_eq!(
+            msg.matches('Q').count(),
+            HELM_STDERR_LIMIT,
+            "exactly the cap should survive"
+        );
         assert!(msg.contains("truncated"), "{msg}");
     }
 
@@ -1612,5 +1632,39 @@ mod tests {
         let msg = helm_command_error("helm repo add", &output_with(&[0xff, 0xfe, b'h', b'i'], 1))
             .to_string();
         assert!(msg.contains("hi"), "{msg}");
+    }
+
+    #[test]
+    fn clip_keeps_input_at_exactly_the_cap_untouched() {
+        let exact = vec![b'y'; HELM_STDERR_LIMIT];
+        let out = clip_helm_stderr(&exact);
+        assert_eq!(out.len(), HELM_STDERR_LIMIT);
+        assert!(!out.contains("truncated"), "the cap itself must not clip");
+    }
+
+    /// Cutting at a fixed byte offset would panic or corrupt if the boundary
+    /// lands mid-character. Build stderr whose byte 800 is inside a 3-byte char.
+    #[test]
+    fn clip_cuts_multibyte_stderr_on_a_char_boundary() {
+        let mut raw = vec![b'z'; HELM_STDERR_LIMIT - 1];
+        raw.extend_from_slice("€€€".as_bytes()); // 3 bytes each
+        let out = clip_helm_stderr(&raw);
+        assert!(out.contains("truncated"));
+        assert!(out.is_char_boundary(out.len()));
+        // The partial character must be dropped, not sliced.
+        assert_eq!(out.matches('z').count(), HELM_STDERR_LIMIT - 1);
+    }
+
+    #[test]
+    fn a_signalled_helm_is_not_described_as_having_exited() {
+        use std::os::unix::process::ExitStatusExt;
+        let signalled = std::process::ExitStatus::from_raw(9); // no exit code
+        assert_eq!(signalled.code(), None, "precondition");
+        let desc = exit_description(&signalled);
+        assert_eq!(desc, "terminated by signal");
+        assert!(
+            !desc.contains("exit"),
+            "must not claim an exit status: {desc}"
+        );
     }
 }


### PR DESCRIPTION
Comes out of diagnosing #92.

## The problem

Both helm invocations in `ensure_helm_repo` sent stderr to `Stdio::null()`, and the failure surfaced as exactly one string:

```
Lifecycle error: helm repo update for kobe-loft-sh returned non-zero status
```

A DNS failure, a TLS error, a proxy rejection and a 404 were indistinguishable. The pool then aggregated all of them into `N instance(s) not reaching Ready`.

That is what made #92 undiagnosable from CI artifacts — and it is why I filed that issue with the wrong root cause and had to retract it. The information needed to diagnose it existed and was being deliberately discarded one line before the error was constructed.

## The change

Capture stderr and include it, clipped to 800 bytes on a char boundary. The non-fatal `repo add` path now logs helm's stderr at debug instead of discarding it, through the same clip.

```rust
Err: helm repo update for kobe-loft-sh returned non-zero status (exit 1):
     Error: looks like "https://charts.loft.sh" is not a valid chart repository...
```

## What the cap does and does not do

Stated precisely, because my first draft of this commit overclaimed on both counts and a review caught it:

- It bounds what is **stored and logged**, not what is buffered. `.output()` reads helm's stderr in full before the limit applies. That is acceptable for a trusted local binary with small diagnostics; it is not a defence against a hostile subprocess.
- The detail reaches **`ClusterInstance.status.message` only**. It does *not* reach the pool's `lastFailureReason` — `reconcile_profile` builds that from pool-level counters and cites a member's message only when the instance controller stamped a `crash_message`, which a provisioning failure never sets. Its own comment says the per-instance error "isn't carried in PoolState". Lease clients still see the generic text; improving that is a pool-controller change, not something this implies.

## Tests

5 new, covering: the stderr text is carried; surrounding whitespace is trimmed; a 10 KB stderr is clipped and marked; an empty stderr still reports the exit code; non-UTF-8 stderr does not panic.

Note the clip test builds an already-buffered `Output`, so it verifies the message shape — it cannot and does not verify anything about buffering.

## Follow-ups this does not do

- `helm repo update` still gets no retry, so a single transient network failure burns a whole provisioning attempt out of the pool's budget of 10.
- Pre-pulling or vendoring the loft-sh chart, the way guest images are already preloaded, would remove the network dependency from the provisioning hot path entirely. That is the actual fix for #92; this change makes the failure legible.

Workspace green, clippy `-D warnings` clean.