### PR TITLE
fix(chart,vcluster): give helm a writable home so repo add can work

### DIFF
--- a/charts/kobe/templates/deployment.yaml
+++ b/charts/kobe/templates/deployment.yaml
@@ -74,6 +74,19 @@ spec:
               value: {{ .Values.poolPublisherServiceAccount | default (printf "%s-pool-publisher" (include "kobe.fullname" .)) | quote }}
             - name: KUBECONFIG_PUBLISHER_IMAGE
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
+            # The vcluster backend shells out to `helm`, which writes its
+            # repository list, cache and data under $HOME by default. The
+            # operator runs as uid 65534 with readOnlyRootFilesystem, so that
+            # write fails and `helm repo add` silently registers nothing —
+            # leaving `helm repo update` to report "no repositories found" and
+            # every vcluster provisioning attempt to fail (#92). Point all three
+            # homes at the existing /tmp emptyDir.
+            - name: HELM_CACHE_HOME
+              value: /tmp/helm/cache
+            - name: HELM_CONFIG_HOME
+              value: /tmp/helm/config
+            - name: HELM_DATA_HOME
+              value: /tmp/helm/data
             {{- if .Values.postgres.urlSecret.name }}
             - name: POSTGRES_URL_DIR
               value: {{ .Values.postgres.urlSecret.mountPath | quote }}

--- a/charts/kobe/templates/deployment.yaml
+++ b/charts/kobe/templates/deployment.yaml
@@ -75,12 +75,23 @@ spec:
             - name: KUBECONFIG_PUBLISHER_IMAGE
               value: "{{ .Values.image.repository }}:{{ .Values.image.tag | default (printf "v%s" .Chart.AppVersion) }}"
             # The vcluster backend shells out to `helm`, which writes its
-            # repository list, cache and data under $HOME by default. The
-            # operator runs as uid 65534 with readOnlyRootFilesystem, so that
-            # write fails and `helm repo add` silently registers nothing —
-            # leaving `helm repo update` to report "no repositories found" and
-            # every vcluster provisioning attempt to fail (#92). Point all three
-            # homes at the existing /tmp emptyDir.
+            # repository list and cached indexes under $HOME by default. The
+            # operator runs as uid 65534 with readOnlyRootFilesystem: true and
+            # no HOME, so it has nowhere writable to put them.
+            #
+            # In #92 `helm repo update` reported "no repositories found", which
+            # proves `helm repo add` registered nothing. It does NOT by itself
+            # prove the cause was the unwritable home — a DNS, TLS or proxy
+            # failure in `repo add` produces the same downstream message, and
+            # that stderr was being discarded. The unwritable home is a real
+            # defect regardless, so fix it here; the error-chaining change in
+            # the same commit is what will identify the cause if it recurs.
+            #
+            # These point into the /tmp emptyDir mounted below (fsGroup 65534
+            # makes it writable); helm creates the subdirectories itself.
+            # CONFIG_HOME holds repositories.yaml and CACHE_HOME the indexes —
+            # those two are what this flow needs. DATA_HOME is set for
+            # completeness so nothing else falls back to an unwritable path.
             - name: HELM_CACHE_HOME
               value: /tmp/helm/cache
             - name: HELM_CONFIG_HOME

--- a/src/backend/vcluster.rs
+++ b/src/backend/vcluster.rs
@@ -370,14 +370,21 @@ impl VclusterBackend {
             .await
             .context("failed to spawn `helm repo add`")?;
         // Non-zero is normal if the repo is already registered, so this is not
-        // fatal — but log what helm said rather than discarding it, since a
-        // genuine failure here is otherwise invisible until `update` fails.
-        if !output.status.success() {
+        // fatal on its own — but keep what helm said. If `update` then fails,
+        // this is very often the real cause and the update error alone points
+        // at the wrong command: in #92 `add` could not write its repository
+        // list, so `update` truthfully reported "no repositories found" while
+        // the actionable failure had already been discarded here.
+        let add_failure = if output.status.success() {
+            None
+        } else {
+            let stderr = clip_helm_stderr(&output.stderr);
             debug!(
-                stderr = %clip_helm_stderr(&output.stderr),
-                "helm repo add returned non-zero (likely already registered); continuing"
+                stderr = %stderr,
+                "helm repo add returned non-zero (may just be already registered); continuing"
             );
-        }
+            Some(stderr)
+        };
         let output = Command::new("helm")
             .args(["repo", "update", HELM_REPO_ALIAS])
             .stdout(Stdio::null())
@@ -386,10 +393,12 @@ impl VclusterBackend {
             .await
             .context("failed to spawn `helm repo update`")?;
         if !output.status.success() {
-            return Err(helm_command_error(
-                &format!("helm repo update for {HELM_REPO_ALIAS}"),
-                &output,
-            ));
+            let err =
+                helm_command_error(&format!("helm repo update for {HELM_REPO_ALIAS}"), &output);
+            return Err(match add_failure {
+                Some(add) => err.context(format!("`helm repo add` had already failed: {add}")),
+                None => err,
+            });
         }
         Ok(())
     }


### PR DESCRIPTION
Addresses #92.

## What is established

The conformance dispatch after #99 merged produced the first legible version of this failure:

```
helm repo update for kobe-loft-sh failed (exited with status 1):
  Error: no repositories found. You must add one before updating
```

That proves one thing: **`helm repo add` ran on the line above and registered nothing.** It reproduces identically across every attempt in [run 31514605857](https://github.com/kunobi-ninja/kobe/actions/runs/31514605857) (`pool-e2e-vcluster-8`, `-9`, `-10`), which is consistent with a deterministic cause rather than the transient network fault I originally claimed in #92.

## What is NOT established

**Why `repo add` failed.** A cross-family review correctly pushed back on my first draft of this PR, which asserted the unwritable helm home as proven fact. It isn't. DNS, TLS, a proxy, or a bad URL in `repo add` would all produce the same downstream "no repositories found" — and that stderr was being discarded, which is exactly why the cause can't be established retrospectively.

So this PR fixes a real defect and adds the instrumentation that will identify the cause if it recurs. It does not claim to have proven the mechanism.

## The defect being fixed

The operator runs with:

```yaml
runAsUser: 65534
readOnlyRootFilesystem: true
```

and no `HELM_*` environment and no `HOME`. helm writes `repositories.yaml` under its config home and repository indexes under its cache home, so it has nowhere writable to put either. That is a genuine bug whether or not it caused #92.

**Chart** — point helm's homes into the `/tmp` emptyDir already mounted (`fsGroup: 65534` makes it writable; helm creates the subdirectories):

```yaml
- name: HELM_CACHE_HOME
  value: /tmp/helm/cache
- name: HELM_CONFIG_HOME
  value: /tmp/helm/config
- name: HELM_DATA_HOME
  value: /tmp/helm/data
```

`CONFIG_HOME` holds `repositories.yaml` and `CACHE_HOME` the indexes — those two are what this flow needs. `DATA_HOME` is set for completeness. Verified against the pinned helm **3.20.2** (`docker/operator.Dockerfile`).

**Backend** — carry the `repo add` stderr into the error when `repo update` subsequently fails:

```
helm repo update for kobe-loft-sh failed (exited with status 1): ...
  Caused by: `helm repo add` had already failed: <what helm actually said>
```

To be precise about the scope: the add stderr was *already* logged at debug. What changes is that it now travels in the returned error, which `instance.rs` renders with `{e:#}` into `ClusterInstance.status.message`. If `repo add` fails but `repo update` succeeds, it remains debug-only — normally benign (an already-present alias), but worth stating.

## Why this took three attempts to diagnose

`ensure_helm_repo` treated a non-zero `repo add` as "likely already registered" and continued, on the stated assumption that `repo update` would "fail downstream with a clearer message". It does fail — but the message names the wrong command. So this was first reported as a pool-accounting problem, then misdiagnosed by me as a network failure.

Same class as #99, one layer down: the information needed to diagnose it was being produced and thrown away.

Workspace green, clippy `-D warnings` clean.