### PR TITLE
chore: bump kobe to v0.39.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.38.0"
+version = "0.39.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.38.0"
+version = "0.39.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.38.0
-appVersion: "0.38.0"
+version: 0.39.0
+appVersion: "0.39.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.38.0
+      image: docker.io/zondax/kobe-operator:v0.39.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.38.0
+      image: docker.io/zondax/kobe-sync:v0.39.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
## Summary
Bumps the kobe workspace + chart version to **v0.39.0**.

`[workspace.package].version` (inherited by `kobe-operator` and `kobectl`), `charts/kobe/Chart.yaml` `version`/`appVersion`, the Artifact Hub `images` annotations, and `Cargo.lock`. `./scripts/check-version-consistency.sh` passes.

## What ships in 0.39.0
Ten commits since v0.38.0, all fixes/hardening:

- `fix(connect-proxy)`: count upgrade failures and say why a request failed (#108, closes #106 + #107)
- `fix(datastore)`: give each cluster its own PostgreSQL role (#105)
- `fix(chart,vcluster)`: give helm a writable home so `repo add` can work (#104)
- `fix(vcluster)`: carry helm's stderr into the provisioning error (#99)
- `fix(kobectl)`: purge left files on disk with their tracking already dropped (#98)
- `fix(reaper)`: stop counting skipped entries as cleaned (#97)
- `fix(kobectl)`: purge must not abandon the batch on one unremovable file (#95)
- `fix(aur)`: publish a real pkgver for the -git package (#94)
- `fix(kobe-sync)`: stop at the authority when probing the virtual apiserver (#91)
- `harden(lease)`: UID-fence ClusterLease↔ClusterInstance binding (#90)

## Release plan
- Squash after CI is green.
- From synced `main`, run `just release` (creates + pushes the signed `v0.39.0` tag).
- Monitor `CI` on the tag, `Publish crate`, `Package Publish`, and the Homebrew / Scoop / AUR / Chocolatey fan-out.

## Known issue, not a blocker
Chocolatey publishing 403s for the `kobe` package id and has never succeeded (v0.37.0 and v0.38.0 both failed the same way); `kunobi` pushes fine with the same API key. Needs a Chocolatey account-side fix, tracked separately.