### PR TITLE
ci(release): call the in-org mirror of _release-rust.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -392,7 +392,19 @@ jobs:
   release-cli:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [checks, version-consistency]
-    uses: zondax/_workflows/.github/workflows/_release-rust.yml@v11
+    # IN-ORG MIRROR of zondax/_workflows@7f61511 (v11) — a byte-identical import;
+    # the tag `v11` resolved to that same content, so this is a no-op for kobe.
+    #
+    # It exists because a runner group's workflow allowlist matches the workflow
+    # a job is DEFINED in (not the caller), and an org-owned group cannot name a
+    # workflow from another org. While kache pointed at `zondax/`, its macOS
+    # signing jobs could not be authorized by any allowlist entry and queued
+    # forever against idle runners with no error. kobe does not use those
+    # runners today, but it shares this workflow — moving both keeps the two
+    # release paths identical and lets kobe adopt signing later without a
+    # second migration. See kunobi-ninja/_workflows for the rationale and the
+    # maintenance contract (the pin and the allowlist must move together).
+    uses: kunobi-ninja/_workflows/.github/workflows/_release-rust.yml@ee8dc66895f75bf79c8fa4c87e06aaeb752e7db5 # v1
     with:
       binary_name: kobe
       build_args: -p kobectl --bin kobe


### PR DESCRIPTION
## Why

Companion to [kunobi-ninja/kache#745](https://github.com/kunobi-ninja/kache/pull/745). kobe and kache share `_release-rust.yml`.

A self-hosted runner group's workflow allowlist matches the workflow a job is **defined in**, not the caller, and an org-owned group **cannot name a workflow from another org**. While kache pointed at `zondax/_workflows`, its macOS signing jobs were therefore unauthorizable by any possible allowlist entry — they queued for over two hours against online, idle runners with no error anywhere, and v0.14.0 only shipped by disabling the restriction.

## What

Repoint at [`kunobi-ninja/_workflows`](https://github.com/kunobi-ninja/_workflows), a byte-identical mirror, pinned to SHA `ee8dc66`.

## Why kobe, when kobe doesn't use those runners

kobe's Darwin builds run on GitHub-hosted runners — I checked every workflow here and none request the `mac-mini` label, so **this changes nothing operationally for kobe today**. It's included so both products' release paths stay identical rather than silently diverging, and so kobe can adopt signing later without repeating this migration.

If you'd rather kobe stayed on the upstream Zondax workflow, this PR can simply be closed — kache#745 stands alone.

## Risk

**No behaviour change.** kobe pinned tag `v11`, which resolves to commit `7f61511`; the mirror imports that commit verbatim (696 lines, `diff` clean against both).

## Ongoing cost

This forks kobe off the shared Zondax workflow, so upstream fixes need deliberate porting. The mirror's README records the maintenance contract — including that the caller pin and the `signing-runners` allowlist entry must move together, or releases break silently.