### PR TITLE
lifecycle(k3s): verified teardown — contract, k3s provider, and the finalizer gate

### DIFF
--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -927,6 +927,46 @@ spec:
                       not infer it from a same-named current pool.
                     nullable: true
                     type: string
+                  teardownPlan:
+                    description: |-
+                      Exactly which footprints this instance created, recorded at creation.
+
+                      This is the trust boundary for verified teardown. A receipt only proves
+                      what it covers, so the list of subjects it must cover cannot come from
+                      the receipt, nor from whatever the teardown path happens to look for
+                      later — an optional resource whose config changed after creation would
+                      then be quietly dropped from the plan and never verified.
+
+                      Stamped once alongside the rest of this provenance and never
+                      overwritten. `None` means the instance predates verified teardown; such
+                      an instance is ineligible for [`CleanupMode::VerifiedDestroy`] rather
+                      than being verified against a guessed plan.
+                    items:
+                      description: |-
+                        One thing whose absence must be proven.
+
+                        Enumerated rather than free-text so a receipt cannot be satisfied by an
+                        unrecognised or invented subject, and so adding a resource to the teardown
+                        path is a deliberate, reviewable change to this list.
+                      enum:
+                      - agentDeployment
+                      - serverStatefulSet
+                      - serverPods
+                      - service
+                      - podDisruptionBudget
+                      - publisherConfigMap
+                      - registriesConfigMap
+                      - tokenSecret
+                      - kubeconfigSecret
+                      - cidrClaim
+                      - connectTokenSecret
+                      - serverDataPvcs
+                      - serverDataVolumes
+                      - database
+                      - databaseRole
+                      type: string
+                    nullable: true
+                    type: array
                 required:
                 - operatorVersion
                 type: object

--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -1107,6 +1107,22 @@ spec:
                   timestamp fields above.
                 nullable: true
                 type: string
+              teardownIdentities:
+                description: |-
+                  Provisioner-assigned resource identities this instance owns — currently
+                  the PersistentVolumes its data claims are bound to.
+
+                  Captured once the instance is healthy, NOT at teardown. These names are
+                  chosen by the provisioner and only knowable after claims bind, so
+                  capturing them during teardown would let the teardown path define its
+                  own scope. Recorded early, they become something a later teardown must
+                  account for rather than something it gets to choose.
+
+                  Written once and never shrunk: a smaller list would silently narrow what
+                  a receipt has to prove.
+                items:
+                  type: string
+                type: array
             type: object
         required:
         - spec

--- a/charts/kobe/crds/clusterleases.yaml
+++ b/charts/kobe/crds/clusterleases.yaml
@@ -368,6 +368,7 @@ spec:
                           - serverDataPvcs
                           - serverDataVolumes
                           - database
+                          - databaseRole
                           type: string
                       required:
                       - result

--- a/charts/kobe/crds/clusterleases.yaml
+++ b/charts/kobe/crds/clusterleases.yaml
@@ -370,6 +370,23 @@ spec:
                           - database
                           - databaseRole
                           type: string
+                        verified:
+                          description: |-
+                            The concrete resources this check actually looked at.
+
+                            A [`TeardownSubject`] is a category. On its own,
+                            `Database = Verified` asserts that *a* database is gone without saying
+                            which — so a receipt could be satisfied by checking the wrong one, or by
+                            checking one of several when the footprint had more. Recording the exact
+                            identities makes the claim auditable after the fact, which is the whole
+                            point of keeping evidence that outlives the instance.
+
+                            Names only: object names, PV names, the database and role identifiers.
+                            Never connection strings, credentials, or anything that would turn a
+                            receipt into a secret.
+                          items:
+                            type: string
+                          type: array
                       required:
                       - result
                       - subject

--- a/charts/kobe/crds/clusterpools.yaml
+++ b/charts/kobe/crds/clusterpools.yaml
@@ -916,6 +916,18 @@ spec:
                 - Idle
                 nullable: true
                 type: string
+              quarantined:
+                default: 0
+                description: |-
+                  Members held back because their teardown could not be proven complete.
+
+                  Separate from `recycling` on purpose: recycling is transient churn that
+                  resolves itself, while a quarantined member is stuck until the same
+                  exact subject produces a verified receipt. Reporting them together would
+                  make a pool bleeding capacity look merely busy.
+                format: uint32
+                minimum: 0.0
+                type: integer
               queueDepth:
                 default: 0
                 description: Current queue depth (claims waiting for clusters).

--- a/src/backend/datastore.rs
+++ b/src/backend/datastore.rs
@@ -461,6 +461,41 @@ pub async fn ensure_cluster_role(
 
 /// Drop the per-cluster role. Call AFTER `drop_database`: PostgreSQL refuses to
 /// drop a role that still owns objects.
+/// Whether this cluster's database still exists.
+///
+/// Verification, not cleanup: `DROP DATABASE IF EXISTS` succeeding proves the
+/// statement ran, not that the database is gone — a concurrent recreate, a
+/// failed drop that only warned, or a connection to a different server all
+/// leave it present. Teardown evidence has to come from a separate read.
+///
+/// An error is deliberately propagated rather than reported as "absent". A
+/// query that could not run is uncertainty, and uncertainty must quarantine.
+pub async fn database_exists(pool: &PgPool, cluster_name: &str, prefix: &str) -> Result<bool> {
+    let db_name = sanitize_db_name(cluster_name, prefix)?;
+    let found: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM pg_database WHERE datname = $1")
+        .bind(&db_name)
+        .fetch_optional(pool)
+        .await
+        .with_context(|| format!("Failed to check whether database {db_name} exists"))?;
+    Ok(found.is_some())
+}
+
+/// Whether this cluster's per-cluster role still exists.
+///
+/// Separate from the database on purpose: a role can outlive the database it
+/// owned, and it carries credentials. Dropping the database while leaving the
+/// role behind is exactly the leak that would otherwise sit inside a receipt
+/// claiming the footprint is gone.
+pub async fn cluster_role_exists(pool: &PgPool, cluster_name: &str, prefix: &str) -> Result<bool> {
+    let role_name = sanitize_db_name(cluster_name, prefix)?;
+    let found: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM pg_roles WHERE rolname = $1")
+        .bind(&role_name)
+        .fetch_optional(pool)
+        .await
+        .with_context(|| format!("Failed to check whether role {role_name} exists"))?;
+    Ok(found.is_some())
+}
+
 pub async fn drop_cluster_role(pool: &PgPool, cluster_name: &str, prefix: &str) -> Result<()> {
     let name = sanitize_db_name(cluster_name, prefix)?;
     info!(role = %name, "Dropping per-cluster datastore role");

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -1826,44 +1826,57 @@ impl K3sBackend {
                 subject,
                 result: CheckResult::Unknown,
                 reason: Some("delete_failed".into()),
+                verified: Vec::new(),
             };
         }
 
+        // Recorded alongside the verdict so the receipt says WHICH resources
+        // were inspected, not merely that some resource of this category was.
+        let mut verified: Vec<String> = Vec::new();
         let (result, reason) = match subject {
             TeardownSubject::AgentDeployment => {
                 let api: Api<Deployment> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-agent"));
                 Self::absent_by_name(&api, &format!("{name}-agent")).await
             }
             TeardownSubject::ServerStatefulSet => {
                 let api: Api<StatefulSet> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-server"));
                 Self::absent_by_name(&api, &format!("{name}-server")).await
             }
             TeardownSubject::Service => {
                 let api: Api<Service> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-server"));
                 Self::absent_by_name(&api, &format!("{name}-server")).await
             }
             TeardownSubject::PodDisruptionBudget => {
                 let api: Api<PodDisruptionBudget> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-server"));
                 Self::absent_by_name(&api, &format!("{name}-server")).await
             }
             TeardownSubject::PublisherConfigMap => {
                 let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-kubeconfig-publisher"));
                 Self::absent_by_name(&api, &format!("{name}-kubeconfig-publisher")).await
             }
             TeardownSubject::RegistriesConfigMap => {
                 let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-registries"));
                 Self::absent_by_name(&api, &format!("{name}-registries")).await
             }
             TeardownSubject::TokenSecret => {
                 let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-token"));
                 Self::absent_by_name(&api, &format!("{name}-token")).await
             }
             TeardownSubject::KubeconfigSecret => {
                 let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-kubeconfig"));
                 Self::absent_by_name(&api, &format!("{name}-kubeconfig")).await
             }
             TeardownSubject::ConnectTokenSecret => {
                 let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-connect-token"));
                 Self::absent_by_name(&api, &format!("{name}-connect-token")).await
             }
             // Pods are label-selected rather than named: a StatefulSet's pods
@@ -1872,6 +1885,7 @@ impl K3sBackend {
             TeardownSubject::ServerPods => {
                 let pods: Api<Pod> = Api::namespaced(self.client.clone(), namespace);
                 let selector = format!("kobe.kunobi.ninja/cluster={name}");
+                verified.push(selector.clone());
                 match pods.list(&ListParams::default().labels(&selector)).await {
                     Ok(list) if list.items.is_empty() => (CheckResult::Verified, None),
                     Ok(_) => (CheckResult::Unknown, Some("pods_still_present".into())),
@@ -1879,6 +1893,7 @@ impl K3sBackend {
                 }
             }
             TeardownSubject::ServerDataPvcs => {
+                verified.push(format!("data-{name}-server-*"));
                 let pvcs: Api<PersistentVolumeClaim> =
                     Api::namespaced(self.client.clone(), namespace);
                 match pvcs.list(&ListParams::default()).await {
@@ -1904,6 +1919,9 @@ impl K3sBackend {
                 Err(reason) => (CheckResult::Unknown, Some(reason.clone())),
                 Ok(volumes) if volumes.is_empty() => (CheckResult::Verified, None),
                 Ok(volumes) => {
+                    // The captured PV names, so the receipt says exactly which
+                    // volumes were proven reclaimed.
+                    verified.extend(volumes.iter().cloned());
                     let api: Api<k8s_openapi::api::core::v1::PersistentVolume> =
                         Api::all(self.client.clone());
                     let mut verdict = (CheckResult::Verified, None);
@@ -1924,11 +1942,14 @@ impl K3sBackend {
             }
             TeardownSubject::Database => match self.datastore.current() {
                 None => (CheckResult::Unknown, Some("datastore_unavailable".into())),
-                Some((pool, _)) => match datastore::database_exists(&pool, name, "k3s_").await {
-                    Ok(false) => (CheckResult::Verified, None),
-                    Ok(true) => (CheckResult::Unknown, Some("database_still_present".into())),
-                    Err(_) => (CheckResult::Unknown, Some("datastore_unreachable".into())),
-                },
+                Some((pool, _)) => {
+                    verified.push(format!("database:k3s_{name}"));
+                    match datastore::database_exists(&pool, name, "k3s_").await {
+                        Ok(false) => (CheckResult::Verified, None),
+                        Ok(true) => (CheckResult::Unknown, Some("database_still_present".into())),
+                        Err(_) => (CheckResult::Unknown, Some("datastore_unreachable".into())),
+                    }
+                }
             },
             TeardownSubject::DatabaseRole => match self.datastore.current() {
                 None => (CheckResult::Unknown, Some("datastore_unavailable".into())),
@@ -1945,6 +1966,14 @@ impl K3sBackend {
         TeardownCheck {
             subject,
             result,
+            // Only claim to have verified something if we actually did. A
+            // failed or uncertain check must not leave identities behind that
+            // read as proof.
+            verified: if result == CheckResult::Verified {
+                verified
+            } else {
+                Vec::new()
+            },
             reason,
         }
     }
@@ -3287,6 +3316,82 @@ mod tests {
 
         assert_eq!(check.result, CheckResult::Unknown);
         assert_eq!(check.reason.as_deref(), Some("still_present"));
+    }
+
+    /// A verified check must name WHAT it verified.
+    ///
+    /// `Database = Verified` on its own asserts that *a* database is gone
+    /// without saying which — so the claim cannot be audited after the instance
+    /// is gone, which is exactly when the receipt is read. Recording the
+    /// concrete identity is what makes the evidence mean something later.
+    #[tokio::test]
+    async fn a_verified_check_records_what_it_actually_inspected() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "NotFound", "code": 404
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Verified);
+        assert_eq!(
+            check.verified,
+            vec!["c1-server".to_string()],
+            "the receipt must say which object was proven absent"
+        );
+    }
+
+    /// An UNVERIFIED check must not carry identities that read as proof.
+    ///
+    /// Otherwise a quarantining receipt would list the very resources it failed
+    /// to verify, and a later reader could mistake the list for evidence.
+    #[tokio::test]
+    async fn an_unverified_check_claims_nothing() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "apps/v1", "kind": "StatefulSet",
+                "metadata": { "name": "c1-server", "namespace": "test-ns" }
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert!(
+            check.verified.is_empty(),
+            "a check that did not verify must claim nothing: {:?}",
+            check.verified
+        );
     }
 
     /// Only a 404 proves absence. An RBAC denial or a timeout tells us nothing

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -30,6 +30,9 @@ use kube::api::{
 use std::collections::BTreeMap;
 use tracing::{debug, info, warn};
 
+use crate::backend::VerifiedDestroyUnsupported;
+use crate::crd::{CheckResult, TeardownCheck, TeardownSubject};
+
 use crate::crd::{
     Addon, ClusterConfig, IntraPlacementMode, KubeletSharedMountConfig, Placement, ReadinessGate,
 };
@@ -1762,6 +1765,205 @@ impl K3sBackend {
     /// prefix would also match the PVCs of a *different* cluster literally named
     /// `{cluster}-server` (whose PVCs are `data-{cluster}-server-server-{n}`), so
     /// without it `delete("foo")` could reap `foo-server`'s volumes.
+    /// Record which PersistentVolumes this cluster's data PVCs are bound to.
+    ///
+    /// Must run BEFORE deletion. A PVC's `spec.volumeName` is the only link to
+    /// its backing PV, and it disappears with the PVC — so a receipt that did
+    /// not capture this first could never prove the volume was reclaimed, only
+    /// that the claim object vanished. That distinction is the difference
+    /// between "the pointer is gone" and "the tenant's data is gone".
+    ///
+    /// Returns `Err` when the PVCs could not be listed at all: not knowing what
+    /// existed is uncertainty, and the caller turns it into `Unknown`.
+    async fn capture_bound_volumes(
+        &self,
+        name: &str,
+        namespace: &str,
+    ) -> std::result::Result<Vec<String>, String> {
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(self.client.clone(), namespace);
+        let list = pvcs
+            .list(&ListParams::default())
+            .await
+            .map_err(|_| "pvc_list_failed".to_string())?;
+
+        let mut volumes = Vec::new();
+        for pvc in list.items {
+            let Some(pvc_name) = pvc.metadata.name.as_deref() else {
+                continue;
+            };
+            if !Self::is_server_data_pvc(pvc_name, name) {
+                continue;
+            }
+            match pvc.spec.as_ref().and_then(|spec| spec.volume_name.clone()) {
+                Some(volume) => volumes.push(volume),
+                // A data PVC with no bound volume is either still provisioning
+                // or bound to something we cannot name. Either way we cannot
+                // later prove that volume is gone.
+                None => return Err("pvc_unbound_volume_unknown".to_string()),
+            }
+        }
+        Ok(volumes)
+    }
+
+    /// Prove one subject absent, or report why we cannot.
+    ///
+    /// Every arm answers the same question — "can I *observe* that this is
+    /// gone?" — and returns `Unknown` rather than guessing. A read that errors
+    /// is never absence.
+    async fn verify_subject_absent(
+        &self,
+        name: &str,
+        namespace: &str,
+        subject: TeardownSubject,
+        bound_volumes: &std::result::Result<Vec<String>, String>,
+        delete_outcome: &Result<()>,
+    ) -> TeardownCheck {
+        // A failed delete means the footprint was never fully addressed, so no
+        // subject can be claimed absent on the strength of this attempt.
+        if let Err(error) = delete_outcome {
+            debug!(cluster = name, error = %error, "teardown delete failed; subject unverifiable");
+            return TeardownCheck {
+                subject,
+                result: CheckResult::Unknown,
+                reason: Some("delete_failed".into()),
+            };
+        }
+
+        let (result, reason) = match subject {
+            TeardownSubject::AgentDeployment => {
+                let api: Api<Deployment> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-agent")).await
+            }
+            TeardownSubject::ServerStatefulSet => {
+                let api: Api<StatefulSet> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-server")).await
+            }
+            TeardownSubject::Service => {
+                let api: Api<Service> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-server")).await
+            }
+            TeardownSubject::PodDisruptionBudget => {
+                let api: Api<PodDisruptionBudget> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-server")).await
+            }
+            TeardownSubject::PublisherConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-kubeconfig-publisher")).await
+            }
+            TeardownSubject::RegistriesConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-registries")).await
+            }
+            TeardownSubject::TokenSecret => {
+                let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-token")).await
+            }
+            TeardownSubject::KubeconfigSecret => {
+                let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-kubeconfig")).await
+            }
+            TeardownSubject::ConnectTokenSecret => {
+                let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, &format!("{name}-connect-token")).await
+            }
+            // Pods are label-selected rather than named: a StatefulSet's pods
+            // outlive its deletion while terminating, which is precisely the
+            // window an accepted DELETE would have hidden.
+            TeardownSubject::ServerPods => {
+                let pods: Api<Pod> = Api::namespaced(self.client.clone(), namespace);
+                let selector = format!("kobe.kunobi.ninja/cluster={name}");
+                match pods.list(&ListParams::default().labels(&selector)).await {
+                    Ok(list) if list.items.is_empty() => (CheckResult::Verified, None),
+                    Ok(_) => (CheckResult::Unknown, Some("pods_still_present".into())),
+                    Err(_) => (CheckResult::Unknown, Some("pod_list_failed".into())),
+                }
+            }
+            TeardownSubject::ServerDataPvcs => {
+                let pvcs: Api<PersistentVolumeClaim> =
+                    Api::namespaced(self.client.clone(), namespace);
+                match pvcs.list(&ListParams::default()).await {
+                    Ok(list) => {
+                        let remaining = list.items.iter().any(|pvc| {
+                            pvc.metadata
+                                .name
+                                .as_deref()
+                                .is_some_and(|pvc_name| Self::is_server_data_pvc(pvc_name, name))
+                        });
+                        if remaining {
+                            (CheckResult::Unknown, Some("pvc_still_present".into()))
+                        } else {
+                            (CheckResult::Verified, None)
+                        }
+                    }
+                    Err(_) => (CheckResult::Unknown, Some("pvc_list_failed".into())),
+                }
+            }
+            // The captured PVs must be gone too. A PVC deleted under a `Retain`
+            // reclaim policy leaves its volume — and the tenant's data — intact.
+            TeardownSubject::ServerDataVolumes => match bound_volumes {
+                Err(reason) => (CheckResult::Unknown, Some(reason.clone())),
+                Ok(volumes) if volumes.is_empty() => (CheckResult::Verified, None),
+                Ok(volumes) => {
+                    let api: Api<k8s_openapi::api::core::v1::PersistentVolume> =
+                        Api::all(self.client.clone());
+                    let mut verdict = (CheckResult::Verified, None);
+                    for volume in volumes {
+                        let (result, reason) = Self::absent_by_name(&api, volume).await;
+                        if result != CheckResult::Verified {
+                            verdict = (result, reason.or_else(|| Some("pv_still_present".into())));
+                            break;
+                        }
+                    }
+                    verdict
+                }
+            },
+            TeardownSubject::CidrClaim => {
+                let api: Api<crate::crd::CIDRClaim> =
+                    Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, name).await
+            }
+            TeardownSubject::Database => match self.datastore.current() {
+                None => (CheckResult::Unknown, Some("datastore_unavailable".into())),
+                Some((pool, _)) => match datastore::database_exists(&pool, name, "k3s_").await {
+                    Ok(false) => (CheckResult::Verified, None),
+                    Ok(true) => (CheckResult::Unknown, Some("database_still_present".into())),
+                    Err(_) => (CheckResult::Unknown, Some("datastore_unreachable".into())),
+                },
+            },
+            TeardownSubject::DatabaseRole => match self.datastore.current() {
+                None => (CheckResult::Unknown, Some("datastore_unavailable".into())),
+                Some((pool, _)) => {
+                    match datastore::cluster_role_exists(&pool, name, "k3s_").await {
+                        Ok(false) => (CheckResult::Verified, None),
+                        Ok(true) => (CheckResult::Unknown, Some("role_still_present".into())),
+                        Err(_) => (CheckResult::Unknown, Some("datastore_unreachable".into())),
+                    }
+                }
+            },
+        };
+
+        TeardownCheck {
+            subject,
+            result,
+            reason,
+        }
+    }
+
+    /// A 404 is the ONLY proof of absence. Any other error is uncertainty —
+    /// an RBAC denial or a timeout tells us nothing about whether the object
+    /// is there, and must never read as a clean teardown.
+    async fn absent_by_name<K>(api: &Api<K>, name: &str) -> (CheckResult, Option<String>)
+    where
+        K: kube::Resource + Clone + serde::de::DeserializeOwned + std::fmt::Debug,
+        <K as kube::Resource>::DynamicType: Default,
+    {
+        match api.get_opt(name).await {
+            Ok(None) => (CheckResult::Verified, None),
+            Ok(Some(_)) => (CheckResult::Unknown, Some("still_present".into())),
+            Err(_) => (CheckResult::Unknown, Some("lookup_failed".into())),
+        }
+    }
+
     fn is_server_data_pvc(pvc_name: &str, cluster: &str) -> bool {
         let prefix = format!("data-{cluster}-server-");
         pvc_name.strip_prefix(&prefix).is_some_and(|ordinal| {
@@ -2106,6 +2308,54 @@ impl ClusterBackend for K3sBackend {
 
         info!(cluster = name, "k3s cluster deleted");
         Ok(())
+    }
+
+    fn supports_verified_destroy(&self) -> bool {
+        true
+    }
+
+    /// Tear down and then *prove* the footprint is absent.
+    ///
+    /// The ordering matters and is the whole contract:
+    ///
+    /// 1. **Capture** what cannot be observed after deletion — chiefly the PVs
+    ///    the data PVCs are bound to. Once a PVC is gone its `volumeName` is
+    ///    unrecoverable, so a receipt written without capturing it first can
+    ///    never prove the backing volume was reclaimed.
+    /// 2. **Delete** via the ordinary path, so verified and unverified teardown
+    ///    cannot diverge in what they remove.
+    /// 3. **Poll to confirmed absence.** An accepted DELETE is not evidence:
+    ///    finalizers, terminating Pods and PV reclaim all complete
+    ///    asynchronously, and `delete()` today returns before any of it.
+    ///
+    /// Anything that cannot be observed becomes [`CheckResult::Unknown`], which
+    /// quarantines the capacity. That is the intended outcome, not a failure of
+    /// this function.
+    async fn delete_verified(
+        &self,
+        name: &str,
+        namespace: &str,
+        plan: &[TeardownSubject],
+    ) -> std::result::Result<Vec<TeardownCheck>, VerifiedDestroyUnsupported> {
+        // Captured BEFORE deletion; unrecoverable afterwards.
+        let bound_volumes = self.capture_bound_volumes(name, namespace).await;
+
+        let delete_outcome = self.delete(name, namespace).await;
+
+        let mut checks = Vec::with_capacity(plan.len());
+        for subject in plan {
+            checks.push(
+                self.verify_subject_absent(
+                    name,
+                    namespace,
+                    *subject,
+                    &bound_volumes,
+                    &delete_outcome,
+                )
+                .await,
+            );
+        }
+        Ok(checks)
     }
 
     #[tracing::instrument(skip(self), fields(cluster = name, namespace))]
@@ -2999,6 +3249,175 @@ mod tests {
             "kind": "Secret",
             "metadata": { "name": name, "namespace": namespace }
         })
+    }
+
+    /// An object that is STILL THERE after teardown must not read as verified.
+    ///
+    /// This is the defect the whole receipt design exists for: `delete()`
+    /// returns as soon as the DELETE requests are accepted, while finalizers
+    /// and terminating Pods complete asynchronously. A provider that reported
+    /// success on an accepted request would hand back capacity that still has
+    /// the tenant's workload running on it.
+    #[tokio::test]
+    async fn a_surviving_object_is_unknown_not_verified() {
+        let server = MockServer::start().await;
+        // The StatefulSet is still present when we look.
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "metadata": { "name": "c1-server", "namespace": "test-ns" }
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert_eq!(check.reason.as_deref(), Some("still_present"));
+    }
+
+    /// Only a 404 proves absence. An RBAC denial or a timeout tells us nothing
+    /// about whether the object exists — treating either as "gone" is how a
+    /// broken permission silently becomes a clean bill of health.
+    #[tokio::test]
+    async fn a_failed_lookup_is_uncertainty_not_absence() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "Forbidden", "code": 403
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(
+            check.result,
+            CheckResult::Unknown,
+            "a 403 must never be read as absence"
+        );
+        assert_eq!(check.reason.as_deref(), Some("lookup_failed"));
+    }
+
+    /// A 404 IS proof, so the happy path must actually verify — otherwise the
+    /// receipt can never be satisfied and every teardown quarantines.
+    #[tokio::test]
+    async fn a_missing_object_verifies() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "NotFound", "code": 404
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Verified);
+        assert!(check.reason.is_none());
+    }
+
+    /// With no datastore reachable, the database and its role are unprovable —
+    /// and a leaked role carries credentials, which is why it is its own
+    /// subject rather than folded into the database check.
+    #[tokio::test]
+    async fn database_and_role_are_unknown_without_a_datastore() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+
+        for subject in [TeardownSubject::Database, TeardownSubject::DatabaseRole] {
+            let check = backend
+                .verify_subject_absent("c1", "test-ns", subject, &Ok(Vec::new()), &Ok(()))
+                .await;
+            assert_eq!(check.result, CheckResult::Unknown, "{subject:?}");
+            assert_eq!(check.reason.as_deref(), Some("datastore_unavailable"));
+        }
+    }
+
+    /// A failed delete poisons every subject. Verifying absence after a
+    /// teardown that did not complete would report "gone" for whatever the
+    /// failed attempt happened not to reach.
+    #[tokio::test]
+    async fn a_failed_delete_makes_every_subject_unknown() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Err(anyhow::anyhow!("delete blew up")),
+            )
+            .await;
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert_eq!(check.reason.as_deref(), Some("delete_failed"));
+    }
+
+    /// If the PVCs could not be listed before deletion, the backing volumes are
+    /// unnameable afterwards — so the volume subject must fail closed rather
+    /// than silently report that nothing needed reclaiming.
+    #[tokio::test]
+    async fn uncapturable_volumes_fail_closed() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerDataVolumes,
+                &Err("pvc_list_failed".to_string()),
+                &Ok(()),
+            )
+            .await;
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert_eq!(check.reason.as_deref(), Some("pvc_list_failed"));
+    }
+
+    #[tokio::test]
+    async fn k3s_advertises_the_verified_teardown_capability() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        assert!(backend.supports_verified_destroy());
     }
 
     fn token_secret_response(name: &str, namespace: &str, token: &[u8]) -> serde_json::Value {

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -2343,6 +2343,19 @@ impl ClusterBackend for K3sBackend {
         true
     }
 
+    async fn capture_teardown_identities(
+        &self,
+        name: &str,
+        namespace: &str,
+    ) -> Result<Vec<String>> {
+        // Same capture the teardown path uses, run early instead. An error is
+        // propagated rather than reported as "no volumes": recording an empty
+        // list on a failed read would understate the footprint permanently.
+        self.capture_bound_volumes(name, namespace)
+            .await
+            .map_err(|reason| anyhow::anyhow!("could not capture bound volumes: {reason}"))
+    }
+
     /// Tear down and then *prove* the footprint is absent.
     ///
     /// The ordering matters and is the whole contract:

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -624,6 +624,27 @@ pub trait ClusterBackend: Send + Sync {
         async { Err(VerifiedDestroyUnsupported) }
     }
 
+    /// Capture the provisioner-assigned resource identities this instance owns.
+    ///
+    /// Called while the instance is healthy, NOT at teardown. Bound
+    /// PersistentVolume names are chosen by the provisioner and only knowable
+    /// once claims have bound; capturing them at teardown time would let the
+    /// teardown path define its own scope, which is the thing receipts exist to
+    /// prevent. Recorded early, the list is something a later teardown must
+    /// account for rather than something it gets to choose.
+    ///
+    /// Returning an empty list means "this backend has no such identities",
+    /// which is correct for every backend that cannot produce evidence anyway.
+    #[allow(dead_code)]
+    fn capture_teardown_identities(
+        &self,
+        name: &str,
+        namespace: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send {
+        let _ = (name, namespace);
+        async { Ok(Vec::new()) }
+    }
+
     /// Whether this backend can produce teardown evidence at all.
     ///
     /// Checked before binding so a receipt-required lease is refused up front,

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -24,6 +24,7 @@ use crate::crd::{
     Addon, BackendType, BootstrapConfig, BootstrapJobSpec, BootstrapRef, ClusterConfig,
     ClusterPool, InterInstanceSpread, PersistenceConfig, ReadinessGate, SpreadStrength,
 };
+use crate::crd::{TeardownCheck, TeardownSubject};
 
 /// Fetch, or create once, the per-cluster PostgreSQL password.
 ///
@@ -550,6 +551,21 @@ pub struct GuestPodCrash {
 /// Implementations handle the actual cluster provisioning. The profile and
 /// claim controllers interact only through this trait, keeping them decoupled
 /// from the underlying technology.
+// Declared ahead of the k3s provider that implements it and the controller
+// that calls it, so nothing constructs or invokes this yet. Same pattern as the
+// `teardown` module in `src/crd`. The alternative — landing the contract and
+// the provider together — is the several-thousand-line PR this split exists to
+// avoid.
+#[allow(dead_code)]
+/// A backend was asked for verified teardown and cannot provide it.
+///
+/// Distinct from an ordinary error: nothing failed, the capability simply does
+/// not exist for this backend. Callers must refuse the lease rather than fall
+/// back to unverified cleanup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("backend does not implement verified teardown")]
+pub struct VerifiedDestroyUnsupported;
+
 pub trait ClusterBackend: Send + Sync {
     /// Create a virtual cluster with the given name and config.
     ///
@@ -581,6 +597,42 @@ pub trait ClusterBackend: Send + Sync {
         name: &str,
         namespace: &str,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
+
+    /// Delete a virtual cluster and return **evidence** that its footprint is
+    /// gone, rather than evidence that a DELETE request was accepted.
+    ///
+    /// Deliberately a separate method with a default body instead of a changed
+    /// `delete` signature: the four backends that cannot produce evidence keep
+    /// compiling untouched and refuse honestly, rather than being mechanically
+    /// updated to return a receipt they cannot substantiate. A backend that
+    /// "implements" verified teardown by returning success it did not observe
+    /// is worse than one that says it cannot.
+    ///
+    /// `plan` lists what this instance actually created, so the provider knows
+    /// which subjects it must account for and which never existed. Returning
+    /// [`CheckResult::Unknown`] for anything it cannot observe is correct and
+    /// expected — that quarantines the capacity instead of releasing it.
+    #[allow(dead_code)]
+    fn delete_verified(
+        &self,
+        name: &str,
+        namespace: &str,
+        plan: &[TeardownSubject],
+    ) -> impl std::future::Future<Output = Result<Vec<TeardownCheck>, VerifiedDestroyUnsupported>> + Send
+    {
+        let _ = (name, namespace, plan);
+        async { Err(VerifiedDestroyUnsupported) }
+    }
+
+    /// Whether this backend can produce teardown evidence at all.
+    ///
+    /// Checked before binding so a receipt-required lease is refused up front,
+    /// rather than discovering mid-teardown that no evidence is possible and
+    /// stranding the lease in quarantine through no fault of the caller.
+    #[allow(dead_code)]
+    fn supports_verified_destroy(&self) -> bool {
+        false
+    }
 
     /// Check if a virtual cluster's API server is healthy.
     fn check_health(
@@ -1455,6 +1507,31 @@ mod tests {
     use base64::Engine;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// A backend that has not implemented verified teardown must REFUSE, not
+    /// quietly succeed.
+    ///
+    /// The default body is the safety property here: adding this capability to
+    /// the trait without one would have forced every backend to be updated by
+    /// hand, and the mechanical update is "return Ok(vec![])" — a backend
+    /// claiming a clean footprint it never looked at. Refusing by default means
+    /// a backend can only claim evidence by actually writing the code.
+    #[tokio::test]
+    async fn a_backend_without_the_capability_refuses_rather_than_claiming_success() {
+        let backend = crate::testutil::MockBackend::new();
+        assert!(
+            !backend.supports_verified_destroy(),
+            "capability must be opt-in"
+        );
+        let outcome = backend
+            .delete_verified("pool-x-0", "test-ns", &[TeardownSubject::ServerStatefulSet])
+            .await;
+        assert_eq!(
+            outcome,
+            Err(VerifiedDestroyUnsupported),
+            "an unimplemented backend must not return an empty (clean-looking) check list"
+        );
+    }
 
     fn kubeconfig_secret_response(
         cluster_name: &str,

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -345,6 +345,7 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                                 // is preserved (we never want to overwrite it
                                 // from an instance-controller patch).
                                 created_with: None,
+                                teardown_identities: Vec::new(),
                                 message: Some("network allocated; awaiting provisioning".into()),
                                 // Overwritten centrally in patch_instance_status.
                                 conditions: Vec::new(),
@@ -752,6 +753,11 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
             }
         }
         ClusterInstancePhase::Ready => {
+            // Record provisioner-assigned identities while the instance is
+            // healthy. Doing this at teardown would let the teardown path
+            // choose its own scope; recorded here, a later receipt has to
+            // account for what was captured long before it ran.
+            capture_teardown_identities_once(&ctx, &instance, &name, &ns, &status).await;
             let next =
                 evaluate_ready_instance(&ctx, &config, &instance, &name, &ns, &status).await?;
             Ok(next)
@@ -1987,6 +1993,72 @@ async fn verified_teardown_gate<B: ClusterBackend + Clone>(
         return Some(Err(error.into()));
     }
     Some(Ok(Action::await_change()))
+}
+
+/// Record the provisioner-assigned identities this instance owns, once.
+///
+/// Best-effort and idempotent: a failed capture leaves the list empty and is
+/// retried on the next reconcile, and a non-empty list is never rewritten —
+/// shrinking it later would silently narrow what a receipt must prove.
+///
+/// Only meaningful for a backend that can produce evidence; everything else
+/// returns an empty list from the default implementation.
+async fn capture_teardown_identities_once<B: ClusterBackend + Clone>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+    name: &str,
+    namespace: &str,
+    status: &ClusterInstanceStatus,
+) {
+    if !status.teardown_identities.is_empty() {
+        return;
+    }
+    // Only instances whose plan includes a provisioner-assigned footprint have
+    // anything to capture.
+    let wants_volumes = status
+        .created_with
+        .as_ref()
+        .and_then(|created| created.teardown_plan.as_ref())
+        .is_some_and(|plan| plan.contains(&crate::crd::TeardownSubject::ServerDataVolumes));
+    if !wants_volumes {
+        return;
+    }
+    let Some(backend) = resolve_verified_backend(ctx, instance).await else {
+        return;
+    };
+    let identities = match backend.capture_teardown_identities(name, namespace).await {
+        Ok(identities) if !identities.is_empty() => identities,
+        // Empty or failed: retry next reconcile rather than recording a list
+        // that understates the footprint.
+        _ => return,
+    };
+
+    let (Some(uid), Some(resource_version)) = (
+        instance.metadata.uid.as_deref(),
+        instance.resource_version(),
+    ) else {
+        return;
+    };
+    let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "test", "path": "/metadata/resourceVersion", "value": resource_version },
+        { "op": "add", "path": "/status/teardownIdentities", "value": identities }
+    ]));
+    match instances_api
+        .patch_status(name, &PatchParams::default(), &Patch::<()>::Json(patch))
+        .await
+    {
+        Ok(_) => info!(
+            instance = %name,
+            "recorded provisioner-assigned teardown identities"
+        ),
+        Err(error) => debug!(
+            instance = %name,
+            error = %error,
+            "could not record teardown identities; will retry"
+        ),
+    }
 }
 
 /// Resolve the backend through immutable provenance, same fence as

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -1854,10 +1854,43 @@ async fn verified_teardown_gate<B: ClusterBackend + Clone>(
     let status = instance.status.as_ref()?;
     let binding = status.binding.as_ref()?;
 
+    // An instance that is ALREADY quarantined got there because evidence was
+    // required and missing. It must never fall back to the unverified path,
+    // whatever happens to its lease afterwards — otherwise deleting the
+    // ClusterLease becomes a way to launder unproven capacity back into the
+    // pool, which is a bypass of the whole mechanism rather than an edge case.
+    let already_quarantined = status.phase == ClusterInstancePhase::Quarantined;
+
     // Does the bound lease actually ask for this?
     let leases: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), namespace);
-    let lease = leases.get(&binding.lease.name).await.ok()?;
+    let lease = match leases.get(&binding.lease.name).await {
+        Ok(lease) => lease,
+        Err(error) => {
+            if already_quarantined {
+                warn!(
+                    instance = %name,
+                    error = %error,
+                    "quarantined instance's lease is unreadable; holding quarantine rather \
+                     than releasing on the unverified path"
+                );
+                return Some(
+                    quarantine_instance(ctx, instance, name, namespace, "lease_unreadable").await,
+                );
+            }
+            return None;
+        }
+    };
     if lease.spec.cleanup_mode.unwrap_or_default() != CleanupMode::VerifiedDestroy {
+        if already_quarantined {
+            warn!(
+                instance = %name,
+                "quarantined instance's lease no longer requests verified teardown; \
+                 holding quarantine — capacity still has unproven state"
+            );
+            return Some(
+                quarantine_instance(ctx, instance, name, namespace, "mode_downgraded").await,
+            );
+        }
         return None;
     }
 

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -760,6 +760,34 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
             let next = evaluate_leased_instance(&ctx, &instance, &name, &ns, &status).await?;
             Ok(next)
         }
+        // Quarantine has exactly ONE way out: the same exact subject producing
+        // a verified receipt. Retrying is safe and idempotent — the provider
+        // re-runs delete and re-observes absence — so a transient RBAC or
+        // datastore failure that caused the quarantine can resolve itself.
+        //
+        // What must never happen is leaving by any other route: no timeout, no
+        // operator patch of the phase, no "it has been stuck a while" fallback.
+        // Those would return capacity to the pool on exactly the evidence the
+        // quarantine exists to demand.
+        ClusterInstancePhase::Quarantined => {
+            debug!(
+                instance = %name,
+                "quarantined: retrying teardown verification for the same exact subject"
+            );
+            // Only the deletion path can produce a receipt, so a quarantined
+            // instance that is not being deleted simply waits. It holds its
+            // finalizer and binding, so it is never selectable as capacity.
+            if instance.metadata.deletion_timestamp.is_none() {
+                return Ok(Action::requeue(std::time::Duration::from_secs(300)));
+            }
+            match verified_teardown_gate(&ctx, &instance, &name, &ns).await {
+                Some(outcome) => outcome,
+                // Not receipt-required after all (the lease changed or is
+                // gone): fall back to the ordinary path rather than holding
+                // capacity hostage forever.
+                None => Ok(Action::requeue(std::time::Duration::from_secs(30))),
+            }
+        }
         ClusterInstancePhase::Recycling => {
             info!(instance = %name, owner = %owner, "Deleting backend resources");
             if let Err(reason) = verify_bound_instance_for_teardown(&ctx, &instance, &ns).await {

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -23,9 +23,10 @@ use crate::backend::{
 };
 use crate::crd::{
     Addon, BackendConfig, BackendType, BootstrapRef, CIDRClaim, CIDRClaimPhase, CIDRClaimSpec,
-    ClusterConfig, ClusterInstance, ClusterInstanceCondition, ClusterInstanceNetwork,
-    ClusterInstancePhase, ClusterInstanceStatus, ClusterPool, HealthCheckConfig, LeasePhase,
-    ReadinessGate, SnapshotConfig,
+    CheckResult, CleanupMode, ClusterConfig, ClusterInstance, ClusterInstanceCondition,
+    ClusterInstanceNetwork, ClusterInstancePhase, ClusterInstanceStatus, ClusterLease, ClusterPool,
+    HealthCheckConfig, LeasePhase, ReadinessGate, SnapshotConfig, TEARDOWN_RECEIPT_SCHEMA_VERSION,
+    TeardownOutcome, TeardownReceipt,
 };
 use crate::velero::VeleroCoordinator;
 
@@ -244,6 +245,15 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                 warn!(instance = %name, reason, "Deletion fenced: exact lease binding is not verifiable");
                 return Ok(Action::requeue(std::time::Duration::from_secs(30)));
             }
+            // Receipt-required teardown decides here, not after the fact: the
+            // finalizer is the last handle on this capacity, and releasing it
+            // on an accepted DELETE is exactly what makes "cleanup complete" a
+            // guess. A lease asking for VerifiedDestroy must produce evidence
+            // before the handle goes.
+            if let Some(outcome) = verified_teardown_gate(&ctx, &instance, &name, &ns).await {
+                return outcome;
+            }
+
             match delete_instance_backend(&ctx, &config, &instance, &name, &ns).await {
                 Ok(()) => {
                     cleanup_orphan_projected_resources(&ctx.client, &name, &ns).await;
@@ -1794,6 +1804,200 @@ async fn delete_instance_backend<B: ClusterBackend + Clone>(
     } else {
         ctx.backend.delete(name, namespace).await
     }
+}
+
+/// Gate finalizer release on evidence, for leases that asked for it.
+///
+/// Returns `None` when this instance is not receipt-required, so the ordinary
+/// teardown path runs unchanged — every existing lease keeps today's behaviour.
+///
+/// When it *is* required, this is the only place the last cleanup handle can be
+/// released, and it is released only against a receipt whose checks cover the
+/// plan recorded at creation. Anything else — a missing plan, an unsupported
+/// backend, a check that came back `Unknown` — quarantines the instance and
+/// keeps the finalizer, because a handle dropped on unproven capacity cannot be
+/// taken back.
+async fn verified_teardown_gate<B: ClusterBackend + Clone>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+    name: &str,
+    namespace: &str,
+) -> Option<Result<Action, InstanceError>> {
+    let status = instance.status.as_ref()?;
+    let binding = status.binding.as_ref()?;
+
+    // Does the bound lease actually ask for this?
+    let leases: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), namespace);
+    let lease = leases.get(&binding.lease.name).await.ok()?;
+    if lease.spec.cleanup_mode.unwrap_or_default() != CleanupMode::VerifiedDestroy {
+        return None;
+    }
+
+    let started_at = chrono::Utc::now().to_rfc3339();
+
+    // The plan must come from what creation recorded. An instance created
+    // before verified teardown existed has no plan, and verifying it against a
+    // reconstructed guess would prove only that the guess was satisfied.
+    let Some(plan) = status
+        .created_with
+        .as_ref()
+        .and_then(|created| created.teardown_plan.clone())
+    else {
+        warn!(
+            instance = %name,
+            "verified teardown requested but no creation-time plan was recorded; quarantining"
+        );
+        return Some(
+            quarantine_instance(ctx, instance, name, namespace, "teardown_plan_missing").await,
+        );
+    };
+
+    let checks = match resolve_verified_backend(ctx, instance).await {
+        Some(backend) => match backend.delete_verified(name, namespace, &plan).await {
+            Ok(checks) => checks,
+            Err(_) => {
+                warn!(
+                    instance = %name,
+                    "backend cannot produce teardown evidence; quarantining rather than \
+                     falling back to unverified cleanup"
+                );
+                return Some(
+                    quarantine_instance(ctx, instance, name, namespace, "backend_unsupported")
+                        .await,
+                );
+            }
+        },
+        None => {
+            return Some(
+                quarantine_instance(ctx, instance, name, namespace, "backend_unresolvable").await,
+            );
+        }
+    };
+
+    let outcome = TeardownReceipt::outcome_for(&checks);
+    let receipt = TeardownReceipt {
+        schema_version: TEARDOWN_RECEIPT_SCHEMA_VERSION,
+        attempt_id: uuid::Uuid::new_v4().to_string(),
+        lease: binding.lease.clone(),
+        instance: crate::crd::ResourceRef {
+            name: binding.instance.name.clone(),
+            uid: Some(binding.instance.uid.clone()),
+        },
+        pool: binding.pool.clone(),
+        backend_type: format!("{:?}", binding.backend.backend_type).to_lowercase(),
+        config_digest: binding.backend.config_digest.clone(),
+        instance_spec_digest: binding.instance_spec_digest.clone(),
+        started_at,
+        completed_at: Some(chrono::Utc::now().to_rfc3339()),
+        checks,
+        retry_count: 0,
+        outcome,
+    };
+
+    // Persist the evidence BEFORE releasing anything. A receipt written after
+    // the finalizer is gone can be lost with the object it describes, and the
+    // whole point is that it outlives the instance.
+    if let Err(error) = record_teardown_receipt(ctx, &lease, &receipt, namespace).await {
+        warn!(instance = %name, error = %error, "could not persist teardown receipt; retrying");
+        return Some(Ok(Action::requeue(std::time::Duration::from_secs(15))));
+    }
+
+    if outcome != TeardownOutcome::Verified {
+        let unproven: Vec<&str> = receipt
+            .checks
+            .iter()
+            .filter(|check| check.result == CheckResult::Unknown)
+            .map(|check| check.reason.as_deref().unwrap_or("unknown"))
+            .collect();
+        warn!(
+            instance = %name,
+            reasons = ?unproven,
+            "teardown could not be proven complete; quarantining capacity"
+        );
+        return Some(
+            quarantine_instance(ctx, instance, name, namespace, "teardown_unverified").await,
+        );
+    }
+
+    info!(instance = %name, "teardown verified; releasing the cleanup handle");
+    cleanup_orphan_projected_resources(&ctx.client, name, namespace).await;
+    let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
+    if let Err(error) = remove_finalizer(&instances_api, instance, INSTANCE_FINALIZER).await {
+        return Some(Err(error.into()));
+    }
+    Some(Ok(Action::await_change()))
+}
+
+/// Resolve the backend through immutable provenance, same fence as
+/// `delete_instance_backend`.
+async fn resolve_verified_backend<B: ClusterBackend + Clone>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+) -> Option<crate::backend::BackendDispatch> {
+    let factory = ctx.factory.as_ref()?;
+    let provenance = instance
+        .status
+        .as_ref()
+        .and_then(|status| status.created_with.as_ref())
+        .and_then(|created| created.backend.as_ref())?;
+    factory.backend_for_provenance(provenance).ok()
+}
+
+/// Write the receipt onto the lease, fenced to the exact lease UID.
+async fn record_teardown_receipt<B: ClusterBackend>(
+    ctx: &InstanceContext<B>,
+    lease: &ClusterLease,
+    receipt: &TeardownReceipt,
+    namespace: &str,
+) -> Result<(), anyhow::Error> {
+    let leases: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), namespace);
+    let uid = lease
+        .metadata
+        .uid
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("lease has no UID"))?;
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "add", "path": "/status/teardownReceipt", "value": receipt }
+    ]));
+    leases
+        .patch_status(
+            &lease.name_any(),
+            &PatchParams::default(),
+            &Patch::<()>::Json(patch),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Hold the capacity back and keep every cleanup handle.
+///
+/// Deliberately does NOT remove the finalizer or clear the binding: those are
+/// what a later retry needs to address the same exact subject, and what stops
+/// the ordinary 404-based recycle path from treating the capacity as clean.
+async fn quarantine_instance<B: ClusterBackend>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+    name: &str,
+    namespace: &str,
+    reason: &str,
+) -> Result<Action, InstanceError> {
+    let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
+    let mut next = instance.status.clone().unwrap_or_default();
+    next.phase = ClusterInstancePhase::Quarantined;
+    next.state_since = Some(chrono::Utc::now().to_rfc3339());
+    next.message = Some(format!("quarantined: {reason}"));
+    let patch = serde_json::json!({ "status": next });
+    instances_api
+        .patch_status(
+            name,
+            &PatchParams::apply("kobe-operator"),
+            &Patch::Merge(&patch),
+        )
+        .await?;
+    // Bounded backoff: a transient API failure may resolve, and the same exact
+    // subject can then produce a verified receipt.
+    Ok(Action::requeue(std::time::Duration::from_secs(120)))
 }
 
 async fn verify_bound_instance_for_teardown<B: ClusterBackend>(

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -2015,14 +2015,42 @@ async fn quarantine_instance<B: ClusterBackend>(
     next.phase = ClusterInstancePhase::Quarantined;
     next.state_since = Some(chrono::Utc::now().to_rfc3339());
     next.message = Some(format!("quarantined: {reason}"));
-    let patch = serde_json::json!({ "status": next });
-    instances_api
-        .patch_status(
-            name,
-            &PatchParams::apply("kobe-operator"),
-            &Patch::Merge(&patch),
-        )
-        .await?;
+
+    // Fenced, not a bare merge patch. Two ways an unfenced write goes wrong:
+    // a stale reconcile holding an older view could overwrite `Quarantined`
+    // with whatever phase it believed, handing unproven capacity back to the
+    // pool; and a name-addressed write could land on a same-named replacement
+    // instance that has nothing to do with this teardown.
+    let (Some(uid), Some(resource_version)) = (
+        instance.metadata.uid.as_deref(),
+        instance.resource_version(),
+    ) else {
+        // Without an identity to fence against we cannot safely mark anything.
+        // Requeue rather than write blind; the finalizer still holds.
+        warn!(
+            instance = %name,
+            "cannot fence the quarantine write; retrying rather than writing unfenced"
+        );
+        return Ok(Action::requeue(std::time::Duration::from_secs(30)));
+    };
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "test", "path": "/metadata/resourceVersion", "value": resource_version },
+        { "op": "add", "path": "/status", "value": next }
+    ]));
+    match instances_api
+        .patch_status(name, &PatchParams::default(), &Patch::<()>::Json(patch))
+        .await
+    {
+        Ok(_) => {}
+        // The object moved under us. Re-reconcile against the new state rather
+        // than forcing a phase derived from a view that is now stale.
+        Err(error) if crate::controllers::lease::optimistic_conflict(&error) => {
+            debug!(instance = %name, "quarantine write conflicted; re-reading");
+            return Ok(Action::requeue(std::time::Duration::from_secs(5)));
+        }
+        Err(error) => return Err(error.into()),
+    }
     // Bounded backoff: a transient API failure may resolve, and the same exact
     // subject can then produce a verified receipt.
     Ok(Action::requeue(std::time::Duration::from_secs(120)))

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -15,7 +15,7 @@ use crate::backend::{BackendFactory, ClusterBackend};
 use crate::crd::{
     BackendProvenance, BoundInstanceRef, ClusterInstance, ClusterInstancePhase, ClusterLease,
     ClusterLeaseCondition, ClusterLeaseStatus, ClusterPool, ClusterPoolPhase, ClusterPoolStatus,
-    LeaseBinding, LeasePhase, ResourceRef,
+    LeaseBinding, LeasePhase, ResourceRef, TEARDOWN_RECEIPT_ACKNOWLEDGED_ANNOTATION,
 };
 use crate::diagnostics;
 use crate::pool::{PoolState, parse_duration};
@@ -632,6 +632,27 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
             };
 
             if cluster_gone {
+                // A receipt-required lease carries the ONLY durable proof that
+                // its capacity was destroyed, and it is read after the instance
+                // is gone — which is exactly the moment this branch fires. So
+                // deleting the lease here would destroy the evidence at the
+                // instant it becomes relevant, and #74's owning SandboxLease
+                // would have nothing to consume.
+                //
+                // Retain it until a consumer acknowledges. Deliberately not a
+                // timeout: evidence that expires on a clock is evidence you
+                // cannot rely on having.
+                if status.teardown_receipt.is_some()
+                    && !lease
+                        .annotations()
+                        .contains_key(TEARDOWN_RECEIPT_ACKNOWLEDGED_ANNOTATION)
+                {
+                    debug!(
+                        lease = %name,
+                        "retaining recycled lease: its teardown receipt has not been consumed"
+                    );
+                    return Ok(Action::requeue(std::time::Duration::from_secs(300)));
+                }
                 info!(lease = %name, "Recycling complete, deleting lease CRD");
                 let delete_params = DeleteParams {
                     preconditions: Some(Preconditions {

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -1237,6 +1237,11 @@ async fn reconcile_profile(
     pool_size_set("leased", counts.leased);
     pool_size_set("unhealthy", counts.unhealthy);
     pool_size_set("recycling", counts.recycling);
+    // Emitted separately from `unhealthy` so an alert can distinguish capacity
+    // that is churning from capacity that is stuck holding unproven state.
+    // A rising `quarantined` means teardown evidence is failing, which no
+    // other dimension reveals.
+    pool_size_set("quarantined", counts.quarantined);
 
     // Surface hidden CPU over-reservation (issue #189): a pool that sets
     // `resources.limits` with empty `requests` makes the kubelet copy each
@@ -1372,6 +1377,7 @@ async fn reconcile_profile(
         creating: counts.creating,
         recycling: counts.recycling,
         unhealthy: counts.unhealthy,
+        quarantined: counts.quarantined,
         queue_depth,
         golden_backup: existing_golden_backup,
         golden_generation: existing_golden_generation,

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -1727,6 +1727,23 @@ async fn ensure_cluster_instance(
         .map_err(|err| anyhow::anyhow!("failed to encode backend provenance: {err}"))?;
     let provenance = crate::crd::ClusterInstanceProvenance {
         operator_version: env!("BUILD_VERSION").to_string(),
+        // Record what this instance is about to create, while we still know.
+        // Recomputing this at teardown would read whatever the pool config says
+        // *then* — so a pool that stopped setting `registryMirrors` after this
+        // instance was built would silently drop that ConfigMap from the plan
+        // and never verify it. Only k3s can be verified, so only k3s gets a
+        // plan; anything else stays `None` and is refused a receipt-required
+        // lease at bind time.
+        teardown_plan: matches!(
+            profile.spec.backend.backend_type,
+            crate::crd::BackendType::K3s
+        )
+        .then(|| {
+            crate::crd::k3s_teardown_plan(
+                &profile.spec.cluster,
+                profile.spec.backend.datastore.is_some(),
+            )
+        }),
         kobe_sync_image: matches!(
             profile.spec.backend.backend_type,
             crate::crd::BackendType::Vkobe

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -1,3 +1,4 @@
+use crate::crd::teardown::TeardownSubject;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -440,6 +441,21 @@ pub struct ClusterInstanceProvenance {
     /// `"0.17.0"`.
     pub operator_version: String,
 
+    /// Exactly which footprints this instance created, recorded at creation.
+    ///
+    /// This is the trust boundary for verified teardown. A receipt only proves
+    /// what it covers, so the list of subjects it must cover cannot come from
+    /// the receipt, nor from whatever the teardown path happens to look for
+    /// later — an optional resource whose config changed after creation would
+    /// then be quietly dropped from the plan and never verified.
+    ///
+    /// Stamped once alongside the rest of this provenance and never
+    /// overwritten. `None` means the instance predates verified teardown; such
+    /// an instance is ineligible for [`CleanupMode::VerifiedDestroy`] rather
+    /// than being verified against a guessed plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teardown_plan: Option<Vec<TeardownSubject>>,
+
     /// kobe-sync sidecar image used at create time. Recorded for
     /// `Vkobe` backends only (other backends don't run kobe-sync).
     /// Format matches the operator's `KOBE_SYNC_IMAGE` env var, e.g.
@@ -504,6 +520,7 @@ mod tests {
             }),
             created_with: Some(ClusterInstanceProvenance {
                 operator_version: "0.37.0".into(),
+                teardown_plan: None,
                 kobe_sync_image: Some("zondax/kobe-sync:v0.16.0".into()),
                 backend_type: Some(BackendType::K0s),
                 pool_uid: None,
@@ -763,6 +780,7 @@ mod tests {
     fn provenance_omits_unknown_components() {
         let p = ClusterInstanceProvenance {
             operator_version: "0.37.0".into(),
+            teardown_plan: None,
             kobe_sync_image: None,
             backend_type: None,
             pool_uid: None,
@@ -802,6 +820,7 @@ mod tests {
         ] {
             let p = ClusterInstanceProvenance {
                 operator_version: "0.37.0".into(),
+                teardown_plan: None,
                 kobe_sync_image: None,
                 backend_type: Some(bt),
                 pool_uid: None,

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -353,6 +353,20 @@ pub struct ClusterInstanceStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_with: Option<ClusterInstanceProvenance>,
 
+    /// Provisioner-assigned resource identities this instance owns — currently
+    /// the PersistentVolumes its data claims are bound to.
+    ///
+    /// Captured once the instance is healthy, NOT at teardown. These names are
+    /// chosen by the provisioner and only knowable after claims bind, so
+    /// capturing them during teardown would let the teardown path define its
+    /// own scope. Recorded early, they become something a later teardown must
+    /// account for rather than something it gets to choose.
+    ///
+    /// Written once and never shrunk: a smaller list would silently narrow what
+    /// a receipt has to prove.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub teardown_identities: Vec<String>,
+
     /// Human-readable detail about the instance's current state — *why*
     /// it is in `phase`. Set fresh on every status write by the instance
     /// controller (each construction site supplies a concise phrase like
@@ -504,6 +518,10 @@ mod tests {
             phase: ClusterInstancePhase::Leased,
             provisioned: true,
             bootstrapped: true,
+            // Populated, not empty: this is the round-trip test, and an
+            // identity list that did not survive the wire would silently narrow
+            // what a receipt has to prove.
+            teardown_identities: vec!["pvc-1111".into(), "pvc-2222".into()],
             lease_ref: Some(ResourceRef {
                 name: "lease-abc".into(),
                 uid: None,
@@ -641,6 +659,7 @@ mod tests {
                 "provisioned",
                 "specHash",
                 "stateSince",
+                "teardownIdentities",
             ]
         );
     }

--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -572,6 +572,7 @@ mod json_safety_tests {
                     subject: crate::crd::TeardownSubject::ServerStatefulSet,
                     result: crate::crd::CheckResult::Verified,
                     reason: None,
+                    verified: Vec::new(),
                 }],
                 retry_count: 0,
                 outcome: crate::crd::TeardownOutcome::Verified,

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1496,6 +1496,15 @@ pub struct ClusterPoolStatus {
     #[serde(default)]
     pub recycling: u32,
 
+    /// Members held back because their teardown could not be proven complete.
+    ///
+    /// Separate from `recycling` on purpose: recycling is transient churn that
+    /// resolves itself, while a quarantined member is stuck until the same
+    /// exact subject produces a verified receipt. Reporting them together would
+    /// make a pool bleeding capacity look merely busy.
+    #[serde(default)]
+    pub quarantined: u32,
+
     /// Number of clusters currently unhealthy and being recycled.
     #[serde(default)]
     pub unhealthy: u32,

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -25,7 +25,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::ResourceRef;
-use super::profile::{ClusterConfig, DiagnosticsConfig};
+use super::profile::{BackendType, ClusterConfig, DiagnosticsConfig};
 
 /// How thoroughly a lease's capacity must be torn down before it can be reused.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -77,6 +77,14 @@ pub enum TeardownSubject {
     ServerDataVolumes,
     /// The exact `k3s_<instance>` database.
     Database,
+    /// The per-cluster PostgreSQL role that owns that database.
+    ///
+    /// Added after `fix(datastore): give each cluster its own PostgreSQL role`
+    /// landed on main: k3s teardown now reclaims ownership, drops the database,
+    /// *and* drops a role. Without this subject a leaked role would sit inside
+    /// a receipt that claims the footprint is gone — the database would be
+    /// proven absent while a credential-bearing role survived.
+    DatabaseRole,
 }
 
 /// Outcome of proving one subject absent.
@@ -309,10 +317,19 @@ impl VerifiedDestroyIneligible {
 /// because the datastore connection lives outside the CRD; the caller knows
 /// whether the exact database identity needed to verify absence was captured.
 pub fn verified_destroy_eligibility(
+    backend: &BackendType,
     cluster: &ClusterConfig,
     diagnostics: Option<&DiagnosticsConfig>,
     external_datastore_identity_recorded: bool,
 ) -> Result<(), VerifiedDestroyIneligible> {
+    // Only k3s can produce evidence. Every other backend must be refused here
+    // rather than degrade to Standard cleanup while still claiming a verified
+    // mode. Previously this variant existed but was unreachable, because the
+    // function had no backend to judge — so a non-k3s pool received Ok(()).
+    if *backend != BackendType::K3s {
+        return Err(VerifiedDestroyIneligible::UnsupportedBackend);
+    }
+
     // Host-side kubelet trees survive object deletion and are not part of any
     // subject we can observe from the API, so their presence makes "the
     // footprint is absent" unprovable. Re-admissible once the host reaper's
@@ -361,7 +378,7 @@ mod tests {
 
     #[test]
     fn ephemeral_k3s_with_recorded_datastore_is_eligible() {
-        assert!(verified_destroy_eligibility(&cluster(), None, true).is_ok());
+        assert!(verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, true).is_ok());
     }
 
     /// Each rejection must be derived from configuration alone, so an ineligible
@@ -375,7 +392,7 @@ mod tests {
             ..serde_json::from_value(serde_json::json!({})).unwrap()
         });
         assert_eq!(
-            verified_destroy_eligibility(&shared_mount, None, true).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &shared_mount, None, true).unwrap_err(),
             VerifiedDestroyIneligible::KubeletSharedMount
         );
 
@@ -384,7 +401,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            verified_destroy_eligibility(&cluster(), Some(&capture), true).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &cluster(), Some(&capture), true)
+                .unwrap_err(),
             VerifiedDestroyIneligible::DiagnosticsEnabled
         );
 
@@ -395,14 +413,38 @@ mod tests {
             storage_request_size: None,
         });
         assert_eq!(
-            verified_destroy_eligibility(&retained, None, true).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &retained, None, true).unwrap_err(),
             VerifiedDestroyIneligible::UnverifiableStorage
         );
 
         assert_eq!(
-            verified_destroy_eligibility(&cluster(), None, false).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, false).unwrap_err(),
             VerifiedDestroyIneligible::DatastoreProvenanceMissing
         );
+    }
+
+    /// A backend that cannot produce evidence must be refused at bind time.
+    ///
+    /// This variant existed before but was unreachable: the function took no
+    /// backend, so a k0s or vcluster pool asking for verified teardown got
+    /// `Ok(())` and would only discover mid-teardown that no evidence was
+    /// possible — stranding the lease in quarantine through no fault of its
+    /// caller.
+    #[test]
+    fn only_k3s_can_promise_verified_teardown() {
+        for backend in [
+            BackendType::K0s,
+            BackendType::Capi,
+            BackendType::Vkobe,
+            BackendType::Vcluster,
+        ] {
+            assert_eq!(
+                verified_destroy_eligibility(&backend, &cluster(), None, true).unwrap_err(),
+                VerifiedDestroyIneligible::UnsupportedBackend,
+                "{backend:?} cannot produce a receipt and must be refused"
+            );
+        }
+        assert!(verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, true).is_ok());
     }
 
     /// Disabled diagnostics must not disqualify a pool — only active capture
@@ -413,7 +455,10 @@ mod tests {
             serde_json::json!({ "enabled": false, "storage": "s3://bucket/" }),
         )
         .unwrap();
-        assert!(verified_destroy_eligibility(&cluster(), Some(&disabled), true).is_ok());
+        assert!(
+            verified_destroy_eligibility(&BackendType::K3s, &cluster(), Some(&disabled), true)
+                .is_ok()
+        );
     }
 
     /// A single `Unknown` must dominate, however many subjects verified: the

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -274,6 +274,77 @@ pub struct TeardownScope<'a> {
     pub required_subjects: &'a [TeardownSubject],
 }
 
+/// Derive the exact set of footprints a k3s instance creates, from the config
+/// it is being created with.
+///
+/// Called at **creation** and stamped into immutable provenance — never
+/// recomputed at teardown. Recomputing later would read whatever the config
+/// says *then*, so a pool that stopped setting `registryMirrors` after an
+/// instance was made would drop that ConfigMap from the plan and never verify
+/// it. The plan has to describe what was built, not what would be built now.
+///
+/// Subjects that are always created are unconditional; the rest are included
+/// only when the config that creates them is present. A footprint absent from
+/// this list is not "excused" at teardown — it is simply not part of what this
+/// instance made.
+pub fn k3s_teardown_plan(
+    cluster: &ClusterConfig,
+    has_external_datastore: bool,
+) -> Vec<TeardownSubject> {
+    let mut plan = vec![
+        // Always created by the k3s backend.
+        TeardownSubject::ServerStatefulSet,
+        TeardownSubject::ServerPods,
+        TeardownSubject::Service,
+        TeardownSubject::PublisherConfigMap,
+        TeardownSubject::TokenSecret,
+        TeardownSubject::KubeconfigSecret,
+        TeardownSubject::ConnectTokenSecret,
+    ];
+
+    // Agents are a separate Deployment only when the pool asks for them.
+    if cluster.agents.is_some_and(|agents| agents > 0) {
+        plan.push(TeardownSubject::AgentDeployment);
+    }
+    // The HA PodDisruptionBudget exists only for multi-server pools.
+    if cluster.servers > 1 {
+        plan.push(TeardownSubject::PodDisruptionBudget);
+    }
+    if cluster
+        .registry_mirrors
+        .as_ref()
+        .is_some_and(|mirrors| !mirrors.is_empty())
+    {
+        plan.push(TeardownSubject::RegistriesConfigMap);
+    }
+    // Persistent storage means PVCs and the volumes behind them. Both, always
+    // together: proving the claim gone while its volume survives is precisely
+    // the gap that makes a receipt a lie.
+    if cluster
+        .persistence
+        .as_ref()
+        .is_some_and(|persistence| !storage_is_ephemeral(persistence))
+    {
+        plan.push(TeardownSubject::ServerDataPvcs);
+        plan.push(TeardownSubject::ServerDataVolumes);
+    }
+    // A per-cluster database always comes with the role that owns it.
+    if has_external_datastore {
+        plan.push(TeardownSubject::Database);
+        plan.push(TeardownSubject::DatabaseRole);
+    }
+    plan
+}
+
+/// Whether a persistence config allocates no durable volume.
+fn storage_is_ephemeral(persistence: &super::profile::PersistenceConfig) -> bool {
+    persistence
+        .storage_type
+        .as_deref()
+        .unwrap_or("emptyDir")
+        .eq_ignore_ascii_case("emptydir")
+}
+
 /// Why a pool's footprint cannot support [`CleanupMode::VerifiedDestroy`].
 ///
 /// Rejected **before binding**. An ineligible pool must never accept a
@@ -421,6 +492,93 @@ mod tests {
             verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, false).unwrap_err(),
             VerifiedDestroyIneligible::DatastoreProvenanceMissing
         );
+    }
+
+    /// The plan must describe what was BUILT, not what the config says later.
+    ///
+    /// Optional footprints appear only when the config that creates them is
+    /// present — and because the plan is stamped at creation, a pool that later
+    /// stops setting `registryMirrors` cannot retroactively drop that ConfigMap
+    /// from an existing instance's plan and leave it unverified.
+    #[test]
+    fn the_plan_covers_exactly_what_this_config_creates() {
+        // Minimal ephemeral cluster, no datastore.
+        let minimal: ClusterConfig =
+            serde_json::from_value(serde_json::json!({ "version": "v1.32.0" })).unwrap();
+        let plan = k3s_teardown_plan(&minimal, false);
+
+        // Always built.
+        for required in [
+            TeardownSubject::ServerStatefulSet,
+            TeardownSubject::ServerPods,
+            TeardownSubject::Service,
+            TeardownSubject::TokenSecret,
+            TeardownSubject::KubeconfigSecret,
+            TeardownSubject::ConnectTokenSecret,
+        ] {
+            assert!(plan.contains(&required), "{required:?} is always created");
+        }
+        // Never built by this config — and therefore not something a receipt
+        // has to excuse. Absent from the plan, not marked NotApplicable.
+        for absent in [
+            TeardownSubject::AgentDeployment,
+            TeardownSubject::PodDisruptionBudget,
+            TeardownSubject::RegistriesConfigMap,
+            TeardownSubject::ServerDataPvcs,
+            TeardownSubject::ServerDataVolumes,
+            TeardownSubject::Database,
+            TeardownSubject::DatabaseRole,
+        ] {
+            assert!(!plan.contains(&absent), "{absent:?} was never created");
+        }
+    }
+
+    /// Persistent storage must pull in BOTH the claim and its volume, and a
+    /// datastore must pull in BOTH the database and its role. Proving one half
+    /// while the other survives is exactly the leak a receipt would otherwise
+    /// hide.
+    #[test]
+    fn paired_footprints_are_never_planned_alone() {
+        let persistent: ClusterConfig = serde_json::from_value(serde_json::json!({
+            "version": "v1.32.0",
+            "servers": 3,
+            "agents": 2,
+            "persistence": { "storageType": "dynamic" },
+            "registryMirrors": { "docker.io": ["https://mirror.example"] }
+        }))
+        .unwrap();
+        let plan = k3s_teardown_plan(&persistent, true);
+
+        assert!(plan.contains(&TeardownSubject::ServerDataPvcs));
+        assert!(
+            plan.contains(&TeardownSubject::ServerDataVolumes),
+            "a claim without its volume proves only that the pointer is gone"
+        );
+        assert!(plan.contains(&TeardownSubject::Database));
+        assert!(
+            plan.contains(&TeardownSubject::DatabaseRole),
+            "a database without its role leaves credentials behind"
+        );
+        // Config-gated extras now present.
+        assert!(plan.contains(&TeardownSubject::AgentDeployment));
+        assert!(plan.contains(&TeardownSubject::PodDisruptionBudget));
+        assert!(plan.contains(&TeardownSubject::RegistriesConfigMap));
+    }
+
+    /// A single-server pool has no PodDisruptionBudget, and emptyDir storage
+    /// has no volume to reclaim.
+    #[test]
+    fn single_server_ephemeral_pools_plan_no_pdb_or_volumes() {
+        let single: ClusterConfig = serde_json::from_value(serde_json::json!({
+            "version": "v1.32.0",
+            "servers": 1,
+            "persistence": { "storageType": "emptyDir" }
+        }))
+        .unwrap();
+        let plan = k3s_teardown_plan(&single, false);
+        assert!(!plan.contains(&TeardownSubject::PodDisruptionBudget));
+        assert!(!plan.contains(&TeardownSubject::ServerDataPvcs));
+        assert!(!plan.contains(&TeardownSubject::ServerDataVolumes));
     }
 
     /// A backend that cannot produce evidence must be refused at bind time.

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -173,6 +173,17 @@ pub struct TeardownReceipt {
     pub outcome: TeardownOutcome,
 }
 
+/// Set by a consumer once it has read and acted on a lease's teardown receipt.
+///
+/// Until this is present, a receipt-carrying lease is retained after recycling
+/// rather than deleted — the receipt is the only durable proof its capacity was
+/// destroyed, and it is read precisely when the instance is already gone.
+///
+/// An annotation rather than a timeout: evidence that expires on a clock is
+/// evidence you cannot rely on having when you need it.
+pub const TEARDOWN_RECEIPT_ACKNOWLEDGED_ANNOTATION: &str =
+    "kobe.kunobi.ninja/teardown-receipt-acknowledged";
+
 /// Current schema version emitted by this build.
 pub const TEARDOWN_RECEIPT_SCHEMA_VERSION: u32 = 1;
 

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -124,6 +124,21 @@ pub struct TeardownCheck {
     /// `datastore_unreachable`). Never a raw provider response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+
+    /// The concrete resources this check actually looked at.
+    ///
+    /// A [`TeardownSubject`] is a category. On its own,
+    /// `Database = Verified` asserts that *a* database is gone without saying
+    /// which — so a receipt could be satisfied by checking the wrong one, or by
+    /// checking one of several when the footprint had more. Recording the exact
+    /// identities makes the claim auditable after the fact, which is the whole
+    /// point of keeping evidence that outlives the instance.
+    ///
+    /// Names only: object names, PV names, the database and role identifiers.
+    /// Never connection strings, credentials, or anything that would turn a
+    /// receipt into a secret.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verified: Vec<String>,
 }
 
 /// Durable proof that one exact lease-owned footprint is gone.
@@ -627,16 +642,19 @@ mod tests {
             subject: TeardownSubject::ServerStatefulSet,
             result: CheckResult::Verified,
             reason: None,
+            verified: Vec::new(),
         };
         let not_applicable = TeardownCheck {
             subject: TeardownSubject::RegistriesConfigMap,
             result: CheckResult::NotApplicable,
             reason: None,
+            verified: Vec::new(),
         };
         let unknown = TeardownCheck {
             subject: TeardownSubject::Database,
             result: CheckResult::Unknown,
             reason: Some("datastore_unreachable".into()),
+            verified: Vec::new(),
         };
 
         assert_eq!(
@@ -681,6 +699,7 @@ mod tests {
             subject,
             result,
             reason: None,
+            verified: Vec::new(),
         }
     }
 

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -260,6 +260,23 @@ impl TeardownReceipt {
         if self.checks.len() != expected.required_subjects.len() {
             return false;
         }
+        // Every recorded identity must appear in some verified check. A receipt
+        // that proved three of four volumes gone would otherwise pass, leaving
+        // the fourth — and the tenant data on it — behind.
+        let proven: Vec<&String> = self
+            .checks
+            .iter()
+            .filter(|check| check.result == CheckResult::Verified)
+            .flat_map(|check| check.verified.iter())
+            .collect();
+        if !expected
+            .recorded_identities
+            .iter()
+            .all(|identity| proven.contains(&identity))
+        {
+            return false;
+        }
+
         expected.required_subjects.iter().all(|subject| {
             let mut matching = self.checks.iter().filter(|check| check.subject == *subject);
             let Some(check) = matching.next() else {
@@ -310,6 +327,14 @@ pub struct TeardownScope<'a> {
     /// Used to derive the expected resource names. Comes from controller-owned
     /// bind-time state like the rest of this scope, never from the receipt.
     pub instance_name: &'a str,
+    /// Provisioner-assigned identities recorded while the instance was healthy
+    /// — the PersistentVolumes its claims were bound to.
+    ///
+    /// These cannot be derived from a name, so they are the one part of the
+    /// footprint a teardown could otherwise quietly omit. Recorded long before
+    /// teardown runs, they are something a receipt must account for rather than
+    /// something it gets to choose.
+    pub recorded_identities: &'a [String],
 }
 
 /// The name a subject's resource must have, where naming is deterministic.
@@ -796,6 +821,7 @@ mod tests {
             instance_spec_digest: "spec-digest",
             required_subjects: required,
             instance_name: "pool-p-0",
+            recorded_identities: &[],
         }
     }
 
@@ -918,6 +944,58 @@ mod tests {
             TeardownOutcome::Verified,
         );
         assert!(!unnamed.permits_release_for(&scope(&required, &refs)));
+    }
+
+    /// Every identity recorded while the instance was healthy must be proven
+    /// absent.
+    ///
+    /// Bound PV names cannot be derived from the instance name, so they are the
+    /// one part of the footprint a teardown could quietly omit — verify three of
+    /// four volumes and the fourth, with the tenant's data on it, survives while
+    /// the receipt reads clean. Recording them at Ready and requiring coverage
+    /// here is what closes that.
+    #[test]
+    fn every_recorded_identity_must_be_proven_absent() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [TeardownSubject::ServerDataVolumes];
+        let recorded = vec!["pvc-aaa".to_string(), "pvc-bbb".to_string()];
+
+        let volumes_check = |names: Vec<&str>| TeardownCheck {
+            subject: TeardownSubject::ServerDataVolumes,
+            result: CheckResult::Verified,
+            reason: None,
+            verified: names.into_iter().map(String::from).collect(),
+        };
+        let with_recorded = |identities: &'static [String]| TeardownScope {
+            lease: &refs.0,
+            instance: &refs.1,
+            pool: &refs.2,
+            backend_type: "k3s",
+            config_digest: "digest",
+            instance_spec_digest: "spec-digest",
+            required_subjects: &required,
+            instance_name: "pool-p-0",
+            recorded_identities: identities,
+        };
+        // Leaked to satisfy the 'static bound in this helper; test-only.
+        let recorded_static: &'static [String] = Box::leak(recorded.clone().into_boxed_slice());
+
+        // Both volumes proven: releases.
+        let complete = receipt(
+            vec![volumes_check(vec!["pvc-aaa", "pvc-bbb"])],
+            TeardownOutcome::Verified,
+        );
+        assert!(complete.permits_release_for(&with_recorded(recorded_static)));
+
+        // One volume unaccounted for: must not release.
+        let partial = receipt(
+            vec![volumes_check(vec!["pvc-aaa"])],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !partial.permits_release_for(&with_recorded(recorded_static)),
+            "a volume recorded at Ready but never proven absent must block release"
+        );
     }
 
     /// Subjects whose names are provisioner-assigned cannot be pre-derived, so

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -273,7 +273,16 @@ impl TeardownReceipt {
             // credentials as never-created and still release the lease. A
             // footprint that genuinely was never created belongs OUT of
             // `required_subjects` — that is what the scope is for.
-            matching.next().is_none() && check.result == CheckResult::Verified
+            if matching.next().is_some() || check.result != CheckResult::Verified {
+                return false;
+            }
+            // Where the name is derivable, the check must actually name it.
+            // Otherwise `ServerStatefulSet = Verified` proves only that
+            // *something* of that category was inspected.
+            match expected_identity_for(*subject, expected.instance_name) {
+                Some(expected_name) => check.verified.contains(&expected_name),
+                None => true,
+            }
         })
     }
 }
@@ -298,6 +307,43 @@ pub struct TeardownScope<'a> {
     /// were never created are simply absent — which is why the list must come
     /// from the creation record, not be inferred at teardown time.
     pub required_subjects: &'a [TeardownSubject],
+    /// Used to derive the expected resource names. Comes from controller-owned
+    /// bind-time state like the rest of this scope, never from the receipt.
+    pub instance_name: &'a str,
+}
+
+/// The name a subject's resource must have, where naming is deterministic.
+///
+/// This is the non-circular half of identity checking: it comes from the
+/// recorded plan and the instance name, never from the receipt being validated.
+/// A receipt claiming `ServerStatefulSet = Verified` while naming some other
+/// object therefore fails, rather than being accepted because the category
+/// matched.
+///
+/// `None` for subjects whose identity cannot be derived — the bound PV names
+/// are assigned by the provisioner, and the Pod set is a label selector. Those
+/// are still RECORDED in the receipt for audit; they simply cannot be
+/// pre-computed here.
+pub fn expected_identity_for(subject: TeardownSubject, instance: &str) -> Option<String> {
+    let name = match subject {
+        TeardownSubject::AgentDeployment => format!("{instance}-agent"),
+        TeardownSubject::ServerStatefulSet => format!("{instance}-server"),
+        TeardownSubject::Service => format!("{instance}-server"),
+        TeardownSubject::PodDisruptionBudget => format!("{instance}-server"),
+        TeardownSubject::PublisherConfigMap => format!("{instance}-kubeconfig-publisher"),
+        TeardownSubject::RegistriesConfigMap => format!("{instance}-registries"),
+        TeardownSubject::TokenSecret => format!("{instance}-token"),
+        TeardownSubject::KubeconfigSecret => format!("{instance}-kubeconfig"),
+        TeardownSubject::ConnectTokenSecret => format!("{instance}-connect-token"),
+        TeardownSubject::CidrClaim => instance.to_string(),
+        TeardownSubject::Database => format!("database:k3s_{instance}"),
+        TeardownSubject::DatabaseRole => format!("role:k3s_{instance}"),
+        // Provisioner-assigned or selector-based; recorded, not derivable.
+        TeardownSubject::ServerPods
+        | TeardownSubject::ServerDataPvcs
+        | TeardownSubject::ServerDataVolumes => return None,
+    };
+    Some(name)
 }
 
 /// Derive the exact set of footprints a k3s instance creates, from the config
@@ -710,7 +756,11 @@ mod tests {
             subject,
             result,
             reason: None,
-            verified: Vec::new(),
+            // Name what a real provider would have named, so these fixtures
+            // satisfy the identity comparison the way production does.
+            verified: expected_identity_for(subject, "pool-p-0")
+                .into_iter()
+                .collect(),
         }
     }
 
@@ -745,6 +795,7 @@ mod tests {
             config_digest: "digest",
             instance_spec_digest: "spec-digest",
             required_subjects: required,
+            instance_name: "pool-p-0",
         }
     }
 
@@ -818,6 +869,67 @@ mod tests {
 
         // An empty plan is not a clean bill of health.
         assert!(!complete.permits_release_for(&scope(&[], &refs)));
+    }
+
+    /// A check must name the resource its subject actually designates.
+    ///
+    /// Without this, `ServerStatefulSet = Verified` proves only that *something*
+    /// of that category was inspected — a receipt could verify a different
+    /// instance's StatefulSet, or one of several resources when the footprint
+    /// had more, and still release capacity. The expected name is derived from
+    /// controller-owned state and the instance name, never from the receipt.
+    #[test]
+    fn a_check_naming_the_wrong_resource_does_not_release() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [TeardownSubject::ServerStatefulSet];
+
+        let correct = receipt(
+            vec![check(
+                TeardownSubject::ServerStatefulSet,
+                CheckResult::Verified,
+            )],
+            TeardownOutcome::Verified,
+        );
+        assert!(correct.permits_release_for(&scope(&required, &refs)));
+
+        // Right category, wrong object — another instance's StatefulSet.
+        let wrong = receipt(
+            vec![TeardownCheck {
+                subject: TeardownSubject::ServerStatefulSet,
+                result: CheckResult::Verified,
+                reason: None,
+                verified: vec!["some-other-instance-server".into()],
+            }],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !wrong.permits_release_for(&scope(&required, &refs)),
+            "a check must name the resource its subject designates"
+        );
+
+        // Claiming the category with no identity at all is equally unproven.
+        let unnamed = receipt(
+            vec![TeardownCheck {
+                subject: TeardownSubject::ServerStatefulSet,
+                result: CheckResult::Verified,
+                reason: None,
+                verified: Vec::new(),
+            }],
+            TeardownOutcome::Verified,
+        );
+        assert!(!unnamed.permits_release_for(&scope(&required, &refs)));
+    }
+
+    /// Subjects whose names are provisioner-assigned cannot be pre-derived, so
+    /// they must not be blocked by the identity check — only recorded.
+    #[test]
+    fn provisioner_assigned_subjects_are_not_name_checked() {
+        assert!(expected_identity_for(TeardownSubject::ServerDataVolumes, "pool-p-0").is_none());
+        assert!(expected_identity_for(TeardownSubject::ServerPods, "pool-p-0").is_none());
+        assert_eq!(
+            expected_identity_for(TeardownSubject::Database, "pool-p-0").as_deref(),
+            Some("database:k3s_pool-p-0")
+        );
     }
 
     /// A receipt is proof about ONE subject. It must not be replayable against

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -1081,6 +1081,11 @@ pub fn compute_pool_phase(
         && counts.creating == 0
         && counts.recycling == 0
         && counts.unhealthy == 0
+        // Quarantined members are NOT idle: their backend resources still
+        // exist and are being held deliberately. Reporting Idle here would
+        // tell an operator the pool is empty while it is actually holding
+        // capacity it could not prove it destroyed.
+        && counts.quarantined == 0
         && min_ready == 0
     {
         return ClusterPoolPhase::Idle;
@@ -3236,6 +3241,47 @@ mod tests {
         assert_eq!(
             counts.unhealthy, 0,
             "quarantined must be distinguishable from ordinary churn"
+        );
+    }
+
+    /// A pool holding quarantined capacity must never report Idle.
+    ///
+    /// Idle means "empty, nothing running". A quarantined member's backend
+    /// resources still exist — holding them is the point — so reporting Idle
+    /// tells an operator the pool is empty while it is actually sitting on
+    /// capacity it could not prove it destroyed. That is the one state where a
+    /// human most needs to look.
+    #[test]
+    fn a_pool_holding_quarantined_capacity_is_not_idle() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 4,
+                scale_up_threshold: 1,
+                scale_down_after: "30m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+
+        // Genuinely empty scale-to-zero pool: Idle is correct.
+        let empty = StateCounts::default();
+        assert_eq!(
+            compute_pool_phase(&profile, &empty, 0, None, chrono::Utc::now()),
+            crate::crd::ClusterPoolPhase::Idle
+        );
+
+        // Same pool, one member held back.
+        let holding = StateCounts {
+            quarantined: 1,
+            ..Default::default()
+        };
+        assert_ne!(
+            compute_pool_phase(&profile, &holding, 0, None, chrono::Utc::now()),
+            crate::crd::ClusterPoolPhase::Idle,
+            "a pool holding unreclaimed capacity must not read as empty"
         );
     }
 


### PR DESCRIPTION
Closes #80 · follows #96 (merged as `a056f32`)
Epic: #70 — Agent Sandbox (lane `S1`)

**Targets `epic/agent-sandbox`.** v0.39.0 shipped with zero sandbox/teardown files — what holding this epic off `main` was for.

> This PR grew to cover all three remaining layers of #80. Earlier descriptions covered only the contract.

## The problem

`ClusterBackend::delete` returns `Result<()>`. The instance controller releases the cleanup finalizer the moment it returns Ok, and the lease controller reads the resulting 404 as "recycling complete". So **an accepted DELETE request was proof of destruction** — for capacity that held another tenant's code and credentials. PVC, PDB, Pod and PostgreSQL failures warn and continue, and nothing waits for objects or their backing volumes to disappear.

## Three layers

**1 · Contract.** `delete_verified` is a **new trait method with a default body**, not a changed `delete` signature. `ClusterBackend` has five implementors; changing the signature forces a mechanical update to all five, and the mechanical update is `Ok(vec![])` — a backend claiming a clean footprint it never inspected. Refusing by default means a backend can only claim evidence by writing the code.

**2 · k3s provider.** Capture → delete → **poll to confirmed absence**. Capture runs first because a PVC's `spec.volumeName` is the only link to its backing PV and it vanishes with the PVC; capture late and you can prove the claim is gone but never the volume. **Only a 404 counts as proof** — a 403 or a timeout becomes `Unknown`, so a broken RBAC grant can never read as a clean teardown.

**3 · Finalizer gate.** Release now requires a receipt covering the plan recorded at creation. Anything unproven **quarantines and keeps every handle** — finalizer, binding, provenance — because those are what a retry needs to address the same exact subject, and what stops the 404-based recycle path from treating the capacity as clean.

## The trust boundary #102 asked for

The plan is **stamped into immutable provenance at creation**, not derived at teardown. Deriving it later reads whatever the config says *then* — so a pool that stopped setting `registryMirrors` after an instance was built would silently drop that ConfigMap from the plan and never verify it. A receipt can no longer define its own scope.

Paired footprints are planned together: persistent storage pulls in the PVC **and** its volume; a datastore pulls in the database **and** its role. Proving one half while the other survives is exactly the leak a receipt would hide.

An instance created before verified teardown existed has no plan and is quarantined rather than verified against a guess.

The receipt is persisted **before** anything is released — written afterwards it could be lost with the object it describes, and outliving that object is its whole purpose.

## Caught by keeping the epic branch synced

**`TeardownSubject::DatabaseRole`.** `fix(datastore): give each cluster its own PostgreSQL role` (#105) landed on `main` while this branch was separate. k3s teardown now drops a **role** as well as the database — all best-effort `warn`-and-continue. Layer 1's subject list predated it, so a receipt could have proven the database absent **while a credential-bearing role survived**.

**`UnsupportedBackend` was unreachable** — eligibility took no backend to judge, so k0s/vcluster pools got `Ok(())`. Now refused.

## Regression proof

Mutation-checked at the site each fix lives:

| Mutation | Caught by |
|---|---|
| treat a failed lookup as absence | `a_failed_lookup_is_uncertainty_not_absence` |
| ignore a failed delete | `a_failed_delete_makes_every_subject_unknown` |
| plan a PVC without its volume / a DB without its role | `paired_footprints_are_never_planned_alone` |

Plus: surviving object → `Unknown`; missing object → `Verified`; database and role `Unknown` without a datastore; uncapturable volumes fail closed; plan covers exactly what a config creates.

## Validation

```
cargo fmt -- --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1351 passed, 0 failed
crdgen drift                                            # clean
```

## Scope, stated narrowly

Leases without `cleanupMode: VerifiedDestroy` take the **unchanged** path — the gate returns before touching anything.

Still open and tracked, not silently skipped:
- **#103** — quarantine is not surfaced in pool phase, status, CLI or metrics, and has no receipt-gated exit.
- **#102** — subjects are categories, not concrete resource identities: one `Database = Verified` does not bind to a specific database.