### PR TITLE
dist(agent-sandbox): validate an operator-installed runtime (external mode)

### DIFF
--- a/charts/kobe/templates/deployment.yaml
+++ b/charts/kobe/templates/deployment.yaml
@@ -68,6 +68,11 @@ spec:
               value: {{ .Values.logLevel | quote }}
             - name: KOBE_SYNC_IMAGE
               value: {{ include "kobe.syncImage" . | quote }}
+            # `managed` is rejected by the operator at startup rather than
+            # here, so the refusal and its reason live in one place and a
+            # direct (non-Helm) deployment cannot route around it.
+            - name: AGENT_SANDBOX_MODE
+              value: {{ .Values.agentSandbox.mode | default "disabled" | quote }}
             - name: POOL_SERVICE_ACCOUNT
               value: {{ .Values.poolServiceAccount | default (include "kobe.serviceAccountName" .) | quote }}
             - name: POOL_PUBLISHER_SERVICE_ACCOUNT

--- a/charts/kobe/values.yaml
+++ b/charts/kobe/values.yaml
@@ -78,6 +78,27 @@ containerSecurityContext:
 # Cluster-side defense-in-depth policies. These are opt-in because they
 # require Kubernetes features that may not be available in every cluster
 # (ValidatingAdmissionPolicy is GA in K8s 1.30+).
+# Upstream Agent Sandbox runtime (kubernetes-sigs/agent-sandbox).
+#
+# Kobe consumes SandboxTemplate / SandboxWarmPool / SandboxClaim from that
+# project. This selects how the runtime gets there.
+#
+#   disabled  (default) Sandbox features are off. Nothing is validated and no
+#             Sandbox API is served, so an upgrade never starts depending on a
+#             runtime you have not installed.
+#
+#   external  You install and own the runtime; kobe validates that the required
+#             APIs are present and version-compatible, and owns nothing.
+#
+#   managed   NOT IMPLEMENTED. It would install and RETAIN cluster-scoped CRDs,
+#             RBAC and a webhook across uninstall — Helm never deletes anything
+#             from a chart's crds/ directory, so those become permanent on any
+#             cluster that installs once. Pending approval on
+#             kunobi-ninja/kobe#72. Selecting it fails with an explicit error
+#             rather than falling back, so it cannot be switched on by accident.
+agentSandbox:
+  mode: disabled
+
 clusterPolicies:
   # Restricts the operator's namespace deletion permission (granted
   # broadly by the ClusterRole, since RBAC cannot pattern-match names)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,7 @@ mod metrics;
 pub mod pki;
 mod pool;
 mod sandbox;
+mod sandbox_runtime;
 mod telemetry;
 mod velero;
 
@@ -46,7 +47,40 @@ async fn main() -> anyhow::Result<()> {
 
     info!("Starting kobe-operator");
 
+    // Refuse an unimplemented or unrecognised Agent Sandbox mode at STARTUP.
+    // Deferring it to the first Sandbox request would leave a cluster running
+    // that looks healthy and fails only when someone tries to use it.
+    let agent_sandbox_mode = match sandbox_runtime::mode_from_env() {
+        Ok(mode) => {
+            info!(?mode, "Agent Sandbox runtime mode");
+            mode
+        }
+        Err(err) => {
+            error!(reason = err.reason_code(), "{err}");
+            std::process::exit(1);
+        }
+    };
+
     let client = Client::try_default().await?;
+
+    // In `external` mode the runtime is the operator's to install, so verify it
+    // is actually there and compatible before anything depends on it. Refused
+    // at startup rather than per-request: a cluster that looks healthy and only
+    // fails when someone tries to use Sandbox is the worse failure.
+    //
+    // Deliberately no create/delete canary — writing a real SandboxClaim is one
+    // of the effects paused on #72. Presence and version are a weaker signal
+    // than a canary, and that limit is stated rather than hidden.
+    if agent_sandbox_mode == sandbox_runtime::AgentSandboxMode::External {
+        match sandbox_runtime::validate_external_runtime(&client).await {
+            Ok(()) => info!("Agent Sandbox runtime validated (external, operator-installed)"),
+            Err(err) => {
+                error!(reason = err.reason_code(), "{err}");
+                std::process::exit(1);
+            }
+        }
+    }
+
     let namespace = std::env::var("OPERATOR_NAMESPACE").unwrap_or_else(|_| "kunobi-pool".into());
     let pod_namespace = std::env::var("POD_NAMESPACE").unwrap_or_else(|_| namespace.clone());
 

--- a/src/sandbox_runtime.rs
+++ b/src/sandbox_runtime.rs
@@ -1,0 +1,275 @@
+//! Validation of an **operator-installed** upstream Agent Sandbox runtime.
+//!
+//! Kobe consumes `SandboxTemplate`, `SandboxWarmPool` and `SandboxClaim` from
+//! the upstream [Agent Sandbox] project. Those APIs have to come from
+//! somewhere, and #72 originally proposed three installation modes. Two of
+//! them — `managed`, which installs and *retains* cluster-scoped CRDs, RBAC and
+//! a webhook across uninstall, and a child-cluster bootstrap performing the
+//! same install with cluster-admin — are paused behind an explicit approval and
+//! are deliberately absent from this module.
+//!
+//! What remains is the mode that needs no approval: the operator installs the
+//! runtime, and **Kobe owns nothing**. This module only answers "is a
+//! compatible runtime present?" before any Sandbox work is admitted.
+//!
+//! # Why validate at all
+//!
+//! Without a check, a missing or mismatched runtime surfaces as an obscure
+//! failure deep in placement — a `SandboxClaim` create that 404s, or worse, one
+//! that succeeds against an incompatible schema and leaves an object no
+//! controller reconciles. Refusing up front, with the version actually found,
+//! turns that into one legible error.
+//!
+//! # What this deliberately does NOT do
+//!
+//! No create/delete canary. Proving the runtime *works* by writing a real
+//! `SandboxClaim` was one of the paused effects, so readiness here rests on API
+//! presence and version compatibility only. That is a genuinely weaker
+//! guarantee — a runtime whose controller is wedged will pass this and fail
+//! later — and it is recorded as such rather than papered over.
+//!
+//! [Agent Sandbox]: https://github.com/kubernetes-sigs/agent-sandbox
+
+use serde::{Deserialize, Serialize};
+
+/// How the upstream Agent Sandbox runtime reaches a cluster.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "lowercase")]
+pub enum AgentSandboxMode {
+    /// Sandbox features are off. Nothing is validated and no Sandbox API is
+    /// served. The default, so an upgrade never starts depending on a runtime
+    /// the operator has not installed.
+    #[default]
+    Disabled,
+    /// The operator installs and owns the runtime; Kobe validates it and owns
+    /// nothing.
+    External,
+}
+
+/// The upstream API version this build is written against.
+///
+/// Pinned rather than "whatever is installed": Kobe projects pool and lease
+/// configuration onto a specific upstream schema, and a different version can
+/// accept the same object while meaning something else by it.
+pub const REQUIRED_AGENT_SANDBOX_API_VERSION: &str = "extensions.agents.x-k8s.io/v1beta1";
+
+/// The upstream CRDs Kobe consumes. All three are required: a runtime with
+/// claims but no warm pools would pass a laxer check and then fail to serve.
+pub const REQUIRED_AGENT_SANDBOX_CRDS: &[&str] = &[
+    "sandboxtemplates.extensions.agents.x-k8s.io",
+    "sandboxwarmpools.extensions.agents.x-k8s.io",
+    "sandboxclaims.extensions.agents.x-k8s.io",
+];
+
+/// Why an operator-installed runtime cannot be used.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum AgentSandboxUnusable {
+    #[error("Agent Sandbox is disabled; set agentSandbox.mode=external to use Sandbox features")]
+    Disabled,
+    #[error("Agent Sandbox CRD {crd} is not installed or not established")]
+    CrdMissing { crd: String },
+    #[error("Agent Sandbox CRD {crd} does not serve {expected} (found: {found})")]
+    VersionMismatch {
+        crd: String,
+        expected: String,
+        found: String,
+    },
+    /// `managed` mode is recognised but refused. Deliberately an explicit
+    /// error, not a silent fall back to `external` or `disabled`: choosing it
+    /// must stay a deliberate act that requires the approval on #72, rather
+    /// than something a config typo can switch on.
+    #[error(
+        "Agent Sandbox managed mode is not implemented: it installs and retains \
+         cluster-scoped CRDs, RBAC and a webhook, which is pending approval on #72. \
+         Install the runtime yourself and use agentSandbox.mode=external."
+    )]
+    ManagedNotApproved,
+}
+
+impl AgentSandboxUnusable {
+    /// Bounded reason code for status, events and metrics.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::Disabled => "disabled",
+            Self::CrdMissing { .. } => "crd_missing",
+            Self::VersionMismatch { .. } => "version_mismatch",
+            Self::ManagedNotApproved => "managed_not_approved",
+        }
+    }
+}
+
+/// Parse the configured mode, refusing `managed` explicitly.
+///
+/// An unrecognised value is refused rather than defaulted: silently treating a
+/// typo as `disabled` would leave an operator who asked for Sandbox features
+/// wondering why nothing works, and treating it as `external` would be worse.
+pub fn parse_mode(configured: &str) -> Result<AgentSandboxMode, AgentSandboxUnusable> {
+    match configured.trim().to_ascii_lowercase().as_str() {
+        "disabled" | "" => Ok(AgentSandboxMode::Disabled),
+        "external" => Ok(AgentSandboxMode::External),
+        "managed" => Err(AgentSandboxUnusable::ManagedNotApproved),
+        _ => Err(AgentSandboxUnusable::Disabled),
+    }
+}
+
+/// Read the configured mode from the environment.
+///
+/// Absent means [`AgentSandboxMode::Disabled`] — a deployment that predates
+/// this setting, or one that never opted in, must not start depending on a
+/// runtime nobody installed.
+pub fn mode_from_env() -> Result<AgentSandboxMode, AgentSandboxUnusable> {
+    parse_mode(&std::env::var("AGENT_SANDBOX_MODE").unwrap_or_default())
+}
+
+/// Whether one CRD, as observed, is established and serves the pinned version.
+///
+/// Pure so the compatibility rule is testable without a cluster: the caller
+/// supplies what the API server reported.
+pub fn crd_is_compatible(
+    crd: &str,
+    established: bool,
+    served_versions: &[String],
+) -> Result<(), AgentSandboxUnusable> {
+    if !established {
+        return Err(AgentSandboxUnusable::CrdMissing {
+            crd: crd.to_string(),
+        });
+    }
+    // The pinned constant is `group/version`; a CRD reports versions alone.
+    let expected_version = REQUIRED_AGENT_SANDBOX_API_VERSION
+        .rsplit('/')
+        .next()
+        .unwrap_or_default();
+    if served_versions
+        .iter()
+        .any(|version| version == expected_version)
+    {
+        return Ok(());
+    }
+    Err(AgentSandboxUnusable::VersionMismatch {
+        crd: crd.to_string(),
+        expected: REQUIRED_AGENT_SANDBOX_API_VERSION.to_string(),
+        found: if served_versions.is_empty() {
+            "none".to_string()
+        } else {
+            served_versions.join(",")
+        },
+    })
+}
+
+/// Validate that a compatible operator-installed runtime is present.
+///
+/// Every required CRD must be established and serve the pinned version. The
+/// first failure is returned rather than a collected list: an operator fixes
+/// these one at a time, and the first one usually explains the rest.
+pub async fn validate_external_runtime(client: &kube::Client) -> Result<(), AgentSandboxUnusable> {
+    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+    use kube::api::Api;
+
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    for name in REQUIRED_AGENT_SANDBOX_CRDS {
+        let observed = crds.get(name).await.ok();
+        let established = observed.as_ref().is_some_and(|crd| {
+            crd.status
+                .as_ref()
+                .and_then(|status| status.conditions.as_ref())
+                .is_some_and(|conditions| {
+                    conditions
+                        .iter()
+                        .any(|c| c.type_ == "Established" && c.status == "True")
+                })
+        });
+        let served: Vec<String> = observed
+            .as_ref()
+            .map(|crd| {
+                crd.spec
+                    .versions
+                    .iter()
+                    .filter(|version| version.served)
+                    .map(|version| version.name.clone())
+                    .collect()
+            })
+            .unwrap_or_default();
+        crd_is_compatible(name, established, &served)?;
+    }
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// `managed` must fail loudly rather than degrade.
+    ///
+    /// It installs and retains cluster-scoped resources, which is pending
+    /// approval on #72. Falling back to `external` or `disabled` would let a
+    /// config value quietly select behaviour nobody approved — and, worse,
+    /// would make the approval look granted to whoever read the running config.
+    #[test]
+    fn managed_mode_is_refused_explicitly_not_degraded() {
+        assert_eq!(
+            parse_mode("managed").unwrap_err(),
+            AgentSandboxUnusable::ManagedNotApproved
+        );
+        assert_eq!(
+            parse_mode("Managed").unwrap_err(),
+            AgentSandboxUnusable::ManagedNotApproved,
+            "case must not be a way around the refusal"
+        );
+    }
+
+    #[test]
+    fn disabled_is_the_default_and_external_is_opt_in() {
+        assert_eq!(AgentSandboxMode::default(), AgentSandboxMode::Disabled);
+        assert_eq!(parse_mode("").unwrap(), AgentSandboxMode::Disabled);
+        assert_eq!(parse_mode("disabled").unwrap(), AgentSandboxMode::Disabled);
+        assert_eq!(parse_mode("external").unwrap(), AgentSandboxMode::External);
+        assert_eq!(
+            parse_mode("  EXTERNAL  ").unwrap(),
+            AgentSandboxMode::External
+        );
+    }
+
+    /// A runtime serving a different version must be refused, not accepted
+    /// because the CRD name matched.
+    ///
+    /// Kobe projects pool and lease configuration onto a specific upstream
+    /// schema. A different version can accept the same object and mean
+    /// something else by it, which surfaces as a claim no controller
+    /// reconciles rather than as an error.
+    #[test]
+    fn a_different_upstream_version_is_refused() {
+        let crd = "sandboxclaims.extensions.agents.x-k8s.io";
+
+        assert!(crd_is_compatible(crd, true, &["v1beta1".into()]).is_ok());
+        // Serving several versions is fine as long as ours is among them.
+        assert!(crd_is_compatible(crd, true, &["v1alpha1".into(), "v1beta1".into()]).is_ok());
+
+        let err = crd_is_compatible(crd, true, &["v1alpha1".into()]).unwrap_err();
+        assert!(matches!(err, AgentSandboxUnusable::VersionMismatch { .. }));
+        assert_eq!(err.reason_code(), "version_mismatch");
+        // The found version belongs in the message: "incompatible" without it
+        // sends an operator digging for what is actually installed.
+        assert!(format!("{err}").contains("v1alpha1"));
+    }
+
+    /// A CRD that exists but is not established is not usable — during install
+    /// or a failed upgrade it can be present and not yet serving.
+    #[test]
+    fn an_unestablished_crd_is_not_usable() {
+        let err =
+            crd_is_compatible("sandboxclaims.extensions.agents.x-k8s.io", false, &[]).unwrap_err();
+        assert!(matches!(err, AgentSandboxUnusable::CrdMissing { .. }));
+        assert_eq!(err.reason_code(), "crd_missing");
+    }
+
+    /// All three CRDs are required. A runtime with claims but no warm pools
+    /// would pass a laxer check and then fail to serve.
+    #[test]
+    fn every_consumed_crd_is_required() {
+        assert_eq!(REQUIRED_AGENT_SANDBOX_CRDS.len(), 3);
+        for crd in REQUIRED_AGENT_SANDBOX_CRDS {
+            assert!(crd.ends_with(".extensions.agents.x-k8s.io"), "{crd}");
+        }
+    }
+}


### PR DESCRIPTION
Closes #72 (narrowed scope)
Epic: #70 — Agent Sandbox (lane `F2`)

## This does not approve the paused effects — it avoids them

@jleni paused #72 pending approval of three effects. **None are implemented here.** The gate stands as written; the scope was narrowed to the part that needs no approval, on the epic owner's decision.

| Paused effect | Status |
|---|---|
| `managed` Helm installs + **retains** cluster-scoped CRDs/RBAC/webhook across uninstall | **Not implemented** |
| Validation creates/deletes a **real `SandboxClaim`** canary | **Not implemented** |
| Child bootstrap performs **cluster-admin** install | **Not implemented** |

## What ships

`agentSandbox.mode: disabled | external`, defaulting to **disabled** — an upgrade never starts depending on a runtime you haven't installed.

In `external` mode the operator installs the runtime and **Kobe owns nothing**. It verifies all three consumed CRDs are established and serve the pinned `extensions.agents.x-k8s.io/v1beta1`.

- **All three are required.** A runtime with claims but no warm pools would pass a laxer check and then fail to serve.
- **The version is pinned**, not accepted as-found. Kobe projects pool and lease config onto a specific schema; another version can accept the same object while meaning something else by it — which surfaces as a claim no controller reconciles rather than as an error.
- **Validated at startup**, not per request. A cluster that looks healthy and fails only when someone first uses Sandbox is the worse failure. The error names the version actually installed.

## `managed` fails loudly

Refused with an explicit error rather than degrading to `external` or `disabled`. Falling back would let a config value quietly select behaviour nobody approved — and would make the approval look granted to anyone reading the running config. Case-insensitive, and an unrecognised value is refused too rather than silently defaulting.

The refusal lives in the operator, not the chart template, so a direct (non-Helm) deployment can't route around it.

## An honest limit

**Presence and version are a weaker guarantee than a canary.** A runtime whose controller is wedged passes this and fails later. That is the direct cost of not writing a live `SandboxClaim`, and it's recorded in the module docs rather than papered over. Worth revisiting if the canary is ever approved.

## Validation

```
cargo fmt -- --check                                    # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1336 passed, 0 failed
helm template (default + external)                      # renders; AGENT_SANDBOX_MODE plumbed
```

## What this unblocks

#73 → #74 → #81–#84 → #76, for clusters where the runtime is operator-installed. `managed` mode can follow as its own change once the retention question is settled — the Helm `crds/` one-way door deserves its own decision, not a side effect of unblocking an epic.

> CI is currently red on runner infrastructure (`mise install bun` fails before any Rust compilation), unrelated to this change.