### PR TITLE
fix(lifecycle): stop the teardown fence from deadlocking recycling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.39.0"
+version = "0.39.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.39.0"
+version = "0.39.1"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.39.0
-appVersion: "0.39.0"
+version: 0.39.1
+appVersion: "0.39.1"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.39.0
+      image: docker.io/zondax/kobe-operator:v0.39.1
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.39.0
+      image: docker.io/zondax/kobe-sync:v0.39.1
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -1801,30 +1801,14 @@ async fn verify_bound_instance_for_teardown<B: ClusterBackend>(
     instance: &ClusterInstance,
     namespace: &str,
 ) -> Result<(), &'static str> {
-    let Some(binding) = instance
-        .status
-        .as_ref()
-        .and_then(|status| status.binding.as_ref())
-    else {
-        // An unbound pool member or standalone instance has no tenant binding
-        // to cross. Pool-managed backend dispatch is still provenance-pinned by
-        // `delete_instance_backend`.
-        return Ok(());
-    };
-    let lease_uid = binding.lease.uid.as_deref().ok_or("lease_uid_missing")?;
-    let resolved = crate::lease_binding::resolve_lease_binding(
-        &ctx.client,
-        namespace,
-        &binding.lease.name,
-        lease_uid,
-        crate::lease_binding::BindingResolveMode::Lifecycle,
-    )
-    .await
-    .map_err(|err| err.reason_code())?;
-    if resolved.instance.metadata.uid != instance.metadata.uid || resolved.binding != *binding {
-        return Err("instance_uid_mismatch");
-    }
-    Ok(())
+    // Teardown-specific policy: fence on positive evidence of the wrong
+    // target, release on absence. The live-pair resolver used here before
+    // could never pass once deletion started — see `verify_instance_teardown`
+    // for the three unsatisfiable gates and the pool-exhaustion deadlock they
+    // produced.
+    crate::lease_binding::verify_instance_teardown(&ctx.client, namespace, instance)
+        .await
+        .map_err(|err| err.reason_code())
 }
 
 /// Best-effort cleanup of host-side resources that a backend's `delete()`

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -1275,8 +1275,16 @@ async fn mark_instance_recycling(
         Err(err) => return Err(err.into()),
     };
     let status = instance.status.clone().unwrap_or_default();
+    // The generation equality holds only while the instance is live: the
+    // apiserver bumps `metadata.generation` when it stamps `deletionTimestamp`
+    // on a finalizer-bearing object, so an instance whose delete is already in
+    // flight reads one generation ahead of the binding and would be judged
+    // "not safe to recycle" forever. Identity is still pinned by the UID,
+    // reciprocal-binding, and lease-reference checks around it.
+    let generation_matches = instance.metadata.deletion_timestamp.is_some()
+        || instance.metadata.generation == Some(binding.instance.observed_generation);
     if instance.metadata.uid.as_deref() != Some(binding.instance.uid.as_str())
-        || instance.metadata.generation != Some(binding.instance.observed_generation)
+        || !generation_matches
         || status.binding.as_ref() != Some(binding)
         || status.lease_ref.as_ref().is_none_or(|reference| {
             reference.name != binding.lease.name || reference.uid != binding.lease.uid
@@ -2975,6 +2983,59 @@ mod tests {
         assert_eq!(action, Action::requeue(std::time::Duration::from_secs(30)));
         let calls = ctx.backend.call_count();
         assert_eq!(calls.delete, 0);
+    }
+
+    /// Recycling must survive the generation bump that deletion itself causes.
+    ///
+    /// The apiserver increments `metadata.generation` when it stamps
+    /// `deletionTimestamp` on a finalizer-bearing object, so an instance whose
+    /// delete is already in flight reads one generation ahead of the binding
+    /// that named it. Requiring equality there judged the exact instance "not
+    /// safe to recycle" on every pass, so the lease never observed recycling
+    /// completion — the other half of the pool-exhaustion deadlock. Drift on a
+    /// *live* instance is still refused.
+    #[tokio::test]
+    async fn deleting_instance_is_still_recyclable_despite_the_deletion_generation_bump() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+        let binding = exact_test_binding("lease-a", "lease-a-uid");
+
+        let mut deleting = exact_instance_for_binding(Some(&binding), "Recycling");
+        deleting["metadata"]["deletionTimestamp"] = serde_json::json!("2026-01-01T00:00:00Z");
+        deleting["metadata"]["finalizers"] =
+            serde_json::json!(["kobe.kunobi.ninja/instance-cleanup"]);
+        deleting["metadata"]["generation"] = serde_json::json!(2);
+
+        let mut live_drift = exact_instance_for_binding(Some(&binding), "Recycling");
+        live_drift["metadata"]["generation"] = serde_json::json!(2);
+
+        let instance_path =
+            "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances/pool-test-1";
+        Mock::given(method("GET"))
+            .and(path(instance_path))
+            .respond_with(ResponseTemplate::new(200).set_body_json(deleting))
+            .up_to_n_times(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(instance_path))
+            .respond_with(ResponseTemplate::new(200).set_body_json(live_drift))
+            .mount(&server)
+            .await;
+
+        assert!(
+            mark_instance_recycling(&client, "test-ns", &binding)
+                .await
+                .unwrap(),
+            "a deleting instance must still count as the exact recycle subject"
+        );
+        assert!(
+            !mark_instance_recycling(&client, "test-ns", &binding)
+                .await
+                .unwrap(),
+            "generation drift on a live instance stays fenced"
+        );
     }
 
     // -----------------------------------------------------------------------

--- a/src/lease_binding.rs
+++ b/src/lease_binding.rs
@@ -27,6 +27,10 @@ pub(crate) enum BindingResolveMode {
 #[derive(Debug)]
 pub(crate) struct ResolvedLeaseBinding {
     pub lease: ClusterLease,
+    /// `#[allow(dead_code)]`: callers work off the validated `binding`, but the
+    /// resolved object stays part of the tuple so a caller needing live
+    /// instance state does not re-fetch it unvalidated.
+    #[allow(dead_code)]
     pub instance: ClusterInstance,
     pub pool: ClusterPool,
     pub binding: LeaseBinding,
@@ -73,6 +77,8 @@ pub(crate) enum BindingResolutionError {
     InstancePhaseMismatch,
     #[error("instance reciprocal binding does not match")]
     ReciprocalBindingMismatch,
+    #[error("lease is still bound to this instance")]
+    LeaseStillBound,
     #[error("instance lease reference does not match binding")]
     LeaseRefMismatch,
     #[error("instance pool reference does not match binding")]
@@ -120,6 +126,7 @@ impl BindingResolutionError {
             Self::InstanceDeleting => "instance_deleting",
             Self::InstancePhaseMismatch => "instance_phase_mismatch",
             Self::ReciprocalBindingMismatch => "reciprocal_binding_mismatch",
+            Self::LeaseStillBound => "lease_still_bound",
             Self::LeaseRefMismatch => "lease_ref_mismatch",
             Self::InstancePoolMismatch => "instance_pool_mismatch",
             Self::InstanceOwnerMismatch => "instance_owner_mismatch",
@@ -297,6 +304,96 @@ pub(crate) async fn resolve_lease_binding(
         pool,
         binding,
     })
+}
+
+/// Verify that a bound `ClusterInstance` is safe to tear down.
+///
+/// # Why this is not `resolve_lease_binding(_, Lifecycle)`
+///
+/// Teardown runs on an instance that is already being destroyed, so the
+/// resolver's live-pair invariants are unsatisfiable by construction:
+///
+/// * Kubernetes bumps `metadata.generation` when it stamps `deletionTimestamp`
+///   on a finalizer-bearing object, so a deleting instance always reads
+///   `generation == observedGeneration + 1` → `InstanceGenerationMismatch`.
+/// * The resolver rejects any instance carrying a `deletionTimestamp`
+///   outright → `InstanceDeleting`.
+/// * The paired lease CR is deleted at the end of recycling →
+///   `LeaseNotFound`.
+///
+/// Each denial fenced the finalizer path *permanently*: the cleanup finalizer
+/// was never released, the `ClusterInstance` stayed in `Recycling` forever,
+/// and the pool filled with undeletable members until every request failed
+/// `pool_exhausted`. The resolver fails closed on *absence*, which is right
+/// for granting tenant access and exactly wrong for reclaiming a corpse.
+///
+/// Teardown therefore fences only on positive evidence that this instance is
+/// the wrong target — a binding describing a different object, or a lease that
+/// is still live and still points here — and fails open on absence.
+pub(crate) async fn verify_instance_teardown(
+    client: &Client,
+    namespace: &str,
+    instance: &ClusterInstance,
+) -> Result<(), BindingResolutionError> {
+    let Some(binding) = instance
+        .status
+        .as_ref()
+        .and_then(|status| status.binding.as_ref())
+    else {
+        // An unbound pool member or standalone instance has no tenant binding
+        // to cross. Backend dispatch stays provenance-pinned by the caller.
+        return Ok(());
+    };
+
+    // Self-consistency: the binding must describe *this* CR. A binding naming
+    // another object is the copy/stale-object case the UID fence exists for.
+    if instance.metadata.uid.as_deref() != Some(binding.instance.uid.as_str())
+        || instance.name_any() != binding.instance.name
+    {
+        return Err(BindingResolutionError::InstanceUidMismatch);
+    }
+
+    let leases: Api<ClusterLease> = Api::namespaced(client.clone(), namespace);
+    let lease = match leases.get(&binding.lease.name).await {
+        Ok(lease) => lease,
+        // The lease is gone, so no tenant can still be holding this instance.
+        Err(kube::Error::Api(ae)) if ae.code == 404 => return Ok(()),
+        // A lookup failure is not evidence either way; the caller requeues.
+        Err(err) => return Err(BindingResolutionError::LeaseLookup(err)),
+    };
+
+    // A same-named replacement lease is somebody else's binding, not a live
+    // claim on this instance.
+    if lease.metadata.uid.as_deref() != binding.lease.uid.as_deref() {
+        return Ok(());
+    }
+    if lease.metadata.deletion_timestamp.is_some() {
+        return Ok(());
+    }
+
+    let lease_status = lease.status.clone().unwrap_or_default();
+    if lease_status.phase != LeasePhase::Bound {
+        return Ok(());
+    }
+    // Only an unexpired `Bound` lease can still be serving a tenant. An absent
+    // or malformed expiry cannot prove liveness, and unlike the access path a
+    // wrong guess here strands a cluster instead of leaking one — so
+    // uncertainty releases.
+    let live = lease_status
+        .expires_at
+        .as_deref()
+        .and_then(|value| chrono::DateTime::parse_from_rfc3339(value).ok())
+        .is_some_and(|expires_at| chrono::Utc::now() < expires_at.with_timezone(&chrono::Utc));
+    if !live {
+        return Ok(());
+    }
+    // Live, and still reciprocally bound to this exact instance: a tenant is
+    // using it. This fence is self-clearing — the lease expires on its TTL.
+    if lease_status.binding.as_ref() == Some(binding) {
+        return Err(BindingResolutionError::LeaseStillBound);
+    }
+
+    Ok(())
 }
 
 fn validate_binding_shape(binding: &LeaseBinding) -> Result<(), BindingResolutionError> {
@@ -718,5 +815,160 @@ mod tests {
                 .reason_code(),
             "binding_malformed"
         );
+    }
+
+    /// Run `verify_instance_teardown` against a mock apiserver that serves
+    /// `lease` for `lease-a` (or 404s when `lease` is `None`).
+    async fn teardown_verdict(
+        instance: serde_json::Value,
+        lease: Option<serde_json::Value>,
+    ) -> Result<(), BindingResolutionError> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let response = match lease {
+            Some(lease) => ResponseTemplate::new(200).set_body_json(lease),
+            None => ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "kind": "Status", "apiVersion": "v1", "status": "Failure",
+                "message": "not found", "reason": "NotFound", "code": 404
+            })),
+        };
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterleases/lease-a",
+            ))
+            .respond_with(response)
+            .mount(&server)
+            .await;
+        let client = crate::testutil::mock_k8s_client(&server);
+        let instance: ClusterInstance = serde_json::from_value(instance).unwrap();
+        verify_instance_teardown(&client, "test-ns", &instance).await
+    }
+
+    /// The production deadlock: an instance whose delete is already in flight
+    /// reads one generation ahead of its binding (the apiserver bumps
+    /// `metadata.generation` when it stamps `deletionTimestamp` on a
+    /// finalizer-bearing object) and its lease has moved on. The live-pair
+    /// resolver denied both facts, so the cleanup finalizer was never
+    /// released: every bound instance became undeletable, the pool filled with
+    /// them, and all leases failed `pool_exhausted`.
+    #[tokio::test]
+    async fn teardown_releases_a_deleting_instance_whose_lease_terminated() {
+        let (_, mut lease, mut instance, _) = exact_objects();
+        instance["metadata"]["deletionTimestamp"] = serde_json::json!("2026-01-01T00:00:00Z");
+        instance["metadata"]["generation"] = serde_json::json!(2);
+        instance["metadata"]["finalizers"] =
+            serde_json::json!(["kobe.kunobi.ninja/instance-cleanup"]);
+        instance["status"]["phase"] = serde_json::json!("Recycling");
+        lease["status"]["phase"] = serde_json::json!("Recycling");
+
+        assert!(
+            teardown_verdict(instance.clone(), Some(lease))
+                .await
+                .is_ok(),
+            "a deleting instance whose lease is recycling must tear down"
+        );
+
+        // The same instance once the lease CR itself is gone.
+        assert!(
+            teardown_verdict(instance, None).await.is_ok(),
+            "a missing lease is not evidence of a live tenant"
+        );
+    }
+
+    /// Absence releases, but positive evidence of the wrong target still
+    /// fences: a binding that names another object must never authorise a
+    /// teardown of this one.
+    #[tokio::test]
+    async fn teardown_fences_a_binding_that_describes_another_instance() {
+        let (_, lease, instance, _) = exact_objects();
+        let mut foreign_uid = instance.clone();
+        foreign_uid["status"]["binding"]["instance"]["uid"] = serde_json::json!("other-uid");
+        assert_eq!(
+            teardown_verdict(foreign_uid, Some(lease.clone()))
+                .await
+                .unwrap_err()
+                .reason_code(),
+            "instance_uid_mismatch"
+        );
+
+        let mut foreign_name = instance;
+        foreign_name["status"]["binding"]["instance"]["name"] = serde_json::json!("pool-p-9");
+        assert_eq!(
+            teardown_verdict(foreign_name, Some(lease))
+                .await
+                .unwrap_err()
+                .reason_code(),
+            "instance_uid_mismatch"
+        );
+    }
+
+    /// A live `Bound` lease still pointing here means a tenant is using the
+    /// cluster. That fence stays — it is self-clearing at the lease TTL, and
+    /// only an unexpired reciprocal lease can hold it.
+    #[tokio::test]
+    async fn teardown_fences_only_a_live_reciprocal_lease() {
+        let (_, mut lease, instance, _) = exact_objects();
+        lease["status"]["expiresAt"] =
+            serde_json::json!((chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339());
+        assert_eq!(
+            teardown_verdict(instance.clone(), Some(lease.clone()))
+                .await
+                .unwrap_err()
+                .reason_code(),
+            "lease_still_bound"
+        );
+
+        // Expired, so no tenant is served even though the phase still reads Bound.
+        let mut expired = lease.clone();
+        expired["status"]["expiresAt"] =
+            serde_json::json!((chrono::Utc::now() - chrono::Duration::minutes(1)).to_rfc3339());
+        assert!(
+            teardown_verdict(instance.clone(), Some(expired))
+                .await
+                .is_ok()
+        );
+
+        // Unprovable liveness releases here (the access path denies instead).
+        let mut malformed = lease.clone();
+        malformed["status"]["expiresAt"] = serde_json::json!("not-a-timestamp");
+        assert!(
+            teardown_verdict(instance.clone(), Some(malformed))
+                .await
+                .is_ok()
+        );
+
+        // A same-named replacement lease is somebody else's binding.
+        let mut replacement = lease.clone();
+        replacement["metadata"]["uid"] = serde_json::json!("replacement-lease-uid");
+        assert!(
+            teardown_verdict(instance.clone(), Some(replacement))
+                .await
+                .is_ok()
+        );
+
+        // A live lease that has moved on to another instance does not hold this one.
+        let mut rebound = lease.clone();
+        rebound["status"]["binding"]["bindingId"] = serde_json::json!("other-binding");
+        assert!(
+            teardown_verdict(instance.clone(), Some(rebound))
+                .await
+                .is_ok()
+        );
+
+        // A lease being deleted cannot keep serving it either.
+        let mut deleting = lease;
+        deleting["metadata"]["deletionTimestamp"] = serde_json::json!("2026-01-01T00:00:00Z");
+        assert!(teardown_verdict(instance, Some(deleting)).await.is_ok());
+    }
+
+    /// An unbound pool member has no tenant binding to cross.
+    #[tokio::test]
+    async fn teardown_releases_an_unbound_instance_without_a_lease_lookup() {
+        let (_, _, mut instance, _) = exact_objects();
+        instance["status"]
+            .as_object_mut()
+            .unwrap()
+            .remove("binding");
+        assert!(teardown_verdict(instance, None).await.is_ok());
     }
 }


### PR DESCRIPTION
## Incident

On int-pro every member of `ci-k3s-kunobi` (10/10, = pool max) is stuck in `Recycling` with the `kobe.kunobi.ninja/instance-cleanup` finalizer never released. `ready`/`creating`/`leased` are all 0, and `kobe_lease_unsatisfiable_total{reason=pool_exhausted}` counted 123 in 6h — CI cannot lease a cluster. The operator is healthy (15.8k ok reconciles in 2h); it is fencing itself.

```
WARN Deletion fenced: exact lease binding is not verifiable
     instance=pool-ci-k3s-kunobi-7200 reason=instance_generation_mismatch
```

## Root cause

`verify_bound_instance_for_teardown` re-validated the binding through `resolve_lease_binding(_, Lifecycle)`. That resolver can never pass once deletion has started, for three independent reasons:

- the apiserver bumps `metadata.generation` when it stamps `deletionTimestamp` on a finalizer-bearing object, so a deleting instance always reads `generation == observedGeneration + 1` → `instance_generation_mismatch` (confirmed in prod: all 10 stuck instances are `gen=2` vs `observedGeneration=1`, with matching spec digests — no actual drift);
- `resolve_lease_binding` rejects any instance carrying a `deletionTimestamp` outright, ungated by mode → `instance_deleting`;
- the paired lease CR is deleted at the end of recycling → `lease_not_found`.

So any instance that was ever leased became permanently undeletable, and the pool filled with them. Introduced in #90, first shipped in v0.39.0 (the deployed image).

`mark_instance_recycling` carries the same generation trap, which is why the paired leases also never observe recycling completion.

## Fix

The resolver fails closed on **absence**. That is correct for granting a tenant access to a live cluster and exactly wrong for reclaiming a corpse. Teardown gets its own policy, `verify_instance_teardown`: fence on positive evidence of the **wrong target**, release on absence.

- Fences: a binding describing a different object (UID/name), or a lease that is still `Bound`, unexpired, and reciprocally pointing at this instance. That last one is the only case where absence-of-proof was protecting anything, and it is self-clearing at the lease TTL.
- Releases: missing/deleting/terminated lease, same-named replacement lease, a live lease that has moved on, generation drift, and the instance's own `deletionTimestamp`.

Why loosening is safe here: the destructive target is pinned by the instance CR itself — the UID self-check plus provenance-pinned backend dispatch in `delete_instance_backend` — so the lease was only ever corroboration. `resolve_lease_binding` and the tenant `Access` path are untouched, as is the reservation path (`instance_matches_binding_subject`): a deleting instance must still never be handed to a new tenant.

## Tests

- `teardown_releases_a_deleting_instance_whose_lease_terminated` — the exact production shape (deleting, gen+1, lease recycling or gone).
- `teardown_fences_a_binding_that_describes_another_instance`, `teardown_fences_only_a_live_reciprocal_lease` — the fences that must hold, incl. expired/malformed-expiry/replacement/rebound/deleting leases.
- `deleting_instance_is_still_recyclable_despite_the_deletion_generation_bump` — verified to fail without the `mark_instance_recycling` change.

794 unit tests green, clippy `-D warnings` clean.

## Deploying this

Merging does not unblock int-pro on its own — the operator image only rolls on a published release. Needs a v0.39.1 release (chart `appVersion`/`version` bump on main first), which shin then auto-deploys. The currently stuck instances can be freed ahead of that by clearing their stale `status.binding`.

## Known follow-up (pre-existing, not touched here)

Released/Expired leases whose binding cannot be verified (`binding_missing` — ~50 of them on int-pro) requeue every 30s indefinitely. They do not hold pool capacity.