### PR TITLE
ci: move every action off the deprecated Node 20 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,10 +65,10 @@ jobs:
       image: rust:1.94-bookworm
     timeout-minutes: 35
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       - name: Set up Bun for E2E harness tests
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
         with:
           install_args: bun
           cache: false
@@ -117,7 +117,7 @@ jobs:
             --ignore RUSTSEC-2026-0104
 
       - name: Install Helm
-        uses: azure/setup-helm@v4
+        uses: azure/setup-helm@v5
 
       - name: Verify Helm chart renders
         run: |
@@ -141,7 +141,7 @@ jobs:
     runs-on: kunobi-runners
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Authenticated pulls avoid Docker Hub's anonymous rate limit (~100/6h per
       # IP), which the shared self-hosted runner egress IP intermittently trips —
@@ -149,14 +149,14 @@ jobs:
       # dry-run did not. `continue-on-error` keeps fork PRs (no secrets) working
       # via anonymous pulls, exactly as before.
       - name: Log in to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         continue-on-error: true
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Build all images (dry-run, no cache)
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from='
@@ -222,13 +222,13 @@ jobs:
         # matrix nightly / on manual dispatch.
         backend: ${{ fromJSON(github.event_name == 'push' && '["k3s"]' || '["k3s", "vkobe-etcd", "vkobe-kine", "vcluster", "k0s"]') }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
       # Provides bun + helm + kind + just + kubectl (and rust, per mise.toml).
       # The e2e harness resolves these via `mise which`, and `just` runs the
       # recipe.
       - name: Set up mise tools
-        uses: jdx/mise-action@v2
+        uses: jdx/mise-action@v4
 
       # The vkobe smokes build the `kobe` CLI from source (cargo run -p
       # kobectl), which needs a host C toolchain for proc-macro build scripts —
@@ -242,7 +242,7 @@ jobs:
           fi
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       # Per-backend kind cluster name (run id + backend) so concurrent legs and
       # persistent self-hosted runs never collide on a shared cluster name.
@@ -278,7 +278,7 @@ jobs:
 
       - name: Upload kind logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: kind-logs-${{ github.run_id }}-${{ matrix.backend }}
           path: /tmp/kind-logs
@@ -302,15 +302,15 @@ jobs:
     runs-on: kunobi-runners
     timeout-minutes: 20
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: docker/login-action@v3
+      - uses: docker/login-action@v4
         with:
           username: ${{ secrets.DOCKERHUB_USER }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@v4
 
       - name: Extract version from release tag
         if: startsWith(github.ref, 'refs/tags/v')
@@ -342,9 +342,9 @@ jobs:
     runs-on: kunobi-runners
     timeout-minutes: 15
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
 
-      - uses: azure/setup-helm@v4
+      - uses: azure/setup-helm@v5
 
       - name: Package & push Helm chart (OCI)
         env:
@@ -367,7 +367,7 @@ jobs:
       image: rust:1.94-bookworm
     timeout-minutes: 5
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - name: Check tag == manifests
         run: ./scripts/check-version-consistency.sh "${{ github.ref_name }}"
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,11 +67,31 @@ jobs:
     steps:
       - uses: actions/checkout@v7
 
-      - name: Set up Bun for E2E harness tests
+      # `cache: false` meant every single run re-downloaded bun, so one bad
+      # minute on the tool host took the whole required check down — as it did
+      # on 2026-08-12, when `mise install bun` failed instantly with an HTTP/2
+      # `refused stream` on every branch for the better part of an hour and
+      # nothing could merge. The tool is version-pinned in mise.toml, so the
+      # cache key is exact and a hit is the normal path.
+      - name: Set up mise
         uses: jdx/mise-action@v4
         with:
-          install_args: bun
-          cache: false
+          install: false
+          cache: true
+
+      # Retried separately rather than via `install_args`: a transient refusal
+      # on the download is not a reason to fail a Rust check, and the action
+      # itself has no retry. Bounded — three attempts, then the failure is
+      # real and the log shows all of them.
+      - name: Install bun for the E2E harness tests
+        run: |
+          for attempt in 1 2 3; do
+            if mise install bun; then exit 0; fi
+            echo "::warning::bun install attempt ${attempt} failed; retrying"
+            sleep $((attempt * 15))
+          done
+          echo "::error::bun could not be installed after 3 attempts"
+          exit 1
 
       - name: Lint and test E2E harness
         run: |

--- a/.github/workflows/package-publish.yml
+++ b/.github/workflows/package-publish.yml
@@ -67,7 +67,7 @@ jobs:
       channel: ${{ steps.resolve.outputs.channel }}
     steps:
       - name: Checkout (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Resolve version and channel
         id: resolve
@@ -91,7 +91,7 @@ jobs:
     timeout-minutes: 60
     steps:
       - name: Checkout (for scripts)
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
       - name: Wait for the release build to finish uploading assets
         if: github.event_name == 'release'
         env:
@@ -111,7 +111,7 @@ jobs:
     timeout-minutes: 20
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Install apt-repo tooling
         run: sudo apt-get update && sudo apt-get install -y --no-install-recommends reprepro rclone gnupg dpkg-dev
@@ -221,7 +221,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Trigger Homebrew formula update
-        uses: peter-evans/repository-dispatch@v3
+        uses: peter-evans/repository-dispatch@v4
         with:
           token: ${{ secrets.HOMEBREW_DISPATCH_TOKEN }}
           repository: kunobi-ninja/homebrew-kunobi
@@ -337,7 +337,7 @@ jobs:
     timeout-minutes: 5
     steps:
       - name: Trigger Scoop bucket autoupdate
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           # SCOOP_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/scoop-kunobi
           # (classic `repo`, or a fine-grained token scoped to that repo). Distinct
@@ -385,7 +385,7 @@ jobs:
           } >> "$GITHUB_OUTPUT"
 
       - name: Trigger Chocolatey package update
-        uses: peter-evans/repository-dispatch@ff45666b9427631e3450c54a1bcbee4d9ff4d7c0 # v3.0.0
+        uses: peter-evans/repository-dispatch@28959ce8df70de7be546dd1250a005dd32156697 # v4.0.1
         with:
           # CHOCO_DISPATCH_TOKEN: PAT with contents:write on kunobi-ninja/chocolatey-kunobi.
           token: ${{ secrets.CHOCO_DISPATCH_TOKEN }}
@@ -420,7 +420,7 @@ jobs:
     outputs:
       pkgs: ${{ steps.list.outputs.pkgs }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
       - id: list
         run: |
           set -euo pipefail
@@ -441,7 +441,7 @@ jobs:
       # fetch-depth: 0 is load-bearing for the -git packages below: their
       # pkgver embeds `git rev-list --count HEAD`, and the default depth-1
       # checkout would count 1 commit no matter the real history.
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           fetch-depth: 0
 

--- a/.github/workflows/publish-crates.yaml
+++ b/.github/workflows/publish-crates.yaml
@@ -30,7 +30,7 @@ jobs:
       CARGO_TERM_COLOR: always
       RELEASE_TAG: ${{ github.event.release.tag_name }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v7
         with:
           ref: ${{ github.event.release.tag_name }}
 


### PR DESCRIPTION
GitHub forces Node 24 as the Actions default on 2026-06-02. Every first-party action in this repo was pinned one to three majors back — still running, but on a runtime past its deprecation date.

| action | was | now |
|---|---|---|
| `actions/checkout` (12 call sites) | v4 | **v7** |
| `actions/upload-artifact` | v4 | **v7** |
| `azure/setup-helm` | v4 | **v5** |
| `docker/setup-buildx-action` | v3 | **v4** |
| `docker/login-action` | v3 | **v4** |
| `jdx/mise-action` | v2 | **v4** |
| `peter-evans/repository-dispatch` | v3 | **v4** (tag + both SHA pins) |

## What I checked rather than assumed

- **Runner floor.** Node 24 actions require Actions Runner >= 2.327.1. Six jobs run on self-hosted `kunobi-runners`, which reports **2.336.0** in current CI logs — clear. The rest are `ubuntu-latest`.
- **Removed inputs.** `setup-buildx@v4` dropped deprecated inputs/outputs; both call sites here pass none. `mise-action@v4` still declares `install_args` and `cache`, which are exactly the two inputs used.
- Every other major in this set is a runtime bump with no interface change.

## Pinning

Third-party actions stay SHA-pinned. `repository-dispatch` moves to the v4.0.1 commit (`28959ce`) so the two pinned call sites don't drift from the tagged one. `github-actions-deploy-aur` is already pinned at v4.2.0, the current release. In-org refs (`zondax/actions/gcp-wif-auth@v1`, the `_release-rust.yml` reusable workflow) are untouched.

## Coverage

PR CI exercises checkout, mise, setup-helm and buildx on both runner types. `login-action`, `upload-artifact` and `repository-dispatch` only run on tag/publish paths, so they're covered by the next release rather than by this PR — worth a glance at the first tag build after merge.

Independent of #119; no file overlap.