### PR TITLE
readiness(sandbox): gate leases on the pool's execution canary

### DIFF
--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -64,6 +64,23 @@ rules:
   - apiGroups: ["extensions.agents.x-k8s.io"]
     resources: ["sandboxtemplates", "sandboxwarmpools", "sandboxclaims"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The upstream `Sandbox` object itself, in the CORE Agent Sandbox group.
+  # Read-only: Kobe creates Sandboxes only indirectly, through claims. It is
+  # read to find the Pod behind a claim, via upstream's own `status.selector`.
+  - apiGroups: ["agents.x-k8s.io"]
+    resources: ["sandboxes"]
+    verbs: ["get", "list", "watch"]
+  # The readiness canary runs an administrator-declared command inside the
+  # Sandbox. Upstream `Ready` describes the container, not the agent in it —
+  # a crash-looped or wedged agent satisfies it, and believing it starts a
+  # paid runtime TTL on a Sandbox that cannot serve.
+  #
+  # `pods/exec` is a powerful verb, so what bounds it matters: the argv comes
+  # from the `SandboxPool` spec, which only an administrator can write, and a
+  # lease selects a pool and nothing else. No caller input reaches this.
+  - apiGroups: [""]
+    resources: ["pods/exec"]
+    verbs: ["create"]
   # Core resources for virtual cluster lifecycle
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets", "serviceaccounts", "pods", "pods/status", "events", "persistentvolumeclaims", "endpoints"]

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -6,3 +6,4 @@ pub mod lease;
 pub mod live_set;
 pub mod profile;
 pub mod sandbox;
+pub mod sandbox_canary;

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -252,6 +252,57 @@ pub async fn reconcile_lease(
         return Ok(Action::requeue(std::time::Duration::from_secs(10)));
     }
 
+    // Upstream `Ready` is a statement about the container, not the agent inside
+    // it. A Pod whose entrypoint crash-looped, whose weights failed to mount,
+    // or whose agent is wedged on a lock satisfies it — and believing it starts
+    // a paid runtime TTL on a Sandbox that cannot serve. The pool's own canary
+    // asks the workload directly.
+    //
+    // The pass is recorded on the lease before anything else, and a recorded
+    // pass is not re-run. Re-executing an administrator's command inside a live
+    // tenant workload on every requeue is not a health check — it is a repeated
+    // side effect on somebody else's Sandbox — and a controller that restarted
+    // between the canary and the Ready write must not run it a second time.
+    let status = lease.status.clone().unwrap_or_default();
+    if !canary_already_passed(&status) {
+        let outcome = crate::controllers::sandbox_canary::evaluate_readiness_canary(
+            &ctx.client,
+            &ctx.namespace,
+            &claim,
+            &pool.spec.template.default_container,
+            &pool.spec.readiness.canary,
+        )
+        .await;
+        if !outcome.is_pass() {
+            // Not ready, and deliberately not an error either way: a failing
+            // canary is a Sandbox that has not come up yet, and an unrunnable
+            // one is no evidence at all. The provisioning deadline already
+            // bounds how long this may repeat, so a Sandbox that never passes
+            // ends as an expiry rather than as a lease that hangs.
+            debug!(
+                lease = %name,
+                outcome = outcome.reason_code(),
+                "readiness canary did not pass; TTL clock has not started"
+            );
+            return Ok(Action::requeue(std::time::Duration::from_secs(10)));
+        }
+        patch_lease_status(
+            &ctx,
+            &name,
+            &serde_json::json!({
+                "conditions": with_condition(
+                    &lease,
+                    READINESS_CANARY_CONDITION,
+                    crate::crd::SandboxConditionStatus::True,
+                    "CanaryPassed",
+                    "Pool readiness canary exited zero inside the Sandbox",
+                ),
+            }),
+        )
+        .await?;
+        debug!(lease = %name, "readiness canary passed");
+    }
+
     // Runtime TTL starts HERE, at observed readiness — not when the request
     // arrived. A caller must not be billed for however long placement and
     // provisioning took, which is the whole reason the provisioning deadline
@@ -259,7 +310,6 @@ pub async fn reconcile_lease(
     let runtime_ttl = crate::pool::parse_duration(&lease.spec.ttl).ok_or_else(|| {
         SandboxPlacementError::Invalid(format!("lease {name} has an invalid TTL"))
     })?;
-    let status = lease.status.clone().unwrap_or_default();
     let observed_generation = lease.metadata.generation.unwrap_or_default();
     // An already-Ready lease reuses its PERSISTED readiness instant. Passing a
     // fresh `now()` on every requeue would make the transition non-idempotent:
@@ -615,8 +665,31 @@ async fn quarantine_lease(
 }
 
 const CLEANUP_VERIFIED_CONDITION: &str = "CleanupVerified";
+/// Durable record that the pool's canary already ran and passed.
+///
+/// Durable rather than in-memory because the alternative is running an
+/// administrator's command inside a live tenant workload again after every
+/// controller restart.
+const READINESS_CANARY_CONDITION: &str = "ReadinessCanary";
 
-/// Build the whole condition list, with `CleanupVerified` upserted into it.
+/// Whether the readiness canary has already been observed to pass.
+fn canary_already_passed(status: &crate::crd::SandboxLeaseStatus) -> bool {
+    status.conditions.iter().any(|condition| {
+        condition.condition_type == READINESS_CANARY_CONDITION
+            && condition.status == crate::crd::SandboxConditionStatus::True
+    })
+}
+
+fn with_cleanup_condition(
+    lease: &SandboxLease,
+    status: crate::crd::SandboxConditionStatus,
+    reason: &str,
+    message: &str,
+) -> Vec<crate::crd::SandboxCondition> {
+    with_condition(lease, CLEANUP_VERIFIED_CONDITION, status, reason, message)
+}
+
+/// Build the whole condition list, with one condition upserted into it.
 ///
 /// The full list is rebuilt because the status patch is a JSON merge patch,
 /// which REPLACES an array rather than merging it: sending one condition alone
@@ -626,8 +699,9 @@ const CLEANUP_VERIFIED_CONDITION: &str = "CleanupVerified";
 /// Kubernetes convention — a timestamp that advanced on every requeue would
 /// make a condition that has been stable for an hour look like it just
 /// flipped.
-fn with_cleanup_condition(
+fn with_condition(
     lease: &SandboxLease,
+    condition_type: &str,
     status: crate::crd::SandboxConditionStatus,
     reason: &str,
     message: &str,
@@ -639,7 +713,7 @@ fn with_cleanup_condition(
         .unwrap_or_default();
     let previous = existing
         .iter()
-        .find(|condition| condition.condition_type == CLEANUP_VERIFIED_CONDITION);
+        .find(|condition| condition.condition_type == condition_type);
     let last_transition_time = match previous {
         Some(previous) if previous.status == status => previous.last_transition_time.clone(),
         _ => Some(chrono::Utc::now().to_rfc3339()),
@@ -647,10 +721,10 @@ fn with_cleanup_condition(
 
     let mut conditions: Vec<_> = existing
         .into_iter()
-        .filter(|condition| condition.condition_type != CLEANUP_VERIFIED_CONDITION)
+        .filter(|condition| condition.condition_type != condition_type)
         .collect();
     conditions.push(crate::crd::SandboxCondition {
-        condition_type: CLEANUP_VERIFIED_CONDITION.into(),
+        condition_type: condition_type.to_string(),
         status,
         reason: reason.to_string(),
         message: message.to_string(),
@@ -994,6 +1068,26 @@ mod tests {
         }
     }
 
+    /// A lease whose canary pass is already recorded.
+    ///
+    /// The canary execs over a websocket, which the HTTP mock cannot serve — so
+    /// tests about what happens *after* readiness record the pass the same way
+    /// a previous reconcile would have, which is also the production path after
+    /// any controller restart.
+    fn lease_past_the_canary() -> SandboxLease {
+        let lease = admitted_lease();
+        let conditions = with_condition(
+            &lease,
+            READINESS_CANARY_CONDITION,
+            crate::crd::SandboxConditionStatus::True,
+            "CanaryPassed",
+            "recorded by an earlier reconcile",
+        );
+        let mut lease = lease;
+        lease.status.as_mut().unwrap().conditions = conditions;
+        lease
+    }
+
     fn claim_json(status: serde_json::Value) -> serde_json::Value {
         serde_json::json!({
             "apiVersion": AGENT_SANDBOX_API_VERSION,
@@ -1111,7 +1205,7 @@ mod tests {
             .mount(&server)
             .await;
 
-        let result = reconcile_lease(Arc::new(admitted_lease()), ctx).await;
+        let result = reconcile_lease(Arc::new(lease_past_the_canary()), ctx).await;
         assert!(result.is_err(), "a failed backstop must fail the reconcile");
         assert_eq!(
             requests_to(&server, "PATCH", LEASE_STATUS_PATH).await,
@@ -1207,6 +1301,114 @@ mod tests {
                 .is_empty(),
             "placement must decline before it touches the API at all"
         );
+    }
+
+    /// A Sandbox upstream calls Ready is not yet a Sandbox that works.
+    ///
+    /// Upstream's condition is about the container. A Pod whose agent
+    /// crash-looped, whose weights failed to mount, or which is wedged on a
+    /// lock satisfies it — and the moment Kobe believes it, the caller's paid
+    /// runtime TTL starts on something that cannot serve. Until the pool's own
+    /// canary passes, nothing is written: no clock, no shutdown time, no Ready.
+    #[tokio::test]
+    async fn upstream_ready_alone_does_not_start_the_clock() {
+        let (ctx, server) = test_context().await;
+        Mock::given(method("GET"))
+            .and(path(POOL_PATH))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(management_pool(POOL_UID, POOL_GENERATION)),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(CLAIMS_PATH))
+            .respond_with(
+                ResponseTemplate::new(201).set_body_json(claim_json(serde_json::json!({}))),
+            )
+            .mount(&server)
+            .await;
+        // Upstream says Ready — and says nothing about the agent inside.
+        Mock::given(method("GET"))
+            .and(path(CLAIM_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(claim_json(serde_json::json!({
+                    "conditions": [{ "type": "Ready", "status": "True" }],
+                    "sandbox": { "name": "sbx" },
+                }))),
+            )
+            .mount(&server)
+            .await;
+        // The Sandbox object is unreachable, so the canary cannot run. That is
+        // absence of evidence, and absence of evidence is not readiness.
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/agents.x-k8s.io/v1beta1/namespaces/test-ns/sandboxes/sbx",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "kind": "Status", "status": "Failure", "code": 404, "reason": "NotFound"
+            })))
+            .mount(&server)
+            .await;
+
+        let action = reconcile_lease(Arc::new(admitted_lease()), ctx)
+            .await
+            .unwrap();
+        assert_ne!(
+            action,
+            Action::await_change(),
+            "the canary must be re-tried"
+        );
+
+        assert_eq!(
+            requests_to(&server, "PATCH", CLAIM_PATH).await,
+            0,
+            "no shutdown time until the workload itself answers"
+        );
+        assert_eq!(
+            requests_to(&server, "PATCH", LEASE_STATUS_PATH).await,
+            0,
+            "an unproven Sandbox must not be marked Ready"
+        );
+    }
+
+    /// A recorded canary pass is not re-run.
+    ///
+    /// The canary executes an administrator-declared command inside a live
+    /// tenant workload. Repeating it on every requeue would turn a health check
+    /// into a recurring side effect on somebody else's Sandbox — and a
+    /// controller that restarted after a pass must not run it again either,
+    /// which is why the record lives on the lease rather than in memory.
+    #[test]
+    fn a_recorded_canary_pass_is_durable() {
+        use crate::crd::SandboxConditionStatus;
+
+        assert!(!canary_already_passed(&Default::default()));
+
+        let lease = lease_past_the_canary();
+        assert!(canary_already_passed(lease.status.as_ref().unwrap()));
+
+        // A recorded FAILURE is not a pass. Only True counts.
+        let mut failed = admitted_lease();
+        failed.status.as_mut().unwrap().conditions = with_condition(
+            &failed,
+            READINESS_CANARY_CONDITION,
+            SandboxConditionStatus::False,
+            "CanaryFailed",
+            "exited non-zero",
+        );
+        assert!(!canary_already_passed(failed.status.as_ref().unwrap()));
+
+        // Nor is somebody else's condition.
+        let mut unrelated = admitted_lease();
+        unrelated.status.as_mut().unwrap().conditions = with_condition(
+            &unrelated,
+            "CleanupVerified",
+            SandboxConditionStatus::True,
+            "TeardownVerified",
+            "gone",
+        );
+        assert!(!canary_already_passed(unrelated.status.as_ref().unwrap()));
     }
 
     // -----------------------------------------------------------------------

--- a/src/controllers/sandbox_canary.rs
+++ b/src/controllers/sandbox_canary.rs
@@ -1,0 +1,511 @@
+//! Pool-defined execution canary for Sandbox readiness (#73).
+//!
+//! # Why the upstream `Ready` condition is not enough
+//!
+//! Upstream reports `Ready` when the Sandbox's Pod is running and its probes
+//! pass. That is a statement about the *container*, not about the agent inside
+//! it. A Pod whose entrypoint crashed into a restart loop, whose model weights
+//! failed to mount, or whose agent process is wedged on a lock can satisfy
+//! every one of those checks — and the moment Kobe believes it, the caller's
+//! runtime TTL starts and they are charged for a Sandbox that cannot serve.
+//!
+//! The canary closes that gap by asking the workload itself. Each pool declares
+//! an argv and a timeout in `spec.readiness.canary`; readiness means that
+//! command exited zero inside the Sandbox.
+//!
+//! # Administrator-owned, never caller-owned
+//!
+//! The argv comes from the `SandboxPool` spec, which only an administrator can
+//! write. A lease selects a pool and nothing else. Were the argv reachable from
+//! lease intent, this would be a remote-execution primitive against the
+//! operator's own credentials rather than a health check.
+//!
+//! # Failing the canary is not the same as failing to run it
+//!
+//! A canary that runs and exits non-zero is evidence the Sandbox is not ready.
+//! A canary that cannot be run at all — the Pod not resolvable yet, an exec
+//! that times out, RBAC refused — is *absence of evidence*, and it is treated
+//! as "not ready yet" rather than as either a pass or a hard failure. The
+//! provisioning deadline already bounds how long that may continue, so an
+//! unrunnable canary ends as an expiry rather than as a lease that hangs.
+
+use k8s_openapi::api::core::v1::Pod;
+use kube::api::{Api, ApiResource, AttachParams, DynamicObject, ListParams};
+use kube::{Client, ResourceExt};
+use tracing::{debug, warn};
+
+use crate::crd::SandboxExecutionCanary;
+
+/// The upstream `Sandbox` kind, which lives in the *core* Agent Sandbox group —
+/// not the `extensions.` group the templates, warm pools and claims are in.
+pub const SANDBOX_API_VERSION: &str = "agents.x-k8s.io/v1beta1";
+pub const SANDBOX_KIND: &str = "Sandbox";
+
+/// What one canary attempt established.
+///
+/// Three outcomes, because "the agent said no" and "nobody could ask" are
+/// different facts. Collapsing them would either mark a broken Sandbox ready
+/// or fail a healthy one for a transient API error.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CanaryOutcome {
+    /// The command ran inside the Sandbox and exited zero.
+    Passed,
+    /// The command ran and did not exit zero. The Sandbox is not ready.
+    Failed { reason: String },
+    /// The command could not be run. No conclusion either way.
+    Inconclusive { reason: String },
+}
+
+impl CanaryOutcome {
+    /// Only an observed success starts the clock.
+    pub fn is_pass(&self) -> bool {
+        matches!(self, Self::Passed)
+    }
+
+    /// Bounded reason code for status, events and logs — never a raw command
+    /// output, which is workload data and may carry secrets.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::Passed => "canary_passed",
+            Self::Failed { .. } => "canary_failed",
+            Self::Inconclusive { .. } => "canary_inconclusive",
+        }
+    }
+}
+
+fn sandbox_resource() -> ApiResource {
+    ApiResource {
+        group: "agents.x-k8s.io".into(),
+        version: "v1beta1".into(),
+        api_version: SANDBOX_API_VERSION.into(),
+        kind: SANDBOX_KIND.into(),
+        plural: "sandboxes".into(),
+    }
+}
+
+/// Resolve the Pod backing one claim, following only documented upstream
+/// fields.
+///
+/// `claim.status.sandbox.name` names the Sandbox, and `sandbox.status.selector`
+/// is upstream's own label selector for its Pods. Both are followed rather than
+/// guessed from a naming convention: a convention that upstream changes would
+/// silently start selecting the wrong Pod, and the wrong Pod is one belonging
+/// to another tenant.
+pub async fn resolve_sandbox_pod(
+    client: &Client,
+    namespace: &str,
+    claim: &DynamicObject,
+) -> Result<Option<String>, String> {
+    let Some(sandbox_name) = claim
+        .data
+        .get("status")
+        .and_then(|status| status.get("sandbox"))
+        .and_then(|sandbox| sandbox.get("name"))
+        .and_then(|name| name.as_str())
+        .filter(|name| !name.is_empty())
+    else {
+        // Normal immediately after readiness: the claim is bound but its status
+        // has not been written back yet.
+        return Ok(None);
+    };
+
+    let sandboxes: Api<DynamicObject> =
+        Api::namespaced_with(client.clone(), namespace, &sandbox_resource());
+    let sandbox = match sandboxes.get(sandbox_name).await {
+        Ok(sandbox) => sandbox,
+        Err(kube::Error::Api(error)) if error.code == 404 => return Ok(None),
+        Err(error) => return Err(format!("sandbox lookup failed: {error}")),
+    };
+
+    let Some(selector) = sandbox
+        .data
+        .get("status")
+        .and_then(|status| status.get("selector"))
+        .and_then(|selector| selector.as_str())
+        .filter(|selector| !selector.is_empty())
+    else {
+        return Ok(None);
+    };
+
+    let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let matching = pods
+        .list(&ListParams::default().labels(selector))
+        .await
+        .map_err(|error| format!("pod lookup failed: {error}"))?;
+
+    // Exactly one running Pod, or none. An ambiguous selector is refused
+    // rather than resolved arbitrarily: executing into "whichever came first"
+    // is how a canary ends up talking to a Pod that is not this lease's.
+    let mut running = matching.into_iter().filter(|pod| {
+        pod.status
+            .as_ref()
+            .and_then(|status| status.phase.as_deref())
+            == Some("Running")
+            && pod.metadata.deletion_timestamp.is_none()
+    });
+    let Some(pod) = running.next() else {
+        return Ok(None);
+    };
+    if running.next().is_some() {
+        return Err("sandbox selector matched more than one running pod".to_string());
+    }
+    Ok(Some(pod.name_any()))
+}
+
+/// Run one pool-declared canary inside the Sandbox Pod.
+///
+/// The exec is wrapped in the pool's own timeout. Without it a wedged agent —
+/// exactly the failure this check exists to catch — would hang the reconcile
+/// rather than fail it, taking the controller's whole worker slot with it.
+pub async fn run_canary(
+    client: &Client,
+    namespace: &str,
+    pod: &str,
+    container: &str,
+    canary: &SandboxExecutionCanary,
+) -> CanaryOutcome {
+    let Some(timeout) = crate::pool::parse_duration(&canary.timeout)
+        .and_then(|timeout| timeout.to_std().ok().filter(|timeout| !timeout.is_zero()))
+    else {
+        return CanaryOutcome::Inconclusive {
+            reason: "canary timeout is not a valid positive duration".to_string(),
+        };
+    };
+
+    let pods: Api<Pod> = Api::namespaced(client.clone(), namespace);
+    let params = AttachParams::default()
+        .container(container)
+        .stdin(false)
+        .stdout(true)
+        .stderr(true);
+
+    let attached = match tokio::time::timeout(timeout, pods.exec(pod, &canary.argv, &params)).await
+    {
+        Ok(Ok(attached)) => attached,
+        Ok(Err(error)) => {
+            return CanaryOutcome::Inconclusive {
+                reason: format!("exec could not be started: {error}"),
+            };
+        }
+        Err(_) => {
+            return CanaryOutcome::Inconclusive {
+                reason: "exec did not start within the canary timeout".to_string(),
+            };
+        }
+    };
+
+    let mut attached = attached;
+    let status = match tokio::time::timeout(timeout, attached.take_status().unwrap()).await {
+        Ok(status) => status,
+        Err(_) => {
+            // Wedged. Abort so the connection does not outlive the reconcile.
+            attached.abort();
+            return CanaryOutcome::Failed {
+                reason: "canary did not complete within its timeout".to_string(),
+            };
+        }
+    };
+
+    interpret_exec_status(status)
+}
+
+/// Turn an exec `Status` into a verdict.
+///
+/// Split out from the exec itself so the rule is testable without a cluster,
+/// and because the interesting judgement is here: a *missing* status means the
+/// command's fate is unknown, which must not read as success.
+pub fn interpret_exec_status(
+    status: Option<k8s_openapi::apimachinery::pkg::apis::meta::v1::Status>,
+) -> CanaryOutcome {
+    let Some(status) = status else {
+        return CanaryOutcome::Inconclusive {
+            reason: "exec returned no completion status".to_string(),
+        };
+    };
+    match status.status.as_deref() {
+        Some("Success") => CanaryOutcome::Passed,
+        // Upstream reports a non-zero exit as `Failure` with reason
+        // `NonZeroExitCode`. The command ran; the workload said no.
+        Some("Failure") => CanaryOutcome::Failed {
+            reason: status
+                .reason
+                .unwrap_or_else(|| "canary exited non-zero".to_string()),
+        },
+        // Anything else is a shape this build does not understand. Refusing to
+        // guess is the point: guessing "success" marks a broken Sandbox ready.
+        other => CanaryOutcome::Inconclusive {
+            reason: format!("unrecognised exec status: {}", other.unwrap_or("<none>")),
+        },
+    }
+}
+
+/// Run the pool's canary against a claim, resolving the Pod first.
+///
+/// Every failure to *reach* the workload is inconclusive rather than a pass or
+/// a failure. The provisioning deadline bounds how long that may repeat.
+pub async fn evaluate_readiness_canary(
+    client: &Client,
+    namespace: &str,
+    claim: &DynamicObject,
+    container: &str,
+    canary: &SandboxExecutionCanary,
+) -> CanaryOutcome {
+    let pod = match resolve_sandbox_pod(client, namespace, claim).await {
+        Ok(Some(pod)) => pod,
+        Ok(None) => {
+            debug!(claim = %claim.name_any(), "sandbox pod not resolvable yet");
+            return CanaryOutcome::Inconclusive {
+                reason: "sandbox pod is not resolvable yet".to_string(),
+            };
+        }
+        Err(reason) => {
+            warn!(claim = %claim.name_any(), reason, "could not resolve sandbox pod");
+            return CanaryOutcome::Inconclusive { reason };
+        }
+    };
+    run_canary(client, namespace, &pod, container, canary).await
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use k8s_openapi::apimachinery::pkg::apis::meta::v1::Status;
+
+    fn status(value: &str, reason: Option<&str>) -> Option<Status> {
+        Some(Status {
+            status: Some(value.to_string()),
+            reason: reason.map(str::to_string),
+            ..Default::default()
+        })
+    }
+
+    /// Only an observed `Success` is a pass.
+    ///
+    /// This is the whole value of the canary: everything it cannot confirm has
+    /// to fall short of "ready", because the alternative is starting a paid
+    /// runtime TTL on a Sandbox that cannot serve.
+    #[test]
+    fn only_an_observed_success_passes() {
+        assert_eq!(
+            interpret_exec_status(status("Success", None)),
+            CanaryOutcome::Passed
+        );
+
+        // The command ran and said no.
+        let failed = interpret_exec_status(status("Failure", Some("NonZeroExitCode")));
+        assert!(matches!(failed, CanaryOutcome::Failed { .. }));
+        assert_eq!(failed.reason_code(), "canary_failed");
+        assert!(!failed.is_pass());
+
+        // Nobody could ask, or the answer was a shape we do not understand.
+        for unknown in [None, status("Weird", None), status("", None)] {
+            let outcome = interpret_exec_status(unknown);
+            assert!(
+                matches!(outcome, CanaryOutcome::Inconclusive { .. }),
+                "expected inconclusive, got {outcome:?}"
+            );
+            assert!(!outcome.is_pass());
+        }
+    }
+
+    /// A malformed timeout must not run an unbounded exec.
+    ///
+    /// The canary exists to catch a wedged agent. An exec with no bound against
+    /// exactly that workload would hang the reconcile and take a controller
+    /// worker with it — turning a detectable fault into an outage.
+    #[tokio::test]
+    async fn a_malformed_timeout_refuses_to_run_the_canary() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        for bad in ["", "  ", "0s", "not-a-duration", "-5m"] {
+            let canary = SandboxExecutionCanary {
+                argv: vec!["/agent".into(), "health".into()],
+                timeout: bad.to_string(),
+            };
+            let outcome = run_canary(&client, "test-ns", "pod-1", "agent", &canary).await;
+            assert!(
+                matches!(outcome, CanaryOutcome::Inconclusive { .. }),
+                "timeout {bad:?} must not run an unbounded exec, got {outcome:?}"
+            );
+        }
+
+        // Nothing was ever sent: the refusal happens before the API is touched.
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty()
+        );
+    }
+
+    /// The Pod is found through upstream's own fields, not a naming guess.
+    ///
+    /// A claim whose status is not yet populated is "not yet", never an error
+    /// and never a pass — that state is normal for the first moments after the
+    /// Ready condition appears.
+    #[tokio::test]
+    async fn an_unpopulated_claim_status_resolves_to_no_pod() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        for data in [
+            serde_json::json!({}),
+            serde_json::json!({ "status": {} }),
+            serde_json::json!({ "status": { "sandbox": {} } }),
+            serde_json::json!({ "status": { "sandbox": { "name": "" } } }),
+        ] {
+            let mut claim = DynamicObject::new(
+                "kobe-sbx-1",
+                &ApiResource {
+                    group: "extensions.agents.x-k8s.io".into(),
+                    version: "v1beta1".into(),
+                    api_version: "extensions.agents.x-k8s.io/v1beta1".into(),
+                    kind: "SandboxClaim".into(),
+                    plural: "sandboxclaims".into(),
+                },
+            );
+            claim.data = data.clone();
+            assert_eq!(
+                resolve_sandbox_pod(&client, "test-ns", &claim).await,
+                Ok(None),
+                "must not resolve a pod from {data}"
+            );
+        }
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty(),
+            "an unpopulated status is answered without an API call"
+        );
+    }
+
+    /// An ambiguous selector is refused rather than resolved arbitrarily.
+    ///
+    /// Executing into "whichever Pod came back first" is how a canary ends up
+    /// talking to a Pod that belongs to another lease.
+    #[tokio::test]
+    async fn an_ambiguous_selector_is_refused() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/agents.x-k8s.io/v1beta1/namespaces/test-ns/sandboxes/sbx",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": SANDBOX_API_VERSION,
+                "kind": SANDBOX_KIND,
+                "metadata": { "name": "sbx", "namespace": "test-ns" },
+                "status": { "selector": "agents.x-k8s.io/sandbox=sbx" },
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/namespaces/test-ns/pods"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "PodList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [
+                    { "metadata": { "name": "pod-a", "namespace": "test-ns" },
+                      "status": { "phase": "Running" } },
+                    { "metadata": { "name": "pod-b", "namespace": "test-ns" },
+                      "status": { "phase": "Running" } },
+                ],
+            })))
+            .mount(&server)
+            .await;
+
+        let mut claim = DynamicObject::new(
+            "kobe-sbx-1",
+            &ApiResource {
+                group: "extensions.agents.x-k8s.io".into(),
+                version: "v1beta1".into(),
+                api_version: "extensions.agents.x-k8s.io/v1beta1".into(),
+                kind: "SandboxClaim".into(),
+                plural: "sandboxclaims".into(),
+            },
+        );
+        claim.data = serde_json::json!({ "status": { "sandbox": { "name": "sbx" } } });
+
+        assert!(
+            resolve_sandbox_pod(&client, "test-ns", &claim)
+                .await
+                .is_err(),
+            "two running pods must be an error, not a coin flip"
+        );
+    }
+
+    /// A Pod that is terminating is not a Pod to execute in.
+    ///
+    /// It still reports `Running` for the whole of its grace period, so a check
+    /// on phase alone would run the canary against a Sandbox on its way out —
+    /// and either pass on borrowed time or fail for the wrong reason.
+    #[tokio::test]
+    async fn a_terminating_pod_is_not_selected() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/agents.x-k8s.io/v1beta1/namespaces/test-ns/sandboxes/sbx",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": SANDBOX_API_VERSION,
+                "kind": SANDBOX_KIND,
+                "metadata": { "name": "sbx", "namespace": "test-ns" },
+                "status": { "selector": "agents.x-k8s.io/sandbox=sbx" },
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path("/api/v1/namespaces/test-ns/pods"))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "PodList",
+                "metadata": { "resourceVersion": "1" },
+                "items": [{
+                    "metadata": {
+                        "name": "pod-a",
+                        "namespace": "test-ns",
+                        "deletionTimestamp": "2026-01-01T00:00:00Z",
+                    },
+                    "status": { "phase": "Running" },
+                }],
+            })))
+            .mount(&server)
+            .await;
+
+        let mut claim = DynamicObject::new(
+            "kobe-sbx-1",
+            &ApiResource {
+                group: "extensions.agents.x-k8s.io".into(),
+                version: "v1beta1".into(),
+                api_version: "extensions.agents.x-k8s.io/v1beta1".into(),
+                kind: "SandboxClaim".into(),
+                plural: "sandboxclaims".into(),
+            },
+        );
+        claim.data = serde_json::json!({ "status": { "sandbox": { "name": "sbx" } } });
+
+        assert_eq!(
+            resolve_sandbox_pod(&client, "test-ns", &claim).await,
+            Ok(None)
+        );
+    }
+}

--- a/src/sandbox_runtime.rs
+++ b/src/sandbox_runtime.rs
@@ -55,10 +55,30 @@ pub const REQUIRED_AGENT_SANDBOX_API_VERSION: &str = "extensions.agents.x-k8s.io
 
 /// The upstream CRDs Kobe consumes. All three are required: a runtime with
 /// claims but no warm pools would pass a laxer check and then fail to serve.
-pub const REQUIRED_AGENT_SANDBOX_CRDS: &[&str] = &[
-    "sandboxtemplates.extensions.agents.x-k8s.io",
-    "sandboxwarmpools.extensions.agents.x-k8s.io",
-    "sandboxclaims.extensions.agents.x-k8s.io",
+/// The core Agent Sandbox group. The `Sandbox` object itself lives here, not
+/// in the `extensions.` group its templates, warm pools and claims are in.
+pub const CORE_AGENT_SANDBOX_API_VERSION: &str = "agents.x-k8s.io/v1beta1";
+
+/// The upstream CRDs Kobe consumes, each with the API version it is consumed
+/// at. All are required: a runtime missing any one of them passes a laxer
+/// check and then fails to serve — and `sandboxes` in particular fails
+/// *silently*, because it is read to find the Pod behind a claim, so its
+/// absence surfaces as leases that never pass readiness rather than as an
+/// error anyone can act on.
+pub const REQUIRED_AGENT_SANDBOX_CRDS: &[(&str, &str)] = &[
+    (
+        "sandboxtemplates.extensions.agents.x-k8s.io",
+        REQUIRED_AGENT_SANDBOX_API_VERSION,
+    ),
+    (
+        "sandboxwarmpools.extensions.agents.x-k8s.io",
+        REQUIRED_AGENT_SANDBOX_API_VERSION,
+    ),
+    (
+        "sandboxclaims.extensions.agents.x-k8s.io",
+        REQUIRED_AGENT_SANDBOX_API_VERSION,
+    ),
+    ("sandboxes.agents.x-k8s.io", CORE_AGENT_SANDBOX_API_VERSION),
 ];
 
 /// Why an operator-installed runtime cannot be used.
@@ -127,6 +147,7 @@ pub fn mode_from_env() -> Result<AgentSandboxMode, AgentSandboxUnusable> {
 /// supplies what the API server reported.
 pub fn crd_is_compatible(
     crd: &str,
+    expected_api_version: &str,
     established: bool,
     served_versions: &[String],
 ) -> Result<(), AgentSandboxUnusable> {
@@ -136,10 +157,7 @@ pub fn crd_is_compatible(
         });
     }
     // The pinned constant is `group/version`; a CRD reports versions alone.
-    let expected_version = REQUIRED_AGENT_SANDBOX_API_VERSION
-        .rsplit('/')
-        .next()
-        .unwrap_or_default();
+    let expected_version = expected_api_version.rsplit('/').next().unwrap_or_default();
     if served_versions
         .iter()
         .any(|version| version == expected_version)
@@ -148,7 +166,7 @@ pub fn crd_is_compatible(
     }
     Err(AgentSandboxUnusable::VersionMismatch {
         crd: crd.to_string(),
-        expected: REQUIRED_AGENT_SANDBOX_API_VERSION.to_string(),
+        expected: expected_api_version.to_string(),
         found: if served_versions.is_empty() {
             "none".to_string()
         } else {
@@ -167,7 +185,7 @@ pub async fn validate_external_runtime(client: &kube::Client) -> Result<(), Agen
     use kube::api::Api;
 
     let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
-    for name in REQUIRED_AGENT_SANDBOX_CRDS {
+    for (name, expected_api_version) in REQUIRED_AGENT_SANDBOX_CRDS {
         let observed = crds.get(name).await.ok();
         let established = observed.as_ref().is_some_and(|crd| {
             crd.status
@@ -190,7 +208,7 @@ pub async fn validate_external_runtime(client: &kube::Client) -> Result<(), Agen
                     .collect()
             })
             .unwrap_or_default();
-        crd_is_compatible(name, established, &served)?;
+        crd_is_compatible(name, expected_api_version, established, &served)?;
     }
     Ok(())
 }
@@ -241,11 +259,14 @@ mod tests {
     fn a_different_upstream_version_is_refused() {
         let crd = "sandboxclaims.extensions.agents.x-k8s.io";
 
-        assert!(crd_is_compatible(crd, true, &["v1beta1".into()]).is_ok());
+        let expected = REQUIRED_AGENT_SANDBOX_API_VERSION;
+        assert!(crd_is_compatible(crd, expected, true, &["v1beta1".into()]).is_ok());
         // Serving several versions is fine as long as ours is among them.
-        assert!(crd_is_compatible(crd, true, &["v1alpha1".into(), "v1beta1".into()]).is_ok());
+        assert!(
+            crd_is_compatible(crd, expected, true, &["v1alpha1".into(), "v1beta1".into()]).is_ok()
+        );
 
-        let err = crd_is_compatible(crd, true, &["v1alpha1".into()]).unwrap_err();
+        let err = crd_is_compatible(crd, expected, true, &["v1alpha1".into()]).unwrap_err();
         assert!(matches!(err, AgentSandboxUnusable::VersionMismatch { .. }));
         assert_eq!(err.reason_code(), "version_mismatch");
         // The found version belongs in the message: "incompatible" without it
@@ -257,8 +278,13 @@ mod tests {
     /// or a failed upgrade it can be present and not yet serving.
     #[test]
     fn an_unestablished_crd_is_not_usable() {
-        let err =
-            crd_is_compatible("sandboxclaims.extensions.agents.x-k8s.io", false, &[]).unwrap_err();
+        let err = crd_is_compatible(
+            "sandboxclaims.extensions.agents.x-k8s.io",
+            REQUIRED_AGENT_SANDBOX_API_VERSION,
+            false,
+            &[],
+        )
+        .unwrap_err();
         assert!(matches!(err, AgentSandboxUnusable::CrdMissing { .. }));
         assert_eq!(err.reason_code(), "crd_missing");
     }
@@ -266,10 +292,24 @@ mod tests {
     /// All three CRDs are required. A runtime with claims but no warm pools
     /// would pass a laxer check and then fail to serve.
     #[test]
-    fn every_consumed_crd_is_required() {
-        assert_eq!(REQUIRED_AGENT_SANDBOX_CRDS.len(), 3);
-        for crd in REQUIRED_AGENT_SANDBOX_CRDS {
-            assert!(crd.ends_with(".extensions.agents.x-k8s.io"), "{crd}");
+    fn every_consumed_crd_is_required_at_the_version_it_is_consumed_at() {
+        assert_eq!(REQUIRED_AGENT_SANDBOX_CRDS.len(), 4);
+        for (crd, expected) in REQUIRED_AGENT_SANDBOX_CRDS {
+            // The name must sit under the group it is validated against;
+            // otherwise a CRD could pass a version check that never applied
+            // to it.
+            let group = expected.rsplit_once('/').unwrap().0;
+            assert!(crd.ends_with(&format!(".{group}")), "{crd} vs {expected}");
         }
+
+        // `sandboxes` lives in the CORE group, and is the one whose absence
+        // fails silently: it is read to find the Pod behind a claim, so a
+        // runtime without it yields leases that never pass readiness rather
+        // than an error.
+        assert!(
+            REQUIRED_AGENT_SANDBOX_CRDS
+                .contains(&("sandboxes.agents.x-k8s.io", CORE_AGENT_SANDBOX_API_VERSION)),
+            "the canary reads Sandbox objects, so the runtime must serve them"
+        );
     }
 }


### PR DESCRIPTION
Closes the last functional gap in #73 · **stacked on #120**
Epic: #70 — Agent Sandbox (lane `P1`)

## Why upstream `Ready` is not enough

Upstream reports `Ready` when the Sandbox's Pod is running and its probes pass. That is a statement about the **container**, not about the agent inside it. A Pod whose entrypoint crash-looped, whose weights failed to mount, or whose agent is wedged on a lock satisfies every one of those checks — and the moment Kobe believes it, the caller's **paid runtime TTL starts** on a Sandbox that cannot serve.

`spec.readiness.canary` existed on `SandboxPool` since #71 and was projected. Nothing executed it. This runs it.

## Administrator-owned, never caller-owned

`pods/exec` under the operator's credentials is a powerful thing to hold, so what bounds it matters: the argv comes from the **`SandboxPool` spec**, which only an administrator can write, and a lease selects a pool and nothing else. No caller input reaches this call. Were the argv reachable from lease intent, this would be a remote-execution primitive rather than a health check.

## Three outcomes, not two

| Result | Meaning | Response |
|---|---|---|
| exits zero | The workload itself says it works | Ready; the clock starts |
| exits non-zero | The workload says no | Not ready — retry |
| cannot be run | No evidence either way | Not ready — retry |

"Failed" and "could not run" both stop readiness, but they are not the same fact, and neither is a pass. Either way **nothing is written**: no clock, no shutdown time, no `Ready`. The provisioning deadline (already enforced in #118) bounds how long that repeats, so a Sandbox that never passes ends as an expiry rather than as a lease that hangs — no new stuck state is introduced.

## Decisions worth review

**The Pod is found through upstream's own fields.** `claim.status.sandbox.name` → the `Sandbox` object → `status.selector` → the Pod. Never a naming convention: a convention upstream later changes would silently start selecting a Pod belonging to **another tenant**. An ambiguous selector is an error rather than a coin flip, and a terminating Pod is excluded — it reports `Running` for the whole of its grace period.

**The exec is bounded by the pool's own timeout.** Without it a wedged agent — precisely the failure this catches — would hang the reconcile and take a controller worker slot with it, turning a detectable fault into an outage. A malformed timeout refuses to run the canary at all rather than running it unbounded.

**A pass is recorded on the lease and never re-run.** Repeating an administrator's command inside a live tenant workload on every requeue is a recurring side effect, not a health check. The record is durable (a `ReadinessCanary` condition) rather than in-memory, so a controller that restarted between the pass and the `Ready` write does not execute it a second time.

**`sandboxes.agents.x-k8s.io` joins the required-CRD set**, at its own group version — it is in the *core* Agent Sandbox group, not the `extensions.` one. Its absence is the one that fails **silently**: it is read to find the Pod, so a runtime without it produces leases that never pass readiness rather than an error anyone can act on. `crd_is_compatible` now takes the expected API version per CRD instead of assuming one group.

## Chart

- `agents.x-k8s.io/sandboxes`: read-only. Kobe creates Sandboxes only indirectly, through claims.
- `pods/exec`: `create`, for the canary.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1430 passed, 0 failed
```

Mutation-checked: treating an inconclusive canary as a pass, and treating any non-failure as a pass, each fail their tests. The reconcile-boundary test drives a claim upstream calls `Ready` whose Sandbox cannot be reached, and asserts that neither the shutdown time nor the lease status is written.

> The canary itself execs over a websocket, which the HTTP mock cannot serve. Tests covering what happens *after* readiness record the canary pass the way a previous reconcile would have — which is also the production path after any controller restart. What is **not** covered by unit tests is the live exec round-trip; that belongs to #76's conformance suite.

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.