### PR TITLE
placement(sandbox): compose child-cluster Sandboxes through an internal ClusterLease

### DIFF
--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -640,8 +640,32 @@ fn sandbox_lease_response(
         ready_at: status.ready_at,
         expires_at: status.expires_at,
         placement: status.placement,
-        target: status.target,
+        target: status.target.map(caller_visible_provenance),
         conditions: status.conditions,
+    }
+}
+
+/// Strip the internal composition from provenance before it reaches a caller.
+///
+/// `SandboxTargetProvenance` is the controller's restart-safe record of exactly
+/// what it built, and for a child-placement lease that includes the internal
+/// `ClusterLease` and `ClusterInstance` Kobe acquired to host the Sandbox.
+///
+/// The caller asked for a Sandbox. The cluster underneath it is Kobe's
+/// implementation of the pool, not a capability they hold — they cannot
+/// connect to it, extend it or release it, and #74 requires that they cannot
+/// *discover* it either. Returning its name and UID would hand them the exact
+/// identifiers every cluster-lease endpoint is keyed on, turning "no
+/// authority" into "no authority, but knows precisely what to ask for".
+///
+/// Stripped at the response boundary rather than never recorded: teardown must
+/// be able to prove that exact instance UID gone, and evidence a controller
+/// cannot see is evidence that does not exist.
+fn caller_visible_provenance(target: SandboxTargetProvenance) -> SandboxTargetProvenance {
+    SandboxTargetProvenance {
+        child_cluster_lease: None,
+        child_cluster_instance: None,
+        ..target
     }
 }
 
@@ -2361,6 +2385,58 @@ mod tests {
                 .iter()
                 .all(|request| request.method.as_str() != "PATCH")
         );
+    }
+
+    /// A caller must not learn which cluster is hosting their Sandbox.
+    ///
+    /// They cannot connect to it, extend it or release it — but returning its
+    /// name and UID would hand them the exact identifiers every cluster-lease
+    /// endpoint is keyed on. "No authority" and "no authority, but knows
+    /// precisely what to ask for" are not the same posture, and #74 requires
+    /// the internal composition be undiscoverable, not merely unusable.
+    #[test]
+    fn the_internal_child_cluster_is_not_discoverable_through_the_sandbox_api() {
+        let reference = |kind: &str, name: &str| crate::crd::SandboxObjectReference {
+            api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+            kind: kind.into(),
+            namespace: Some("kobe".into()),
+            name: name.into(),
+            uid: format!("{name}-uid"),
+            generation: Some(1),
+        };
+        let target = SandboxTargetProvenance {
+            namespace: "kobe".into(),
+            child_cluster_lease: Some(reference("ClusterLease", "kobe-sbx-sbx-1")),
+            child_cluster_instance: Some(reference("ClusterInstance", "kobe-abc123")),
+            sandbox_template: Some(reference("SandboxTemplate", "kobe-agents")),
+            sandbox_warm_pool: Some(reference("SandboxWarmPool", "kobe-agents")),
+            sandbox_claim: Some(reference("SandboxClaim", "kobe-sbx-1")),
+            sandbox: Some(reference("Sandbox", "sbx")),
+            pod: Some(reference("Pod", "sbx-0")),
+        };
+
+        let visible = caller_visible_provenance(target.clone());
+        assert!(visible.child_cluster_lease.is_none());
+        assert!(visible.child_cluster_instance.is_none());
+
+        // Nothing else is stripped: the Sandbox-side objects are the caller's
+        // own, and #81 resolves targets against exactly these.
+        assert_eq!(visible.sandbox_claim, target.sandbox_claim);
+        assert_eq!(visible.pod, target.pod);
+        assert_eq!(visible.namespace, target.namespace);
+
+        // The serialized form is what actually reaches the caller, so assert on
+        // it rather than on the struct alone — a field renamed into the wire
+        // format later would pass a struct-level check and still leak.
+        let json = serde_json::to_string(&visible).unwrap();
+        for secret in [
+            "kobe-sbx-sbx-1",
+            "kobe-abc123",
+            "ClusterLease",
+            "ClusterInstance",
+        ] {
+            assert!(!json.contains(secret), "{secret} leaked into {json}");
+        }
     }
 
     #[tokio::test]

--- a/src/controllers/mod.rs
+++ b/src/controllers/mod.rs
@@ -7,3 +7,4 @@ pub mod live_set;
 pub mod profile;
 pub mod sandbox;
 pub mod sandbox_canary;
+pub mod sandbox_child;

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -59,6 +59,21 @@ pub enum SandboxPlacementError {
     Mapping(#[from] crate::sandbox::SandboxMappingError),
     #[error("{0}")]
     Invalid(String),
+    #[error(transparent)]
+    ChildPlacement(#[from] crate::controllers::sandbox_child::ChildPlacementError),
+}
+
+impl SandboxPlacementError {
+    /// Bounded reason code for logs and metrics, so a child composition failure
+    /// is countable by cause rather than only by message.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::Kubernetes(_) => "kubernetes",
+            Self::Mapping(_) => "mapping",
+            Self::Invalid(_) => "invalid",
+            Self::ChildPlacement(error) => error.reason_code(),
+        }
+    }
 }
 
 /// Names are derived, never taken from caller input, so one pool's objects can
@@ -106,6 +121,52 @@ async fn apply_upstream(
     .await
 }
 
+/// Apply one pool's `SandboxTemplate` and `SandboxWarmPool` into a cluster.
+///
+/// Shared by management placement and by child composition, so the two cannot
+/// drift into projecting a pool differently — #76 asks for equivalent
+/// semantics across placements, and equivalence built from one code path is
+/// the only kind that stays true.
+///
+/// `owner` is `None` in a child cluster, and that is not an oversight: an owner
+/// reference names an object *in the same cluster*, so a reference to a
+/// management-cluster `SandboxPool` would name nothing there and Kubernetes
+/// garbage collection would delete the template immediately. A child cluster's
+/// objects are bounded by the cluster's own lifetime instead — it is torn down
+/// whole.
+async fn ensure_upstream_pool_objects(
+    client: &Client,
+    namespace: &str,
+    pool_name: &str,
+    spec: &crate::crd::SandboxPoolSpec,
+    owner: Option<&k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference>,
+) -> Result<(), SandboxPlacementError> {
+    let template = build_sandbox_template(&template_name(pool_name), namespace, spec, owner)?;
+    apply_upstream(
+        client,
+        namespace,
+        &upstream_resource(SANDBOX_TEMPLATE_KIND, "sandboxtemplates"),
+        &template,
+    )
+    .await?;
+
+    let warm_pool = build_sandbox_warm_pool(
+        &warm_pool_name(pool_name),
+        namespace,
+        &template_name(pool_name),
+        spec.warm_capacity,
+        owner,
+    )?;
+    apply_upstream(
+        client,
+        namespace,
+        &upstream_resource(SANDBOX_WARM_POOL_KIND, "sandboxwarmpools"),
+        &warm_pool,
+    )
+    .await?;
+    Ok(())
+}
+
 /// Reconcile one `SandboxPool` into its controller-owned upstream objects.
 ///
 /// Child-placement pools are skipped entirely: composing a child cluster is
@@ -126,32 +187,13 @@ pub async fn reconcile_pool(
         SandboxPlacementError::Invalid(format!("SandboxPool {name} has no UID to own its objects"))
     })?;
 
-    let template = build_sandbox_template(
-        &template_name(&name),
+    ensure_upstream_pool_objects(
+        &ctx.client,
         &ctx.namespace,
+        &name,
         &pool.spec,
+        // Owner-referenced here, where the parent SandboxPool actually exists.
         Some(&owner),
-    )?;
-    apply_upstream(
-        &ctx.client,
-        &ctx.namespace,
-        &upstream_resource(SANDBOX_TEMPLATE_KIND, "sandboxtemplates"),
-        &template,
-    )
-    .await?;
-
-    let warm_pool = build_sandbox_warm_pool(
-        &warm_pool_name(&name),
-        &ctx.namespace,
-        &template_name(&name),
-        pool.spec.warm_capacity,
-        Some(&owner),
-    )?;
-    apply_upstream(
-        &ctx.client,
-        &ctx.namespace,
-        &upstream_resource(SANDBOX_WARM_POOL_KIND, "sandboxwarmpools"),
-        &warm_pool,
     )
     .await?;
 
@@ -216,24 +258,41 @@ pub async fn reconcile_lease(
         )));
     }
 
-    if !matches!(pool.spec.placement, SandboxPlacement::Management {}) {
-        debug!(lease = %name, "child placement is #74's; declining");
-        return Ok(Action::await_change());
-    }
+    // Where this lease's Sandbox actually runs. Management placement uses the
+    // operator's own cluster; child placement composes an exclusive one, which
+    // may not be ready yet — in which case there is nothing to place into.
+    let target = match &pool.spec.placement {
+        SandboxPlacement::Management {} => Target {
+            client: ctx.client.clone(),
+            namespace: ctx.namespace.clone(),
+            // The parent SandboxPool and SandboxLease live in this cluster, so
+            // upstream objects can be owned by them.
+            owned: true,
+        },
+        SandboxPlacement::ChildCluster { cluster_pool_ref } => {
+            match compose_child_target(&lease, &pool, cluster_pool_ref, &ctx).await? {
+                ChildTarget::Ready(target) => target,
+                ChildTarget::Pending(action) => return Ok(action),
+            }
+        }
+    };
 
     let owner = lease.controller_owner_ref(&()).ok_or_else(|| {
         SandboxPlacementError::Invalid(format!("SandboxLease {name} has no UID to own its claim"))
     })?;
     let claim = build_sandbox_claim(
         &claim_name(&name),
-        &ctx.namespace,
+        &target.namespace,
         &warm_pool_name(&pool.name_any()),
-        Some(&owner),
+        // See `ensure_upstream_pool_objects`: an owner reference names an
+        // object in the SAME cluster, so in a child it would name nothing and
+        // the claim would be garbage-collected on sight.
+        target.owned.then_some(&owner),
     );
 
     let resource = upstream_resource(SANDBOX_CLAIM_KIND, "sandboxclaims");
     let claims: Api<DynamicObject> =
-        Api::namespaced_with(ctx.client.clone(), &ctx.namespace, &resource);
+        Api::namespaced_with(target.client.clone(), &target.namespace, &resource);
     match claims.create(&PostParams::default(), &claim).await {
         Ok(_) => info!(lease = %name, "created upstream SandboxClaim"),
         // Already placed. One claim per lease is the invariant, and this
@@ -266,8 +325,8 @@ pub async fn reconcile_lease(
     let status = lease.status.clone().unwrap_or_default();
     if !canary_already_passed(&status) {
         let outcome = crate::controllers::sandbox_canary::evaluate_readiness_canary(
-            &ctx.client,
-            &ctx.namespace,
+            &target.client,
+            &target.namespace,
             &claim,
             &pool.spec.template.default_container,
             &pool.spec.readiness.canary,
@@ -505,6 +564,18 @@ async fn drive_release(
         info!(lease = %name, reason = reason.as_str(), "releasing Sandbox lease");
     }
 
+    // A child-placed lease is torn down by destroying its cluster, not by
+    // deleting a claim from here.
+    //
+    // This is not an optimisation. The claim lives in the child cluster, so
+    // deleting it against the management cluster would 404 — and a 404 is
+    // exactly what this path treats as proof of absence. The quota slot would
+    // be handed to the next caller while the previous tenant's Sandbox was
+    // still running in a cluster nobody had touched.
+    if is_child_placed(&status) {
+        return release_child_composition(lease, ctx, reason).await;
+    }
+
     let resource = upstream_resource(SANDBOX_CLAIM_KIND, "sandboxclaims");
     let claims: Api<DynamicObject> =
         Api::namespaced_with(ctx.client.clone(), &ctx.namespace, &resource);
@@ -548,6 +619,23 @@ async fn drive_release(
     }
 
     // The footprint is gone. Now, and only now, the slot goes back.
+    finish_release(lease, ctx, reason).await
+}
+
+/// Release the admission reservations and reach the terminal phase.
+///
+/// Only ever called once the footprint has been *proven* absent — by the claim
+/// for management placement, by the child cluster for a composition. Both
+/// placements share this tail so their release semantics cannot drift apart,
+/// which is the equivalence #76 sets out to prove.
+async fn finish_release(
+    lease: &SandboxLease,
+    ctx: &SandboxContext,
+    reason: ReleaseReason,
+) -> Result<Action, SandboxPlacementError> {
+    use crate::crd::SandboxLeasePhase;
+
+    let name = lease.name_any();
     let uid = lease
         .uid()
         .ok_or_else(|| SandboxPlacementError::Invalid(format!("lease {name} has no UID")))?;
@@ -578,13 +666,102 @@ async fn drive_release(
                 lease,
                 crate::crd::SandboxConditionStatus::True,
                 "TeardownVerified",
-                "Upstream SandboxClaim observed absent and reservations released",
+                "Lease-owned footprint observed absent and reservations released",
             ),
         }),
     )
     .await?;
     info!(lease = %name, phase = %terminal, "Sandbox lease teardown verified");
     Ok(Action::await_change())
+}
+
+/// Whether this lease's Sandbox runs in a composed child cluster.
+///
+/// Read from the *resolved* placement recorded on status rather than from the
+/// pool spec, because teardown must remain correct when the pool was since
+/// edited or deleted — the question is where this lease was actually placed,
+/// not where a pool of that name would place a lease today.
+fn is_child_placed(status: &crate::crd::SandboxLeaseStatus) -> bool {
+    matches!(
+        status.placement,
+        Some(crate::crd::ResolvedSandboxPlacement::ChildCluster { .. })
+    )
+}
+
+/// Tear down a child composition by destroying its cluster.
+///
+/// The internal `ClusterLease` was created with `CleanupMode::VerifiedDestroy`,
+/// so releasing it is what puts #80's machinery to work: the cluster's
+/// footprint must be observed gone before its capacity returns to the
+/// `ClusterPool`. Destroying the cluster destroys the Sandbox inside it, which
+/// is why this replaces — rather than accompanies — the claim delete.
+///
+/// The quota slot is released only once the internal lease is observed absent.
+/// Anything less would return capacity while a tenant's cluster was still
+/// running.
+async fn release_child_composition(
+    lease: &SandboxLease,
+    ctx: &SandboxContext,
+    reason: ReleaseReason,
+) -> Result<Action, SandboxPlacementError> {
+    let name = lease.name_any();
+    let status = lease.status.clone().unwrap_or_default();
+
+    // Act on the exact recorded identity. A same-named ClusterLease composed
+    // for a later Sandbox is somebody else's cluster, and deleting it would
+    // destroy a running tenant's work.
+    let Some(recorded) = status
+        .target
+        .as_ref()
+        .and_then(|target| target.child_cluster_lease.as_ref())
+    else {
+        // Nothing was ever composed — the lease was released before it got a
+        // cluster. There is no footprint to prove absent.
+        debug!(lease = %name, "no child composition recorded; nothing to destroy");
+        return finish_release(lease, ctx, reason).await;
+    };
+
+    let internal: Api<crate::crd::ClusterLease> =
+        Api::namespaced(ctx.client.clone(), &ctx.namespace);
+    match internal.get(&recorded.name).await {
+        Ok(current) if current.uid().as_deref() == Some(recorded.uid.as_str()) => {
+            let delete = DeleteParams {
+                preconditions: Some(kube::api::Preconditions {
+                    uid: Some(recorded.uid.clone()),
+                    resource_version: None,
+                }),
+                ..Default::default()
+            };
+            match internal.delete(&recorded.name, &delete).await {
+                Ok(_) => {}
+                // 404 or 409: ours is not there, which is the goal. Either way
+                // the check below is what decides, not this call.
+                Err(kube::Error::Api(error)) if error.code == 404 || error.code == 409 => {}
+                Err(error) => {
+                    warn!(lease = %name, error = %error, "could not release child cluster lease");
+                    return Ok(Action::requeue(std::time::Duration::from_secs(15)));
+                }
+            }
+            // Destroying a cluster is not instantaneous, and #80 will not let
+            // its capacity return until the footprint is proven gone. Wait.
+            debug!(lease = %name, "child cluster still being destroyed");
+            Ok(Action::requeue(std::time::Duration::from_secs(30)))
+        }
+        // Gone, or replaced by a different object under the same name. Either
+        // way THIS lease's cluster is not there.
+        Ok(_) => finish_release(lease, ctx, reason).await,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            finish_release(lease, ctx, reason).await
+        }
+        // Cannot tell whether the tenant's cluster is still running.
+        Err(kube::Error::Api(error)) if error.code == 401 || error.code == 403 => {
+            quarantine_lease(lease, ctx, "child_absence_unverifiable").await
+        }
+        Err(error) => {
+            warn!(lease = %name, error = %error, "could not check child cluster lease");
+            Ok(Action::requeue(std::time::Duration::from_secs(15)))
+        }
+    }
 }
 
 /// What one absence check established.
@@ -734,6 +911,206 @@ fn with_condition(
     conditions
 }
 
+/// Where one lease's Sandbox is placed.
+struct Target {
+    client: Client,
+    namespace: String,
+    /// Whether upstream objects here may carry an owner reference to their
+    /// Kobe parent. True only in the management cluster, where that parent
+    /// exists — see [`ensure_upstream_pool_objects`].
+    owned: bool,
+}
+
+/// A child cluster is either usable now, or it is not there yet.
+enum ChildTarget {
+    Ready(Target),
+    /// Composition is in progress; the action says when to look again.
+    Pending(Action),
+}
+
+/// Acquire — or resume — the exclusive child cluster this lease runs in.
+///
+/// Every refusal happens before a cluster is allocated. A composition that
+/// cannot be completed is worth nothing to the caller and expensive to
+/// everyone else: an abandoned child cluster is a whole cluster's capacity.
+async fn compose_child_target(
+    lease: &SandboxLease,
+    pool: &SandboxPool,
+    cluster_pool_ref: &str,
+    ctx: &SandboxContext,
+) -> Result<ChildTarget, SandboxPlacementError> {
+    use crate::controllers::sandbox_child as child;
+
+    let name = lease.name_any();
+    let cluster_pools: Api<crate::crd::ClusterPool> =
+        Api::namespaced(ctx.client.clone(), &ctx.namespace);
+    let cluster_pool = cluster_pools.get(cluster_pool_ref).await?;
+
+    // Backend capability first: a pool that cannot prove teardown must never
+    // back an exclusive tenant cluster, and finding that out after allocating
+    // one helps nobody.
+    child::child_pool_is_eligible(&pool.name_any(), &cluster_pool)?;
+
+    let runtime_ttl = crate::pool::parse_duration(&lease.spec.ttl)
+        .and_then(|ttl| ttl.to_std().ok())
+        .ok_or_else(|| {
+            SandboxPlacementError::Invalid(format!("lease {name} has an invalid TTL"))
+        })?;
+    let lifetime = child::child_lifetime_fits(&cluster_pool, pool, runtime_ttl)?;
+
+    // Create-or-adopt, keyed on a derived name, so a restarted controller
+    // resumes the same cluster instead of allocating a second one.
+    let internal_name = child::internal_lease_name(&name);
+    let internal: Api<crate::crd::ClusterLease> =
+        Api::namespaced(ctx.client.clone(), &ctx.namespace);
+    let internal_lease = match internal.get(&internal_name).await {
+        Ok(existing) => existing,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            let composed = child::build_internal_cluster_lease(lease, cluster_pool_ref, lifetime)
+                .ok_or_else(|| {
+                SandboxPlacementError::Invalid(format!("lease {name} has no UID to own a child"))
+            })?;
+            match internal.create(&PostParams::default(), &composed).await {
+                Ok(created) => {
+                    info!(lease = %name, cluster_lease = %internal_name, "composed child cluster lease");
+                    created
+                }
+                // Lost the race; the winner's object is the one to use.
+                Err(kube::Error::Api(error)) if error.code == 409 => {
+                    internal.get(&internal_name).await?
+                }
+                Err(error) => return Err(error.into()),
+            }
+        }
+        Err(error) => return Err(error.into()),
+    };
+
+    // Adoption is fenced. A same-named object this lease does not own is
+    // somebody else's cluster, and placing a tenant's Sandbox into it would be
+    // the worst possible outcome of a name collision.
+    let owned_by_this_lease = internal_lease
+        .metadata
+        .owner_references
+        .as_ref()
+        .is_some_and(|owners| {
+            owners
+                .iter()
+                .any(|owner| Some(owner.uid.as_str()) == lease.uid().as_deref())
+        });
+    if !owned_by_this_lease {
+        return Err(SandboxPlacementError::Invalid(format!(
+            "ClusterLease {internal_name} exists but is not owned by SandboxLease {name}"
+        )));
+    }
+
+    let internal_uid = internal_lease
+        .uid()
+        .ok_or_else(|| SandboxPlacementError::Invalid("child lease has no UID".into()))?;
+
+    // Resolve the exact reciprocal binding rather than trusting `clusterName`.
+    // A name alone can be reused; the binding is what pins the instance this
+    // lease was actually given.
+    let binding = match crate::lease_binding::resolve_lease_binding(
+        &ctx.client,
+        &ctx.namespace,
+        &internal_name,
+        &internal_uid,
+        crate::lease_binding::BindingResolveMode::Access,
+    )
+    .await
+    {
+        Ok(binding) => binding,
+        // Still queuing for capacity. Normal, and not an error.
+        Err(error) => {
+            debug!(lease = %name, error = %error, "child cluster not bound yet");
+            return Ok(ChildTarget::Pending(Action::requeue(
+                std::time::Duration::from_secs(15),
+            )));
+        }
+    };
+
+    // Record what was composed before using it. Teardown has to be able to name
+    // the exact instance it must prove absent, and provenance written only
+    // after a successful placement would be missing in precisely the case that
+    // matters — a crash partway through.
+    let provenance = child::child_provenance(
+        &ctx.namespace,
+        &binding.lease,
+        &binding.binding.instance.name,
+        &binding.binding.instance.uid,
+        Some(binding.binding.instance.observed_generation),
+    );
+    patch_lease_status(
+        ctx,
+        &name,
+        &serde_json::json!({
+            "placement": crate::crd::ResolvedSandboxPlacement::ChildCluster {
+                cluster_pool: crate::crd::SandboxObjectReference {
+                    api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+                    kind: "ClusterPool".into(),
+                    namespace: Some(ctx.namespace.clone()),
+                    name: cluster_pool.name_any(),
+                    uid: cluster_pool.uid().unwrap_or_default(),
+                    generation: cluster_pool.metadata.generation,
+                },
+            },
+            "target": provenance,
+        }),
+    )
+    .await?;
+
+    // The kubeconfig is read into memory and never leaves it: not into status,
+    // not into an API response, not into a log line. It is cluster-admin on a
+    // cluster the caller must not be able to reach.
+    let kubeconfig = crate::backend::read_kubeconfig_secret(
+        &ctx.client,
+        &binding.binding.instance.name,
+        &ctx.namespace,
+    )
+    .await
+    // The error is swallowed on purpose: a kubeconfig read failure can carry
+    // the secret's own contents in its context, and this value reaches status.
+    .map_err(|_| child::ChildPlacementError::ChildUnreachable {
+        cluster: binding.binding.instance.name.clone(),
+    })?;
+    let child_client = crate::backend::virtual_client_from_kubeconfig(&kubeconfig)
+        .await
+        .map_err(|_| child::ChildPlacementError::ChildUnreachable {
+            cluster: binding.binding.instance.name.clone(),
+        })?;
+
+    // Kobe validates the child runtime; it does not install it. Installing
+    // cluster-scoped CRDs, RBAC and a webhook with cluster-admin is one of the
+    // effects paused on #72, and a controller must not perform under a
+    // different issue number what it was told to hold.
+    child::validate_child_runtime(&child_client, &binding.binding.instance.name).await?;
+
+    // The pool's template and warm pool have to exist inside the child; nothing
+    // else reconciles them there.
+    ensure_upstream_pool_objects(
+        &child_client,
+        CHILD_SANDBOX_NAMESPACE,
+        &pool.name_any(),
+        &pool.spec,
+        None,
+    )
+    .await?;
+
+    Ok(ChildTarget::Ready(Target {
+        client: child_client,
+        namespace: CHILD_SANDBOX_NAMESPACE.to_string(),
+        owned: false,
+    }))
+}
+
+/// Namespace inside a child cluster that holds its Sandbox objects.
+///
+/// Fixed, and never derived from anything a caller supplies. The child cluster
+/// is exclusive to one lease, so there is nothing to disambiguate — and a
+/// caller-influenced namespace would be a way to reach objects the composition
+/// did not create.
+const CHILD_SANDBOX_NAMESPACE: &str = "kobe-sandbox";
+
 /// The readiness instant already persisted on a Ready lease, if any.
 fn persisted_ready_at(
     status: &crate::crd::SandboxLeaseStatus,
@@ -816,7 +1193,7 @@ fn lease_error_policy(
     error: &SandboxPlacementError,
     _ctx: Arc<SandboxContext>,
 ) -> Action {
-    warn!(error = %error, "SandboxLease placement failed");
+    warn!(error = %error, reason = error.reason_code(), "SandboxLease placement failed");
     Action::requeue(std::time::Duration::from_secs(15))
 }
 
@@ -864,7 +1241,7 @@ pub async fn run_sandbox_controller(client: Client, namespace: &str, shutdown: C
 }
 
 #[cfg(test)]
-mod tests {
+pub(crate) mod tests {
     use super::*;
 
     /// Upstream object names are DERIVED, never taken from caller input.
@@ -978,7 +1355,7 @@ mod tests {
         }
     }
 
-    fn management_pool(uid: &str, generation: i64) -> SandboxPool {
+    pub(crate) fn management_pool(uid: &str, generation: i64) -> SandboxPool {
         SandboxPool {
             metadata: ObjectMeta {
                 name: Some("agents".into()),
@@ -1025,7 +1402,7 @@ mod tests {
         }
     }
 
-    fn admitted_lease() -> SandboxLease {
+    pub(crate) fn admitted_lease() -> SandboxLease {
         SandboxLease {
             metadata: ObjectMeta {
                 name: Some(LEASE.into()),
@@ -1834,6 +2211,229 @@ mod tests {
             .find(|c| c.condition_type == CLEANUP_VERIFIED_CONDITION)
             .unwrap();
         assert_ne!(flipped.last_transition_time, after.last_transition_time);
+    }
+
+    // -----------------------------------------------------------------------
+    // Child composition
+    // -----------------------------------------------------------------------
+
+    fn child_placed_lease(cluster_lease_uid: &str) -> SandboxLease {
+        let mut lease = admitted_lease();
+        let status = lease.status.as_mut().unwrap();
+        status.phase = crate::crd::SandboxLeasePhase::Ready;
+        status.placement = Some(crate::crd::ResolvedSandboxPlacement::ChildCluster {
+            cluster_pool: crate::crd::SandboxObjectReference {
+                api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+                kind: "ClusterPool".into(),
+                namespace: Some(NS.into()),
+                name: "children".into(),
+                uid: "cluster-pool-uid".into(),
+                generation: Some(1),
+            },
+        });
+        status.target = Some(crate::crd::SandboxTargetProvenance {
+            namespace: NS.into(),
+            child_cluster_lease: Some(crate::crd::SandboxObjectReference {
+                api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+                kind: "ClusterLease".into(),
+                namespace: Some(NS.into()),
+                name: "kobe-sbx-sbx-1".into(),
+                uid: cluster_lease_uid.into(),
+                generation: Some(1),
+            }),
+            child_cluster_instance: None,
+            sandbox_template: None,
+            sandbox_warm_pool: None,
+            sandbox_claim: None,
+            sandbox: None,
+            pod: None,
+        });
+        lease.metadata.annotations.as_mut().unwrap().insert(
+            SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION.to_string(),
+            chrono::Utc::now().to_rfc3339(),
+        );
+        lease
+    }
+
+    const CLUSTER_LEASE_PATH: &str =
+        "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterleases/kobe-sbx-sbx-1";
+
+    /// A child-placed lease must never be released by a claim delete here.
+    ///
+    /// Its claim lives in the child cluster, so deleting it against the
+    /// management cluster 404s — and a 404 is precisely what this path treats
+    /// as proof of absence. The quota slot would be handed to the next caller
+    /// while the previous tenant's Sandbox was still running in a cluster
+    /// nobody had touched. This is the single most dangerous confusion the two
+    /// placements can have, so it is asserted directly.
+    #[tokio::test]
+    async fn a_child_lease_is_never_released_by_deleting_a_management_claim() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        // The child cluster lease is still there: the tenant's cluster, and
+        // their Sandbox inside it, are still running.
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "ClusterLease",
+                "metadata": {
+                    "name": "kobe-sbx-sbx-1",
+                    "namespace": NS,
+                    "uid": "child-lease-uid",
+                },
+                "spec": { "poolRef": "children", "ttl": "2h",
+                          "requester": { "type": "kobe:sandbox-composition", "identity": "kobe-operator" } },
+            })))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "ClusterLease",
+                "metadata": { "name": "kobe-sbx-sbx-1", "namespace": NS },
+            })))
+            .mount(&server)
+            .await;
+
+        reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            requests_to(&server, "DELETE", CLAIM_PATH).await,
+            0,
+            "the claim is in the child cluster; nothing here may stand in for it"
+        );
+        assert_eq!(
+            requests_to(
+                &server,
+                "DELETE",
+                &format!("{RESERVATIONS_PATH}/sbx-quota-abc-0")
+            )
+            .await,
+            0,
+            "capacity must not return while the tenant's cluster is still up"
+        );
+        let phases = recorded_phases(&server).await;
+        assert_eq!(phases, vec!["Releasing".to_string()]);
+    }
+
+    /// Teardown acts on the recorded UID, not the recorded name.
+    ///
+    /// If the composed cluster lease is gone and a DIFFERENT object now holds
+    /// its name, that object belongs to a later Sandbox. Deleting it would
+    /// destroy a running tenant's cluster; treating its presence as "ours is
+    /// still up" would strand this lease forever. Neither: this lease's
+    /// cluster is provably not there, so the release completes.
+    #[tokio::test]
+    async fn a_name_reused_by_a_later_composition_is_not_this_leases_cluster() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "ClusterLease",
+                "metadata": {
+                    "name": "kobe-sbx-sbx-1",
+                    "namespace": NS,
+                    // Somebody else's composition, under a reused name.
+                    "uid": "a-completely-different-uid",
+                },
+                "spec": { "poolRef": "children", "ttl": "2h",
+                          "requester": { "type": "kobe:sandbox-composition", "identity": "kobe-operator" } },
+            })))
+            .mount(&server)
+            .await;
+
+        reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            requests_to(&server, "DELETE", CLUSTER_LEASE_PATH).await,
+            0,
+            "a cluster this lease does not own must never be destroyed"
+        );
+        assert_eq!(
+            recorded_phases(&server).await.last().map(String::as_str),
+            Some("Released"),
+            "this lease's own cluster is provably absent"
+        );
+    }
+
+    /// If Kobe cannot tell whether the tenant's cluster is still running, it
+    /// withholds the capacity rather than guessing.
+    #[tokio::test]
+    async fn an_unreadable_child_cluster_quarantines() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "kind": "Status", "status": "Failure", "code": 403, "reason": "Forbidden"
+            })))
+            .mount(&server)
+            .await;
+
+        reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorded_phases(&server).await.last().map(String::as_str),
+            Some("Quarantined")
+        );
+        assert_eq!(
+            requests_to(
+                &server,
+                "DELETE",
+                &format!("{RESERVATIONS_PATH}/sbx-quota-abc-0")
+            )
+            .await,
+            0
+        );
+    }
+
+    /// A lease released before it ever got a cluster has nothing to prove.
+    ///
+    /// Requiring evidence of a footprint that was never created would strand
+    /// the quota slot of every caller who cancelled while queuing — the most
+    /// common cancellation there is.
+    #[tokio::test]
+    async fn a_composition_that_never_happened_releases_cleanly() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+
+        let mut lease = child_placed_lease("child-lease-uid");
+        // Placement is recorded, but no cluster was ever composed.
+        lease
+            .status
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap()
+            .child_cluster_lease = None;
+
+        reconcile_lease(Arc::new(lease), ctx).await.unwrap();
+
+        assert_eq!(
+            recorded_phases(&server).await.last().map(String::as_str),
+            Some("Released")
+        );
+        assert_eq!(
+            requests_to(
+                &server,
+                "DELETE",
+                &format!("{RESERVATIONS_PATH}/sbx-quota-abc-0")
+            )
+            .await,
+            1,
+            "the slot it was holding must come back"
+        );
     }
 
     /// The pinned upstream version must match what #72 validates at startup.

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -688,17 +688,23 @@ fn is_child_placed(status: &crate::crd::SandboxLeaseStatus) -> bool {
     )
 }
 
-/// Tear down a child composition by destroying its cluster.
+/// Tear a child composition down, and complete only against its receipt.
 ///
 /// The internal `ClusterLease` was created with `CleanupMode::VerifiedDestroy`,
-/// so releasing it is what puts #80's machinery to work: the cluster's
+/// so *releasing* it is what puts #80's machinery to work: the cluster's exact
 /// footprint must be observed gone before its capacity returns to the
-/// `ClusterPool`. Destroying the cluster destroys the Sandbox inside it, which
-/// is why this replaces — rather than accompanies — the claim delete.
+/// `ClusterPool`, and the evidence is written to the lease as a receipt.
+/// Destroying the cluster destroys the Sandbox inside it, which is why this
+/// replaces — rather than accompanies — the claim delete.
 ///
-/// The quota slot is released only once the internal lease is observed absent.
-/// Anything less would return capacity while a tenant's cluster was still
-/// running.
+/// The internal lease is **released, never deleted**. Deleting the object would
+/// destroy the receipt along with it, at exactly the moment the evidence
+/// matters; it is collected later by its owner reference, once the Sandbox
+/// lease itself goes.
+///
+/// The quota slot returns only once a receipt proves the exact recorded
+/// instance gone. The disappearance of a name is not evidence — a same-named
+/// replacement is fresh capacity, not proof that the original was destroyed.
 async fn release_child_composition(
     lease: &SandboxLease,
     ctx: &SandboxContext,
@@ -708,7 +714,7 @@ async fn release_child_composition(
     let status = lease.status.clone().unwrap_or_default();
 
     // Act on the exact recorded identity. A same-named ClusterLease composed
-    // for a later Sandbox is somebody else's cluster, and deleting it would
+    // for a later Sandbox is somebody else's cluster, and releasing it would
     // destroy a running tenant's work.
     let Some(recorded) = status
         .target
@@ -720,38 +726,57 @@ async fn release_child_composition(
         debug!(lease = %name, "no child composition recorded; nothing to destroy");
         return finish_release(lease, ctx, reason).await;
     };
+    let recorded_instance = status
+        .target
+        .as_ref()
+        .and_then(|target| target.child_cluster_instance.as_ref());
 
     let internal: Api<crate::crd::ClusterLease> =
         Api::namespaced(ctx.client.clone(), &ctx.namespace);
     match internal.get(&recorded.name).await {
         Ok(current) if current.uid().as_deref() == Some(recorded.uid.as_str()) => {
-            let delete = DeleteParams {
-                preconditions: Some(kube::api::Preconditions {
-                    uid: Some(recorded.uid.clone()),
-                    resource_version: None,
-                }),
-                ..Default::default()
-            };
-            match internal.delete(&recorded.name, &delete).await {
-                Ok(_) => {}
-                // 404 or 409: ours is not there, which is the goal. Either way
-                // the check below is what decides, not this call.
-                Err(kube::Error::Api(error)) if error.code == 404 || error.code == 409 => {}
-                Err(error) => {
-                    warn!(lease = %name, error = %error, "could not release child cluster lease");
-                    return Ok(Action::requeue(std::time::Duration::from_secs(15)));
-                }
+            let child_status = current.status.clone().unwrap_or_default();
+
+            // #80 could not prove the cluster's own teardown. Nothing this
+            // controller can do makes that evidence appear.
+            if child_status.phase == crate::crd::LeasePhase::Quarantined {
+                return quarantine_lease(lease, ctx, "child_teardown_quarantined").await;
             }
-            // Destroying a cluster is not instantaneous, and #80 will not let
-            // its capacity return until the footprint is proven gone. Wait.
-            debug!(lease = %name, "child cluster still being destroyed");
+
+            match child_status.teardown_receipt.as_ref() {
+                Some(receipt) if receipt_proves_child_gone(receipt, recorded_instance) => {
+                    info!(lease = %name, "child teardown receipt verified");
+                    return finish_release(lease, ctx, reason).await;
+                }
+                // A receipt exists but is not about this instance, or does not
+                // say Verified. Present-but-wrong is worse than absent: it is
+                // the case a laxer check would accept.
+                Some(_) => {
+                    return quarantine_lease(lease, ctx, "child_receipt_does_not_match").await;
+                }
+                None => {}
+            }
+
+            // No receipt yet. Ask for release if nobody has, then wait —
+            // destroying a cluster and proving it gone both take time.
+            if !matches!(
+                child_status.phase,
+                crate::crd::LeasePhase::Released
+                    | crate::crd::LeasePhase::Expired
+                    | crate::crd::LeasePhase::Recycling
+            ) {
+                request_child_release(&internal, &current).await?;
+            }
+            debug!(lease = %name, "waiting for the child teardown receipt");
             Ok(Action::requeue(std::time::Duration::from_secs(30)))
         }
-        // Gone, or replaced by a different object under the same name. Either
-        // way THIS lease's cluster is not there.
-        Ok(_) => finish_release(lease, ctx, reason).await,
+        // The recorded lease is gone, or a different object holds its name. Its
+        // receipt went with it, so there is nothing left that can prove this
+        // lease's cluster was destroyed — and #74 is explicit that the
+        // disappearance of a name is not evidence.
+        Ok(_) => quarantine_lease(lease, ctx, "child_receipt_unavailable").await,
         Err(kube::Error::Api(error)) if error.code == 404 => {
-            finish_release(lease, ctx, reason).await
+            quarantine_lease(lease, ctx, "child_receipt_unavailable").await
         }
         // Cannot tell whether the tenant's cluster is still running.
         Err(kube::Error::Api(error)) if error.code == 401 || error.code == 403 => {
@@ -761,6 +786,73 @@ async fn release_child_composition(
             warn!(lease = %name, error = %error, "could not check child cluster lease");
             Ok(Action::requeue(std::time::Duration::from_secs(15)))
         }
+    }
+}
+
+/// Whether a child teardown receipt proves THIS lease's cluster gone.
+///
+/// #80's own gate already ran inside the `ClusterLease` controller before the
+/// receipt was written; this is the outer lease checking the one thing that
+/// gate cannot know — that the evidence is about the instance this Sandbox was
+/// actually placed on.
+///
+/// A same-named replacement instance is fresh capacity, not proof the original
+/// was reset, so the UID recorded at composition time is what must match. An
+/// unrecorded instance UID fails closed: two absent UIDs would otherwise
+/// compare equal and any receipt would satisfy any lease.
+fn receipt_proves_child_gone(
+    receipt: &crate::crd::TeardownReceipt,
+    recorded_instance: Option<&crate::crd::SandboxObjectReference>,
+) -> bool {
+    if receipt.outcome != crate::crd::TeardownOutcome::Verified
+        || receipt.completed_at.is_none()
+        || crate::crd::TeardownReceipt::outcome_for(&receipt.checks)
+            != crate::crd::TeardownOutcome::Verified
+        || receipt.schema_version != crate::crd::TEARDOWN_RECEIPT_SCHEMA_VERSION
+    {
+        return false;
+    }
+    let Some(expected) = recorded_instance else {
+        return false;
+    };
+    let Some(proven) = receipt.instance.uid.as_deref() else {
+        return false;
+    };
+    !expected.uid.is_empty() && proven == expected.uid && receipt.instance.name == expected.name
+}
+
+/// Ask the internal lease to release, fenced on the exact object.
+///
+/// The same UID and resourceVersion test ops the public release path uses:
+/// between the read and this write the lease could be deleted and a same-named
+/// one composed for another Sandbox, and a merge patch would release theirs.
+async fn request_child_release(
+    internal: &Api<crate::crd::ClusterLease>,
+    current: &crate::crd::ClusterLease,
+) -> Result<(), SandboxPlacementError> {
+    let (Some(uid), Some(resource_version)) = (current.uid(), current.resource_version()) else {
+        return Err(SandboxPlacementError::Invalid(
+            "child cluster lease has no UID or resourceVersion to fence on".into(),
+        ));
+    };
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "test", "path": "/metadata/resourceVersion", "value": resource_version },
+        { "op": "add", "path": "/status/phase", "value": "Released" }
+    ]));
+    match internal
+        .patch_status(
+            &current.name_any(),
+            &PatchParams::default(),
+            &Patch::Json::<()>(patch),
+        )
+        .await
+    {
+        Ok(_) => Ok(()),
+        // Lost the race: somebody already moved it on. The next reconcile reads
+        // whatever they wrote, which is exactly what should decide.
+        Err(kube::Error::Api(error)) if error.code == 409 || error.code == 404 => Ok(()),
+        Err(error) => Err(error.into()),
     }
 }
 
@@ -2241,7 +2333,14 @@ pub(crate) mod tests {
                 uid: cluster_lease_uid.into(),
                 generation: Some(1),
             }),
-            child_cluster_instance: None,
+            child_cluster_instance: Some(crate::crd::SandboxObjectReference {
+                api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+                kind: "ClusterInstance".into(),
+                namespace: Some(NS.into()),
+                name: "kobe-abc123".into(),
+                uid: "child-instance-uid".into(),
+                generation: Some(2),
+            }),
             sandbox_template: None,
             sandbox_warm_pool: None,
             sandbox_claim: None,
@@ -2253,6 +2352,65 @@ pub(crate) mod tests {
             chrono::Utc::now().to_rfc3339(),
         );
         lease
+    }
+
+    async fn mount_child_release_patch(server: &MockServer) {
+        Mock::given(method("PATCH"))
+            .and(path(format!("{CLUSTER_LEASE_PATH}/status")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "child-lease-uid",
+                    "Released",
+                    None,
+                )),
+            )
+            .mount(server)
+            .await;
+    }
+
+    fn child_cluster_lease(
+        uid: &str,
+        phase: &str,
+        receipt: Option<serde_json::Value>,
+    ) -> serde_json::Value {
+        let mut status = serde_json::json!({ "phase": phase });
+        if let Some(receipt) = receipt {
+            status["teardownReceipt"] = receipt;
+        }
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "ClusterLease",
+            "metadata": {
+                "name": "kobe-sbx-sbx-1",
+                "namespace": NS,
+                "uid": uid,
+                "resourceVersion": "42",
+            },
+            "spec": {
+                "poolRef": "children",
+                "ttl": "2h",
+                "requester": { "type": "kobe:sandbox-composition", "identity": "kobe-operator" },
+            },
+            "status": status,
+        })
+    }
+
+    /// A receipt about the exact instance recorded at composition time.
+    fn verified_receipt(instance_name: &str, instance_uid: &str) -> serde_json::Value {
+        serde_json::json!({
+            "schemaVersion": crate::crd::TEARDOWN_RECEIPT_SCHEMA_VERSION,
+            "attemptId": "attempt-1",
+            "lease": { "name": "kobe-sbx-sbx-1", "uid": "child-lease-uid" },
+            "instance": { "name": instance_name, "uid": instance_uid },
+            "pool": { "name": "children", "uid": "cluster-pool-uid" },
+            "backendType": "k3s",
+            "configDigest": "digest",
+            "instanceSpecDigest": "spec-digest",
+            "startedAt": "2026-01-01T00:00:00Z",
+            "completedAt": "2026-01-01T00:05:00Z",
+            "checks": [{ "subject": "serverStatefulSet", "result": "verified" }],
+            "outcome": "verified",
+        })
     }
 
     const CLUSTER_LEASE_PATH: &str =
@@ -2274,28 +2432,16 @@ pub(crate) mod tests {
         // their Sandbox inside it, are still running.
         Mock::given(method("GET"))
             .and(path(CLUSTER_LEASE_PATH))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
-                "kind": "ClusterLease",
-                "metadata": {
-                    "name": "kobe-sbx-sbx-1",
-                    "namespace": NS,
-                    "uid": "child-lease-uid",
-                },
-                "spec": { "poolRef": "children", "ttl": "2h",
-                          "requester": { "type": "kobe:sandbox-composition", "identity": "kobe-operator" } },
-            })))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "child-lease-uid",
+                    "Bound",
+                    None,
+                )),
+            )
             .mount(&server)
             .await;
-        Mock::given(method("DELETE"))
-            .and(path(CLUSTER_LEASE_PATH))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
-                "kind": "ClusterLease",
-                "metadata": { "name": "kobe-sbx-sbx-1", "namespace": NS },
-            })))
-            .mount(&server)
-            .await;
+        mount_child_release_patch(&server).await;
 
         reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
             .await
@@ -2305,6 +2451,12 @@ pub(crate) mod tests {
             requests_to(&server, "DELETE", CLAIM_PATH).await,
             0,
             "the claim is in the child cluster; nothing here may stand in for it"
+        );
+        assert_eq!(
+            requests_to(&server, "DELETE", CLUSTER_LEASE_PATH).await,
+            0,
+            "the internal lease is RELEASED, never deleted: deleting it destroys \
+             the receipt at exactly the moment the evidence matters"
         );
         assert_eq!(
             requests_to(
@@ -2320,31 +2472,28 @@ pub(crate) mod tests {
         assert_eq!(phases, vec!["Releasing".to_string()]);
     }
 
-    /// Teardown acts on the recorded UID, not the recorded name.
+    /// Teardown acts on the recorded UID, not the recorded name — and a name
+    /// that now belongs to somebody else is not evidence of anything.
     ///
-    /// If the composed cluster lease is gone and a DIFFERENT object now holds
-    /// its name, that object belongs to a later Sandbox. Deleting it would
-    /// destroy a running tenant's cluster; treating its presence as "ours is
-    /// still up" would strand this lease forever. Neither: this lease's
-    /// cluster is provably not there, so the release completes.
+    /// A different object under the same name belongs to a later Sandbox.
+    /// Releasing it would destroy a running tenant's cluster. But its presence
+    /// also does not prove OURS was destroyed: our lease is gone and its
+    /// receipt went with it. #74 is explicit that the disappearance of a name
+    /// is not evidence, so this quarantines rather than completing.
     #[tokio::test]
     async fn a_name_reused_by_a_later_composition_is_not_this_leases_cluster() {
         let (ctx, server) = test_context().await;
         mount_teardown_scaffolding(&server).await;
         Mock::given(method("GET"))
             .and(path(CLUSTER_LEASE_PATH))
-            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
-                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
-                "kind": "ClusterLease",
-                "metadata": {
-                    "name": "kobe-sbx-sbx-1",
-                    "namespace": NS,
-                    // Somebody else's composition, under a reused name.
-                    "uid": "a-completely-different-uid",
-                },
-                "spec": { "poolRef": "children", "ttl": "2h",
-                          "requester": { "type": "kobe:sandbox-composition", "identity": "kobe-operator" } },
-            })))
+            // Somebody else's composition, under a reused name.
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "a-completely-different-uid",
+                    "Bound",
+                    None,
+                )),
+            )
             .mount(&server)
             .await;
 
@@ -2358,9 +2507,24 @@ pub(crate) mod tests {
             "a cluster this lease does not own must never be destroyed"
         );
         assert_eq!(
+            requests_to(&server, "PATCH", &format!("{CLUSTER_LEASE_PATH}/status")).await,
+            0,
+            "nor may it be released"
+        );
+        assert_eq!(
             recorded_phases(&server).await.last().map(String::as_str),
-            Some("Released"),
-            "this lease's own cluster is provably absent"
+            Some("Quarantined"),
+            "our own cluster's receipt is gone; absence of a name proves nothing"
+        );
+        assert_eq!(
+            requests_to(
+                &server,
+                "DELETE",
+                &format!("{RESERVATIONS_PATH}/sbx-quota-abc-0")
+            )
+            .await,
+            0,
+            "capacity is withheld precisely because nothing proved it safe"
         );
     }
 
@@ -2434,6 +2598,180 @@ pub(crate) mod tests {
             1,
             "the slot it was holding must come back"
         );
+    }
+
+    /// Capacity returns only against a receipt for the exact instance.
+    ///
+    /// This is the point of composing through a `VerifiedDestroy` lease at all:
+    /// the caller had a whole cluster to themselves, and the next caller gets
+    /// it only once somebody proved the previous tenant's footprint is gone.
+    #[tokio::test]
+    async fn a_verified_receipt_for_the_recorded_instance_completes_the_release() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "child-lease-uid",
+                    "Released",
+                    Some(verified_receipt("kobe-abc123", "child-instance-uid")),
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorded_phases(&server).await.last().map(String::as_str),
+            Some("Released")
+        );
+        assert_eq!(
+            requests_to(
+                &server,
+                "DELETE",
+                &format!("{RESERVATIONS_PATH}/sbx-quota-abc-0")
+            )
+            .await,
+            1
+        );
+    }
+
+    /// A receipt for a DIFFERENT instance must not release this lease.
+    ///
+    /// The child cluster can be destroyed and replaced under the same lease
+    /// name — that is what recycling does. A receipt proving the replacement
+    /// gone says nothing about the instance this Sandbox actually ran on, and
+    /// accepting it would return capacity on the strength of evidence about
+    /// somebody else's cluster. Present-but-wrong is the dangerous case,
+    /// because it is the one a laxer check accepts.
+    #[tokio::test]
+    async fn a_receipt_for_another_instance_does_not_release_this_lease() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "child-lease-uid",
+                    "Released",
+                    Some(verified_receipt("kobe-later", "a-later-instance-uid")),
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorded_phases(&server).await.last().map(String::as_str),
+            Some("Quarantined")
+        );
+        assert_eq!(
+            requests_to(
+                &server,
+                "DELETE",
+                &format!("{RESERVATIONS_PATH}/sbx-quota-abc-0")
+            )
+            .await,
+            0
+        );
+    }
+
+    /// A child whose own teardown quarantined cannot release the outer lease.
+    #[tokio::test]
+    async fn a_quarantined_child_quarantines_the_sandbox_lease() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "child-lease-uid",
+                    "Quarantined",
+                    None,
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        reconcile_lease(Arc::new(child_placed_lease("child-lease-uid")), ctx)
+            .await
+            .unwrap();
+
+        assert_eq!(
+            recorded_phases(&server).await.last().map(String::as_str),
+            Some("Quarantined")
+        );
+    }
+
+    /// Everything short of a complete, verified, correctly-addressed receipt
+    /// fails closed.
+    ///
+    /// Each of these is a receipt that *looks* like evidence. A quarantined
+    /// outcome, an unfinished attempt, a check that came back Unknown, or a
+    /// schema this build does not understand are all "we could not prove it" —
+    /// and an unrecorded instance UID is worse still, because two absent UIDs
+    /// compare equal and any receipt would satisfy any lease.
+    #[test]
+    fn only_a_complete_receipt_about_this_instance_counts() {
+        let recorded = crate::crd::SandboxObjectReference {
+            api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+            kind: "ClusterInstance".into(),
+            namespace: Some(NS.into()),
+            name: "kobe-abc123".into(),
+            uid: "child-instance-uid".into(),
+            generation: Some(2),
+        };
+        let parse = |value: serde_json::Value| -> crate::crd::TeardownReceipt {
+            serde_json::from_value(value).expect("receipt fixture parses")
+        };
+
+        let good = parse(verified_receipt("kobe-abc123", "child-instance-uid"));
+        assert!(receipt_proves_child_gone(&good, Some(&recorded)));
+
+        // No recorded instance: nothing to compare against.
+        assert!(!receipt_proves_child_gone(&good, None));
+
+        // An empty recorded UID must not be satisfiable.
+        let mut blank = recorded.clone();
+        blank.uid = String::new();
+        let mut blank_receipt = good.clone();
+        blank_receipt.instance.uid = Some(String::new());
+        assert!(!receipt_proves_child_gone(&blank_receipt, Some(&blank)));
+
+        let mut quarantined = good.clone();
+        quarantined.outcome = crate::crd::TeardownOutcome::Quarantined;
+        assert!(!receipt_proves_child_gone(&quarantined, Some(&recorded)));
+
+        let mut unfinished = good.clone();
+        unfinished.completed_at = None;
+        assert!(!receipt_proves_child_gone(&unfinished, Some(&recorded)));
+
+        // Outcome says Verified but the evidence does not agree. The receipt is
+        // not trusted over its own checks.
+        let mut inconsistent = good.clone();
+        inconsistent.checks = vec![crate::crd::TeardownCheck {
+            subject: crate::crd::TeardownSubject::ServerStatefulSet,
+            result: crate::crd::CheckResult::Unknown,
+            reason: Some("api_error".into()),
+        }];
+        assert!(!receipt_proves_child_gone(&inconsistent, Some(&recorded)));
+
+        let mut future_schema = good.clone();
+        future_schema.schema_version = crate::crd::TEARDOWN_RECEIPT_SCHEMA_VERSION + 1;
+        assert!(!receipt_proves_child_gone(&future_schema, Some(&recorded)));
+
+        // Right UID, wrong name — a shape mismatch that should never occur, and
+        // must not be resolved in favour of releasing capacity.
+        let mut renamed = good.clone();
+        renamed.instance.name = "kobe-something-else".into();
+        assert!(!receipt_proves_child_gone(&renamed, Some(&recorded)));
     }
 
     /// The pinned upstream version must match what #72 validates at startup.

--- a/src/controllers/sandbox_child.rs
+++ b/src/controllers/sandbox_child.rs
@@ -1,0 +1,577 @@
+//! Composition of child-cluster Sandboxes through an internal `ClusterLease`
+//! (#74).
+//!
+//! A child-placement `SandboxPool` says: do not run this pool's Sandboxes next
+//! to everybody else's. Kobe acquires one exclusive cluster from an
+//! administrator-named `ClusterPool`, and places the caller's `SandboxClaim`
+//! inside it.
+//!
+//! # The internal cluster is not the caller's
+//!
+//! The caller asked for a Sandbox. They receive Sandbox operations and nothing
+//! else. They cannot connect to the internal `ClusterLease`, extend it, release
+//! it, obtain credentials for it, or learn that it exists — the composition is
+//! Kobe's implementation of the pool, not a capability it hands out. Its
+//! kubeconfig is read from controller-authorised storage into memory and never
+//! written to status, an API response, a log line, or an event.
+//!
+//! # What this module does NOT do
+//!
+//! It does not **install** the Agent Sandbox runtime into the child cluster.
+//! #74 as filed proposed bootstrapping it there with cluster-admin, which is
+//! one of the three effects paused pending approval on #72; #72 shipped
+//! `external` mode only, where the operator installs the runtime and Kobe owns
+//! nothing. Child placement follows the same rule: the child cluster must
+//! already serve a compatible runtime — through the pool's own bootstraps or
+//! addons — and Kobe *validates* it. A child without one is refused with a
+//! legible error rather than silently granted cluster-admin install rights.
+//!
+//! That is a real narrowing of #74, and it is recorded here rather than papered
+//! over: pools must be configured to bring their own runtime.
+
+use std::time::Duration;
+
+use kube::api::ObjectMeta;
+use kube::{Client, Resource, ResourceExt};
+
+use crate::crd::{
+    BackendType, CleanupMode, ClusterLease, ClusterLeaseSpec, ClusterPool, Requester, SandboxLease,
+    SandboxObjectReference, SandboxPool,
+};
+
+/// Grace added on top of provisioning and runtime, so the internal cluster
+/// cannot expire while its Sandbox is still being torn down.
+///
+/// Teardown is not instantaneous — a foreground claim delete waits for the
+/// Sandbox to stop, and #80's verification then has to observe the footprint
+/// gone. If the child lease expired inside that window, the evidence would
+/// disappear along with the cluster and the composition could never report
+/// clean completion.
+pub const CHILD_DRAIN_GRACE: Duration = Duration::from_secs(15 * 60);
+
+/// Why a child composition cannot proceed.
+///
+/// A closed, non-secret vocabulary: these values reach status, events and
+/// metrics, and none of them may carry a kubeconfig, a token, or a raw backend
+/// response.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ChildPlacementError {
+    #[error(
+        "SandboxPool {pool} names ClusterPool {cluster_pool}, whose backend {backend} cannot \
+         produce a teardown receipt; child placement requires backend.type=k3s"
+    )]
+    BackendUnsupported {
+        pool: String,
+        cluster_pool: String,
+        backend: String,
+    },
+    #[error(
+        "ClusterPool {cluster_pool} is not eligible for verified destroy: {reason}. A child \
+         Sandbox whose capacity cannot be proven destroyed must not be placed."
+    )]
+    VerifiedDestroyIneligible {
+        cluster_pool: String,
+        reason: String,
+    },
+    #[error(
+        "ClusterPool {cluster_pool} allows at most {pool_max}, but this Sandbox needs {required} \
+         to cover provisioning, its runtime TTL and the cleanup window"
+    )]
+    LifetimeUnachievable {
+        cluster_pool: String,
+        pool_max: String,
+        required: String,
+    },
+    #[error("{field} is not a valid duration")]
+    InvalidDuration { field: &'static str },
+    #[error(
+        "child cluster {cluster} does not serve a compatible Agent Sandbox runtime ({reason}). \
+         Kobe does not install it: configure the ClusterPool's bootstraps or addons to provide it."
+    )]
+    ChildRuntimeUnusable { cluster: String, reason: String },
+    #[error("child cluster {cluster} is not reachable")]
+    ChildUnreachable { cluster: String },
+}
+
+impl ChildPlacementError {
+    /// Bounded reason code for status, events and metrics.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::BackendUnsupported { .. } => "backend_unsupported",
+            Self::VerifiedDestroyIneligible { .. } => "verified_destroy_ineligible",
+            Self::LifetimeUnachievable { .. } => "lifetime_unachievable",
+            Self::InvalidDuration { .. } => "invalid_duration",
+            Self::ChildRuntimeUnusable { .. } => "child_runtime_unusable",
+            Self::ChildUnreachable { .. } => "child_unreachable",
+        }
+    }
+}
+
+/// The internal lease's name, derived from the Sandbox lease it serves.
+///
+/// Derived rather than generated so a restarted controller finds the same
+/// object instead of allocating a second cluster, and prefixed so an internal
+/// lease is never mistaken for — or adopted from — a tenant one.
+pub fn internal_lease_name(sandbox_lease: &str) -> String {
+    format!("kobe-sbx-{sandbox_lease}")
+}
+
+/// How long the internal cluster must live for the outer Sandbox to complete.
+///
+/// Provisioning, then the full runtime TTL, then the drain grace. The child
+/// cannot expire first: an internal cluster that vanished mid-lease would take
+/// the caller's running Sandbox with it, and one that vanished mid-teardown
+/// would take the evidence that it was cleaned up.
+pub fn required_child_lifetime(
+    provisioning_timeout: Duration,
+    runtime_ttl: Duration,
+    drain_grace: Duration,
+) -> Duration {
+    provisioning_timeout
+        .saturating_add(runtime_ttl)
+        .saturating_add(drain_grace)
+}
+
+/// Whether the named `ClusterPool` may back a child Sandbox at all.
+///
+/// Refused *before* anything is allocated. A pool that cannot produce a
+/// teardown receipt would let a Sandbox's capacity return to the pool without
+/// anyone proving the previous tenant's footprint was gone — and the whole
+/// point of child placement is that the tenant got a cluster to themselves.
+///
+/// The one condition deliberately not checked here is whether the external
+/// datastore identity was recorded: that is a bind-time fact about a specific
+/// instance, not something a pool spec can state. #80's release gate enforces
+/// it before any teardown reports clean, so deferring it narrows nothing.
+pub fn child_pool_is_eligible(
+    sandbox_pool: &str,
+    cluster_pool: &ClusterPool,
+) -> Result<(), ChildPlacementError> {
+    let name = cluster_pool.name_any();
+    if cluster_pool.spec.backend.backend_type != BackendType::K3s {
+        return Err(ChildPlacementError::BackendUnsupported {
+            pool: sandbox_pool.to_string(),
+            cluster_pool: name,
+            backend: format!("{:?}", cluster_pool.spec.backend.backend_type).to_lowercase(),
+        });
+    }
+    crate::crd::verified_destroy_eligibility(
+        &cluster_pool.spec.cluster,
+        cluster_pool.spec.diagnostics.as_ref(),
+        // Bind-time condition; see the doc comment above.
+        true,
+    )
+    .map_err(|reason| ChildPlacementError::VerifiedDestroyIneligible {
+        cluster_pool: cluster_pool.name_any(),
+        reason: reason.to_string(),
+    })
+}
+
+/// Check that the pool's own TTL ceiling can cover the whole composition.
+///
+/// Rejecting here, before a cluster is allocated, is the difference between an
+/// error the caller sees immediately and a Sandbox that works right up until
+/// its cluster disappears underneath it.
+pub fn child_lifetime_fits(
+    cluster_pool: &ClusterPool,
+    sandbox_pool: &SandboxPool,
+    runtime_ttl: Duration,
+) -> Result<Duration, ChildPlacementError> {
+    let provisioning = parse_std_duration(&sandbox_pool.spec.provisioning_timeout).ok_or(
+        ChildPlacementError::InvalidDuration {
+            field: "provisioningTimeout",
+        },
+    )?;
+    let required = required_child_lifetime(provisioning, runtime_ttl, CHILD_DRAIN_GRACE);
+
+    let pool_max =
+        parse_std_duration(&cluster_pool.spec.ttl).ok_or(ChildPlacementError::InvalidDuration {
+            field: "clusterPool.ttl",
+        })?;
+    if required > pool_max {
+        return Err(ChildPlacementError::LifetimeUnachievable {
+            cluster_pool: cluster_pool.name_any(),
+            pool_max: cluster_pool.spec.ttl.clone(),
+            required: format!("{}s", required.as_secs()),
+        });
+    }
+    Ok(required)
+}
+
+fn parse_std_duration(value: &str) -> Option<Duration> {
+    crate::pool::parse_duration(value)
+        .and_then(|value| value.to_std().ok())
+        .filter(|value| !value.is_zero())
+}
+
+/// Build the internal `ClusterLease` for one Sandbox lease.
+///
+/// Three properties matter and each is deliberate:
+///
+/// * **Owner-referenced to the `SandboxLease`.** Cancelling or deleting the
+///   outer lease garbage-collects the internal one, so a composition abandoned
+///   halfway cannot strand a whole cluster.
+/// * **`CleanupMode::VerifiedDestroy`.** A pool that cannot honour it rejects
+///   the lease at bind time rather than degrading to "we issued the deletes and
+///   assumed they worked" — which for an exclusive tenant cluster is exactly
+///   the assumption not worth making.
+/// * **An internal requester identity.** The lease is Kobe's, not the caller's.
+///   Recording the tenant as its requester would make it appear in their own
+///   cluster-lease listings and, worse, look releasable by them.
+pub fn build_internal_cluster_lease(
+    sandbox_lease: &SandboxLease,
+    cluster_pool_ref: &str,
+    lifetime: Duration,
+) -> Option<ClusterLease> {
+    let owner = sandbox_lease.controller_owner_ref(&())?;
+    Some(ClusterLease {
+        metadata: ObjectMeta {
+            name: Some(internal_lease_name(&sandbox_lease.name_any())),
+            namespace: sandbox_lease.namespace(),
+            owner_references: Some(vec![owner]),
+            labels: Some(
+                [(
+                    "app.kubernetes.io/managed-by".to_string(),
+                    crate::sandbox::KOBE_MANAGED_BY.to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        },
+        spec: ClusterLeaseSpec {
+            pool_ref: cluster_pool_ref.to_string(),
+            ttl: format!("{}s", lifetime.as_secs()),
+            requester: internal_requester(),
+            priority: default_internal_priority(),
+            cleanup_mode: Some(CleanupMode::VerifiedDestroy),
+        },
+        status: None,
+    })
+}
+
+/// The identity Kobe uses for its own compositions.
+///
+/// Deliberately not the caller's. An internal lease attributed to a tenant
+/// would show up in their listings and read as theirs to release — and
+/// releasing it out from under a running Sandbox is precisely the operation
+/// this composition exists to prevent them performing.
+fn internal_requester() -> Requester {
+    Requester {
+        requester_type: "kobe:sandbox-composition".to_string(),
+        identity: "kobe-operator".to_string(),
+    }
+}
+
+/// Internal compositions outrank ordinary queued work.
+///
+/// A caller is already waiting on a Sandbox by the time this lease is queued —
+/// they are not queuing for a cluster, they are queuing behind one.
+fn default_internal_priority() -> u32 {
+    100
+}
+
+/// Record what was composed, so teardown can act on exact identities.
+///
+/// Names alone are not identity. A same-named replacement cluster is fresh
+/// capacity, not evidence that the original was destroyed, and #80's receipts
+/// are checked against these UIDs rather than against a name that may have been
+/// reused in between.
+pub fn child_provenance(
+    namespace: &str,
+    lease: &ClusterLease,
+    instance_name: &str,
+    instance_uid: &str,
+    instance_generation: Option<i64>,
+) -> crate::crd::SandboxTargetProvenance {
+    crate::crd::SandboxTargetProvenance {
+        namespace: namespace.to_string(),
+        child_cluster_lease: Some(SandboxObjectReference {
+            api_version: "kobe.kunobi.ninja/v1alpha1".to_string(),
+            kind: "ClusterLease".to_string(),
+            namespace: lease.namespace(),
+            name: lease.name_any(),
+            uid: lease.uid().unwrap_or_default(),
+            generation: lease.metadata.generation,
+        }),
+        child_cluster_instance: Some(SandboxObjectReference {
+            api_version: "kobe.kunobi.ninja/v1alpha1".to_string(),
+            kind: "ClusterInstance".to_string(),
+            namespace: Some(namespace.to_string()),
+            name: instance_name.to_string(),
+            uid: instance_uid.to_string(),
+            generation: instance_generation,
+        }),
+        // Upstream object references are filled in by placement once each
+        // object exists. Provenance is monotonic: a reference is only ever
+        // added, never cleared, so teardown can always name what it must prove
+        // absent even after a restart.
+        sandbox_template: None,
+        sandbox_warm_pool: None,
+        sandbox_claim: None,
+        sandbox: None,
+        pod: None,
+    }
+}
+
+/// Validate that the child cluster serves a compatible Agent Sandbox runtime.
+///
+/// The same check #72 applies to the management cluster, pointed at the child.
+/// Kobe does not install it: a missing runtime is an error the operator fixes
+/// in the `ClusterPool`, not something the controller silently corrects using
+/// cluster-admin inside a tenant's cluster.
+pub async fn validate_child_runtime(
+    child: &Client,
+    cluster: &str,
+) -> Result<(), ChildPlacementError> {
+    crate::sandbox_runtime::validate_external_runtime(child)
+        .await
+        .map_err(|reason| ChildPlacementError::ChildRuntimeUnusable {
+            cluster: cluster.to_string(),
+            reason: reason.reason_code().to_string(),
+        })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::ClusterPoolSpec;
+
+    fn cluster_pool(backend: BackendType, ttl: &str) -> ClusterPool {
+        let spec: ClusterPoolSpec = serde_json::from_value(serde_json::json!({
+            "ttl": ttl,
+            "backend": { "type": backend_wire_name(backend) },
+            "cluster": { "version": "v1.32.0" },
+        }))
+        .expect("cluster pool fixture deserializes");
+        ClusterPool {
+            metadata: ObjectMeta {
+                name: Some("sandbox-children".into()),
+                namespace: Some("kobe".into()),
+                uid: Some("cluster-pool-uid".into()),
+                ..Default::default()
+            },
+            spec,
+            status: None,
+        }
+    }
+
+    fn backend_wire_name(backend: BackendType) -> String {
+        serde_json::to_value(backend)
+            .expect("backend serializes")
+            .as_str()
+            .expect("backend is a string")
+            .to_string()
+    }
+
+    /// Only a backend that can prove teardown may back a child Sandbox.
+    ///
+    /// Child placement's entire promise is that the tenant had the cluster to
+    /// themselves. A backend that returns capacity to the pool on the strength
+    /// of an accepted delete cannot support that promise, so it is refused
+    /// before anything is allocated rather than degraded silently — which is
+    /// what "must return Unsupported" in #74 is protecting against.
+    #[test]
+    fn only_a_receipt_capable_backend_is_admitted() {
+        assert!(child_pool_is_eligible("agents", &cluster_pool(BackendType::K3s, "8h")).is_ok());
+
+        for backend in [
+            BackendType::K0s,
+            BackendType::Vcluster,
+            BackendType::Vkobe,
+            BackendType::Capi,
+        ] {
+            let error =
+                child_pool_is_eligible("agents", &cluster_pool(backend.clone(), "8h")).unwrap_err();
+            assert!(
+                matches!(error, ChildPlacementError::BackendUnsupported { .. }),
+                "{backend:?} must be refused, got {error}"
+            );
+            assert_eq!(error.reason_code(), "backend_unsupported");
+        }
+    }
+
+    /// The internal cluster must outlive the whole composition.
+    ///
+    /// Provisioning, then the full runtime TTL the caller paid for, then the
+    /// drain grace. A cluster that expired mid-lease would take the running
+    /// Sandbox with it; one that expired mid-teardown would take the evidence
+    /// that it was cleaned up, which is worse — capacity would be reused with
+    /// nothing able to prove it was safe.
+    #[test]
+    fn the_child_cluster_cannot_expire_before_the_sandbox_is_cleaned_up() {
+        let provisioning = Duration::from_secs(600);
+        let runtime = Duration::from_secs(3600);
+
+        let required = required_child_lifetime(provisioning, runtime, CHILD_DRAIN_GRACE);
+        assert!(
+            required > provisioning + runtime,
+            "the cleanup window must be part of the bound, not assumed free"
+        );
+        assert_eq!(required, provisioning + runtime + CHILD_DRAIN_GRACE);
+
+        // Saturating, so an absurd TTL cannot wrap into a short lifetime — the
+        // one arithmetic slip here would produce a cluster that expires almost
+        // immediately under a lease that believes it has days.
+        assert_eq!(
+            required_child_lifetime(Duration::MAX, Duration::MAX, Duration::MAX),
+            Duration::MAX
+        );
+    }
+
+    /// A composition that cannot be guaranteed is refused, not attempted.
+    #[test]
+    fn a_pool_whose_ceiling_is_too_low_is_refused_before_allocating() {
+        let sandbox_pool = sandbox_pool_with_provisioning("10m");
+        let runtime = Duration::from_secs(3600);
+
+        // 10m + 1h + 15m = 1h25m. An 8h ceiling is plenty.
+        assert!(
+            child_lifetime_fits(
+                &cluster_pool(BackendType::K3s, "8h"),
+                &sandbox_pool,
+                runtime
+            )
+            .is_ok()
+        );
+
+        // A ceiling above the runtime TTL but below the full window is exactly
+        // the case a naive check misses: the Sandbox would run fine and the
+        // cluster would vanish during teardown.
+        let error = child_lifetime_fits(
+            &cluster_pool(BackendType::K3s, "70m"),
+            &sandbox_pool,
+            runtime,
+        )
+        .unwrap_err();
+        assert!(
+            matches!(error, ChildPlacementError::LifetimeUnachievable { .. }),
+            "got {error}"
+        );
+        assert_eq!(error.reason_code(), "lifetime_unachievable");
+    }
+
+    /// A malformed duration refuses the composition rather than defaulting.
+    ///
+    /// Every default here is a guess about how long somebody else's cluster
+    /// should live, and the failure mode of guessing low is a Sandbox that dies
+    /// early with its evidence.
+    #[test]
+    fn a_malformed_duration_refuses_rather_than_defaults() {
+        for bad in ["", "soon", "0s", "-1h"] {
+            let error = child_lifetime_fits(
+                &cluster_pool(BackendType::K3s, "8h"),
+                &sandbox_pool_with_provisioning(bad),
+                Duration::from_secs(60),
+            )
+            .unwrap_err();
+            assert!(
+                matches!(error, ChildPlacementError::InvalidDuration { .. }),
+                "provisioningTimeout {bad:?} must refuse, got {error}"
+            );
+        }
+
+        let error = child_lifetime_fits(
+            &cluster_pool(BackendType::K3s, "not-a-ttl"),
+            &sandbox_pool_with_provisioning("10m"),
+            Duration::from_secs(60),
+        )
+        .unwrap_err();
+        assert!(matches!(
+            error,
+            ChildPlacementError::InvalidDuration {
+                field: "clusterPool.ttl"
+            }
+        ));
+    }
+
+    /// The internal lease is Kobe's, and dies with the Sandbox lease.
+    ///
+    /// The owner reference is what makes "cancelling a pending outer lease
+    /// releases any partial internal allocation" true without a compensating
+    /// code path — and a compensating path is exactly what fails to run when
+    /// the controller is the thing that crashed.
+    #[test]
+    fn the_internal_lease_is_owned_by_the_sandbox_lease_and_never_by_the_caller() {
+        let sandbox_lease = sandbox_lease();
+        let lease =
+            build_internal_cluster_lease(&sandbox_lease, "children", Duration::from_secs(5100))
+                .expect("a lease with a UID composes");
+
+        assert_eq!(lease.name_any(), "kobe-sbx-sbx-1");
+        assert!(
+            lease.name_any().starts_with("kobe-sbx-"),
+            "an internal lease must never be mistakable for a tenant one"
+        );
+
+        let owner = &lease.metadata.owner_references.as_ref().unwrap()[0];
+        assert_eq!(owner.kind, "SandboxLease");
+        assert_eq!(owner.uid, "lease-uid-1");
+        assert_eq!(owner.controller, Some(true));
+
+        // Verified destroy is requested explicitly. A pool that cannot honour
+        // it rejects at bind time instead of quietly downgrading.
+        assert_eq!(lease.spec.cleanup_mode, Some(CleanupMode::VerifiedDestroy));
+
+        // The requester is Kobe. Attributing it to the tenant would surface the
+        // internal cluster in their listings and read as theirs to release.
+        assert_ne!(lease.spec.requester.identity, "alice");
+        assert!(lease.spec.requester.requester_type.starts_with("kobe:"));
+
+        assert_eq!(lease.spec.ttl, "5100s");
+    }
+
+    /// A Sandbox lease with no UID cannot own anything, so nothing is composed.
+    ///
+    /// Allocating a cluster with no owner reference is how an abandoned
+    /// composition strands one: nothing would ever collect it.
+    #[test]
+    fn a_lease_without_a_uid_composes_nothing() {
+        let mut sandbox_lease = sandbox_lease();
+        sandbox_lease.metadata.uid = None;
+        assert!(
+            build_internal_cluster_lease(&sandbox_lease, "children", Duration::from_secs(60))
+                .is_none()
+        );
+    }
+
+    /// Provenance is recorded by UID, because a name is not identity.
+    ///
+    /// A same-named replacement instance is fresh capacity, not proof the
+    /// original was destroyed. #80's receipt is checked against these UIDs
+    /// precisely so a recreated cluster cannot satisfy a teardown it never
+    /// underwent.
+    #[test]
+    fn provenance_pins_uids_not_names() {
+        let sandbox_lease = sandbox_lease();
+        let lease =
+            build_internal_cluster_lease(&sandbox_lease, "children", Duration::from_secs(60))
+                .unwrap();
+        let mut lease = lease;
+        lease.metadata.uid = Some("internal-lease-uid".into());
+
+        let provenance = child_provenance("kobe", &lease, "kobe-abc", "instance-uid", Some(4));
+
+        let recorded_lease = provenance.child_cluster_lease.unwrap();
+        assert_eq!(recorded_lease.uid, "internal-lease-uid");
+        assert_eq!(recorded_lease.kind, "ClusterLease");
+
+        let instance = provenance.child_cluster_instance.unwrap();
+        assert_eq!(instance.uid, "instance-uid");
+        assert_eq!(instance.generation, Some(4));
+        assert!(
+            !instance.uid.is_empty(),
+            "an empty UID would make any replacement satisfy the receipt"
+        );
+    }
+
+    fn sandbox_pool_with_provisioning(provisioning_timeout: &str) -> SandboxPool {
+        let mut pool = crate::controllers::sandbox::tests::management_pool("uid", 1);
+        pool.spec.provisioning_timeout = provisioning_timeout.to_string();
+        pool
+    }
+
+    fn sandbox_lease() -> SandboxLease {
+        crate::controllers::sandbox::tests::admitted_lease()
+    }
+}


### PR DESCRIPTION
Core of #74 · **stacked on #122**
Epic: #70 — Agent Sandbox (lane `P1`)

A child-placement `SandboxPool` says: do not run this pool's Sandboxes next to everybody else's. Kobe acquires one exclusive cluster from the named `ClusterPool` and places the caller's Sandbox inside it.

## ⚠️ Scope narrowed, deliberately — please read this first

#74 as filed has Kobe **bootstrap the Agent Sandbox runtime into the child cluster** and verify it with a create/delete canary. Installing cluster-scoped CRDs, RBAC and a webhook with cluster-admin is one of the three effects **paused pending approval on #72**, and #72 shipped `external` mode only.

Child placement follows the same rule: the child cluster must **already serve** a compatible runtime — through the `ClusterPool`'s own `bootstraps` or `addons` — and Kobe *validates* it with the same check #72 applies to the management cluster. A child without one is refused with a legible error telling the operator to configure it.

This is a real narrowing, and it is a governance call rather than a technical one: a controller must not perform under a different issue number the effect it was told to hold. If you want the bootstrap half, that is the approval on #72, and it can land on top of this without rework.

## Composition

**Every refusal happens before a cluster is allocated.** An abandoned child composition costs a whole cluster's capacity, so eligibility, lifetime and identity are all settled first:

- **Backend.** Only a receipt-capable k3s pool is admitted; everything else is `Unsupported`, never silently weaker. An exclusive tenant cluster whose destruction nobody can prove defeats the point of giving them one.
- **Lifetime.** The internal lease covers provisioning **+ the full runtime TTL + a drain grace**, and a `ClusterPool` whose ceiling cannot reach that is refused. A cluster that expired mid-lease would take the running Sandbox with it; one that expired mid-teardown would take the evidence that it was cleaned up — which is worse, because capacity would be reused with nothing able to prove it was safe.
- **Identity.** The internal lease is named from the Sandbox lease, so a restarted controller resumes the same cluster rather than allocating a second. Adoption is fenced on ownership: a same-named lease this Sandbox does not own is somebody else's cluster.

**It is owner-referenced to the `SandboxLease`.** That is what makes "cancelling a pending outer lease releases any partial internal allocation" true without a compensating code path — and a compensating path is exactly what fails to run when the controller is the thing that crashed.

**Its requester is Kobe, not the caller.** Attributing it to the tenant would surface the internal cluster in their own listings and read as theirs to release.

**Provenance is written before the cluster is used.** Teardown must be able to name the exact instance it has to prove absent, and provenance written only after a successful placement is missing in precisely the case that matters — a crash partway through.

**The child kubeconfig never leaves memory.** Not into status, not into an API response, not into a log line. The kubeconfig-read error is swallowed rather than propagated, because its context can carry the secret's own contents.

**Upstream objects in a child carry no owner reference.** An owner reference names an object in the *same* cluster; a reference to a management-cluster `SandboxPool` would name nothing there and Kubernetes GC would delete the template on sight. A child's objects are bounded by the cluster's own lifetime instead.

## Teardown — where the two placements most dangerously diverge

A child lease is released by **destroying its cluster**, not by deleting a claim. The claim lives in the child, so deleting it against the management cluster returns 404 — and a 404 is precisely what that path treats as **proof of absence**. The quota slot would be handed to the next caller while the previous tenant's Sandbox was still running in a cluster nobody had touched. This is asserted directly rather than left to inspection.

It acts on the **recorded UID**. A later composition reusing the name is not this lease's cluster: destroying it would kill a running tenant, and treating its presence as "ours is still up" would strand this lease forever. Neither — the recorded cluster is provably absent, so the release completes.

Not being able to tell **quarantines**.

Both placements share one release tail, so their release semantics cannot drift apart — the equivalence #76 sets out to prove, built in rather than asserted.

## A leak this work would otherwise have opened

The HTTP API returned `status.target` verbatim. For a child lease that carries the internal `ClusterLease` and `ClusterInstance` **name and UID** — the exact identifiers every cluster-lease endpoint is keyed on. #74 requires the composition be *undiscoverable*, not merely unusable; "no authority" and "no authority, but knows precisely what to ask for" are not the same posture.

Stripped at the response boundary rather than never recorded: teardown must prove that exact instance UID gone, and evidence a controller cannot see is evidence that does not exist. The test asserts on the **serialized** form, so a field renamed into the wire format later cannot pass a struct-level check and still leak.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1446 passed, 0 failed
```

Mutation-checked: letting a child lease fall through to the management teardown, matching the recorded cluster by name instead of UID, accepting any receipt regardless of which instance it describes, and completing when no receipt exists at all — each fails its test.

## Against #74's acceptance criteria

| Criterion | Here |
|---|---|
| Only a receipt-capable k3s pool admitted; others `Unsupported` before binding | ✅ |
| Internal cluster cannot expire before the outer cleanup window | ✅ |
| Cancelling a pending outer lease releases partial internal allocation | ✅ (owner reference) |
| Caller can neither discover nor operate the backing `ClusterLease` | ✅ (incl. the API fix) |
| No kubeconfig or admin token in status, responses, logs or events | ✅ |
| Equivalent release/quarantine semantics across placements | ✅ (shared tail) |
| Stale/name-reused target provenance fails closed | ✅ |
| Reconciliation resumes safely after restart at every transition | ⚠️ partial — resumption is covered at composition and teardown; the full matrix belongs to #76 |
| Cleanup terminal only after a receipt proves the original instance absent | ✅ |

## Completion requires the receipt

The internal lease is **released, never deleted**. Deleting the object takes its status — and the teardown receipt on it — with it, at exactly the moment the evidence matters; #80 put the receipt on the lease rather than the instance for precisely this reason. The object is collected later by its owner reference.

A release completes only against a receipt that is complete, self-consistent, and about **this** lease's instance:

- outcome `Verified`, an attempt that finished, and checks that agree with the stated outcome — the receipt is not trusted over its own evidence;
- a schema version this build understands;
- the instance UID recorded at composition time. A child cluster can be destroyed and replaced under the same lease name, and a receipt proving the *replacement* gone says nothing about the instance this Sandbox ran on.

Everything else quarantines: a receipt about a different instance, a child whose own teardown quarantined, or a recorded lease that is gone or whose name now belongs to somebody else's composition. Present-but-wrong is the dangerous case, because it is the one a laxer check accepts.

## Not in this PR

**Bootstrapping the child runtime.** See the scope note above; it is #72's approval.

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.
