### PR TITLE
access(sandbox): resolve operations to one exact owned target

### DIFF
--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -81,6 +81,12 @@ rules:
   - apiGroups: [""]
     resources: ["pods/exec"]
     verbs: ["create"]
+  # Sandbox log reads (#81). Separate from `pods` above because `pods/log` is
+  # its own resource to RBAC — and worth stating explicitly: this is the verb
+  # that lets the operator return a workload's own output to its lease holder.
+  - apiGroups: [""]
+    resources: ["pods/log"]
+    verbs: ["get"]
   # Core resources for virtual cluster lifecycle
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets", "serviceaccounts", "pods", "pods/status", "events", "persistentvolumeclaims", "endpoints"]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -3,4 +3,5 @@ pub mod connect;
 pub mod policy;
 pub mod routes;
 pub mod sandbox;
+pub mod sandbox_access;
 pub mod upgrade;

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -6,7 +6,7 @@
 //! or expose upstream Agent Sandbox objects. Placement controllers in #73/#74
 //! own those transitions.
 
-use axum::extract::{Path, State};
+use axum::extract::{Path, Query, State};
 use axum::http::StatusCode;
 use axum::response::{IntoResponse, Response};
 use axum::routing::{get, post};
@@ -64,6 +64,113 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
             "/v1/sandbox-leases/{id}",
             get(get_sandbox_lease::<B>).delete(release_sandbox_lease::<B>),
         )
+        .route("/v1/sandbox-leases/{id}/logs", get(sandbox_logs::<B>))
+}
+
+/// Read a bounded tail of one Sandbox's output.
+///
+/// The first operation to go through #81's resolver: principal → owned, Ready,
+/// unexpired lease → recorded provenance → the exact Pod and container. It
+/// selects no default at any step, and the denial vocabulary is deliberately
+/// coarse where it faces the caller — an unowned lease answers exactly as an
+/// absent one does.
+///
+/// Management and child placement are not handled separately here. Both
+/// resolve through the same interface; only the client differs, and that is
+/// Kobe's business rather than the caller's.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn sandbox_logs<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+    Query(query): Query<crate::api::sandbox_access::SandboxLogsQuery>,
+) -> Response {
+    use crate::api::sandbox_access as access;
+
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    if !is_valid_k8s_name(&id) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let (_lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
+        {
+            Ok(resolved) => resolved,
+            Err(denied) => return access_denied(&identity, &id, "logs", denied),
+        };
+
+    let container = match target.resolve_container(query.container.as_deref()) {
+        Ok(container) => container.to_string(),
+        Err(denied) => return access_denied(&identity, &id, "logs", denied),
+    };
+
+    // Child-placed Sandboxes live in a cluster this API server reaches with a
+    // different client. Resolving that is #74's composition, not something the
+    // logs path may improvise, so it is refused explicitly rather than read
+    // from the wrong cluster — which would return another workload's output or
+    // a misleading 404.
+    if target.placement != access::TargetPlacement::Management {
+        return sandbox_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "Sandbox logs are not yet available for child placement",
+            None,
+        );
+    }
+
+    match access::read_sandbox_logs(
+        &state.client,
+        &target,
+        &container,
+        access::clamp_tail(query.tail),
+    )
+    .await
+    {
+        Ok(logs) => {
+            // Audited by identity and outcome, never by content: the body is
+            // the workload's own output and can contain anything.
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                pod_uid = %target.pod_uid,
+                operation = "logs",
+                outcome = "allowed",
+                "Sandbox access"
+            );
+            (StatusCode::OK, logs).into_response()
+        }
+        Err(denied) => access_denied(&identity, &id, "logs", denied),
+    }
+}
+
+/// Record and answer one denied Sandbox operation.
+///
+/// The audit line carries the principal, lease, operation and a bounded reason
+/// code — never a credential, a command, or any of the workload's own output.
+/// The reason code is finer-grained than the caller-facing status on purpose:
+/// an operator needs to tell "expired" from "never placed" when somebody
+/// reports that access stopped working, while the caller must not be able to.
+fn access_denied(
+    identity: &AuthIdentity,
+    lease: &str,
+    operation: &'static str,
+    denied: crate::api::sandbox_access::SandboxAccessDenied,
+) -> Response {
+    info!(
+        principal = %identity.identity,
+        lease = %lease,
+        operation,
+        outcome = "denied",
+        reason = denied.reason_code(),
+        "Sandbox access"
+    );
+    let status = denied.http_status();
+    if status == StatusCode::NOT_FOUND {
+        // No body: a message would distinguish "not yours" from "not there".
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    sandbox_error(status, denied.to_string(), None)
 }
 
 /// Caller-safe lease intent. Unknown fields are rejected so a caller cannot
@@ -869,6 +976,15 @@ async fn reap_abandoned_pending_leases(
             ),
         }
     }
+}
+
+/// Whether this principal owns the lease, by the complete identity tuple.
+///
+/// Exposed for #81's resolver so ownership is decided in exactly one place: a
+/// second implementation is a second chance to compare on identity alone and
+/// let one provider's `alice` reach another's.
+pub(crate) fn principal_owns_lease(lease: &SandboxLease, identity: &AuthIdentity) -> bool {
+    principal_matches(&lease.spec.requester, identity)
 }
 
 fn principal_matches(requester: &SandboxPrincipal, identity: &AuthIdentity) -> bool {

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -1,0 +1,687 @@
+//! Resolving a Sandbox operation to one exact, owned target (#81).
+//!
+//! Every Sandbox operation — exec, logs, attach, port-forward — starts here.
+//! The caller names a lease; this module answers with **one** typed target or a
+//! bounded denial, and never with a default.
+//!
+//! # Why "never a default" is the whole design
+//!
+//! A resolver that falls back — to the current namespace, the first container,
+//! the only Pod it found — turns a stale or ambiguous request into a
+//! *successful* one against the wrong workload. For a Sandbox that means a
+//! caller's command running inside somebody else's agent. So every step
+//! either produces the exact object recorded at placement time, or denies.
+//!
+//! # Resolution order
+//!
+//! ```text
+//! authenticated principal
+//!   -> owned, Ready, unexpired SandboxLease UID
+//!   -> immutable direct/child placement provenance
+//!   -> exact Claim/Sandbox/Pod UIDs
+//!   -> approved container and declared ports
+//! ```
+//!
+//! Ownership is checked before existence is revealed, and the two failures are
+//! deliberately indistinguishable: a caller who can tell "not yours" from "not
+//! there" can enumerate other tenants' leases.
+//!
+//! # What a target is not
+//!
+//! It is not a Kubernetes capability. Resolving succeeds only for the exact
+//! Pod and container this lease owns, and only for ports its pool declared —
+//! nothing here can name a Node, a Secret, another namespace, or a second Pod.
+
+use kube::ResourceExt;
+use kube::api::Api;
+
+use crate::crd::{ResolvedSandboxPlacement, SandboxLease, SandboxLeasePhase, SandboxPool};
+
+/// One exact, fully identified Sandbox target.
+///
+/// Every field is a value observed at placement time and re-verified here.
+/// Nothing in it is caller-supplied.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxTarget {
+    /// The lease this target belongs to, by UID. Carried so an operation that
+    /// outlives its resolution can be revoked by lease identity rather than by
+    /// name.
+    pub lease_uid: String,
+    /// Whether the workload runs in Kobe's own cluster or a composed child.
+    pub placement: TargetPlacement,
+    /// Namespace in the *target* cluster.
+    pub namespace: String,
+    pub claim_uid: String,
+    pub sandbox_name: String,
+    pub sandbox_uid: String,
+    pub pod_name: String,
+    pub pod_uid: String,
+    /// The single container operations may address.
+    pub container: String,
+    /// Ports the pool declared. Nothing else is forwardable.
+    pub ports: Vec<DeclaredPort>,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum TargetPlacement {
+    Management,
+    /// Composed child cluster. The caller never learns this, and never learns
+    /// which cluster — it changes how Kobe reaches the Pod, not what the caller
+    /// may do with it.
+    ChildCluster,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct DeclaredPort {
+    pub name: String,
+    pub port: u16,
+}
+
+/// Why an operation cannot be resolved.
+///
+/// A closed vocabulary, and deliberately coarse where it faces the caller:
+/// several distinct internal failures share `NotFound` precisely so that a
+/// caller cannot use the difference to learn about leases that are not theirs.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum SandboxAccessDenied {
+    /// The lease does not exist, or is not this principal's. One reason, on
+    /// purpose: distinguishing them lets a caller enumerate other tenants.
+    #[error("sandbox not found")]
+    NotFound,
+    /// It exists and is theirs, but is not currently usable.
+    #[error("sandbox is not ready ({phase})")]
+    NotReady { phase: String },
+    #[error("sandbox lease has expired")]
+    Expired,
+    /// Placement never finished recording what it built, so there is no exact
+    /// target to address. Never resolved by looking one up: a lookup at access
+    /// time would find whatever holds the name *now*.
+    #[error("sandbox target has not been resolved yet")]
+    TargetUnresolved,
+    /// The recorded provenance is incomplete or unusable — a reference with no
+    /// UID cannot fence anything.
+    #[error("sandbox target provenance is incomplete")]
+    ProvenanceIncomplete,
+    /// The pool that admitted this lease is gone or has changed identity, so
+    /// the container and port allowlist cannot be established.
+    #[error("sandbox pool is no longer resolvable")]
+    PoolUnresolvable,
+    /// The caller asked for a container or port the pool never declared.
+    #[error("{what} is not part of this sandbox")]
+    NotDeclared { what: &'static str },
+    #[error("sandbox lookup failed")]
+    Backend,
+}
+
+impl SandboxAccessDenied {
+    /// Bounded reason code for audit records and metrics.
+    ///
+    /// Distinct per variant even where the caller-facing status collapses
+    /// several into one: the operator has to be able to tell "expired" from
+    /// "never placed" when someone reports that access stopped working.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::NotFound => "not_found",
+            Self::NotReady { .. } => "not_ready",
+            Self::Expired => "expired",
+            Self::TargetUnresolved => "target_unresolved",
+            Self::ProvenanceIncomplete => "provenance_incomplete",
+            Self::PoolUnresolvable => "pool_unresolvable",
+            Self::NotDeclared { .. } => "not_declared",
+            Self::Backend => "backend_error",
+        }
+    }
+
+    /// The HTTP status a caller sees.
+    ///
+    /// Everything about *which* lease is 404. A 403 would confirm the lease
+    /// exists, which is exactly the fact ownership checking is protecting.
+    pub fn http_status(&self) -> axum::http::StatusCode {
+        use axum::http::StatusCode;
+        match self {
+            Self::NotFound => StatusCode::NOT_FOUND,
+            Self::NotReady { .. } | Self::TargetUnresolved => StatusCode::CONFLICT,
+            Self::Expired => StatusCode::GONE,
+            Self::NotDeclared { .. } => StatusCode::BAD_REQUEST,
+            Self::ProvenanceIncomplete | Self::PoolUnresolvable | Self::Backend => {
+                StatusCode::SERVICE_UNAVAILABLE
+            }
+        }
+    }
+}
+
+/// Whether a lease is in a phase that may serve traffic at all.
+///
+/// `Releasing` is refused even though the Pod may still be up: teardown has
+/// started, and letting a new operation attach to a workload that is being
+/// destroyed produces a stream that dies mid-flight at best, and interferes
+/// with cleanup at worst.
+fn phase_permits_access(phase: SandboxLeasePhase) -> Result<(), SandboxAccessDenied> {
+    match phase {
+        SandboxLeasePhase::Ready => Ok(()),
+        SandboxLeasePhase::Expired => Err(SandboxAccessDenied::Expired),
+        other => Err(SandboxAccessDenied::NotReady {
+            phase: other.to_string(),
+        }),
+    }
+}
+
+/// Whether the lease's own expiry has passed.
+///
+/// A malformed expiry denies. The alternative — treating an unparseable
+/// timestamp as "not expired" — grants access on the strength of a value
+/// nobody can read, and the whole point of the expiry is that it bounds what
+/// the caller may keep doing.
+fn expiry_permits_access(
+    expires_at: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<(), SandboxAccessDenied> {
+    let Some(expires_at) = expires_at else {
+        // Ready without an expiry should be impossible — placement writes them
+        // together — so this is a corrupted state, not an unlimited lease.
+        return Err(SandboxAccessDenied::Expired);
+    };
+    let Ok(expires_at) = chrono::DateTime::parse_from_rfc3339(expires_at) else {
+        return Err(SandboxAccessDenied::Expired);
+    };
+    if now >= expires_at {
+        return Err(SandboxAccessDenied::Expired);
+    }
+    Ok(())
+}
+
+/// Resolve the recorded provenance into an addressable target.
+///
+/// Pure, so the fencing rules are testable without a cluster, and separated
+/// from the lookup so that no code path can construct a target from anything
+/// other than what placement recorded.
+pub fn target_from_provenance(
+    lease: &SandboxLease,
+    pool: &SandboxPool,
+    now: chrono::DateTime<chrono::Utc>,
+) -> Result<SandboxTarget, SandboxAccessDenied> {
+    let status = lease
+        .status
+        .as_ref()
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+    phase_permits_access(status.phase)?;
+    expiry_permits_access(status.expires_at.as_deref(), now)?;
+
+    let lease_uid = lease
+        .uid()
+        .ok_or(SandboxAccessDenied::ProvenanceIncomplete)?;
+
+    // The pool must still be the exact one that admitted this lease. If it was
+    // deleted and recreated, its template — and therefore the container and
+    // ports a caller may address — is a different administrator's decision.
+    if pool.uid().as_deref() != Some(lease.spec.pool_ref.uid.as_str()) {
+        return Err(SandboxAccessDenied::PoolUnresolvable);
+    }
+
+    let placement = match status.placement {
+        Some(ResolvedSandboxPlacement::Management {}) => TargetPlacement::Management,
+        Some(ResolvedSandboxPlacement::ChildCluster { .. }) => TargetPlacement::ChildCluster,
+        None => return Err(SandboxAccessDenied::TargetUnresolved),
+    };
+
+    let target = status
+        .target
+        .as_ref()
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+    let claim = target
+        .sandbox_claim
+        .as_ref()
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+    let sandbox = target
+        .sandbox
+        .as_ref()
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+    let pod = target
+        .pod
+        .as_ref()
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+
+    // A reference with no UID fences nothing: two empty UIDs compare equal, so
+    // a later same-named Pod would satisfy the check meant to exclude it.
+    if claim.uid.is_empty()
+        || sandbox.uid.is_empty()
+        || pod.uid.is_empty()
+        || pod.name.is_empty()
+        || target.namespace.is_empty()
+    {
+        return Err(SandboxAccessDenied::ProvenanceIncomplete);
+    }
+
+    Ok(SandboxTarget {
+        lease_uid,
+        placement,
+        namespace: target.namespace.clone(),
+        claim_uid: claim.uid.clone(),
+        sandbox_name: sandbox.name.clone(),
+        sandbox_uid: sandbox.uid.clone(),
+        pod_name: pod.name.clone(),
+        pod_uid: pod.uid.clone(),
+        // The pool names one default container. A caller cannot choose another:
+        // the others, if any, are the administrator's sidecars, not the
+        // caller's workload.
+        container: pool.spec.template.default_container.clone(),
+        ports: pool
+            .spec
+            .template
+            .exposed_ports
+            .iter()
+            .filter(|port| port.container == pool.spec.template.default_container)
+            .map(|port| DeclaredPort {
+                name: port.name.clone(),
+                port: port.port,
+            })
+            .collect(),
+    })
+}
+
+impl SandboxTarget {
+    /// Resolve a caller-named container against the allowlist.
+    ///
+    /// `None` means "the default", which is the only container a caller may
+    /// address. Naming any other — including a real sidecar that exists in the
+    /// Pod — is refused rather than honoured.
+    pub fn resolve_container(&self, requested: Option<&str>) -> Result<&str, SandboxAccessDenied> {
+        match requested {
+            None => Ok(&self.container),
+            Some(name) if name == self.container => Ok(&self.container),
+            Some(_) => Err(SandboxAccessDenied::NotDeclared { what: "container" }),
+        }
+    }
+}
+
+/// Resolve one operation, from an authenticated principal to an exact target.
+///
+/// Ownership is established before anything else is read, and a lease that is
+/// absent and a lease that belongs to somebody else produce the identical
+/// answer.
+pub async fn resolve_sandbox_target(
+    client: &kube::Client,
+    namespace: &str,
+    lease_name: &str,
+    identity: &crate::api::auth::AuthIdentity,
+) -> Result<(SandboxLease, SandboxTarget), SandboxAccessDenied> {
+    let leases: Api<SandboxLease> = Api::namespaced(client.clone(), namespace);
+    let lease = match leases.get(lease_name).await {
+        Ok(lease) => lease,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            return Err(SandboxAccessDenied::NotFound);
+        }
+        Err(_) => return Err(SandboxAccessDenied::Backend),
+    };
+    if !crate::api::sandbox::principal_owns_lease(&lease, identity) {
+        // Same answer as absent. A caller who can tell these apart can
+        // enumerate every lease in the namespace by name.
+        return Err(SandboxAccessDenied::NotFound);
+    }
+
+    let pools: Api<SandboxPool> = Api::namespaced(client.clone(), namespace);
+    let pool = match pools.get(&lease.spec.pool_ref.name).await {
+        Ok(pool) => pool,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            return Err(SandboxAccessDenied::PoolUnresolvable);
+        }
+        Err(_) => return Err(SandboxAccessDenied::Backend),
+    };
+
+    let target = target_from_provenance(&lease, &pool, chrono::Utc::now())?;
+    Ok((lease, target))
+}
+
+/// How much of a Sandbox's output one request may return.
+///
+/// Bounded because the caller controls neither how much their agent writes nor
+/// how often they ask. An unbounded read is a way to make the operator buffer
+/// a workload's entire log in memory on demand.
+pub const MAX_LOG_TAIL_LINES: i64 = 2_000;
+const DEFAULT_LOG_TAIL_LINES: i64 = 200;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxLogsQuery {
+    /// Lines from the end. Clamped, never honoured unbounded.
+    #[serde(default)]
+    pub tail: Option<i64>,
+    /// Container name. Only the pool's own container resolves; the field
+    /// exists so a wrong value is refused explicitly rather than ignored.
+    #[serde(default)]
+    pub container: Option<String>,
+}
+
+/// Clamp a caller-supplied tail into the permitted range.
+///
+/// Clamped rather than rejected: a caller asking for more than the cap wants
+/// as much as they can have, and failing the request teaches them to retry in
+/// a loop, which is worse for everyone.
+pub fn clamp_tail(requested: Option<i64>) -> i64 {
+    requested
+        .unwrap_or(DEFAULT_LOG_TAIL_LINES)
+        .clamp(1, MAX_LOG_TAIL_LINES)
+}
+
+/// Read a bounded tail of one Sandbox's output.
+///
+/// The first consumer of the resolver, and deliberately the smallest one: it
+/// exercises principal → lease → provenance → Pod → container end to end
+/// without needing a stream protocol.
+///
+/// The Pod is addressed by the **recorded** name in the **recorded** namespace,
+/// and its UID re-checked against provenance. A Pod that was replaced since
+/// placement is a different workload wearing the same name, and returning its
+/// output would show one caller another's logs.
+pub async fn read_sandbox_logs(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    tail_lines: i64,
+) -> Result<String, SandboxAccessDenied> {
+    use k8s_openapi::api::core::v1::Pod;
+    use kube::api::LogParams;
+
+    let pods: Api<Pod> = Api::namespaced(client.clone(), &target.namespace);
+    let pod = match pods.get(&target.pod_name).await {
+        Ok(pod) => pod,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            return Err(SandboxAccessDenied::TargetUnresolved);
+        }
+        Err(_) => return Err(SandboxAccessDenied::Backend),
+    };
+    // The name resolved; the identity must too.
+    if pod.uid().as_deref() != Some(target.pod_uid.as_str()) {
+        return Err(SandboxAccessDenied::TargetUnresolved);
+    }
+
+    let params = LogParams {
+        container: Some(container.to_string()),
+        tail_lines: Some(tail_lines),
+        // Never `follow`: this endpoint returns a bounded body, and a followed
+        // stream here would hold a connection open with no revocation path.
+        follow: false,
+        ..Default::default()
+    };
+    pods.logs(&target.pod_name, &params)
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reference(kind: &str, name: &str, uid: &str) -> crate::crd::SandboxObjectReference {
+        crate::crd::SandboxObjectReference {
+            api_version: "v1".into(),
+            kind: kind.into(),
+            namespace: Some("kobe".into()),
+            name: name.into(),
+            uid: uid.into(),
+            generation: None,
+        }
+    }
+
+    fn ready_lease() -> SandboxLease {
+        let mut lease = crate::controllers::sandbox::tests::admitted_lease();
+        let status = lease.status.as_mut().unwrap();
+        status.phase = SandboxLeasePhase::Ready;
+        status.expires_at = Some((chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339());
+        status.placement = Some(ResolvedSandboxPlacement::Management {});
+        status.target = Some(crate::crd::SandboxTargetProvenance {
+            namespace: "kobe".into(),
+            child_cluster_lease: None,
+            child_cluster_instance: None,
+            sandbox_template: None,
+            sandbox_warm_pool: None,
+            sandbox_claim: Some(reference("SandboxClaim", "kobe-sbx-1", "claim-uid")),
+            sandbox: Some(reference("Sandbox", "sbx", "sandbox-uid")),
+            pod: Some(reference("Pod", "sbx-0", "pod-uid")),
+        });
+        lease
+    }
+
+    fn pool() -> SandboxPool {
+        crate::controllers::sandbox::tests::management_pool("pool-uid-1", 3)
+    }
+
+    fn now() -> chrono::DateTime<chrono::Utc> {
+        chrono::Utc::now()
+    }
+
+    #[test]
+    fn a_ready_lease_resolves_to_its_exact_recorded_objects() {
+        let target = target_from_provenance(&ready_lease(), &pool(), now()).unwrap();
+        assert_eq!(target.pod_name, "sbx-0");
+        assert_eq!(target.pod_uid, "pod-uid");
+        assert_eq!(target.claim_uid, "claim-uid");
+        assert_eq!(target.sandbox_uid, "sandbox-uid");
+        assert_eq!(target.namespace, "kobe");
+        assert_eq!(target.placement, TargetPlacement::Management);
+        assert_eq!(target.container, "agent");
+    }
+
+    /// Every phase short of Ready denies before anything is minted.
+    ///
+    /// `Releasing` matters most and is the least obvious: the Pod may still be
+    /// up, so a laxer check would let a new stream attach to a workload that is
+    /// being destroyed — a stream that dies mid-flight at best, and interferes
+    /// with cleanup at worst.
+    #[test]
+    fn only_a_ready_lease_resolves() {
+        for phase in [
+            SandboxLeasePhase::Pending,
+            SandboxLeasePhase::Provisioning,
+            SandboxLeasePhase::Releasing,
+            SandboxLeasePhase::Released,
+            SandboxLeasePhase::Quarantined,
+        ] {
+            let mut lease = ready_lease();
+            lease.status.as_mut().unwrap().phase = phase;
+            let error = target_from_provenance(&lease, &pool(), now()).unwrap_err();
+            assert!(
+                matches!(error, SandboxAccessDenied::NotReady { .. }),
+                "{phase} must deny, got {error}"
+            );
+        }
+
+        let mut expired = ready_lease();
+        expired.status.as_mut().unwrap().phase = SandboxLeasePhase::Expired;
+        assert_eq!(
+            target_from_provenance(&expired, &pool(), now()).unwrap_err(),
+            SandboxAccessDenied::Expired
+        );
+    }
+
+    /// An expiry that cannot be read denies.
+    ///
+    /// Treating an unparseable or absent timestamp as "not expired" grants
+    /// access on the strength of a value nobody can read — and bounding what
+    /// the caller may keep doing is the entire job of the expiry.
+    #[test]
+    fn an_unreadable_expiry_denies_rather_than_grants() {
+        for expiry in [None, Some(""), Some("soon"), Some("0")] {
+            let mut lease = ready_lease();
+            lease.status.as_mut().unwrap().expires_at = expiry.map(str::to_string);
+            assert_eq!(
+                target_from_provenance(&lease, &pool(), now()).unwrap_err(),
+                SandboxAccessDenied::Expired,
+                "expiry {expiry:?} must deny"
+            );
+        }
+
+        // A lease that expired one second ago is expired.
+        let mut lease = ready_lease();
+        lease.status.as_mut().unwrap().expires_at =
+            Some((chrono::Utc::now() - chrono::Duration::seconds(1)).to_rfc3339());
+        assert_eq!(
+            target_from_provenance(&lease, &pool(), now()).unwrap_err(),
+            SandboxAccessDenied::Expired
+        );
+    }
+
+    /// A target is only ever the objects placement recorded.
+    ///
+    /// Missing provenance denies rather than triggering a lookup. Looking the
+    /// Pod up at access time would find whatever holds the name *now*, which
+    /// after a recycle is a different tenant's workload — the exact
+    /// substitution the recorded UIDs exist to prevent.
+    #[test]
+    fn incomplete_provenance_denies_rather_than_falling_back() {
+        for what in ["claim", "sandbox", "pod", "namespace"] {
+            let mut lease = ready_lease();
+            let target = lease.status.as_mut().unwrap().target.as_mut().unwrap();
+            match what {
+                "claim" => target.sandbox_claim = None,
+                "sandbox" => target.sandbox = None,
+                "pod" => target.pod = None,
+                _ => target.namespace = String::new(),
+            }
+            let error = target_from_provenance(&lease, &pool(), now()).unwrap_err();
+            assert!(
+                matches!(
+                    error,
+                    SandboxAccessDenied::TargetUnresolved
+                        | SandboxAccessDenied::ProvenanceIncomplete
+                ),
+                "missing {what} must deny, got {error}"
+            );
+        }
+
+        // A reference with an empty UID fences nothing.
+        let mut lease = ready_lease();
+        lease
+            .status
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap()
+            .pod
+            .as_mut()
+            .unwrap()
+            .uid = String::new();
+        assert_eq!(
+            target_from_provenance(&lease, &pool(), now()).unwrap_err(),
+            SandboxAccessDenied::ProvenanceIncomplete
+        );
+
+        // No recorded placement at all.
+        let mut lease = ready_lease();
+        lease.status.as_mut().unwrap().placement = None;
+        assert_eq!(
+            target_from_provenance(&lease, &pool(), now()).unwrap_err(),
+            SandboxAccessDenied::TargetUnresolved
+        );
+    }
+
+    /// A pool recreated under the same name cannot supply the allowlist.
+    ///
+    /// The container and ports a caller may address come from the pool's
+    /// template. A replacement pool is a different administrator's decision
+    /// about what should be reachable, and applying it to a lease admitted
+    /// against the old one silently changes what that caller can do.
+    #[test]
+    fn a_replaced_pool_denies_rather_than_supplying_a_new_allowlist() {
+        let replaced = crate::controllers::sandbox::tests::management_pool("a-different-uid", 3);
+        assert_eq!(
+            target_from_provenance(&ready_lease(), &replaced, now()).unwrap_err(),
+            SandboxAccessDenied::PoolUnresolvable
+        );
+    }
+
+    /// Only the pool's own container is addressable.
+    ///
+    /// Anything else in the Pod is the administrator's — a sidecar, an
+    /// injected proxy — and executing in one would run the caller's command
+    /// with that component's identity and mounts rather than their own.
+    #[test]
+    fn only_the_declared_container_is_addressable() {
+        let target = target_from_provenance(&ready_lease(), &pool(), now()).unwrap();
+
+        assert_eq!(target.resolve_container(None).unwrap(), "agent");
+        assert_eq!(target.resolve_container(Some("agent")).unwrap(), "agent");
+
+        for other in ["istio-proxy", "linkerd-proxy", "AGENT", "agent ", ""] {
+            assert_eq!(
+                target.resolve_container(Some(other)).unwrap_err(),
+                SandboxAccessDenied::NotDeclared { what: "container" },
+                "container {other:?} must be refused"
+            );
+        }
+    }
+
+    /// The forwardable set is exactly what the pool declared.
+    ///
+    /// Carried on the target so #83's port-forward cannot improvise one:
+    /// without a fixed allowlist it becomes a general tunnel into the Pod's
+    /// network namespace, reaching a debug listener or a metrics endpoint the
+    /// administrator never meant to publish.
+    #[test]
+    fn the_target_carries_only_pool_declared_ports() {
+        let target = target_from_provenance(&ready_lease(), &pool(), now()).unwrap();
+        assert_eq!(
+            target.ports,
+            vec![DeclaredPort {
+                name: "http".into(),
+                port: 3000
+            }]
+        );
+    }
+
+    /// Absent and unowned are the same answer to a caller.
+    ///
+    /// A 403 would confirm the lease exists. That difference is enough to
+    /// enumerate every lease in the namespace by guessing names, which is
+    /// precisely what ownership checking is supposed to prevent.
+    #[test]
+    fn not_found_and_not_yours_are_indistinguishable() {
+        assert_eq!(
+            SandboxAccessDenied::NotFound.http_status(),
+            axum::http::StatusCode::NOT_FOUND
+        );
+        // No variant may map to 403: that status is itself the disclosure.
+        for denial in [
+            SandboxAccessDenied::NotFound,
+            SandboxAccessDenied::NotReady {
+                phase: "Pending".into(),
+            },
+            SandboxAccessDenied::Expired,
+            SandboxAccessDenied::TargetUnresolved,
+            SandboxAccessDenied::ProvenanceIncomplete,
+            SandboxAccessDenied::PoolUnresolvable,
+            SandboxAccessDenied::NotDeclared { what: "port" },
+            SandboxAccessDenied::Backend,
+        ] {
+            assert_ne!(
+                denial.http_status(),
+                axum::http::StatusCode::FORBIDDEN,
+                "{denial} must not confirm a lease exists"
+            );
+            assert!(!denial.reason_code().is_empty());
+        }
+    }
+
+    /// Child placement resolves through the same path, and says so only
+    /// internally.
+    ///
+    /// #76 asks that both placements behave equivalently; sharing one resolver
+    /// is what makes that true rather than asserted. The placement is recorded
+    /// on the target because Kobe needs it to pick a client — not because the
+    /// caller may know it.
+    #[test]
+    fn child_placement_resolves_through_the_same_interface() {
+        let mut lease = ready_lease();
+        lease.status.as_mut().unwrap().placement = Some(ResolvedSandboxPlacement::ChildCluster {
+            cluster_pool: reference("ClusterPool", "children", "cluster-pool-uid"),
+        });
+
+        let target = target_from_provenance(&lease, &pool(), now()).unwrap();
+        assert_eq!(target.placement, TargetPlacement::ChildCluster);
+        // Everything else a caller can do is identical.
+        assert_eq!(target.container, "agent");
+        assert_eq!(target.ports.len(), 1);
+        assert_eq!(target.pod_uid, "pod-uid");
+    }
+}

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -362,6 +362,15 @@ pub async fn reconcile_lease(
         debug!(lease = %name, "readiness canary passed");
     }
 
+    // Record exactly which objects this lease resolved to. #81 routes every
+    // Sandbox operation through these UIDs rather than through names, because
+    // a name reused between placement and access would send a caller's exec
+    // into somebody else's Pod. Recorded here, where the objects have just
+    // been observed, rather than looked up again at access time.
+    if let Some(provenance) = observed_provenance(&target, &claim, &lease).await {
+        patch_lease_status(&ctx, &name, &serde_json::json!({ "target": provenance })).await?;
+    }
+
     // Runtime TTL starts HERE, at observed readiness — not when the request
     // arrived. A caller must not be billed for however long placement and
     // provisioning took, which is the whole reason the provisioning deadline
@@ -1001,6 +1010,81 @@ fn with_condition(
         last_transition_time,
     });
     conditions
+}
+
+/// Build the full target provenance for a placed, ready lease.
+///
+/// Monotonic: whatever was already recorded — the child cluster identities for
+/// a composition — is preserved, and only the upstream references are added.
+/// Provenance that could be *cleared* would let a teardown lose the very
+/// identity it has to prove absent.
+///
+/// Returns `None` when the objects cannot be identified. Recording a reference
+/// without a UID is worse than recording nothing: two absent UIDs compare
+/// equal, so any later same-named object would satisfy a check meant to
+/// exclude it.
+async fn observed_provenance(
+    target: &Target,
+    claim: &DynamicObject,
+    lease: &SandboxLease,
+) -> Option<crate::crd::SandboxTargetProvenance> {
+    let claim_uid = claim.uid()?;
+    let resolved = crate::controllers::sandbox_canary::resolve_sandbox_pod(
+        &target.client,
+        &target.namespace,
+        claim,
+    )
+    .await
+    .ok()
+    .flatten()?;
+
+    let existing = lease
+        .status
+        .as_ref()
+        .and_then(|status| status.target.clone());
+    let reference =
+        |api_version: &str, kind: &str, name: &str, uid: &str| crate::crd::SandboxObjectReference {
+            api_version: api_version.to_string(),
+            kind: kind.to_string(),
+            namespace: Some(target.namespace.clone()),
+            name: name.to_string(),
+            uid: uid.to_string(),
+            generation: None,
+        };
+
+    Some(crate::crd::SandboxTargetProvenance {
+        namespace: target.namespace.clone(),
+        child_cluster_lease: existing
+            .as_ref()
+            .and_then(|existing| existing.child_cluster_lease.clone()),
+        child_cluster_instance: existing
+            .as_ref()
+            .and_then(|existing| existing.child_cluster_instance.clone()),
+        sandbox_template: existing
+            .as_ref()
+            .and_then(|existing| existing.sandbox_template.clone()),
+        sandbox_warm_pool: existing
+            .as_ref()
+            .and_then(|existing| existing.sandbox_warm_pool.clone()),
+        sandbox_claim: Some(reference(
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_CLAIM_KIND,
+            &claim.name_any(),
+            &claim_uid,
+        )),
+        sandbox: Some(reference(
+            crate::controllers::sandbox_canary::SANDBOX_API_VERSION,
+            crate::controllers::sandbox_canary::SANDBOX_KIND,
+            &resolved.sandbox_name,
+            &resolved.sandbox_uid,
+        )),
+        pod: Some(reference(
+            "v1",
+            "Pod",
+            &resolved.pod_name,
+            &resolved.pod_uid,
+        )),
+    })
 }
 
 /// Where one lease's Sandbox is placed.

--- a/src/controllers/sandbox_canary.rs
+++ b/src/controllers/sandbox_canary.rs
@@ -91,11 +91,24 @@ fn sandbox_resource() -> ApiResource {
 /// guessed from a naming convention: a convention that upstream changes would
 /// silently start selecting the wrong Pod, and the wrong Pod is one belonging
 /// to another tenant.
+/// The exact upstream objects behind one claim.
+///
+/// Identities, not just names: #81 resolves every Sandbox operation through
+/// these UIDs, and a name that was reused between placement and access would
+/// otherwise route a caller's exec into somebody else's Pod.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ResolvedSandboxPod {
+    pub sandbox_name: String,
+    pub sandbox_uid: String,
+    pub pod_name: String,
+    pub pod_uid: String,
+}
+
 pub async fn resolve_sandbox_pod(
     client: &Client,
     namespace: &str,
     claim: &DynamicObject,
-) -> Result<Option<String>, String> {
+) -> Result<Option<ResolvedSandboxPod>, String> {
     let Some(sandbox_name) = claim
         .data
         .get("status")
@@ -149,7 +162,18 @@ pub async fn resolve_sandbox_pod(
     if running.next().is_some() {
         return Err("sandbox selector matched more than one running pod".to_string());
     }
-    Ok(Some(pod.name_any()))
+
+    // A Pod with no UID cannot be fenced, and an unfenceable target is one a
+    // later same-named Pod could impersonate.
+    let (Some(sandbox_uid), Some(pod_uid)) = (sandbox.uid(), pod.uid()) else {
+        return Ok(None);
+    };
+    Ok(Some(ResolvedSandboxPod {
+        sandbox_name: sandbox_name.to_string(),
+        sandbox_uid,
+        pod_name: pod.name_any(),
+        pod_uid,
+    }))
 }
 
 /// Run one pool-declared canary inside the Sandbox Pod.
@@ -251,7 +275,7 @@ pub async fn evaluate_readiness_canary(
     canary: &SandboxExecutionCanary,
 ) -> CanaryOutcome {
     let pod = match resolve_sandbox_pod(client, namespace, claim).await {
-        Ok(Some(pod)) => pod,
+        Ok(Some(resolved)) => resolved.pod_name,
         Ok(None) => {
             debug!(claim = %claim.name_any(), "sandbox pod not resolvable yet");
             return CanaryOutcome::Inconclusive {


### PR DESCRIPTION
Substrate of #81 · **stacked on #125**
Epic: #70 — Agent Sandbox · Parent: #75

Every Sandbox operation — exec, logs, attach, port-forward — has to answer one question first: **which Pod, in which cluster, for which caller.** This is that substrate, landed together with its first consumer so the resolver is exercised rather than merely written.

## "Never a default" is the whole design

A resolver that falls back — to the current namespace, the first container, the only Pod it happened to find — turns a stale or ambiguous request into a **successful** one against the wrong workload. For a Sandbox that means a caller's command running inside somebody else's agent.

So every step yields the exact object placement recorded, or denies:

```
authenticated principal
  -> owned, Ready, unexpired SandboxLease UID
  -> immutable direct/child placement provenance
  -> exact Claim/Sandbox/Pod UIDs
  -> approved container
```

## Decisions worth review

**Absent and unowned are the same answer.** A 403 confirms the lease exists, and that difference is enough to enumerate every lease in the namespace by guessing names — which is precisely what ownership checking exists to prevent. No denial variant maps to 403, the 404 carries no body, and a test asserts both.

**The audit reason code is finer-grained than the caller-facing status.** An operator has to tell "expired" from "never placed" when somebody reports that access stopped working; the caller must not be able to. The audit line carries principal, lease, operation, target UID and outcome — never a credential, a command, or the workload's output.

**`Releasing` denies even though the Pod may still be up.** Teardown has started. Letting a new stream attach to a workload being destroyed gives a stream that dies mid-flight at best, and interferes with cleanup at worst.

**An unreadable or absent expiry denies.** Treating it as "not expired" grants access on the strength of a value nobody can read — and bounding what the caller may keep doing is the entire job of the expiry.

**Missing provenance denies rather than triggering a lookup.** Looking the Pod up at access time finds whatever holds the name *now*; after a recycle that is another tenant's workload. A reference with an **empty UID** also denies: two empty UIDs compare equal, so a later same-named Pod would satisfy the check meant to exclude it.

**Only the pool's own container is addressable.** Anything else in the Pod is the administrator's — a sidecar, an injected proxy — and executing there runs the caller's command with that component's identity and mounts rather than their own.

**A pool recreated under the same name denies** rather than supplying a new allowlist. Its template is a different administrator's decision about what should be reachable, and silently applying it changes what an already-admitted caller can do.

## Placement now records what the resolver consumes

The exact `SandboxClaim` / `Sandbox` / `Pod` identities, written when those objects have just been observed, and **monotonically** — provenance that could be cleared would let a teardown lose the identity it has to prove absent.

## First consumer: a bounded log tail

Deliberately the smallest operation that exercises the whole chain without needing a stream protocol.

- The tail is **clamped**, not rejected — refusing an over-large request teaches callers to retry in a loop, which costs more than serving the cap once.
- `follow` is never set: this returns a bounded body, and a followed stream here would hold a connection open with no revocation path.
- Unknown query fields are **refused rather than ignored**. `follow`, `previous`, `sinceSeconds` and `limitBytes` are all real `LogParams` options; silently dropping one a caller sent means they believe they set a bound that was never applied.
- The Pod's UID is re-checked against provenance before its output is returned.
- Child placement is refused explicitly rather than read from the management cluster, which would return another workload's output or a misleading 404.

## Chart

`pods/log` (`get`) — its own resource to RBAC, and worth stating explicitly: this is the verb that lets the operator return a workload's own output to its lease holder.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1455 passed, 0 failed
```

Mutation-checked: honouring a caller-named container, treating an unparseable expiry as valid, and accepting an empty UID each fail their tests.

## Against #81's acceptance criteria

| Criterion | Here |
|---|---|
| Management and child placement resolve through the same typed interface | ✅ |
| Foreign identities get 404, indistinguishable from absent | ✅ |
| Pending/Releasing/Released/Expired/Quarantined/malformed-expiry/missing-target/stale-UID deny before minting | ✅ |
| Namespace, Claim, Sandbox, Pod, container, pool substitution fail closed | ✅ |
| Only approved containers resolve | ✅ |
| Only pool-declared ports resolve | ⚠️ the allowlist is carried on the target; the resolver method lands with #83's port-forward, which consumes it |
| Audit without credentials, stdin, env, stdout or stderr | ✅ |
| Scoped credentials cannot read Secrets, mutate RBAC, create Pods… | ❌ **not yet** — see below |
| Release/expiry cancels already-upgraded streams on every replica | ❌ **not yet** — no streams exist until #83 |
| Existing ClusterLease connect behaviour unchanged | ✅ untouched |

## Not in this PR

**Per-lease credential minting** (ServiceAccount / Role / RoleBinding / TokenRequest in the target namespace). Today the operator's own client reaches the Pod, bounded by the resolver rather than by a scoped token. The resolver is the precondition for minting — you cannot scope a credential to a target you have not resolved — and it is the larger half; minting is the next layer.

**Stream revocation on release.** There are no upgraded streams yet: the log read returns a bounded body. This becomes real with #83 and lands with it.

Both are called out rather than glossed, and neither weakens what is here — the resolver denies before any of it is reached.

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.