### PR TITLE
access(sandbox): mint per-lease single-Pod credentials, and add bounded exec

### DIFF
--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -87,6 +87,17 @@ rules:
   - apiGroups: [""]
     resources: ["pods/log"]
     verbs: ["get"]
+  # Per-lease scoped credentials (#81). Kobe mints a ServiceAccount whose Role
+  # names exactly one Pod, then a short-lived token for it, and reaches the
+  # tenant's Sandbox as THAT identity rather than as itself.
+  #
+  # `serviceaccounts/token` is the mint. It is bounded by RBAC's own escalation
+  # rule: a Role may only be created granting permissions the creator already
+  # holds, so this cannot manufacture authority the operator lacks — it can
+  # only hand out less.
+  - apiGroups: [""]
+    resources: ["serviceaccounts/token"]
+    verbs: ["create"]
   # Core resources for virtual cluster lifecycle
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets", "serviceaccounts", "pods", "pods/status", "events", "persistentvolumeclaims", "endpoints"]

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -4,4 +4,5 @@ pub mod policy;
 pub mod routes;
 pub mod sandbox;
 pub mod sandbox_access;
+pub mod sandbox_credentials;
 pub mod upgrade;

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -65,6 +65,92 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
             get(get_sandbox_lease::<B>).delete(release_sandbox_lease::<B>),
         )
         .route("/v1/sandbox-leases/{id}/logs", get(sandbox_logs::<B>))
+        .route("/v1/sandbox-leases/{id}/exec", post(sandbox_exec::<B>))
+}
+
+/// How long one exec may run before it is abandoned.
+///
+/// The caller chooses the command, so they choose how long it takes. Without a
+/// bound, `sleep infinity` holds an API worker permanently — from inside a
+/// sandbox that exists precisely because its occupant is not trusted.
+const SANDBOX_EXEC_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(60);
+
+/// Run one command inside a Sandbox and return its bounded output.
+///
+/// Request/response only: no stdin, no TTY, no shell. Those need a stream
+/// protocol with its own revocation story, which is #83, and a shell would make
+/// quoting the security boundary.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn sandbox_exec<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+    Json(request): Json<crate::api::sandbox_access::SandboxExecRequest>,
+) -> Response {
+    use crate::api::sandbox_access as access;
+    use crate::api::sandbox_credentials as credentials;
+
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    if !is_valid_k8s_name(&id) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let (_lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
+        {
+            Ok(resolved) => resolved,
+            Err(denied) => return access_denied(&identity, &id, "exec", denied),
+        };
+    let container = match target.resolve_container(request.container.as_deref()) {
+        Ok(container) => container.to_string(),
+        Err(denied) => return access_denied(&identity, &id, "exec", denied),
+    };
+    if target.placement != access::TargetPlacement::Management {
+        return sandbox_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "Sandbox exec is not yet available for child placement",
+            None,
+        );
+    }
+
+    let scoped = match credentials::scoped_client(
+        &state.client,
+        &target,
+        credentials::SandboxOperation::Exec,
+    )
+    .await
+    {
+        Ok(client) => client,
+        Err(denied) => return access_denied(&identity, &id, "exec", denied),
+    };
+
+    match access::exec_in_sandbox(
+        &scoped,
+        &target,
+        &container,
+        &request.command,
+        SANDBOX_EXEC_TIMEOUT,
+    )
+    .await
+    {
+        Ok(result) => {
+            // The command and its output are the caller's own data and are
+            // never audited. Identity, target and outcome are.
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                pod_uid = %target.pod_uid,
+                operation = "exec",
+                outcome = "allowed",
+                success = result.success,
+                "Sandbox access"
+            );
+            (StatusCode::OK, Json(result)).into_response()
+        }
+        Err(denied) => access_denied(&identity, &id, "exec", denied),
+    }
 }
 
 /// Read a bounded tail of one Sandbox's output.
@@ -119,13 +205,23 @@ async fn sandbox_logs<B: ClusterBackend>(
         );
     }
 
-    match access::read_sandbox_logs(
+    // The read runs under a credential that cannot name a second Pod, rather
+    // than under the operator's own authority. The resolver has already denied
+    // everything it should — this is the layer that makes a bug in the request
+    // path a 403 instead of a privilege escalation.
+    let scoped = match crate::api::sandbox_credentials::scoped_client(
         &state.client,
         &target,
-        &container,
-        access::clamp_tail(query.tail),
+        crate::api::sandbox_credentials::SandboxOperation::Logs,
     )
     .await
+    {
+        Ok(client) => client,
+        Err(denied) => return access_denied(&identity, &id, "logs", denied),
+    };
+
+    match access::read_sandbox_logs(&scoped, &target, &container, access::clamp_tail(query.tail))
+        .await
     {
         Ok(logs) => {
             // Audited by identity and outcome, never by content: the body is

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -408,6 +408,140 @@ pub async fn read_sandbox_logs(
         .map_err(|_| SandboxAccessDenied::Backend)
 }
 
+/// The largest command output one exec response may carry.
+///
+/// The caller controls what they run, so they control how much it prints.
+/// Without a cap, `cat /dev/urandom` is a way to make the operator buffer
+/// unbounded memory on request — from inside a sandbox that exists precisely
+/// because its occupant is not trusted.
+pub const MAX_EXEC_OUTPUT_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(deny_unknown_fields)]
+pub struct SandboxExecRequest {
+    /// argv. Executed directly — never through a shell, which would make
+    /// quoting the security boundary.
+    pub command: Vec<String>,
+    #[serde(default)]
+    pub container: Option<String>,
+}
+
+#[derive(Debug, serde::Serialize)]
+pub struct SandboxExecResponse {
+    pub stdout: String,
+    pub stderr: String,
+    /// Whether the command exited zero. A numeric exit code is not always
+    /// available over this protocol, and inventing one would be worse than
+    /// reporting what is actually known.
+    pub success: bool,
+    /// Whether output was cut off at the cap. Reported rather than silently
+    /// truncated: a caller parsing partial output as complete is how a
+    /// truncation becomes a wrong answer instead of an obvious one.
+    pub truncated: bool,
+}
+
+/// Run one command inside the Sandbox and return its bounded output.
+///
+/// No stdin and no TTY: this is the request/response surface, and both of those
+/// need a stream protocol with its own revocation story (#83). No shell either
+/// — argv is executed directly, so quoting is never the security boundary.
+pub async fn exec_in_sandbox(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    command: &[String],
+    timeout: std::time::Duration,
+) -> Result<SandboxExecResponse, SandboxAccessDenied> {
+    use k8s_openapi::api::core::v1::Pod;
+    use kube::api::AttachParams;
+    if command.is_empty() || command.iter().any(|argument| argument.is_empty()) {
+        return Err(SandboxAccessDenied::NotDeclared { what: "command" });
+    }
+
+    let pods: Api<Pod> = Api::namespaced(client.clone(), &target.namespace);
+    // The name resolved at placement; the identity must still match, or this is
+    // a different workload wearing the same name.
+    let pod = pods
+        .get(&target.pod_name)
+        .await
+        .map_err(|_| SandboxAccessDenied::TargetUnresolved)?;
+    if pod.uid().as_deref() != Some(target.pod_uid.as_str()) {
+        return Err(SandboxAccessDenied::TargetUnresolved);
+    }
+
+    let params = AttachParams::default()
+        .container(container)
+        .stdin(false)
+        .stdout(true)
+        .stderr(true)
+        .tty(false);
+
+    let mut attached = tokio::time::timeout(timeout, pods.exec(&target.pod_name, command, &params))
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+
+    let mut stdout = Vec::new();
+    let mut stderr = Vec::new();
+    let mut truncated = false;
+    if let Some(mut stream) = attached.stdout() {
+        truncated |= read_capped(&mut stream, &mut stdout, MAX_EXEC_OUTPUT_BYTES, timeout).await;
+    }
+    if let Some(mut stream) = attached.stderr() {
+        truncated |= read_capped(&mut stream, &mut stderr, MAX_EXEC_OUTPUT_BYTES, timeout).await;
+    }
+
+    let status = tokio::time::timeout(timeout, attached.take_status().unwrap()).await;
+    let success = match status {
+        Ok(Some(status)) => status.status.as_deref() == Some("Success"),
+        // Wedged or unreported. Not a success: the caller must not read
+        // "we could not tell" as "it worked".
+        _ => {
+            attached.abort();
+            false
+        }
+    };
+
+    Ok(SandboxExecResponse {
+        // Lossy on purpose: a sandboxed command's output is arbitrary bytes,
+        // and refusing to return anything because byte 900k was not UTF-8
+        // would lose the 899k that were.
+        stdout: String::from_utf8_lossy(&stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+        success,
+        truncated,
+    })
+}
+
+/// Read at most `cap` bytes, reporting whether more was waiting.
+///
+/// Stops reading at the cap rather than reading everything and truncating
+/// afterwards — the memory is spent either way if you read first.
+async fn read_capped<R>(
+    stream: &mut R,
+    into: &mut Vec<u8>,
+    cap: usize,
+    timeout: std::time::Duration,
+) -> bool
+where
+    R: tokio::io::AsyncRead + Unpin,
+{
+    use tokio::io::AsyncReadExt;
+
+    let mut limited = stream.take((cap + 1) as u64);
+    if tokio::time::timeout(timeout, limited.read_to_end(into))
+        .await
+        .is_err()
+    {
+        return true;
+    }
+    if into.len() > cap {
+        into.truncate(cap);
+        return true;
+    }
+    false
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -628,6 +762,184 @@ mod tests {
                 port: 3000
             }]
         );
+    }
+
+    /// A caller cannot ask the operator to buffer an unbounded log.
+    ///
+    /// They control neither how much their agent writes nor how often they
+    /// ask. Clamping rather than rejecting is deliberate: refusing an
+    /// over-large request teaches callers to retry in a loop, which costs more
+    /// than serving the cap once.
+    #[test]
+    fn a_log_tail_is_always_bounded() {
+        assert_eq!(clamp_tail(None), 200);
+        assert_eq!(clamp_tail(Some(50)), 50);
+        assert_eq!(clamp_tail(Some(MAX_LOG_TAIL_LINES)), MAX_LOG_TAIL_LINES);
+
+        for requested in [MAX_LOG_TAIL_LINES + 1, i64::MAX, 0, -1, i64::MIN] {
+            let clamped = clamp_tail(Some(requested));
+            assert!(
+                (1..=MAX_LOG_TAIL_LINES).contains(&clamped),
+                "tail {requested} clamped to {clamped}, outside the permitted range"
+            );
+        }
+    }
+
+    /// Unknown log options are refused, not ignored.
+    ///
+    /// `follow`, `previous`, `sinceSeconds` and `limitBytes` are all real
+    /// `LogParams` options. Silently dropping one a caller sent means they
+    /// believe they set a bound that was never applied.
+    #[test]
+    fn unknown_log_options_are_refused_rather_than_ignored() {
+        assert!(
+            serde_json::from_value::<SandboxLogsQuery>(
+                serde_json::json!({ "tail": 10, "container": "agent" })
+            )
+            .is_ok()
+        );
+
+        for smuggled in [
+            "follow",
+            "previous",
+            "sinceSeconds",
+            "limitBytes",
+            "podName",
+        ] {
+            assert!(
+                serde_json::from_value::<SandboxLogsQuery>(serde_json::json!({ smuggled: "true" }))
+                    .is_err(),
+                "{smuggled} must be refused, not ignored"
+            );
+        }
+    }
+
+    /// A command must be argv, and must not be empty.
+    ///
+    /// An empty argv, or one with an empty element, is a request whose meaning
+    /// is decided by the container runtime rather than by the caller — and
+    /// there is no reading of "run nothing" that should reach a tenant's
+    /// workload.
+    #[tokio::test]
+    async fn an_empty_command_is_refused_before_the_pod_is_touched() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+        let target = target_from_provenance(&ready_lease(), &pool(), now()).unwrap();
+
+        for command in [
+            vec![],
+            vec![String::new()],
+            vec!["sh".into(), String::new()],
+        ] {
+            let error = exec_in_sandbox(
+                &client,
+                &target,
+                "agent",
+                &command,
+                std::time::Duration::from_secs(1),
+            )
+            .await
+            .unwrap_err();
+            assert_eq!(
+                error,
+                SandboxAccessDenied::NotDeclared { what: "command" },
+                "command {command:?} must be refused"
+            );
+        }
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty(),
+            "a malformed command is refused before the Pod is touched"
+        );
+    }
+
+    /// Exec requests carry argv and nothing else.
+    ///
+    /// `tty`, `stdin`, `pod` and `namespace` are all things a caller might try
+    /// to send. Silently ignoring one means they believe they set something
+    /// that was never applied; accepting one would be worse.
+    #[test]
+    fn exec_requests_cannot_smuggle_execution_settings() {
+        assert!(
+            serde_json::from_value::<SandboxExecRequest>(
+                serde_json::json!({ "command": ["/agent", "status"] })
+            )
+            .is_ok()
+        );
+
+        for smuggled in [
+            "tty",
+            "stdin",
+            "pod",
+            "namespace",
+            "container_name",
+            "shell",
+        ] {
+            assert!(
+                serde_json::from_value::<SandboxExecRequest>(
+                    serde_json::json!({ "command": ["true"], smuggled: "x" })
+                )
+                .is_err(),
+                "{smuggled} must be refused, not ignored"
+            );
+        }
+
+        // `command` is not optional: there is no default command.
+        assert!(serde_json::from_value::<SandboxExecRequest>(serde_json::json!({})).is_err());
+    }
+
+    /// Output is capped, and the cap is reported.
+    ///
+    /// The caller chooses what runs, so they choose how much it prints —
+    /// `cat /dev/urandom` from inside a sandbox is otherwise a way to make the
+    /// operator buffer unbounded memory on request. Reporting the truncation
+    /// matters as much as applying it: a caller parsing partial output as
+    /// complete turns a cap into a wrong answer.
+    #[tokio::test]
+    async fn command_output_is_capped_and_the_truncation_is_reported() {
+        let mut into = Vec::new();
+        let mut source = std::io::Cursor::new(vec![b'x'; MAX_EXEC_OUTPUT_BYTES * 2]);
+        let truncated = read_capped(
+            &mut source,
+            &mut into,
+            MAX_EXEC_OUTPUT_BYTES,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+        assert!(truncated, "the caller must be told output was cut off");
+        assert_eq!(into.len(), MAX_EXEC_OUTPUT_BYTES);
+
+        // Output that fits is returned whole, and not flagged.
+        let mut into = Vec::new();
+        let mut source = std::io::Cursor::new(b"hello".to_vec());
+        let truncated = read_capped(
+            &mut source,
+            &mut into,
+            MAX_EXEC_OUTPUT_BYTES,
+            std::time::Duration::from_secs(5),
+        )
+        .await;
+        assert!(!truncated);
+        assert_eq!(into, b"hello");
+
+        // Exactly at the cap is not truncation.
+        let mut into = Vec::new();
+        let mut source = std::io::Cursor::new(vec![b'x'; MAX_EXEC_OUTPUT_BYTES]);
+        assert!(
+            !read_capped(
+                &mut source,
+                &mut into,
+                MAX_EXEC_OUTPUT_BYTES,
+                std::time::Duration::from_secs(5)
+            )
+            .await
+        );
+        assert_eq!(into.len(), MAX_EXEC_OUTPUT_BYTES);
     }
 
     /// Absent and unowned are the same answer to a caller.

--- a/src/api/sandbox_credentials.rs
+++ b/src/api/sandbox_credentials.rs
@@ -1,0 +1,445 @@
+//! Short-lived, single-Pod credentials for one Sandbox operation (#81).
+//!
+//! The resolver answers *which* Pod. This answers *with what authority* Kobe
+//! touches it.
+//!
+//! # Why not just use the operator's own client
+//!
+//! Because the operator's client is cluster-admin-adjacent, and a bug anywhere
+//! in the request path — a mis-parsed name, a header that survived, a proxy
+//! that followed a redirect — is then a bug with the operator's authority
+//! behind it. Minting a credential that *cannot* name a second Pod turns those
+//! bugs from privilege escalation into a 403.
+//!
+//! This is defence in depth, not the primary control: the resolver already
+//! denies before anything is minted. But the two fail differently, and that is
+//! the point of having both.
+//!
+//! # What the credential can do
+//!
+//! Exactly one Pod, by name, and only the subresources the operation needs.
+//! `resourceNames` is what makes that true — an RBAC rule without it grants the
+//! verb over every Pod in the namespace, which in a management cluster is every
+//! tenant's Sandbox at once.
+//!
+//! It cannot read Secrets, mutate RBAC, create Pods, list anything, reach
+//! Nodes, or cross namespaces. Those are not omissions to be filled in later:
+//! a Sandbox operation needs none of them, and each would be reachable from a
+//! caller-facing path.
+//!
+//! # Lifetime
+//!
+//! Minted per operation with a short expiry, and never persisted. A token in a
+//! CRD, a response, an event or a log is a token somebody can replay after the
+//! lease it belonged to is gone.
+
+use k8s_openapi::api::authentication::v1::{TokenRequest, TokenRequestSpec};
+use k8s_openapi::api::core::v1::ServiceAccount;
+use k8s_openapi::api::rbac::v1::{PolicyRule, Role, RoleBinding, RoleRef, Subject};
+use kube::api::{Api, ObjectMeta, Patch, PatchParams, PostParams};
+
+use crate::api::sandbox_access::{SandboxAccessDenied, SandboxTarget};
+
+/// How long a minted token is valid.
+///
+/// Long enough to complete an operation and survive a retry; short enough that
+/// a leaked one is worthless before anyone can use it. Streams that outlive it
+/// are already authenticated — Kubernetes does not re-check mid-connection —
+/// which is why #83's revocation cancels streams rather than relying on expiry.
+pub const TOKEN_LIFETIME_SECONDS: i64 = 600;
+
+/// What a credential is being minted for.
+///
+/// Each operation gets only the subresources it needs. `Logs` cannot exec, and
+/// `Exec` cannot port-forward: an operation that only reads output has no
+/// business holding the verb that runs commands.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum SandboxOperation {
+    Logs,
+    Exec,
+}
+
+impl SandboxOperation {
+    /// The exact Pod subresources this operation needs.
+    pub fn subresources(self) -> &'static [(&'static str, &'static str)] {
+        match self {
+            // `get` on `pods` as well: the client verifies the Pod's UID before
+            // returning output, and that read must not need a broader rule.
+            Self::Logs => &[("pods", "get"), ("pods/log", "get")],
+            Self::Exec => &[("pods", "get"), ("pods/exec", "create")],
+        }
+    }
+
+    /// Bounded label for audit records.
+    pub fn as_str(self) -> &'static str {
+        match self {
+            Self::Logs => "logs",
+            Self::Exec => "exec",
+        }
+    }
+}
+
+/// Names are derived from the lease UID, never from anything a caller supplies.
+///
+/// The UID rather than the name because lease names are recycled: a credential
+/// object left behind by a previous lease would otherwise be adopted by its
+/// same-named successor, quietly granting the new caller access scoped to the
+/// old caller's Pod.
+pub fn credential_name(lease_uid: &str) -> String {
+    // A UID is 36 characters; `kobe-sbx-` plus that is well inside the 253-char
+    // limit for these object names.
+    format!("kobe-sbx-{lease_uid}")
+}
+
+/// The RBAC rules for one operation against one exact Pod.
+///
+/// Pure, because this is the security boundary and it must be assertable
+/// without a cluster.
+pub fn scoped_rules(target: &SandboxTarget, operation: SandboxOperation) -> Vec<PolicyRule> {
+    operation
+        .subresources()
+        .iter()
+        .map(|(resource, verb)| PolicyRule {
+            api_groups: Some(vec![String::new()]),
+            resources: Some(vec![(*resource).to_string()]),
+            verbs: vec![(*verb).to_string()],
+            // The whole point. Without `resourceNames` this grants the verb
+            // over every Pod in the namespace — in a management cluster, every
+            // tenant's Sandbox at once.
+            resource_names: Some(vec![target.pod_name.clone()]),
+            non_resource_urls: None,
+        })
+        .collect()
+}
+
+/// Create — or converge — the ServiceAccount, Role and RoleBinding for a lease.
+///
+/// Server-side applied so a repeated operation converges instead of failing on
+/// conflict, and so a drifted Role is corrected rather than trusted. Drift
+/// matters here more than usual: a Role edited to drop its `resourceNames` is
+/// a namespace-wide grant that looks, by name, exactly like the scoped one.
+async fn ensure_scoped_identity(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    operation: SandboxOperation,
+) -> Result<String, SandboxAccessDenied> {
+    let name = credential_name(&target.lease_uid);
+    let namespace = &target.namespace;
+    let params = PatchParams::apply(crate::sandbox::KOBE_MANAGED_BY).force();
+
+    let metadata = || ObjectMeta {
+        name: Some(name.clone()),
+        namespace: Some(namespace.clone()),
+        labels: Some(
+            [
+                (
+                    "app.kubernetes.io/managed-by".to_string(),
+                    crate::sandbox::KOBE_MANAGED_BY.to_string(),
+                ),
+                (
+                    "kobe.kunobi.ninja/sandbox-lease-uid".to_string(),
+                    target.lease_uid.clone(),
+                ),
+            ]
+            .into_iter()
+            .collect(),
+        ),
+        ..Default::default()
+    };
+
+    let accounts: Api<ServiceAccount> = Api::namespaced(client.clone(), namespace);
+    accounts
+        .patch(
+            &name,
+            &params,
+            &Patch::Apply(&ServiceAccount {
+                metadata: metadata(),
+                // No automounted token: nothing runs as this account. It exists
+                // only to be the subject of a TokenRequest.
+                automount_service_account_token: Some(false),
+                ..Default::default()
+            }),
+        )
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+
+    let roles: Api<Role> = Api::namespaced(client.clone(), namespace);
+    roles
+        .patch(
+            &name,
+            &params,
+            &Patch::Apply(&Role {
+                metadata: metadata(),
+                rules: Some(scoped_rules(target, operation)),
+            }),
+        )
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+
+    let bindings: Api<RoleBinding> = Api::namespaced(client.clone(), namespace);
+    bindings
+        .patch(
+            &name,
+            &params,
+            &Patch::Apply(&RoleBinding {
+                metadata: metadata(),
+                role_ref: RoleRef {
+                    api_group: "rbac.authorization.k8s.io".to_string(),
+                    kind: "Role".to_string(),
+                    name: name.clone(),
+                },
+                subjects: Some(vec![Subject {
+                    kind: "ServiceAccount".to_string(),
+                    name: name.clone(),
+                    namespace: Some(namespace.clone()),
+                    api_group: None,
+                }]),
+            }),
+        )
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+
+    Ok(name)
+}
+
+/// Mint a short-lived token for one operation against one Pod.
+///
+/// The returned string is a bearer token. It is never logged, never returned to
+/// a caller, and never stored — a token that outlives the operation is a token
+/// somebody can replay after the lease it belonged to is gone.
+pub async fn mint_scoped_token(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    operation: SandboxOperation,
+) -> Result<String, SandboxAccessDenied> {
+    let name = ensure_scoped_identity(client, target, operation).await?;
+    let accounts: Api<ServiceAccount> = Api::namespaced(client.clone(), &target.namespace);
+
+    let request = TokenRequest {
+        metadata: ObjectMeta {
+            name: Some(name.clone()),
+            namespace: Some(target.namespace.clone()),
+            ..Default::default()
+        },
+        spec: TokenRequestSpec {
+            // No audiences override: the token is for this cluster's API
+            // server, which is the only thing it should ever authenticate to.
+            audiences: vec![],
+            expiration_seconds: Some(TOKEN_LIFETIME_SECONDS),
+            bound_object_ref: None,
+        },
+        status: None,
+    };
+
+    tracing::debug!(
+        operation = operation.as_str(),
+        pod = %target.pod_name,
+        "minting scoped Sandbox credential"
+    );
+    let issued = accounts
+        .create_token_request(&name, &PostParams::default(), &request)
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+
+    issued
+        .status
+        .map(|status| status.token)
+        .filter(|token| !token.is_empty())
+        .ok_or(SandboxAccessDenied::Backend)
+}
+
+/// The operator's own cluster configuration, resolved once.
+///
+/// Reused so every scoped client keeps the operator's endpoint and trust
+/// anchors — only the identity differs. Resolved lazily rather than at startup
+/// so a deployment that never serves a Sandbox operation does not require it.
+static BASE_CONFIG: tokio::sync::OnceCell<kube::Config> = tokio::sync::OnceCell::const_new();
+
+async fn base_config() -> Result<&'static kube::Config, SandboxAccessDenied> {
+    BASE_CONFIG
+        .get_or_try_init(|| async {
+            kube::Config::infer()
+                .await
+                .map_err(|_| SandboxAccessDenied::Backend)
+        })
+        .await
+}
+
+/// Build a client that can reach only this Sandbox's Pod.
+///
+/// The endpoint and trust anchors come from the operator's own configuration;
+/// only the identity differs. Every other authorisation on that config is
+/// **dropped** rather than merged: an inherited client certificate would
+/// out-rank the bearer token and silently restore the operator's authority,
+/// which is the one thing this function exists to remove.
+pub async fn scoped_client(
+    base: &kube::Client,
+    target: &SandboxTarget,
+    operation: SandboxOperation,
+) -> Result<kube::Client, SandboxAccessDenied> {
+    let token = mint_scoped_token(base, target, operation).await?;
+
+    let mut config = base_config().await?.clone();
+    config.auth_info = kube::config::AuthInfo {
+        token: Some(token.into()),
+        ..Default::default()
+    };
+    config.default_namespace = target.namespace.clone();
+
+    kube::Client::try_from(config).map_err(|_| SandboxAccessDenied::Backend)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn target() -> SandboxTarget {
+        SandboxTarget {
+            lease_uid: "lease-uid-1".into(),
+            placement: crate::api::sandbox_access::TargetPlacement::Management,
+            namespace: "kobe".into(),
+            claim_uid: "claim-uid".into(),
+            sandbox_name: "sbx".into(),
+            sandbox_uid: "sandbox-uid".into(),
+            pod_name: "sbx-0".into(),
+            pod_uid: "pod-uid".into(),
+            container: "agent".into(),
+            ports: vec![],
+        }
+    }
+
+    /// A credential must never be able to name a second Pod.
+    ///
+    /// `resourceNames` is the entire boundary. An RBAC rule without it grants
+    /// the verb over every Pod in the namespace — in a management cluster,
+    /// every tenant's Sandbox at once. This is the assertion that would catch
+    /// that rule being loosened.
+    #[test]
+    fn every_rule_is_pinned_to_exactly_one_pod() {
+        for operation in [SandboxOperation::Logs, SandboxOperation::Exec] {
+            let rules = scoped_rules(&target(), operation);
+            assert!(!rules.is_empty(), "{operation:?} must grant something");
+            for rule in &rules {
+                assert_eq!(
+                    rule.resource_names.as_deref(),
+                    Some(["sbx-0".to_string()].as_slice()),
+                    "{operation:?} rule {rule:?} is not pinned to one Pod"
+                );
+                assert_eq!(rule.api_groups.as_deref(), Some([String::new()].as_slice()));
+                assert!(
+                    rule.non_resource_urls.is_none(),
+                    "a Sandbox operation needs no non-resource URLs"
+                );
+            }
+        }
+    }
+
+    /// Each operation gets only what it needs.
+    ///
+    /// An operation that reads output has no business holding the verb that
+    /// runs commands. If these ever collapsed into one rule set, a `logs`
+    /// request would be minting an exec-capable token.
+    #[test]
+    fn operations_do_not_borrow_each_others_authority() {
+        let verbs = |operation: SandboxOperation| -> Vec<String> {
+            scoped_rules(&target(), operation)
+                .iter()
+                .flat_map(|rule| {
+                    let resource = rule.resources.as_ref().unwrap()[0].clone();
+                    rule.verbs
+                        .iter()
+                        .map(move |verb| format!("{resource}:{verb}"))
+                })
+                .collect()
+        };
+
+        let logs = verbs(SandboxOperation::Logs);
+        assert!(logs.contains(&"pods/log:get".to_string()));
+        assert!(
+            !logs.iter().any(|granted| granted.contains("exec")
+                || granted.contains("portforward")
+                || granted.contains("create")),
+            "reading logs must not grant execution: {logs:?}"
+        );
+
+        let exec = verbs(SandboxOperation::Exec);
+        assert!(exec.contains(&"pods/exec:create".to_string()));
+        assert!(!exec.iter().any(|granted| granted.contains("/log")));
+
+        // Port-forward lands with #83, which consumes it. It is deliberately
+        // absent rather than declared-but-unused: an operation nothing can
+        // request should not have a rule set waiting for it.
+    }
+
+    /// Nothing a Sandbox operation does requires the dangerous verbs.
+    ///
+    /// Enumerated explicitly rather than left implicit: this is the list #81
+    /// commits to, and a rule set that grew one of them should fail here rather
+    /// than in an audit.
+    #[test]
+    fn scoped_rules_reach_nothing_beyond_one_pod() {
+        for operation in [SandboxOperation::Logs, SandboxOperation::Exec] {
+            for rule in scoped_rules(&target(), operation) {
+                let resources = rule.resources.clone().unwrap_or_default();
+                for forbidden in [
+                    "secrets",
+                    "configmaps",
+                    "serviceaccounts",
+                    "nodes",
+                    "roles",
+                    "rolebindings",
+                    "namespaces",
+                    "persistentvolumes",
+                ] {
+                    assert!(
+                        !resources.iter().any(|resource| resource == forbidden),
+                        "{operation:?} must not reach {forbidden}"
+                    );
+                }
+                for forbidden in ["list", "watch", "delete", "deletecollection", "*"] {
+                    assert!(
+                        !rule.verbs.iter().any(|verb| verb == forbidden),
+                        "{operation:?} must not be granted {forbidden}: {rule:?}"
+                    );
+                }
+                // `create` on bare `pods` would be a way to start a workload
+                // that outlives the lease entirely.
+                if resources.iter().any(|resource| resource == "pods") {
+                    assert_eq!(rule.verbs, vec!["get".to_string()]);
+                }
+            }
+        }
+    }
+
+    /// Credential objects are named by lease UID, not lease name.
+    ///
+    /// Lease names are recycled. A Role left behind by a previous lease and
+    /// adopted by its same-named successor would scope the new caller's
+    /// credential to the OLD caller's Pod — a cross-tenant grant produced
+    /// entirely by naming.
+    #[test]
+    fn credential_names_are_fenced_by_uid() {
+        let first = credential_name("uid-aaa");
+        let second = credential_name("uid-bbb");
+        assert_ne!(first, second);
+        assert!(first.starts_with("kobe-sbx-"));
+        // Comfortably inside the 253-character object-name limit even for a
+        // full UUID.
+        assert!(credential_name(&"u".repeat(36)).len() < 253);
+    }
+
+    /// A minted token lives for minutes, not for the lease.
+    ///
+    /// A token valid for the lease's whole TTL is one a leak makes useful for
+    /// hours. Short expiry does not revoke an already-upgraded stream —
+    /// Kubernetes does not re-check mid-connection — which is exactly why #83
+    /// cancels streams rather than relying on this.
+    #[test]
+    fn tokens_are_short_lived() {
+        const { assert!(TOKEN_LIFETIME_SECONDS <= 900) };
+        const { assert!(TOKEN_LIFETIME_SECONDS >= 60) };
+        // Restated where a reader will see it: a token valid for an hour is one
+        // a leak makes useful for an hour, and one too short to survive a retry
+        // is its own failure mode.
+    }
+}


### PR DESCRIPTION
Completes #81 · **stacked on #126**
Epic: #70 — Agent Sandbox · Parent: #75

The resolver answers **which** Pod. This answers **with what authority** Kobe touches it.

## Why the operator's own client is not good enough

It is cluster-admin-adjacent. A bug anywhere in the request path — a mis-parsed name, a header that survived, a proxy that followed a redirect — is then a bug with the operator's authority behind it.

Kobe now mints a ServiceAccount whose Role names **exactly one Pod**, requests a short-lived token for it, and reaches the tenant's Sandbox as that identity. A credential that *cannot* name a second Pod turns those bugs from privilege escalation into a 403.

This is defence in depth, not the primary control — the resolver still denies before anything is minted. The two fail differently, which is the point of having both.

## The boundary

**`resourceNames` is the entire boundary.** An RBAC rule without it grants the verb over every Pod in the namespace — in a management cluster, that is every tenant's Sandbox at once. A test asserts every rule carries it.

**Each operation gets only its own subresources.** Reading logs does not carry the verb that runs commands. If these ever collapsed into one rule set, a `logs` request would be minting an exec-capable token.

**Nothing reaches Secrets, RBAC, Nodes, namespaces, or `list`/`watch`/`delete`.** Enumerated in a test rather than left implicit: this is the list #81 commits to, and a rule set that grew one should fail here rather than in an audit.

**Credential objects are named by lease UID, not lease name.** Names recycle. A Role left behind by a previous lease and adopted by its same-named successor would scope the new caller's credential to the **old** caller's Pod — a cross-tenant grant produced entirely by naming.

**Tokens live ten minutes and are never persisted.** A token in a CRD, a response, an event or a log is one somebody can replay after the lease it belonged to is gone.

**The scoped client keeps the operator's endpoint and trust anchors but drops every other authorisation.** An inherited client certificate would out-rank the bearer token and silently restore exactly what this removes.

Roles are server-side applied so a drifted one is corrected rather than trusted — drift matters more than usual here, because a Role edited to drop its `resourceNames` is a namespace-wide grant that looks, by name, identical to the scoped one.

## Bounded exec

The request/response surface #81 describes. Not #82: no persistence, no idempotency.

- **No shell.** argv is executed directly, so quoting is never the security boundary.
- **No stdin, no TTY.** Both need a stream protocol with its own revocation story — #83.
- **Output is capped, and the truncation is reported.** The caller chooses what runs, so they choose how much it prints; `cat /dev/urandom` from inside a sandbox is otherwise a way to make the operator buffer unbounded memory on request. Reporting matters as much as capping: a caller parsing partial output as complete turns a cap into a wrong answer.
- **A wall-clock bound**, because `sleep infinity` would otherwise hold an API worker permanently.
- **An unreported exit status is not success.** "We could not tell" must not read as "it worked".
- **Unknown request fields are refused, not ignored** — `tty`, `stdin`, `pod`, `namespace` are all things a caller might try to send, and `command` has no default.

## A correction to #126

Two tests were silently deleted by a later edit in that PR — the log tail bound and the log query-field rejection — while its body claimed both were covered. The behaviours were correct throughout; only the coverage was lost. Both are restored here.

## Chart

`serviceaccounts/token` (`create`). Bounded by RBAC's own escalation rule: a Role may only be created granting permissions the creator already holds, so this cannot manufacture authority the operator lacks — only hand out less.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1465 passed, 0 failed
```

Mutation-checked: dropping the `resourceNames` pin, and letting logs borrow exec's authority, each fail their tests.

## #81 acceptance criteria now met

| Criterion | |
|---|---|
| Scoped credentials cannot read Secrets, mutate RBAC, create Pods, access Nodes, or cross namespaces | ✅ |
| Credentials short-lived, never in CRDs, responses, events, logs or test artifacts | ✅ |
| Lease-specific ServiceAccount/Role/RoleBinding + TokenRequest in the exact target namespace | ✅ |
| Only the exact Kobe-owned Pod/container subresources the operation needs | ✅ |

Still open, and landing with the PRs that create the conditions for them:

- **Stream revocation on release** — there are still no upgraded streams; exec here is request/response. This becomes real with #83 and lands with it.
- **Port-forward's port allowlist** — the declared set is carried on the target; the resolver method lands with #83, which consumes it.
- **Child placement** for both operations — refused explicitly rather than read from the wrong cluster.

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.