### PR TITLE
access(sandbox): add bounded TTY attach and declared-port forwarding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -696,6 +696,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b52af3cb4058c895d37317bb27508dccc8e5f2d39454016b297bf4a400597b8"
 dependencies = [
  "axum-core",
+ "base64 0.22.1",
  "bytes",
  "form_urlencoded",
  "futures-util",
@@ -714,8 +715,10 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
+ "sha1",
  "sync_wrapper",
  "tokio",
+ "tokio-tungstenite",
  "tower",
  "tower-layer",
  "tower-service",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,7 +56,7 @@ kube = { version = "3.0", features = ["runtime", "derive", "client", "ws"] }
 k8s-openapi = { version = "0.27", features = ["v1_32", "schemars"] }
 
 # Web framework
-axum = { version = "0.8", features = ["json", "matched-path"] }
+axum = { version = "0.8", features = ["json", "matched-path", "ws"] }
 tower = "0.5"
 tower-http = { version = "0.6", features = ["cors", "trace"] }
 

--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -79,7 +79,7 @@ rules:
   # from the `SandboxPool` spec, which only an administrator can write, and a
   # lease selects a pool and nothing else. No caller input reaches this.
   - apiGroups: [""]
-    resources: ["pods/exec"]
+    resources: ["pods/exec", "pods/attach", "pods/portforward"]
     verbs: ["create"]
   # Sandbox log reads (#81). Separate from `pods` above because `pods/log` is
   # its own resource to RBAC — and worth stating explicitly: this is the verb

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,4 +6,5 @@ pub mod sandbox;
 pub mod sandbox_access;
 pub mod sandbox_credentials;
 pub mod sandbox_streams;
+pub mod sandbox_transport;
 pub mod upgrade;

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -66,6 +66,268 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
         )
         .route("/v1/sandbox-leases/{id}/logs", get(sandbox_logs::<B>))
         .route("/v1/sandbox-leases/{id}/exec", post(sandbox_exec::<B>))
+        .route("/v1/sandbox-leases/{id}/attach", get(sandbox_attach::<B>))
+        .route(
+            "/v1/sandbox-leases/{id}/port-forward",
+            get(sandbox_port_forward::<B>),
+        )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SandboxAttachQuery {
+    /// argv to run. Absent attaches to the container's existing process
+    /// instead of starting a new one.
+    #[serde(default)]
+    command: Option<Vec<String>>,
+    #[serde(default)]
+    container: Option<String>,
+    /// Allocate a terminal. Off by default: a TTY merges stderr into stdout
+    /// and changes how the workload buffers, so it must be asked for.
+    #[serde(default)]
+    tty: bool,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct SandboxPortForwardQuery {
+    /// A pool-declared port name or number. Nothing else resolves.
+    port: String,
+}
+
+/// Everything an interactive operation needs, resolved before the upgrade.
+///
+/// Resolution happens *before* the WebSocket handshake completes on purpose:
+/// a denial has to be an HTTP status the caller's client understands, not a
+/// close frame delivered a moment after a successful-looking upgrade.
+struct UpgradeContext {
+    target: crate::api::sandbox_access::SandboxTarget,
+    container: String,
+    scoped: kube::Client,
+}
+
+async fn prepare_upgrade<B: ClusterBackend>(
+    state: &AppState<B>,
+    identity: &AuthIdentity,
+    id: &str,
+    operation: crate::api::sandbox_credentials::SandboxOperation,
+    requested_container: Option<&str>,
+) -> Result<UpgradeContext, Response> {
+    use crate::api::sandbox_access as access;
+
+    require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await?;
+    if !is_valid_k8s_name(id) {
+        return Err(StatusCode::NOT_FOUND.into_response());
+    }
+
+    let (_lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, id, identity).await {
+            Ok(resolved) => resolved,
+            Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
+        };
+    let container = match target.resolve_container(requested_container) {
+        Ok(container) => container.to_string(),
+        Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
+    };
+    if target.placement != access::TargetPlacement::Management {
+        return Err(sandbox_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "Interactive Sandbox access is not yet available for child placement",
+            None,
+        ));
+    }
+
+    // Concurrency is checked before the upgrade, so a caller over the limit
+    // gets a status rather than a socket that closes immediately.
+    if !crate::api::sandbox_streams::may_start_stream(
+        crate::api::sandbox_streams::registry(),
+        &target.lease_uid,
+    )
+    .await
+    {
+        return Err(access_denied_with(
+            identity,
+            id,
+            operation.as_str(),
+            "concurrency_limit",
+            StatusCode::TOO_MANY_REQUESTS,
+            "Too many concurrent operations for this Sandbox lease",
+        ));
+    }
+
+    let scoped =
+        match crate::api::sandbox_credentials::scoped_client(&state.client, &target, operation)
+            .await
+        {
+            Ok(client) => client,
+            Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
+        };
+
+    Ok(UpgradeContext {
+        target,
+        container,
+        scoped,
+    })
+}
+
+/// Interactive exec or attach over a bounded WebSocket.
+///
+/// The caller's socket never reaches the API server: Kobe terminates it,
+/// opens a separate connection with a credential scoped to one Pod, and copies
+/// bytes. Nothing the caller sends becomes part of a Kubernetes request.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn sandbox_attach<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+    Query(query): Query<SandboxAttachQuery>,
+    upgrade: axum::extract::WebSocketUpgrade,
+) -> Response {
+    use crate::api::sandbox_credentials::SandboxOperation;
+    use crate::api::sandbox_transport as transport;
+
+    if let Some(command) = query.command.as_ref()
+        && (command.is_empty() || command.iter().any(String::is_empty))
+    {
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "command must be non-empty argv",
+            None,
+        );
+    }
+
+    let context = match prepare_upgrade(
+        &state,
+        &identity,
+        &id,
+        SandboxOperation::Exec,
+        query.container.as_deref(),
+    )
+    .await
+    {
+        Ok(context) => context,
+        Err(response) => return response,
+    };
+
+    let principal = identity.identity.clone();
+    upgrade.on_upgrade(move |mut socket| async move {
+        let guard = crate::api::sandbox_streams::registry()
+            .register(&context.target.lease_uid)
+            .await;
+        let revoked = guard.cancelled();
+
+        let pods: kube::Api<k8s_openapi::api::core::v1::Pod> =
+            kube::Api::namespaced(context.scoped.clone(), &context.target.namespace);
+        let params = kube::api::AttachParams::default()
+            .container(&context.container)
+            .stdin(true)
+            .stdout(true)
+            // A TTY merges stderr into stdout at the kernel level, so asking
+            // for both is a contradiction rather than a preference.
+            .stderr(!query.tty)
+            .tty(query.tty);
+
+        let attached = match query.command.as_ref() {
+            Some(command) => pods.exec(&context.target.pod_name, command, &params).await,
+            None => pods.attach(&context.target.pod_name, &params).await,
+        };
+        let mut attached = match attached {
+            Ok(attached) => attached,
+            Err(_) => {
+                transport::close_with(&mut socket, transport::StreamEnd::TargetError).await;
+                return;
+            }
+        };
+
+        let mut limits = transport::StreamLimits::new(
+            transport::IDLE_TIMEOUT,
+            transport::MAX_STREAM_DURATION,
+            transport::MAX_STREAM_BYTES,
+        );
+        let end = transport::pump_attached(&mut socket, &mut attached, &mut limits, revoked).await;
+        attached.abort();
+        transport::close_with(&mut socket, end).await;
+
+        info!(
+            principal = %principal,
+            lease = %id,
+            pod_uid = %context.target.pod_uid,
+            operation = "attach",
+            outcome = "closed",
+            reason = end.code(),
+            caller_fault = end.is_caller_fault(),
+            "Sandbox stream"
+        );
+    })
+}
+
+/// Forward one pool-declared port over a bounded WebSocket.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn sandbox_port_forward<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+    Query(query): Query<SandboxPortForwardQuery>,
+    upgrade: axum::extract::WebSocketUpgrade,
+) -> Response {
+    use crate::api::sandbox_credentials::SandboxOperation;
+    use crate::api::sandbox_transport as transport;
+
+    let context =
+        match prepare_upgrade(&state, &identity, &id, SandboxOperation::PortForward, None).await {
+            Ok(context) => context,
+            Err(response) => return response,
+        };
+
+    // Only what the pool declared. Without this the forward is a general
+    // tunnel into the Pod's network namespace, reaching a debug listener or a
+    // metrics endpoint the administrator never meant to publish.
+    let port = match context.target.resolve_port(&query.port) {
+        Ok(port) => port,
+        Err(denied) => return access_denied(&identity, &id, "port-forward", denied),
+    };
+
+    let principal = identity.identity.clone();
+    upgrade.on_upgrade(move |mut socket| async move {
+        let guard = crate::api::sandbox_streams::registry()
+            .register(&context.target.lease_uid)
+            .await;
+        let revoked = guard.cancelled();
+
+        let pods: kube::Api<k8s_openapi::api::core::v1::Pod> =
+            kube::Api::namespaced(context.scoped.clone(), &context.target.namespace);
+        let mut forwarder = match pods.portforward(&context.target.pod_name, &[port]).await {
+            Ok(forwarder) => forwarder,
+            Err(_) => {
+                transport::close_with(&mut socket, transport::StreamEnd::TargetError).await;
+                return;
+            }
+        };
+        let Some(mut stream) = forwarder.take_stream(port) else {
+            transport::close_with(&mut socket, transport::StreamEnd::TargetError).await;
+            return;
+        };
+
+        let mut limits = transport::StreamLimits::new(
+            transport::IDLE_TIMEOUT,
+            transport::MAX_STREAM_DURATION,
+            transport::MAX_STREAM_BYTES,
+        );
+        let end = transport::pump_duplex(&mut socket, &mut stream, &mut limits, revoked).await;
+        transport::close_with(&mut socket, end).await;
+
+        info!(
+            principal = %principal,
+            lease = %id,
+            pod_uid = %context.target.pod_uid,
+            operation = "port-forward",
+            port,
+            outcome = "closed",
+            reason = end.code(),
+            caller_fault = end.is_caller_fault(),
+            "Sandbox stream"
+        );
+    })
 }
 
 /// How long one exec may run before it is abandoned.

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -280,6 +280,24 @@ pub fn target_from_provenance(
 }
 
 impl SandboxTarget {
+    /// Resolve a caller-named port against the pool's declaration.
+    ///
+    /// Accepts a declared name or a declared number, and nothing else. Without
+    /// this, port-forward is a general tunnel into the Pod's network namespace
+    /// — reaching a debug listener, a metrics endpoint, or anything else bound
+    /// on localhost that the administrator never meant to publish.
+    pub fn resolve_port(&self, requested: &str) -> Result<u16, SandboxAccessDenied> {
+        if let Some(port) = self.ports.iter().find(|port| port.name == requested) {
+            return Ok(port.port);
+        }
+        if let Ok(number) = requested.parse::<u16>()
+            && let Some(port) = self.ports.iter().find(|port| port.port == number)
+        {
+            return Ok(port.port);
+        }
+        Err(SandboxAccessDenied::NotDeclared { what: "port" })
+    }
+
     /// Resolve a caller-named container against the allowlist.
     ///
     /// `None` means "the default", which is the only container a caller may
@@ -744,6 +762,33 @@ mod tests {
                 "container {other:?} must be refused"
             );
         }
+    }
+
+    /// Only pool-declared ports are forwardable.
+    ///
+    /// Without this, port-forward is a general tunnel into the Pod's network
+    /// namespace — reaching a debug listener, a metrics endpoint, or anything
+    /// else bound on localhost that the administrator never meant to publish.
+    #[test]
+    fn only_declared_ports_are_forwardable() {
+        let target = target_from_provenance(&ready_lease(), &pool(), now()).unwrap();
+
+        assert_eq!(target.resolve_port("http").unwrap(), 3000);
+        assert_eq!(target.resolve_port("3000").unwrap(), 3000);
+
+        for undeclared in ["9090", "22", "ssh", "", "3000 ", "0"] {
+            assert_eq!(
+                target.resolve_port(undeclared).unwrap_err(),
+                SandboxAccessDenied::NotDeclared { what: "port" },
+                "port {undeclared:?} must be refused"
+            );
+        }
+
+        // Alternate spellings of a DECLARED port are fine, and deliberately
+        // so: the allowlist is checked against the resolved number, not the
+        // string. Refusing `03000` would reject a request for a port the pool
+        // published, which is a usability bug rather than a boundary.
+        assert_eq!(target.resolve_port("03000").unwrap(), 3000);
     }
 
     /// The forwardable set is exactly what the pool declared.

--- a/src/api/sandbox_credentials.rs
+++ b/src/api/sandbox_credentials.rs
@@ -57,6 +57,7 @@ pub const TOKEN_LIFETIME_SECONDS: i64 = 600;
 pub enum SandboxOperation {
     Logs,
     Exec,
+    PortForward,
 }
 
 impl SandboxOperation {
@@ -67,6 +68,7 @@ impl SandboxOperation {
             // returning output, and that read must not need a broader rule.
             Self::Logs => &[("pods", "get"), ("pods/log", "get")],
             Self::Exec => &[("pods", "get"), ("pods/exec", "create")],
+            Self::PortForward => &[("pods", "get"), ("pods/portforward", "create")],
         }
     }
 
@@ -75,6 +77,7 @@ impl SandboxOperation {
         match self {
             Self::Logs => "logs",
             Self::Exec => "exec",
+            Self::PortForward => "port-forward",
         }
     }
 }
@@ -316,7 +319,11 @@ mod tests {
     /// that rule being loosened.
     #[test]
     fn every_rule_is_pinned_to_exactly_one_pod() {
-        for operation in [SandboxOperation::Logs, SandboxOperation::Exec] {
+        for operation in [
+            SandboxOperation::Logs,
+            SandboxOperation::Exec,
+            SandboxOperation::PortForward,
+        ] {
             let rules = scoped_rules(&target(), operation);
             assert!(!rules.is_empty(), "{operation:?} must grant something");
             for rule in &rules {
@@ -364,11 +371,14 @@ mod tests {
 
         let exec = verbs(SandboxOperation::Exec);
         assert!(exec.contains(&"pods/exec:create".to_string()));
-        assert!(!exec.iter().any(|granted| granted.contains("/log")));
+        assert!(!exec.iter().any(|granted| granted.contains("portforward")));
 
-        // Port-forward lands with #83, which consumes it. It is deliberately
-        // absent rather than declared-but-unused: an operation nothing can
-        // request should not have a rule set waiting for it.
+        let forward = verbs(SandboxOperation::PortForward);
+        assert!(forward.contains(&"pods/portforward:create".to_string()));
+        assert!(
+            !forward.iter().any(|granted| granted.contains("exec")),
+            "forwarding a port must not carry the verb that runs commands: {forward:?}"
+        );
     }
 
     /// Nothing a Sandbox operation does requires the dangerous verbs.
@@ -378,7 +388,11 @@ mod tests {
     /// than in an audit.
     #[test]
     fn scoped_rules_reach_nothing_beyond_one_pod() {
-        for operation in [SandboxOperation::Logs, SandboxOperation::Exec] {
+        for operation in [
+            SandboxOperation::Logs,
+            SandboxOperation::Exec,
+            SandboxOperation::PortForward,
+        ] {
             for rule in scoped_rules(&target(), operation) {
                 let resources = rule.resources.clone().unwrap_or_default();
                 for forbidden in [

--- a/src/api/sandbox_transport.rs
+++ b/src/api/sandbox_transport.rs
@@ -1,0 +1,761 @@
+//! Bounded interactive transport for Sandbox operations (#83).
+//!
+//! Two things a caller can want that a request/response API cannot give them:
+//! a terminal, and a TCP connection to a declared port. Both need a stream, and
+//! a stream needs limits, a framing, and a way to be closed by somebody other
+//! than the caller.
+//!
+//! # Not a Kubernetes proxy
+//!
+//! The caller's WebSocket never reaches the API server. Kobe terminates it,
+//! resolves the target through #81, opens a *separate* connection with a
+//! credential scoped to one Pod, and copies bytes between the two. Nothing the
+//! caller sends becomes part of a Kubernetes request: not a path, not a header,
+//! not a protocol negotiation. That is the difference between "exec into your
+//! Sandbox" and "an authenticated tunnel to the API server".
+//!
+//! # Framing
+//!
+//! Binary frames, first byte a channel, matching Kubernetes' own `v4` channel
+//! convention so tooling written against one reads naturally against the other:
+//!
+//! ```text
+//! 0  stdin      caller -> sandbox
+//! 1  stdout     sandbox -> caller
+//! 2  stderr     sandbox -> caller
+//! 3  error      sandbox -> caller   (a bounded reason, never a raw response)
+//! 4  resize     caller -> sandbox   ({"width":N,"height":N})
+//! ```
+//!
+//! An unknown channel from the caller is refused rather than ignored. Ignoring
+//! it means a client that believes it sent a resize, or a signal, and was
+//! silently disregarded.
+//!
+//! # Limits are not optional
+//!
+//! Every one of these exists because the caller controls the workload:
+//!
+//! * **idle timeout** — an abandoned terminal holds a connection to the target
+//!   cluster indefinitely, and nobody notices because nothing is wrong.
+//! * **maximum duration** — an *active* stream would otherwise outlive any
+//!   sensible bound simply by staying busy.
+//! * **byte ceiling** — `yes` is a one-word denial-of-service.
+//! * **concurrency** — enforced before upgrade, from #83's registry.
+//!
+//! A stream is also cancelled the moment its lease stops permitting access.
+//! Kubernetes authenticates an upgraded connection once; nothing but an
+//! explicit cancel closes it.
+
+use std::time::Duration;
+
+use axum::extract::ws::{Message, WebSocket};
+use futures::{SinkExt, StreamExt};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio_util::sync::CancellationToken;
+use tracing::debug;
+
+/// Channel bytes, matching Kubernetes' `v4` convention.
+pub const CHANNEL_STDIN: u8 = 0;
+pub const CHANNEL_STDOUT: u8 = 1;
+pub const CHANNEL_STDERR: u8 = 2;
+pub const CHANNEL_ERROR: u8 = 3;
+pub const CHANNEL_RESIZE: u8 = 4;
+
+/// Closed after this long with nothing in either direction.
+///
+/// An abandoned terminal is the common case — somebody closes a laptop — and it
+/// holds a connection to the target cluster with nothing to signal that
+/// anything is wrong.
+pub const IDLE_TIMEOUT: Duration = Duration::from_secs(15 * 60);
+
+/// Closed after this long regardless of activity.
+///
+/// The idle timeout does not bound an *active* stream: a session that stays
+/// busy would otherwise live as long as the lease, which defeats having a
+/// separate transport bound at all.
+pub const MAX_STREAM_DURATION: Duration = Duration::from_secs(4 * 60 * 60);
+
+/// Most bytes carried in one direction before the stream is closed.
+///
+/// `yes > /dev/null` is a one-word way to make the operator relay unbounded
+/// traffic from inside a sandbox whose occupant is, by construction, not
+/// trusted.
+pub const MAX_STREAM_BYTES: u64 = 512 * 1024 * 1024;
+
+/// Why a stream ended.
+///
+/// Reported to the caller on the error channel as a bounded code, so a client
+/// can distinguish "your lease ended" from "you hit a limit" from "the workload
+/// exited" without ever seeing a raw backend response.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StreamEnd {
+    /// The workload closed it. The ordinary case.
+    Completed,
+    /// The lease stopped permitting access.
+    Revoked,
+    IdleTimeout,
+    DurationExceeded,
+    ByteLimitExceeded,
+    /// The caller sent something this protocol does not define.
+    ProtocolViolation,
+    /// The target connection failed.
+    TargetError,
+}
+
+impl StreamEnd {
+    pub fn code(self) -> &'static str {
+        match self {
+            Self::Completed => "completed",
+            Self::Revoked => "revoked",
+            Self::IdleTimeout => "idle_timeout",
+            Self::DurationExceeded => "duration_exceeded",
+            Self::ByteLimitExceeded => "byte_limit_exceeded",
+            Self::ProtocolViolation => "protocol_violation",
+            Self::TargetError => "target_error",
+        }
+    }
+
+    /// Whether the caller could have prevented it. Used only for logging, so an
+    /// operator can separate their own faults from callers' behaviour.
+    pub fn is_caller_fault(self) -> bool {
+        matches!(
+            self,
+            Self::IdleTimeout
+                | Self::DurationExceeded
+                | Self::ByteLimitExceeded
+                | Self::ProtocolViolation
+        )
+    }
+}
+
+/// A caller frame, once validated.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum CallerFrame {
+    Stdin(Vec<u8>),
+    Resize {
+        width: u16,
+        height: u16,
+    },
+    /// The caller closed the stream.
+    Close,
+}
+
+/// Parse one inbound frame.
+///
+/// Everything a caller may send is enumerated here. Anything else is a
+/// violation rather than a no-op: silently dropping a frame leaves a client
+/// believing it resized a terminal, or sent input, that never arrived.
+pub fn parse_caller_frame(message: &Message) -> Result<CallerFrame, StreamEnd> {
+    let payload = match message {
+        Message::Binary(payload) => payload.as_ref(),
+        Message::Close(_) => return Ok(CallerFrame::Close),
+        // Ping/pong are the transport's own; they never carry a channel.
+        Message::Ping(_) | Message::Pong(_) => return Ok(CallerFrame::Stdin(Vec::new())),
+        // Text frames are not part of this protocol. Accepting them would mean
+        // two encodings for stdin, and a client that guessed wrong would send
+        // silently-mangled bytes to a shell.
+        Message::Text(_) => return Err(StreamEnd::ProtocolViolation),
+    };
+
+    let Some((&channel, body)) = payload.split_first() else {
+        // An empty frame has no channel, so there is no way to know what the
+        // caller meant by it.
+        return Err(StreamEnd::ProtocolViolation);
+    };
+
+    match channel {
+        CHANNEL_STDIN => Ok(CallerFrame::Stdin(body.to_vec())),
+        CHANNEL_RESIZE => {
+            #[derive(serde::Deserialize)]
+            #[serde(deny_unknown_fields)]
+            struct Resize {
+                width: u16,
+                height: u16,
+            }
+            let resize: Resize =
+                serde_json::from_slice(body).map_err(|_| StreamEnd::ProtocolViolation)?;
+            // A zero dimension is not a terminal. Passing it through makes the
+            // workload's own tty handling the thing that has to cope.
+            if resize.width == 0 || resize.height == 0 {
+                return Err(StreamEnd::ProtocolViolation);
+            }
+            Ok(CallerFrame::Resize {
+                width: resize.width,
+                height: resize.height,
+            })
+        }
+        // stdout, stderr and error are outbound only. A caller sending one is
+        // either confused or trying something; neither is a reason to guess.
+        _ => Err(StreamEnd::ProtocolViolation),
+    }
+}
+
+/// Frame one outbound chunk.
+pub fn server_frame(channel: u8, payload: &[u8]) -> Message {
+    let mut framed = Vec::with_capacity(payload.len() + 1);
+    framed.push(channel);
+    framed.extend_from_slice(payload);
+    Message::Binary(framed.into())
+}
+
+/// Tracks the limits that end a stream.
+///
+/// Separated from the copying so the rules are testable without a socket, and
+/// because these bounds are the reason the transport is safe to expose at all.
+#[derive(Debug)]
+pub struct StreamLimits {
+    started: tokio::time::Instant,
+    last_activity: tokio::time::Instant,
+    bytes: u64,
+    idle_timeout: Duration,
+    max_duration: Duration,
+    max_bytes: u64,
+}
+
+impl StreamLimits {
+    pub fn new(idle_timeout: Duration, max_duration: Duration, max_bytes: u64) -> Self {
+        Self::starting_at(
+            tokio::time::Instant::now(),
+            idle_timeout,
+            max_duration,
+            max_bytes,
+        )
+    }
+
+    /// The start instant is a parameter so every bound is decided by arithmetic
+    /// on values the caller supplies. A type that read the clock internally
+    /// could only be tested against the clock, which is how limit bugs stay
+    /// hidden until production.
+    pub fn starting_at(
+        now: tokio::time::Instant,
+        idle_timeout: Duration,
+        max_duration: Duration,
+        max_bytes: u64,
+    ) -> Self {
+        Self {
+            started: now,
+            last_activity: now,
+            bytes: 0,
+            idle_timeout,
+            max_duration,
+            max_bytes,
+        }
+    }
+
+    /// Record traffic in either direction and re-check every bound.
+    pub fn record(&mut self, bytes: usize, now: tokio::time::Instant) -> Result<(), StreamEnd> {
+        self.last_activity = now;
+        self.bytes = self.bytes.saturating_add(bytes as u64);
+        if self.bytes > self.max_bytes {
+            return Err(StreamEnd::ByteLimitExceeded);
+        }
+        self.check(now)
+    }
+
+    /// Re-check the time-based bounds without any traffic.
+    pub fn check(&self, now: tokio::time::Instant) -> Result<(), StreamEnd> {
+        if now.duration_since(self.started) >= self.max_duration {
+            return Err(StreamEnd::DurationExceeded);
+        }
+        if now.duration_since(self.last_activity) >= self.idle_timeout {
+            return Err(StreamEnd::IdleTimeout);
+        }
+        Ok(())
+    }
+
+    /// How long until the next bound would fire, so the loop can wake exactly
+    /// then rather than polling.
+    pub fn next_deadline(&self, now: tokio::time::Instant) -> Duration {
+        let until_idle = self
+            .idle_timeout
+            .saturating_sub(now.duration_since(self.last_activity));
+        let until_max = self
+            .max_duration
+            .saturating_sub(now.duration_since(self.started));
+        until_idle.min(until_max)
+    }
+}
+
+/// Copy bytes between the caller's WebSocket and one duplex target stream.
+///
+/// Used for port-forward, where both sides are opaque byte streams. Exec has
+/// three channels and is handled separately.
+///
+/// The stream ends on the first of: the caller closing it, the target closing
+/// it, any limit, or revocation. Revocation is checked in the same `select` as
+/// the traffic so a cancelled lease closes the socket immediately rather than
+/// on the next byte — which for an idle terminal could be never.
+pub async fn pump_duplex<S>(
+    socket: &mut WebSocket,
+    target: &mut S,
+    limits: &mut StreamLimits,
+    revoked: CancellationToken,
+) -> StreamEnd
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let mut buffer = vec![0u8; 32 * 1024];
+    loop {
+        let now = tokio::time::Instant::now();
+        if let Err(end) = limits.check(now) {
+            return end;
+        }
+        let deadline = limits.next_deadline(now);
+
+        tokio::select! {
+            _ = revoked.cancelled() => return StreamEnd::Revoked,
+            _ = tokio::time::sleep(deadline) => {
+                // A bound came due. `check` decides which, so the reported
+                // reason always matches the rule that actually fired.
+                return limits
+                    .check(tokio::time::Instant::now())
+                    .err()
+                    .unwrap_or(StreamEnd::IdleTimeout);
+            }
+            inbound = socket.next() => {
+                match inbound {
+                    Some(Ok(message)) => {
+                        let frame = match parse_caller_frame(&message) {
+                            Ok(frame) => frame,
+                            Err(end) => return end,
+                        };
+                        match frame {
+                            CallerFrame::Close => return StreamEnd::Completed,
+                            // A forwarded port has no terminal to resize.
+                            CallerFrame::Resize { .. } => return StreamEnd::ProtocolViolation,
+                            CallerFrame::Stdin(bytes) => {
+                                if bytes.is_empty() {
+                                    continue;
+                                }
+                                if let Err(end) = limits.record(bytes.len(), tokio::time::Instant::now()) {
+                                    return end;
+                                }
+                                if target.write_all(&bytes).await.is_err() {
+                                    return StreamEnd::TargetError;
+                                }
+                            }
+                        }
+                    }
+                    Some(Err(_)) | None => return StreamEnd::Completed,
+                }
+            }
+            read = target.read(&mut buffer) => {
+                match read {
+                    // The workload closed its side.
+                    Ok(0) => return StreamEnd::Completed,
+                    Ok(count) => {
+                        if let Err(end) = limits.record(count, tokio::time::Instant::now()) {
+                            return end;
+                        }
+                        if socket
+                            .send(server_frame(CHANNEL_STDOUT, &buffer[..count]))
+                            .await
+                            .is_err()
+                        {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Err(_) => return StreamEnd::TargetError,
+                }
+            }
+        }
+    }
+}
+
+/// Tell the caller why their stream ended, then close it.
+///
+/// A bounded code on the error channel, never a backend message: those can
+/// carry namespaces, node names, and other people's object names.
+pub async fn close_with(socket: &mut WebSocket, end: StreamEnd) {
+    debug!(reason = end.code(), "closing Sandbox stream");
+    let _ = socket
+        .send(server_frame(
+            CHANNEL_ERROR,
+            format!(r#"{{"reason":"{}"}}"#, end.code()).as_bytes(),
+        ))
+        .await;
+    let _ = socket.send(Message::Close(None)).await;
+}
+
+/// Copy between the caller's WebSocket and a three-channel exec/attach session.
+///
+/// Distinct from [`pump_duplex`] because exec has stdout and stderr as separate
+/// streams and a resize channel. Merging them would lose the distinction the
+/// caller's terminal needs — a client cannot colour stderr it cannot identify.
+pub async fn pump_attached(
+    socket: &mut WebSocket,
+    attached: &mut kube::api::AttachedProcess,
+    limits: &mut StreamLimits,
+    revoked: CancellationToken,
+) -> StreamEnd {
+    let mut stdin = attached.stdin();
+    let mut stdout = attached.stdout();
+    let mut stderr = attached.stderr();
+    let mut resize = attached.terminal_size();
+
+    let mut out_buffer = vec![0u8; 32 * 1024];
+    let mut err_buffer = vec![0u8; 32 * 1024];
+
+    loop {
+        let now = tokio::time::Instant::now();
+        if let Err(end) = limits.check(now) {
+            return end;
+        }
+        let deadline = limits.next_deadline(now);
+
+        // `read` on an `Option<impl AsyncRead>` needs a concrete future each
+        // pass; `futures::future::OptionFuture` keeps a closed channel from
+        // completing instantly and spinning the loop.
+        let stdout_read = async {
+            match stdout.as_mut() {
+                Some(stream) => Some(stream.read(&mut out_buffer).await),
+                None => std::future::pending().await,
+            }
+        };
+        let stderr_read = async {
+            match stderr.as_mut() {
+                Some(stream) => Some(stream.read(&mut err_buffer).await),
+                None => std::future::pending().await,
+            }
+        };
+
+        tokio::select! {
+            _ = revoked.cancelled() => return StreamEnd::Revoked,
+            _ = tokio::time::sleep(deadline) => {
+                return limits
+                    .check(tokio::time::Instant::now())
+                    .err()
+                    .unwrap_or(StreamEnd::IdleTimeout);
+            }
+            inbound = socket.next() => {
+                match inbound {
+                    Some(Ok(message)) => {
+                        let frame = match parse_caller_frame(&message) {
+                            Ok(frame) => frame,
+                            Err(end) => return end,
+                        };
+                        match frame {
+                            CallerFrame::Close => return StreamEnd::Completed,
+                            CallerFrame::Stdin(bytes) => {
+                                if bytes.is_empty() {
+                                    continue;
+                                }
+                                if let Err(end) =
+                                    limits.record(bytes.len(), tokio::time::Instant::now())
+                                {
+                                    return end;
+                                }
+                                let Some(stdin) = stdin.as_mut() else {
+                                    // The caller sent input to a session that
+                                    // has no stdin. Refusing beats discarding:
+                                    // silently dropping keystrokes is the kind
+                                    // of bug that gets blamed on the workload.
+                                    return StreamEnd::ProtocolViolation;
+                                };
+                                if stdin.write_all(&bytes).await.is_err() {
+                                    return StreamEnd::TargetError;
+                                }
+                            }
+                            CallerFrame::Resize { width, height } => {
+                                let Some(resize) = resize.as_mut() else {
+                                    // Explicitly unsupported rather than
+                                    // ignored: #83 requires resize to fail
+                                    // loudly where the session has no terminal.
+                                    return StreamEnd::ProtocolViolation;
+                                };
+                                if resize
+                                    .send(kube::api::TerminalSize { width, height })
+                                    .await
+                                    .is_err()
+                                {
+                                    return StreamEnd::TargetError;
+                                }
+                            }
+                        }
+                    }
+                    Some(Err(_)) | None => return StreamEnd::Completed,
+                }
+            }
+            read = stdout_read => {
+                match read {
+                    Some(Ok(0)) | None => {
+                        // Closed. Stop selecting on it, and let the session end
+                        // when stderr closes too.
+                        stdout = None;
+                        if stderr.is_none() {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Some(Ok(count)) => {
+                        if let Err(end) = limits.record(count, tokio::time::Instant::now()) {
+                            return end;
+                        }
+                        if socket
+                            .send(server_frame(CHANNEL_STDOUT, &out_buffer[..count]))
+                            .await
+                            .is_err()
+                        {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Some(Err(_)) => return StreamEnd::TargetError,
+                }
+            }
+            read = stderr_read => {
+                match read {
+                    Some(Ok(0)) | None => {
+                        stderr = None;
+                        if stdout.is_none() {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Some(Ok(count)) => {
+                        if let Err(end) = limits.record(count, tokio::time::Instant::now()) {
+                            return end;
+                        }
+                        if socket
+                            .send(server_frame(CHANNEL_STDERR, &err_buffer[..count]))
+                            .await
+                            .is_err()
+                        {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Some(Err(_)) => return StreamEnd::TargetError,
+                }
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn binary(bytes: Vec<u8>) -> Message {
+        Message::Binary(bytes.into())
+    }
+
+    /// Everything a caller may send is enumerated; anything else ends the
+    /// stream.
+    ///
+    /// Silently ignoring an unknown frame is the failure that matters: a client
+    /// believes it resized a terminal, or sent input, and it never arrived. A
+    /// caller writing to stdout or the error channel is either confused or
+    /// probing, and neither is a reason to guess.
+    #[test]
+    fn only_defined_inbound_channels_are_accepted() {
+        assert_eq!(
+            parse_caller_frame(&binary(vec![CHANNEL_STDIN, b'h', b'i'])).unwrap(),
+            CallerFrame::Stdin(b"hi".to_vec())
+        );
+        assert_eq!(
+            parse_caller_frame(&binary(
+                [
+                    vec![CHANNEL_RESIZE],
+                    br#"{"width":120,"height":40}"#.to_vec()
+                ]
+                .concat()
+            ))
+            .unwrap(),
+            CallerFrame::Resize {
+                width: 120,
+                height: 40
+            }
+        );
+
+        // Outbound-only channels, and anything undefined.
+        for channel in [CHANNEL_STDOUT, CHANNEL_STDERR, CHANNEL_ERROR, 5, 200, 255] {
+            assert_eq!(
+                parse_caller_frame(&binary(vec![channel, b'x'])).unwrap_err(),
+                StreamEnd::ProtocolViolation,
+                "channel {channel} must be refused"
+            );
+        }
+
+        // An empty frame has no channel, so there is no way to know what was
+        // meant by it.
+        assert_eq!(
+            parse_caller_frame(&binary(vec![])).unwrap_err(),
+            StreamEnd::ProtocolViolation
+        );
+
+        // Text frames would be a second encoding for stdin; a client that
+        // guessed wrong would send silently-mangled bytes to a shell.
+        assert_eq!(
+            parse_caller_frame(&Message::Text("hi".into())).unwrap_err(),
+            StreamEnd::ProtocolViolation
+        );
+    }
+
+    /// A malformed or nonsensical resize is refused, not forwarded.
+    ///
+    /// Passing a zero dimension through makes the workload's own tty handling
+    /// the thing that has to cope with it — which is exactly the sort of input
+    /// a sandboxed process should never receive from the platform itself.
+    #[test]
+    fn a_nonsensical_resize_is_refused() {
+        let resize = |body: &str| {
+            parse_caller_frame(&binary(
+                [vec![CHANNEL_RESIZE], body.as_bytes().to_vec()].concat(),
+            ))
+        };
+
+        assert!(resize(r#"{"width":80,"height":24}"#).is_ok());
+
+        for bad in [
+            r#"{"width":0,"height":24}"#,
+            r#"{"width":80,"height":0}"#,
+            r#"{"width":0,"height":0}"#,
+            r#"{"width":80}"#,
+            r#"{"width":80,"height":24,"cols":1}"#,
+            r#"{"width":-1,"height":24}"#,
+            r#"{"width":99999999,"height":24}"#,
+            "not json",
+            "",
+        ] {
+            assert_eq!(
+                resize(bad).unwrap_err(),
+                StreamEnd::ProtocolViolation,
+                "resize {bad:?} must be refused"
+            );
+        }
+    }
+
+    /// Every bound actually binds, and reports the rule that fired.
+    ///
+    /// Reporting matters: a client that cannot tell "you were idle" from "your
+    /// lease ended" cannot decide whether reconnecting is sensible.
+    #[test]
+    fn each_limit_ends_the_stream_for_its_own_reason() {
+        let start = tokio::time::Instant::now();
+
+        // Bytes.
+        let mut limits =
+            StreamLimits::starting_at(start, Duration::from_secs(60), Duration::from_secs(600), 10);
+        assert!(limits.record(10, start).is_ok());
+        assert_eq!(
+            limits.record(1, start).unwrap_err(),
+            StreamEnd::ByteLimitExceeded
+        );
+
+        // Idle: quiet for long enough, even though the total duration is fine.
+        let limits = StreamLimits::starting_at(
+            start,
+            Duration::from_secs(60),
+            Duration::from_secs(600),
+            1024,
+        );
+        assert!(limits.check(start + Duration::from_secs(59)).is_ok());
+        assert_eq!(
+            limits.check(start + Duration::from_secs(60)).unwrap_err(),
+            StreamEnd::IdleTimeout
+        );
+
+        // Duration: busy throughout, so never idle — this is the bound the idle
+        // timeout cannot supply.
+        let mut limits = StreamLimits::starting_at(
+            start,
+            Duration::from_secs(60),
+            Duration::from_secs(600),
+            1_000_000,
+        );
+        for second in 1..600 {
+            assert!(
+                limits
+                    .record(1, start + Duration::from_secs(second))
+                    .is_ok(),
+                "an active stream must not trip the idle bound at {second}s"
+            );
+        }
+        assert_eq!(
+            limits
+                .record(1, start + Duration::from_secs(600))
+                .unwrap_err(),
+            StreamEnd::DurationExceeded
+        );
+    }
+
+    /// The loop sleeps until the next bound rather than polling.
+    ///
+    /// A poll loop on an idle terminal is a busy wait per open stream; the
+    /// deadline is what makes an abandoned session cost nothing until it is
+    /// closed.
+    #[test]
+    fn the_next_deadline_is_the_nearest_bound() {
+        let start = tokio::time::Instant::now();
+        let limits = StreamLimits::starting_at(
+            start,
+            Duration::from_secs(60),
+            Duration::from_secs(600),
+            1024,
+        );
+
+        assert_eq!(limits.next_deadline(start), Duration::from_secs(60));
+        assert_eq!(
+            limits.next_deadline(start + Duration::from_secs(30)),
+            Duration::from_secs(30)
+        );
+
+        // Late in a long-running stream the total duration is nearer than the
+        // idle window, and the deadline has to follow whichever is closer.
+        let limits = StreamLimits::starting_at(
+            start,
+            Duration::from_secs(600),
+            Duration::from_secs(60),
+            1024,
+        );
+        assert_eq!(limits.next_deadline(start), Duration::from_secs(60));
+
+        // Never negative: a bound already passed wakes immediately.
+        assert_eq!(
+            limits.next_deadline(start + Duration::from_secs(9999)),
+            Duration::ZERO
+        );
+    }
+
+    /// Outbound frames carry their channel, and nothing else is prepended.
+    #[test]
+    fn server_frames_are_channel_prefixed() {
+        let Message::Binary(framed) = server_frame(CHANNEL_STDOUT, b"out") else {
+            panic!("server frames are binary");
+        };
+        assert_eq!(framed.as_ref(), &[CHANNEL_STDOUT, b'o', b'u', b't']);
+
+        let Message::Binary(empty) = server_frame(CHANNEL_STDERR, b"") else {
+            panic!("server frames are binary");
+        };
+        assert_eq!(empty.as_ref(), &[CHANNEL_STDERR]);
+    }
+
+    /// Every end reason is distinguishable and non-empty.
+    ///
+    /// The code is all the caller gets — a backend message could carry
+    /// namespaces, node names, or other tenants' object names — so it has to
+    /// carry the whole distinction on its own.
+    #[test]
+    fn every_end_reason_is_a_distinct_bounded_code() {
+        let ends = [
+            StreamEnd::Completed,
+            StreamEnd::Revoked,
+            StreamEnd::IdleTimeout,
+            StreamEnd::DurationExceeded,
+            StreamEnd::ByteLimitExceeded,
+            StreamEnd::ProtocolViolation,
+            StreamEnd::TargetError,
+        ];
+        let mut codes: Vec<&str> = ends.iter().map(|end| end.code()).collect();
+        codes.sort_unstable();
+        let unique = codes.len();
+        codes.dedup();
+        assert_eq!(codes.len(), unique, "end reasons must be distinguishable");
+        assert!(codes.iter().all(|code| !code.is_empty()));
+
+        // Revocation is not the caller's fault; a limit is. The distinction
+        // drives whether an operator should be looking at their own service.
+        assert!(!StreamEnd::Revoked.is_caller_fault());
+        assert!(!StreamEnd::TargetError.is_caller_fault());
+        assert!(StreamEnd::IdleTimeout.is_caller_fault());
+        assert!(StreamEnd::ByteLimitExceeded.is_caller_fault());
+    }
+}


### PR DESCRIPTION
Transport half of #83 · **stacked on #128**
Epic: #70 — Agent Sandbox · Parent: #75

Two things a caller can want that a request/response API cannot give them: a terminal, and a TCP connection to a declared port. Both need a stream — and a stream needs limits, a framing, and a way to be closed by somebody other than the caller. #128 supplied the last of those. This is the transport.

## Not a Kubernetes proxy

The caller's WebSocket **never reaches the API server**. Kobe terminates it, resolves the target through #81, opens a *separate* connection with a credential scoped to one Pod, and copies bytes between the two.

Nothing the caller sends becomes part of a Kubernetes request: not a path, not a header, not a protocol negotiation. That is the difference between "exec into your Sandbox" and "an authenticated tunnel to the API server", and it is why the framing is Kobe's rather than a passthrough.

## Framing

Binary frames, leading channel byte, matching Kubernetes' own `v4` convention so tooling written against one reads naturally against the other:

| | | |
|---|---|---|
| `0` | stdin | caller → sandbox |
| `1` | stdout | sandbox → caller |
| `2` | stderr | sandbox → caller |
| `3` | error | sandbox → caller — a bounded reason, never a raw response |
| `4` | resize | caller → sandbox |

**Everything a caller may send is enumerated; anything else ends the stream.** Silently ignoring a frame leaves a client believing it resized a terminal, or sent input, that never arrived. A caller writing to stdout or the error channel is either confused or probing, and neither is a reason to guess. Text frames are refused for the same reason — two encodings for stdin means a client that guesses wrong sends silently-mangled bytes to a shell.

## Limits, each for its own reason

- **idle** — an abandoned terminal (somebody closed a laptop) holds a connection to the target cluster with nothing to signal that anything is wrong.
- **duration** — the idle bound does not constrain an *active* stream, which would otherwise live as long as the lease and defeat having a transport bound at all.
- **bytes** — `yes > /dev/null` is a one-word way to make the operator relay unbounded traffic, from inside a sandbox whose occupant is by construction not trusted.
- **concurrency** — checked **before** the upgrade, so a caller over the limit gets a status rather than a socket that closes immediately.

The loop sleeps until the *nearest* bound rather than polling, so an idle session costs nothing until it is closed, and the reported reason always comes from re-checking which rule actually fired rather than from which branch woke up.

`StreamLimits` takes its start instant as a parameter: a type that read the clock internally could only be tested against the clock, which is how limit bugs stay hidden until production.

## Other decisions worth review

**Resolution happens before the handshake completes.** A denial has to be an HTTP status the caller's client understands, not a close frame delivered a moment after a successful-looking upgrade.

**Resize on a session with no terminal fails loudly**, as does input to a session with no stdin — #83 asks for exactly this, and the alternative is dropped keystrokes that get blamed on the workload.

**A zero terminal dimension is refused, not forwarded.** Making the workload's own tty handling cope with it is precisely the sort of input a sandboxed process should never receive from the platform itself.

**Asking for a TTY and separate stderr is a contradiction** — a TTY merges them at the kernel level — so `stderr` follows from `tty` rather than being independently selectable.

**End reasons are bounded codes.** A backend message could carry namespaces, node names, or other tenants' object names, so the code carries the whole distinction on its own: a client that cannot tell "you were idle" from "your lease ended" cannot decide whether reconnecting is sensible.

**Port-forward resolves only pool-declared ports.** Alternate spellings of a *declared* port (`03000`) are accepted deliberately — the allowlist is checked against the resolved number, not the string, and refusing them would reject a request for a port the pool published.

## Chart

`pods/attach` and `pods/portforward` join `pods/exec`.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1479 passed, 0 failed
```

Mutation-checked: ignoring unknown inbound channels, and removing the byte ceiling, each fail their tests.

## Against #83's acceptance criteria

| Criterion | |
|---|---|
| Exact upgrade protocols without exposing a general API path | ✅ Kobe terminates the socket; nothing passes through |
| Only the owned, Ready, unexpired lease's exact Pod UID, container, declared port | ✅ via #81 |
| Operation timeout, idle timeout, max duration, byte limits, concurrency | ✅ |
| Resize and bounded signals where supported, explicit failure where not | ⚠️ resize yes; **signal forwarding is not implemented** — it needs a channel the Kubernetes exec protocol does not define, so it belongs with a runner contract (#82) |
| Another identity receives 404 and cannot operate or discover a stream | ✅ |
| Callers cannot choose namespace, Pod, container, undeclared port, path, protocol, header | ✅ |
| Release/expiry closes existing streams on every replica | ✅ (#128) |
| Cached contexts cannot outlive expiry, revocation, or a UID change | ✅ |
| Direct and child placements expose identical behaviour | ❌ child is refused explicitly — see below |
| Existing ClusterLease exec/attach/port-forward compatibility unchanged | ✅ untouched |

## Not in this PR

**Child placement.** Interactive access to a composed child cluster is refused with `501` rather than read from the management cluster, which would find nothing or — worse — somebody else's Pod. Closing it means giving the API server a path to the child's kubeconfig, which is #74's composition seen from the request side rather than the controller's. It is the last gap between the two placements and it blocks #76.

**Signal forwarding.** No channel exists for it in the Kubernetes exec protocol; it needs a runner-side contract, which is #82.

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.