### PR TITLE
access(sandbox): serve every operation against composed child clusters

### DIFF
--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -120,7 +120,7 @@ async fn prepare_upgrade<B: ClusterBackend>(
         return Err(StatusCode::NOT_FOUND.into_response());
     }
 
-    let (_lease, target) =
+    let (lease, target) =
         match access::resolve_sandbox_target(&state.client, &state.namespace, id, identity).await {
             Ok(resolved) => resolved,
             Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
@@ -129,14 +129,6 @@ async fn prepare_upgrade<B: ClusterBackend>(
         Ok(container) => container.to_string(),
         Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
     };
-    if target.placement != access::TargetPlacement::Management {
-        return Err(sandbox_error(
-            StatusCode::NOT_IMPLEMENTED,
-            "Interactive Sandbox access is not yet available for child placement",
-            None,
-        ));
-    }
-
     // Concurrency is checked before the upgrade, so a caller over the limit
     // gets a status rather than a socket that closes immediately.
     if !crate::api::sandbox_streams::may_start_stream(
@@ -155,10 +147,22 @@ async fn prepare_upgrade<B: ClusterBackend>(
         ));
     }
 
+    // Both placements go through the same resolution. Child composition
+    // changes which cluster the Pod is in; it changes nothing about what the
+    // caller may do, which is the equivalence #76 sets out to prove.
+    let cluster = match access::resolve_target_cluster(
+        &state.client,
+        &state.namespace,
+        &lease,
+        &target,
+    )
+    .await
+    {
+        Ok(cluster) => cluster,
+        Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
+    };
     let scoped =
-        match crate::api::sandbox_credentials::scoped_client(&state.client, &target, operation)
-            .await
-        {
+        match crate::api::sandbox_credentials::scoped_client(&cluster, &target, operation).await {
             Ok(client) => client,
             Err(denied) => return Err(access_denied(identity, id, operation.as_str(), denied)),
         };
@@ -359,7 +363,7 @@ async fn sandbox_exec<B: ClusterBackend>(
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    let (_lease, target) =
+    let (lease, target) =
         match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
         {
             Ok(resolved) => resolved,
@@ -369,24 +373,24 @@ async fn sandbox_exec<B: ClusterBackend>(
         Ok(container) => container.to_string(),
         Err(denied) => return access_denied(&identity, &id, "exec", denied),
     };
-    if target.placement != access::TargetPlacement::Management {
-        return sandbox_error(
-            StatusCode::NOT_IMPLEMENTED,
-            "Sandbox exec is not yet available for child placement",
-            None,
-        );
-    }
-
-    let scoped = match credentials::scoped_client(
+    let cluster = match access::resolve_target_cluster(
         &state.client,
+        &state.namespace,
+        &lease,
         &target,
-        credentials::SandboxOperation::Exec,
     )
     .await
     {
-        Ok(client) => client,
+        Ok(cluster) => cluster,
         Err(denied) => return access_denied(&identity, &id, "exec", denied),
     };
+    let scoped =
+        match credentials::scoped_client(&cluster, &target, credentials::SandboxOperation::Exec)
+            .await
+        {
+            Ok(client) => client,
+            Err(denied) => return access_denied(&identity, &id, "exec", denied),
+        };
 
     // Registered for the duration, so releasing or expiring the lease cancels
     // the command rather than letting it run on inside a workload that is
@@ -477,7 +481,7 @@ async fn sandbox_logs<B: ClusterBackend>(
         return StatusCode::NOT_FOUND.into_response();
     }
 
-    let (_lease, target) =
+    let (lease, target) =
         match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
         {
             Ok(resolved) => resolved,
@@ -489,25 +493,23 @@ async fn sandbox_logs<B: ClusterBackend>(
         Err(denied) => return access_denied(&identity, &id, "logs", denied),
     };
 
-    // Child-placed Sandboxes live in a cluster this API server reaches with a
-    // different client. Resolving that is #74's composition, not something the
-    // logs path may improvise, so it is refused explicitly rather than read
-    // from the wrong cluster — which would return another workload's output or
-    // a misleading 404.
-    if target.placement != access::TargetPlacement::Management {
-        return sandbox_error(
-            StatusCode::NOT_IMPLEMENTED,
-            "Sandbox logs are not yet available for child placement",
-            None,
-        );
-    }
-
     // The read runs under a credential that cannot name a second Pod, rather
     // than under the operator's own authority. The resolver has already denied
     // everything it should — this is the layer that makes a bug in the request
     // path a 403 instead of a privilege escalation.
-    let scoped = match crate::api::sandbox_credentials::scoped_client(
+    let cluster = match access::resolve_target_cluster(
         &state.client,
+        &state.namespace,
+        &lease,
+        &target,
+    )
+    .await
+    {
+        Ok(cluster) => cluster,
+        Err(denied) => return access_denied(&identity, &id, "logs", denied),
+    };
+    let scoped = match crate::api::sandbox_credentials::scoped_client(
+        &cluster,
         &target,
         crate::api::sandbox_credentials::SandboxOperation::Logs,
     )

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -350,6 +350,114 @@ pub async fn resolve_sandbox_target(
     Ok((lease, target))
 }
 
+/// The cluster a resolved target's operations run against.
+///
+/// Both variants carry a `Config` rather than only a `Client` because #81
+/// re-authenticates: it mints a per-lease token and needs the endpoint and
+/// trust anchors *without* the identity that came with them.
+pub struct TargetCluster {
+    /// Admin-capable client for the cluster the Pod is in. Used only to mint
+    /// the scoped credential, never to touch the Pod.
+    pub admin: kube::Client,
+    /// The configuration a scoped client is rebuilt from.
+    pub config: kube::Config,
+}
+
+/// Resolve the cluster one target's operations run against.
+///
+/// Management placement is the operator's own cluster. Child placement follows
+/// the provenance recorded at composition — and re-verifies it, because the
+/// composition may have been recycled since: the internal `ClusterLease` must
+/// still exist with the recorded UID, and its binding must still name the
+/// recorded instance.
+///
+/// A child cluster is never resolved by *name*. The recorded UIDs are what
+/// stop a recycled cluster, or a later Sandbox's composition reusing the name,
+/// from receiving this caller's exec.
+///
+/// Constructed per request rather than cached. A cache here would have to be
+/// invalidated on lease expiry, revocation, and any UID or provenance change —
+/// #83 requires exactly that — and a cache that outlives one of those is worse
+/// than no cache at all, because it hands a caller access their lease no longer
+/// grants.
+pub async fn resolve_target_cluster(
+    client: &kube::Client,
+    namespace: &str,
+    lease: &SandboxLease,
+    target: &SandboxTarget,
+) -> Result<TargetCluster, SandboxAccessDenied> {
+    if target.placement == TargetPlacement::Management {
+        let config = crate::api::sandbox_credentials::operator_config()
+            .await
+            .map_err(|_| SandboxAccessDenied::Backend)?
+            .clone();
+        return Ok(TargetCluster {
+            admin: client.clone(),
+            config,
+        });
+    }
+
+    let provenance = lease
+        .status
+        .as_ref()
+        .and_then(|status| status.target.as_ref())
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+    let recorded_lease = provenance
+        .child_cluster_lease
+        .as_ref()
+        .ok_or(SandboxAccessDenied::ProvenanceIncomplete)?;
+    let recorded_instance = provenance
+        .child_cluster_instance
+        .as_ref()
+        .ok_or(SandboxAccessDenied::ProvenanceIncomplete)?;
+    if recorded_lease.uid.is_empty() || recorded_instance.uid.is_empty() {
+        return Err(SandboxAccessDenied::ProvenanceIncomplete);
+    }
+
+    // The internal lease must still be the exact one this Sandbox was composed
+    // onto. A same-named lease belonging to a later composition is somebody
+    // else's cluster.
+    let internal: Api<crate::crd::ClusterLease> = Api::namespaced(client.clone(), namespace);
+    let current = match internal.get(&recorded_lease.name).await {
+        Ok(current) => current,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            return Err(SandboxAccessDenied::TargetUnresolved);
+        }
+        Err(_) => return Err(SandboxAccessDenied::Backend),
+    };
+    if current.uid().as_deref() != Some(recorded_lease.uid.as_str()) {
+        return Err(SandboxAccessDenied::TargetUnresolved);
+    }
+
+    // And it must still be bound to the recorded instance. A recycled cluster
+    // keeps the lease name and changes the instance underneath it, which is
+    // precisely the substitution the recorded UID exists to catch.
+    let binding = current
+        .status
+        .as_ref()
+        .and_then(|status| status.binding.as_ref())
+        .ok_or(SandboxAccessDenied::TargetUnresolved)?;
+    if binding.instance.uid != recorded_instance.uid
+        || binding.instance.name != recorded_instance.name
+    {
+        return Err(SandboxAccessDenied::TargetUnresolved);
+    }
+
+    // The kubeconfig is read into memory and never leaves it. The error is
+    // swallowed rather than propagated: its context can carry the Secret's own
+    // contents, and this value reaches a caller-facing status.
+    let kubeconfig =
+        crate::backend::read_kubeconfig_secret(client, &recorded_instance.name, namespace)
+            .await
+            .map_err(|_| SandboxAccessDenied::Backend)?;
+    let config = crate::backend::virtual_config_from_kubeconfig(&kubeconfig)
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+    let admin = kube::Client::try_from(config.clone()).map_err(|_| SandboxAccessDenied::Backend)?;
+
+    Ok(TargetCluster { admin, config })
+}
+
 /// How much of a Sandbox's output one request may return.
 ///
 /// Bounded because the caller controls neither how much their agent writes nor
@@ -985,6 +1093,169 @@ mod tests {
             .await
         );
         assert_eq!(into.len(), MAX_EXEC_OUTPUT_BYTES);
+    }
+
+    fn child_lease_with(cluster_lease_uid: &str, instance_uid: &str) -> SandboxLease {
+        let mut lease = ready_lease();
+        let status = lease.status.as_mut().unwrap();
+        status.placement = Some(ResolvedSandboxPlacement::ChildCluster {
+            cluster_pool: reference("ClusterPool", "children", "cluster-pool-uid"),
+        });
+        let target = status.target.as_mut().unwrap();
+        target.child_cluster_lease = Some(reference(
+            "ClusterLease",
+            "kobe-sbx-sbx-1",
+            cluster_lease_uid,
+        ));
+        target.child_cluster_instance =
+            Some(reference("ClusterInstance", "kobe-abc123", instance_uid));
+        lease
+    }
+
+    fn cluster_lease_json(uid: &str, instance_name: &str, instance_uid: &str) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "ClusterLease",
+            "metadata": { "name": "kobe-sbx-sbx-1", "namespace": "kobe", "uid": uid },
+            "spec": {
+                "poolRef": "children",
+                "ttl": "2h",
+                "requester": { "type": "kobe:sandbox-composition", "identity": "kobe-operator" },
+            },
+            "status": {
+                "phase": "Bound",
+                "binding": {
+                    "bindingId": "binding-1",
+                    "lease": { "name": "kobe-sbx-sbx-1", "uid": uid },
+                    "instance": {
+                        "name": instance_name,
+                        "uid": instance_uid,
+                        "observedGeneration": 2,
+                    },
+                    "pool": { "name": "children", "uid": "cluster-pool-uid" },
+                    "backend": { "type": "k3s", "configDigest": "digest" },
+                    "instanceSpecDigest": "spec-digest",
+                },
+            },
+        })
+    }
+
+    const CLUSTER_LEASE_PATH: &str =
+        "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/kobe/clusterleases/kobe-sbx-sbx-1";
+
+    /// A recycled child cluster must not receive this lease's operations.
+    ///
+    /// The internal `ClusterLease` name survives a recycle; the instance
+    /// underneath it does not. Resolving by name would send a caller's exec
+    /// into whatever cluster now answers to it — a different tenant's, or a
+    /// fresh one their lease was never placed on.
+    #[tokio::test]
+    async fn a_recycled_child_cluster_is_refused() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        // The lease is still there under the recorded UID, but it is now bound
+        // to a different instance.
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(cluster_lease_json(
+                "child-lease-uid",
+                "kobe-recycled",
+                "a-different-instance-uid",
+            )))
+            .mount(&server)
+            .await;
+
+        let lease = child_lease_with("child-lease-uid", "child-instance-uid");
+        let target = target_from_provenance(&lease, &pool(), now()).unwrap();
+        let error = resolve_target_cluster(&client, "kobe", &lease, &target)
+            .await
+            .err()
+            .expect("a recycled instance must not resolve");
+        assert_eq!(error, SandboxAccessDenied::TargetUnresolved);
+
+        // Nothing was read from the child: no kubeconfig Secret was fetched,
+        // so no credential could have been minted against the wrong cluster.
+        assert_eq!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| request.url.path().contains("/secrets/"))
+                .count(),
+            0
+        );
+    }
+
+    /// A composition whose lease was replaced under the same name is refused.
+    #[tokio::test]
+    async fn a_name_reused_by_a_later_composition_is_refused() {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(cluster_lease_json(
+                "somebody-elses-lease-uid",
+                "kobe-abc123",
+                "child-instance-uid",
+            )))
+            .mount(&server)
+            .await;
+
+        let lease = child_lease_with("child-lease-uid", "child-instance-uid");
+        let target = target_from_provenance(&lease, &pool(), now()).unwrap();
+        assert_eq!(
+            resolve_target_cluster(&client, "kobe", &lease, &target)
+                .await
+                .err()
+                .expect("a reused name must not resolve"),
+            SandboxAccessDenied::TargetUnresolved
+        );
+    }
+
+    /// Provenance without UIDs cannot fence a child cluster at all.
+    ///
+    /// Two absent UIDs compare equal, so a check written against them would
+    /// accept any cluster — which is the whole failure this resolution exists
+    /// to prevent.
+    #[tokio::test]
+    async fn child_provenance_without_uids_is_refused() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        for (lease_uid, instance_uid) in [("", "instance"), ("lease", ""), ("", "")] {
+            let lease = child_lease_with(lease_uid, instance_uid);
+            // `target_from_provenance` is unaffected — the Pod refs are intact —
+            // so the refusal has to come from cluster resolution itself.
+            let target = target_from_provenance(&lease, &pool(), now()).unwrap();
+            assert_eq!(
+                resolve_target_cluster(&client, "kobe", &lease, &target)
+                    .await
+                    .err()
+                    .expect("an unfenced child must not resolve"),
+                SandboxAccessDenied::ProvenanceIncomplete
+            );
+        }
+
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .is_empty(),
+            "unfenced provenance is refused before anything is looked up"
+        );
     }
 
     /// Absent and unowned are the same answer to a caller.

--- a/src/api/sandbox_credentials.rs
+++ b/src/api/sandbox_credentials.rs
@@ -258,7 +258,7 @@ pub async fn mint_scoped_token(
 /// so a deployment that never serves a Sandbox operation does not require it.
 static BASE_CONFIG: tokio::sync::OnceCell<kube::Config> = tokio::sync::OnceCell::const_new();
 
-async fn base_config() -> Result<&'static kube::Config, SandboxAccessDenied> {
+pub async fn operator_config() -> Result<&'static kube::Config, SandboxAccessDenied> {
     BASE_CONFIG
         .get_or_try_init(|| async {
             kube::Config::infer()
@@ -276,13 +276,17 @@ async fn base_config() -> Result<&'static kube::Config, SandboxAccessDenied> {
 /// out-rank the bearer token and silently restore the operator's authority,
 /// which is the one thing this function exists to remove.
 pub async fn scoped_client(
-    base: &kube::Client,
+    cluster: &crate::api::sandbox_access::TargetCluster,
     target: &SandboxTarget,
     operation: SandboxOperation,
 ) -> Result<kube::Client, SandboxAccessDenied> {
-    let token = mint_scoped_token(base, target, operation).await?;
+    // Minted in the cluster the Pod is in — for a child composition that is the
+    // child cluster, not Kobe's. A token issued by the management cluster would
+    // not authenticate there at all, and reaching the child as its admin
+    // identity is exactly what this replaces.
+    let token = mint_scoped_token(&cluster.admin, target, operation).await?;
 
-    let mut config = base_config().await?.clone();
+    let mut config = cluster.config.clone();
     config.auth_info = kube::config::AuthInfo {
         token: Some(token.into()),
         ..Default::default()

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -702,8 +702,12 @@ pub async fn read_kubeconfig_secret(
     Ok(kubeconfig)
 }
 
-/// Build a `kube::Client` targeting a virtual cluster from its kubeconfig YAML.
-pub async fn virtual_client_from_kubeconfig(kubeconfig_yaml: &str) -> Result<Client> {
+/// Build a `kube::Config` targeting a virtual cluster from its kubeconfig YAML.
+///
+/// Separated from the client so a caller that must *re-authenticate* against
+/// the same cluster — #81 mints a per-lease token and needs the endpoint and
+/// trust anchors without the admin identity — can do so without re-parsing.
+pub async fn virtual_config_from_kubeconfig(kubeconfig_yaml: &str) -> Result<Config> {
     let kubeconfig = kube::config::Kubeconfig::from_yaml(kubeconfig_yaml)?;
     let mut config = Config::from_custom_kubeconfig(kubeconfig, &Default::default())
         .await
@@ -711,6 +715,12 @@ pub async fn virtual_client_from_kubeconfig(kubeconfig_yaml: &str) -> Result<Cli
     // Virtual clusters use self-signed CAs; we trust them because we created them
     // and we're connecting cluster-internal (pod-to-service DNS).
     config.accept_invalid_certs = true;
+    Ok(config)
+}
+
+/// Build a `kube::Client` targeting a virtual cluster from its kubeconfig YAML.
+pub async fn virtual_client_from_kubeconfig(kubeconfig_yaml: &str) -> Result<Client> {
+    let config = virtual_config_from_kubeconfig(kubeconfig_yaml).await?;
     Client::try_from(config).context("Failed to create client from kubeconfig")
 }
 


### PR DESCRIPTION
Closes the placement gap in #81/#83 · **stacked on #129**
Epic: #70 — Agent Sandbox · Parent: #75 · Unblocks #76

Every Sandbox operation — logs, exec, attach, port-forward — refused child placement with `501` rather than reading from the management cluster, where the Pod does not exist. That refusal was correct (a lookup there finds nothing, or worse, somebody else's Pod under the same name) but it left the two placements visibly different, which is exactly the equivalence #76 sets out to prove.

Both now resolve through one path. **Child composition changes which cluster the Pod is in; it changes nothing about what the caller may do.**

## A child cluster is never resolved by name

Three fences, and each catches a different real substitution:

- **The internal `ClusterLease` must still exist under the UID recorded at composition.** A later Sandbox's composition reusing the name is not this caller's cluster.
- **Its binding must still name the recorded instance.** A recycled cluster keeps the lease name and replaces the instance underneath it — the substitution the recorded UID exists to catch.
- **Provenance without UIDs is refused before anything is looked up.** Two absent UIDs compare equal, so a check written against them would accept any cluster at all.

## Credentials are minted where the Pod is

A token issued by the management cluster would not authenticate in a child at all, and reaching the child as its *admin* identity is precisely what per-lease credentials replace. So `scoped_client` now takes the resolved cluster rather than the operator's own — the endpoint and trust anchors come from the child's kubeconfig, the identity from a token minted there and scoped to one Pod.

The child kubeconfig is read into memory and never leaves it. Its read error is swallowed rather than propagated, because the error context can carry the Secret's own contents and the value reaches a caller-facing status.

## Not cached, deliberately

A cache would have to be invalidated on lease expiry, revocation, and any UID or provenance change — #83 requires exactly that — and a cache that outlives one of those hands a caller access their lease no longer grants. Per-request resolution costs a `get` and a `Secret` read; that is the right trade until it measurably is not.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1482 passed, 0 failed
```

Mutation-checked: resolving the child by name alone — ignoring either the recorded lease UID or the recorded instance UID — fails its tests. The recycled-cluster test also asserts that **no kubeconfig Secret was read**, so a wrong resolution could not have minted a credential against the wrong cluster before failing.

## What this unblocks

| | |
|---|---|
| #81: management and child resolve through the same typed interface | ✅ now true end to end, not just in the resolver |
| #83: direct and child placements expose identical TTY and port-forward behaviour | ✅ |
| #76: dual-placement conformance | now has something to conform |

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.