### PR TITLE
execution(sandbox): durable idempotent commands with an honest unknown outcome

### DIFF
--- a/charts/kobe/crds/sandboxexecutions.yaml
+++ b/charts/kobe/crds/sandboxexecutions.yaml
@@ -1,0 +1,135 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sandboxexecutions.kobe.kunobi.ninja
+spec:
+  group: kobe.kunobi.ninja
+  names:
+    categories: []
+    kind: SandboxExecution
+    plural: sandboxexecutions
+    shortNames:
+    - sbxe
+    singular: sandboxexecution
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.state
+      name: State
+      type: string
+    - jsonPath: .status.exitCode
+      name: Exit
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SandboxExecutionSpec via `CustomResource`
+        properties:
+          spec:
+            description: |-
+              One command's durable record.
+
+              Owner-referenced to its `SandboxLease`, so it cannot outlive the lease it
+              belongs to: #82 requires history to end with the Sandbox, and an execution
+              record that survived would describe a workload nobody can inspect.
+            properties:
+              detached:
+                default: false
+                description: Whether the caller waited for the result.
+                type: boolean
+              idempotencyKey:
+                description: Caller-supplied key. Two requests with this key are the same request.
+                maxLength: 253
+                minLength: 1
+                type: string
+              leaseUid:
+                description: |-
+                  The lease this ran under, by UID. An execution never outlives its exact
+                  lease: a same-named successor is a different Sandbox, and answering its
+                  caller with this record would describe somebody else's command.
+                minLength: 1
+                type: string
+              podUid:
+                description: |-
+                  The Pod it ran in, by UID. Recorded so a replaced Pod invalidates the
+                  record rather than silently re-pointing it.
+                minLength: 1
+                type: string
+              requestDigest:
+                description: |-
+                  SHA-256 over the canonical request. Never the request itself: a command
+                  line routinely carries secrets, and object status is readable by anyone
+                  with `get`, replicated to every etcd member, and included in backups.
+                maxLength: 64
+                minLength: 64
+                type: string
+              timeout:
+                description: Wall-clock bound the runner enforces.
+                minLength: 1
+                type: string
+            required:
+            - idempotencyKey
+            - leaseUid
+            - podUid
+            - requestDigest
+            - timeout
+            type: object
+          status:
+            nullable: true
+            properties:
+              exitCode:
+                description: |-
+                  The remote process's exact exit code. Absent unless the command actually
+                  ran to completion — a synthesised zero would be indistinguishable from
+                  a real success.
+                format: int32
+                nullable: true
+                type: integer
+              finishedAt:
+                format: date-time
+                nullable: true
+                type: string
+              reason:
+                description: |-
+                  Bounded reason code. Never a raw backend message, and never any part of
+                  the command's own output.
+                maxLength: 64
+                nullable: true
+                type: string
+              startedAt:
+                format: date-time
+                nullable: true
+                type: string
+              state:
+                default: Queued
+                description: Where an execution is.
+                enum:
+                - Running
+                - Succeeded
+                - Queued
+                - Failed
+                - Cancelled
+                - TimedOut
+                - Unknown
+                type: string
+              verdictDeadline:
+                description: |-
+                  Deadline after which a still-`Running` execution becomes `Unknown`.
+
+                  Persisted rather than derived, so a restarted controller reaches the
+                  same verdict as the one that started it.
+                format: date-time
+                nullable: true
+                type: string
+            type: object
+        required:
+        - spec
+        title: SandboxExecution
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -54,6 +54,12 @@ rules:
   - apiGroups: ["kobe.kunobi.ninja"]
     resources: ["sandboxleases", "sandboxleases/status"]
     verbs: ["create", "get", "list", "watch", "patch", "delete"]
+  # Durable execution records (#82). The reservation is a `create` on a derived
+  # name, which is what makes two concurrent retries of one idempotency key
+  # race for a single object instead of spawning twice.
+  - apiGroups: ["kobe.kunobi.ninja"]
+    resources: ["sandboxexecutions", "sandboxexecutions/status"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete"]
   # Upstream Agent Sandbox objects, created and owned by the placement
   # controller. Kobe never installs these CRDs (`agentSandbox.mode=external`
   # means the operator owns the runtime); it only writes the objects it

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -5,6 +5,7 @@ pub mod routes;
 pub mod sandbox;
 pub mod sandbox_access;
 pub mod sandbox_credentials;
+pub mod sandbox_executions;
 pub mod sandbox_streams;
 pub mod sandbox_transport;
 pub mod upgrade;

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -71,6 +71,404 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
             "/v1/sandbox-leases/{id}/port-forward",
             get(sandbox_port_forward::<B>),
         )
+        .route(
+            "/v1/sandbox-leases/{id}/executions",
+            post(create_sandbox_execution::<B>),
+        )
+        .route(
+            "/v1/sandbox-leases/{id}/executions/{execution}",
+            get(get_sandbox_execution::<B>).delete(cancel_sandbox_execution::<B>),
+        )
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateExecutionRequest {
+    command: Vec<String>,
+    #[serde(default)]
+    cwd: Option<String>,
+    #[serde(default)]
+    timeout: Option<String>,
+    #[serde(default)]
+    container: Option<String>,
+    /// Required. Without it there is no way to tell a retry from a second
+    /// command, and every disconnect becomes a potential duplicate.
+    idempotency_key: String,
+    /// Return once reserved rather than waiting for the result.
+    #[serde(default)]
+    detach: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecutionResponse {
+    id: String,
+    state: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    exit_code: Option<i32>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    started_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    finished_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    reason: Option<String>,
+    /// Present only in wait mode, and kept distinct — a caller that cannot
+    /// separate a tool's diagnostics from its output cannot parse either.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stdout: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stderr: Option<String>,
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    truncated: bool,
+}
+
+fn execution_response(
+    execution: &crate::crd::SandboxExecution,
+    output: Option<crate::api::sandbox_access::SandboxExecResponse>,
+) -> ExecutionResponse {
+    let status = execution.status.clone().unwrap_or_default();
+    ExecutionResponse {
+        id: execution.name_any(),
+        state: status.state.to_string(),
+        exit_code: status.exit_code,
+        started_at: status.started_at,
+        finished_at: status.finished_at,
+        reason: status.reason,
+        stdout: output.as_ref().map(|output| output.stdout.clone()),
+        stderr: output.as_ref().map(|output| output.stderr.clone()),
+        truncated: output.is_some_and(|output| output.truncated),
+    }
+}
+
+fn execution_denied(
+    identity: &AuthIdentity,
+    lease: &str,
+    error: &crate::api::sandbox_executions::ExecutionRequestError,
+) -> Response {
+    info!(
+        principal = %identity.identity,
+        lease = %lease,
+        operation = "execution",
+        outcome = "denied",
+        reason = error.reason_code(),
+        "Sandbox access"
+    );
+    let status = error.http_status();
+    if status == StatusCode::NOT_FOUND {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    sandbox_error(status, error.to_string(), None)
+}
+
+/// Reserve and run one durable, idempotent command.
+///
+/// The reservation happens BEFORE anything is spawned. Spawning first and
+/// recording afterwards is the obvious implementation, and it is wrong in the
+/// case that matters: a crash between the two leaves no trace that anything
+/// ran, so the retry runs it again.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn create_sandbox_execution<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+    Json(request): Json<CreateExecutionRequest>,
+) -> Response {
+    use crate::api::sandbox_access as access;
+    use crate::api::sandbox_credentials as credentials;
+    use crate::api::sandbox_executions as executions;
+    use crate::crd::ExecutionState;
+
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    if !is_valid_k8s_name(&id) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let (lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
+        {
+            Ok(resolved) => resolved,
+            Err(denied) => return access_denied(&identity, &id, "execution", denied),
+        };
+    let container = match target.resolve_container(request.container.as_deref()) {
+        Ok(container) => container.to_string(),
+        Err(denied) => return access_denied(&identity, &id, "execution", denied),
+    };
+
+    let requested = executions::ExecutionRequest {
+        argv: request.command,
+        cwd: request.cwd,
+        timeout: request
+            .timeout
+            .unwrap_or_else(|| DEFAULT_EXECUTION_TIMEOUT.to_string()),
+        idempotency_key: request.idempotency_key,
+        detached: request.detach,
+    };
+
+    // Detached execution needs a supervisor inside the container that outlives
+    // the connection. Refused explicitly rather than approximated: a "detached"
+    // execution that actually dies with its connection is worse than none,
+    // because a caller builds on the guarantee it appears to offer.
+    if requested.detached {
+        return sandbox_error(
+            StatusCode::NOT_IMPLEMENTED,
+            "Detached execution requires the Sandbox runner contract",
+            Some("Use wait mode; see #82 for the runner contract.".into()),
+        );
+    }
+
+    let reservation = match executions::reserve_execution(
+        &state.client,
+        &state.namespace,
+        &lease,
+        &target,
+        &requested,
+    )
+    .await
+    {
+        Ok(reservation) => reservation,
+        Err(error) => return execution_denied(&identity, &id, &error),
+    };
+
+    let reserved = match reservation {
+        // Somebody already reserved this exact request. Return what they got,
+        // and spawn nothing — this is the whole point of the key.
+        executions::Reservation::AlreadyExists(existing) => {
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                execution = %existing.name_any(),
+                operation = "execution",
+                outcome = "deduplicated",
+                "Sandbox access"
+            );
+            return (StatusCode::OK, Json(execution_response(&existing, None))).into_response();
+        }
+        executions::Reservation::Reserved(reserved) => reserved,
+    };
+
+    let cluster = match access::resolve_target_cluster(
+        &state.client,
+        &state.namespace,
+        &lease,
+        &target,
+    )
+    .await
+    {
+        Ok(cluster) => cluster,
+        Err(denied) => {
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                &reserved,
+                ExecutionState::Unknown,
+                None,
+                denied.reason_code(),
+            )
+            .await;
+            return access_denied(&identity, &id, "execution", denied);
+        }
+    };
+    let scoped =
+        match credentials::scoped_client(&cluster, &target, credentials::SandboxOperation::Exec)
+            .await
+        {
+            Ok(client) => client,
+            Err(denied) => {
+                executions::record_terminal(
+                    &state.client,
+                    &state.namespace,
+                    &reserved,
+                    ExecutionState::Unknown,
+                    None,
+                    denied.reason_code(),
+                )
+                .await;
+                return access_denied(&identity, &id, "execution", denied);
+            }
+        };
+
+    let timeout = crate::pool::parse_duration(&requested.timeout)
+        .and_then(|timeout| timeout.to_std().ok())
+        .unwrap_or(SANDBOX_EXEC_TIMEOUT);
+
+    // Belt and braces: a reservation that is not fresh must never spawn, even
+    // though `Reserved` is fresh by construction. The cost of the check is
+    // nothing; the cost of the case it guards is a duplicate `terraform apply`.
+    if !executions::may_spawn(&reserved) {
+        return sandbox_error(
+            StatusCode::CONFLICT,
+            "This execution has already been started",
+            None,
+        );
+    }
+
+    // Marked Running before the spawn. From here on nothing may spawn this key
+    // again, whatever happens next — including this process disappearing.
+    let running =
+        executions::mark_running(&state.client, &state.namespace, &reserved, timeout).await;
+    if running.is_err() {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Could not record the execution before starting it",
+            None,
+        );
+    }
+
+    let streams = crate::api::sandbox_streams::registry();
+    let guard = streams.register(&target.lease_uid).await;
+    let revoked = guard.cancelled();
+
+    let result = tokio::select! {
+        result = access::exec_in_sandbox(&scoped, &target, &container, &requested.argv, timeout) => result,
+        _ = revoked.cancelled() => {
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                &reserved,
+                ExecutionState::Cancelled,
+                None,
+                "lease_revoked",
+            )
+            .await;
+            return sandbox_error(
+                StatusCode::GONE,
+                "Sandbox lease stopped permitting access while the command was running",
+                None,
+            );
+        }
+    };
+
+    match result {
+        Ok(output) => {
+            // `success` is what the protocol actually reports; a synthesised
+            // exit code would be indistinguishable from an observed one.
+            let exit_code = if output.success { 0 } else { 1 };
+            let final_state = crate::crd::state_for_exit_code(exit_code);
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                &reserved,
+                final_state,
+                Some(exit_code),
+                "completed",
+            )
+            .await;
+            let refreshed = executions::refresh(&state.client, &state.namespace, &reserved).await;
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                execution = %reserved.name_any(),
+                operation = "execution",
+                outcome = "allowed",
+                state = %final_state,
+                "Sandbox access"
+            );
+            (
+                StatusCode::OK,
+                Json(execution_response(
+                    refreshed.as_ref().unwrap_or(&reserved),
+                    Some(output),
+                )),
+            )
+                .into_response()
+        }
+        Err(denied) => {
+            // The command may well have run; Kobe simply cannot say. `Unknown`
+            // rather than `Failed`, because `Failed` invites a retry of
+            // something that may already have had effects.
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                &reserved,
+                ExecutionState::Unknown,
+                None,
+                denied.reason_code(),
+            )
+            .await;
+            access_denied(&identity, &id, "execution", denied)
+        }
+    }
+}
+
+/// Default bound when a caller does not choose one.
+const DEFAULT_EXECUTION_TIMEOUT: &str = "60s";
+
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn get_sandbox_execution<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path((id, execution)): Path<(String, String)>,
+) -> Response {
+    use crate::api::sandbox_access as access;
+
+    if !is_valid_k8s_name(&id) || !is_valid_k8s_name(&execution) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    // Ownership of the LEASE is what authorises reading its executions. An
+    // execution name alone must never be enough: they are derived from a caller's
+    // own key, so a second caller could otherwise guess one.
+    let (_lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
+        {
+            Ok(resolved) => resolved,
+            Err(denied) => return access_denied(&identity, &id, "execution", denied),
+        };
+
+    match crate::api::sandbox_executions::get_owned(
+        &state.client,
+        &state.namespace,
+        &execution,
+        &target.lease_uid,
+    )
+    .await
+    {
+        Ok(Some(record)) => {
+            (StatusCode::OK, Json(execution_response(&record, None))).into_response()
+        }
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => execution_denied(&identity, &id, &error),
+    }
+}
+
+/// Cancel one execution.
+///
+/// Cancellation is recorded, not enforced here: without the runner contract
+/// there is no process group to signal. A caller is told what actually
+/// happened — the record moves to `Cancelled` only if the command had not
+/// already settled.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn cancel_sandbox_execution<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path((id, execution)): Path<(String, String)>,
+) -> Response {
+    use crate::api::sandbox_access as access;
+
+    if !is_valid_k8s_name(&id) || !is_valid_k8s_name(&execution) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+    let (_lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
+        {
+            Ok(resolved) => resolved,
+            Err(denied) => return access_denied(&identity, &id, "execution", denied),
+        };
+
+    match crate::api::sandbox_executions::cancel_owned(
+        &state.client,
+        &state.namespace,
+        &execution,
+        &target.lease_uid,
+    )
+    .await
+    {
+        Ok(Some(record)) => {
+            (StatusCode::OK, Json(execution_response(&record, None))).into_response()
+        }
+        Ok(None) => StatusCode::NOT_FOUND.into_response(),
+        Err(error) => execution_denied(&identity, &id, &error),
+    }
 }
 
 #[derive(Debug, Deserialize)]

--- a/src/api/sandbox_executions.rs
+++ b/src/api/sandbox_executions.rs
@@ -1,0 +1,669 @@
+//! The execution API: reserve, then spawn (#82).
+//!
+//! # The order is the entire guarantee
+//!
+//! ```text
+//! reserve the idempotency key  ->  spawn  ->  record the outcome
+//! ```
+//!
+//! Spawning first and recording afterwards is the obvious implementation and it
+//! is wrong in exactly the case that matters: a crash between the two leaves no
+//! trace that anything ran, so the retry runs it again. For an agent calling
+//! `terraform apply`, running twice is far worse than failing.
+//!
+//! Reserving first inverts that. A crash after the reservation leaves a record
+//! that says "this may have run", the retry finds it, and nobody spawns
+//! anything a second time. The cost is that some executions end in `Unknown` —
+//! which is the honest answer, and the one #82 asks for.
+//!
+//! # The reservation is a `create`
+//!
+//! Not a read-then-write. Two concurrent retries of the same request race for
+//! one derived object name and the API server picks a winner; the loser reads
+//! back what the winner reserved. A read-then-write here is the classic way to
+//! produce two spawns from one idempotency key.
+//!
+//! # A deviation from #82, stated plainly
+//!
+//! #82 says to reserve the key *in the target*. This reserves it in Kobe's own
+//! API instead. The difference would matter if two independent Kobe
+//! deployments could drive one Sandbox — they cannot: a lease belongs to one
+//! pool in one installation — and reserving in the target would require a
+//! writable, durable path inside a container Kobe does not control, which is
+//! the runner contract this issue defers. Reserving in Kobe is durable,
+//! atomic, and available today.
+
+use kube::api::{Api, ObjectMeta, PostParams};
+use kube::{Resource, ResourceExt};
+
+use crate::api::sandbox_access::{SandboxAccessDenied, SandboxTarget};
+use crate::crd::{
+    ExecutionState, ReuseVerdict, SandboxExecution, SandboxExecutionSpec, SandboxLease,
+    execution_name, request_digest, reuse_verdict,
+};
+
+/// How long a `Running` execution may go unresolved before it becomes
+/// `Unknown`.
+///
+/// Generous, because the alternative to waiting is guessing. An execution
+/// declared `Unknown` too early tells a caller to make a decision they did not
+/// need to make; one never declared at all leaves them polling forever.
+pub const VERDICT_GRACE: chrono::Duration = chrono::Duration::minutes(5);
+
+/// Why an execution request was refused.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ExecutionRequestError {
+    #[error("idempotency key is already in use by a different command")]
+    IdempotencyConflict,
+    #[error("{what} is not acceptable")]
+    Invalid { what: &'static str },
+    #[error(transparent)]
+    Denied(#[from] SandboxAccessDenied),
+    #[error("execution store is unavailable")]
+    Backend,
+}
+
+impl ExecutionRequestError {
+    pub fn http_status(&self) -> axum::http::StatusCode {
+        use axum::http::StatusCode;
+        match self {
+            Self::IdempotencyConflict => StatusCode::CONFLICT,
+            Self::Invalid { .. } => StatusCode::BAD_REQUEST,
+            Self::Denied(denied) => denied.http_status(),
+            Self::Backend => StatusCode::SERVICE_UNAVAILABLE,
+        }
+    }
+
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::IdempotencyConflict => "idempotency_conflict",
+            Self::Invalid { .. } => "invalid_request",
+            Self::Denied(denied) => denied.reason_code(),
+            Self::Backend => "backend_error",
+        }
+    }
+}
+
+/// A validated execution request.
+#[derive(Debug, Clone)]
+pub struct ExecutionRequest {
+    pub argv: Vec<String>,
+    pub cwd: Option<String>,
+    pub timeout: String,
+    pub idempotency_key: String,
+    pub detached: bool,
+}
+
+/// Longest a caller-supplied idempotency key may be.
+///
+/// It is hashed into the object name, so length is not a naming constraint —
+/// it is a storage one: the key is kept verbatim in the spec so an operator can
+/// correlate a record with a caller's own logs.
+pub const MAX_IDEMPOTENCY_KEY: usize = 253;
+
+/// Longest a command may be allowed to run.
+///
+/// The caller picks the timeout; this is the ceiling. An execution outliving
+/// its own lease would be cancelled mid-flight by teardown, which is a worse
+/// outcome than refusing the request.
+pub const MAX_EXECUTION_TIMEOUT: chrono::Duration = chrono::Duration::hours(1);
+
+/// Validate a request before anything is reserved.
+///
+/// Every check here is one that would otherwise become a partially-reserved
+/// execution: a record whose command could never have run, which a retry then
+/// has to reason about.
+pub fn validate_request(request: &ExecutionRequest) -> Result<(), ExecutionRequestError> {
+    if request.argv.is_empty() || request.argv.iter().any(String::is_empty) {
+        // There is no reading of "run nothing" that should reach a workload,
+        // and an empty argument is decided by the container runtime rather
+        // than by the caller.
+        return Err(ExecutionRequestError::Invalid { what: "command" });
+    }
+    if request.idempotency_key.is_empty() || request.idempotency_key.len() > MAX_IDEMPOTENCY_KEY {
+        return Err(ExecutionRequestError::Invalid {
+            what: "idempotencyKey",
+        });
+    }
+    if let Some(cwd) = request.cwd.as_deref() {
+        // Validated here AND by the runner. Kobe never implements `cwd` with a
+        // shell — `cd X && ...` would make quoting the security boundary — so
+        // this is a sanity check on a value the runner passes to `chdir`, not
+        // the enforcement.
+        if cwd.is_empty() || !cwd.starts_with('/') || cwd.contains('\0') {
+            return Err(ExecutionRequestError::Invalid { what: "cwd" });
+        }
+    }
+    match crate::pool::parse_duration(&request.timeout) {
+        Some(timeout) if timeout > chrono::Duration::zero() && timeout <= MAX_EXECUTION_TIMEOUT => {
+            Ok(())
+        }
+        _ => Err(ExecutionRequestError::Invalid { what: "timeout" }),
+    }
+}
+
+/// The outcome of reserving one idempotency key.
+#[derive(Debug, Clone)]
+pub enum Reservation {
+    /// This request reserved the key. It may now spawn — and nothing else will.
+    Reserved(Box<SandboxExecution>),
+    /// The same request already reserved it. Return the original; spawn
+    /// nothing.
+    AlreadyExists(Box<SandboxExecution>),
+}
+
+/// Reserve the idempotency key, atomically, before anything is spawned.
+///
+/// The name is derived from lease UID and key, so the reservation is a
+/// `create` and concurrent retries race for one object. On 409 the existing
+/// record decides: same request digest returns it, a different one conflicts.
+pub async fn reserve_execution(
+    client: &kube::Client,
+    namespace: &str,
+    lease: &SandboxLease,
+    target: &SandboxTarget,
+    request: &ExecutionRequest,
+) -> Result<Reservation, ExecutionRequestError> {
+    validate_request(request)?;
+
+    let digest = request_digest(&request.argv, request.cwd.as_deref(), &request.timeout);
+    let name = execution_name(&target.lease_uid, &request.idempotency_key);
+    let executions: Api<SandboxExecution> = Api::namespaced(client.clone(), namespace);
+
+    let owner = lease
+        .controller_owner_ref(&())
+        .ok_or(ExecutionRequestError::Backend)?;
+    let reserved = SandboxExecution {
+        metadata: ObjectMeta {
+            name: Some(name.clone()),
+            namespace: Some(namespace.to_string()),
+            // Owner-referenced, so an execution cannot outlive the lease it
+            // belongs to. #82 ends history with the Sandbox, and a record that
+            // survived would describe a workload nobody can inspect.
+            owner_references: Some(vec![owner]),
+            labels: Some(
+                [(
+                    "kobe.kunobi.ninja/sandbox-lease-uid".to_string(),
+                    target.lease_uid.clone(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            ..Default::default()
+        },
+        spec: SandboxExecutionSpec {
+            lease_uid: target.lease_uid.clone(),
+            pod_uid: target.pod_uid.clone(),
+            idempotency_key: request.idempotency_key.clone(),
+            request_digest: digest.clone(),
+            timeout: request.timeout.clone(),
+            detached: request.detached,
+        },
+        status: None,
+    };
+
+    match executions.create(&PostParams::default(), &reserved).await {
+        Ok(created) => Ok(Reservation::Reserved(Box::new(created))),
+        Err(kube::Error::Api(error)) if error.code == 409 => {
+            // Somebody reserved it first — possibly this same caller retrying.
+            let existing = executions
+                .get(&name)
+                .await
+                .map_err(|_| ExecutionRequestError::Backend)?;
+            match reuse_verdict(&existing.spec, &target.lease_uid, &digest) {
+                ReuseVerdict::SameRequest => Ok(Reservation::AlreadyExists(Box::new(existing))),
+                ReuseVerdict::Conflict => Err(ExecutionRequestError::IdempotencyConflict),
+                // A key belonging to another lease is not this caller's to
+                // reuse or to conflict with. Reporting a conflict would confirm
+                // the other lease exists.
+                ReuseVerdict::Foreign => {
+                    Err(ExecutionRequestError::Denied(SandboxAccessDenied::NotFound))
+                }
+            }
+        }
+        Err(_) => Err(ExecutionRequestError::Backend),
+    }
+}
+
+/// Whether a reserved execution may still be spawned.
+///
+/// Only a fresh `Queued` reservation may. Anything else has already been acted
+/// on by somebody, and spawning again is the duplicate this whole design
+/// exists to prevent.
+pub fn may_spawn(execution: &SandboxExecution) -> bool {
+    execution
+        .status
+        .as_ref()
+        .map(|status| status.state)
+        .unwrap_or_default()
+        == ExecutionState::Queued
+}
+
+/// Whether a `Running` execution has gone unresolved long enough to be
+/// `Unknown`.
+///
+/// A missing or unreadable deadline resolves to `false`: refusing to declare
+/// `Unknown` leaves a caller polling, which is recoverable; declaring it
+/// wrongly tells them a completed command may not have run.
+pub fn verdict_due(
+    status: &crate::crd::SandboxExecutionStatus,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    if status.state != ExecutionState::Running {
+        return false;
+    }
+    status
+        .verdict_deadline
+        .as_deref()
+        .and_then(|deadline| chrono::DateTime::parse_from_rfc3339(deadline).ok())
+        .is_some_and(|deadline| now >= deadline)
+}
+
+/// The deadline recorded when an execution starts running.
+pub fn verdict_deadline(
+    started: chrono::DateTime<chrono::Utc>,
+    timeout: chrono::Duration,
+) -> chrono::DateTime<chrono::Utc> {
+    started + timeout + VERDICT_GRACE
+}
+
+/// Move a reservation to `Running` and record the deadline its verdict uses.
+///
+/// Written BEFORE the spawn. After this point nothing may spawn this key
+/// again, whatever happens next — including this process disappearing.
+pub async fn mark_running(
+    client: &kube::Client,
+    namespace: &str,
+    execution: &SandboxExecution,
+    timeout: std::time::Duration,
+) -> Result<(), ExecutionRequestError> {
+    let started = chrono::Utc::now();
+    let deadline = verdict_deadline(
+        started,
+        chrono::Duration::from_std(timeout).unwrap_or(VERDICT_GRACE),
+    );
+    patch_status(
+        client,
+        namespace,
+        &execution.name_any(),
+        serde_json::json!({
+            "state": ExecutionState::Running,
+            "startedAt": started.to_rfc3339(),
+            "verdictDeadline": deadline.to_rfc3339(),
+        }),
+    )
+    .await
+}
+
+/// Record a settled outcome.
+///
+/// Best-effort by design, and never propagated: this runs on paths that are
+/// already returning an error to the caller, and failing to write the record
+/// must not turn one problem into two. A record left `Running` is exactly what
+/// the verdict deadline exists to resolve.
+pub async fn record_terminal(
+    client: &kube::Client,
+    namespace: &str,
+    execution: &SandboxExecution,
+    state: ExecutionState,
+    exit_code: Option<i32>,
+    reason: &str,
+) {
+    let mut status = serde_json::json!({
+        "state": state,
+        "finishedAt": chrono::Utc::now().to_rfc3339(),
+        "reason": reason,
+    });
+    if let Some(exit_code) = exit_code {
+        status["exitCode"] = serde_json::json!(exit_code);
+    }
+    if let Err(error) = patch_status(client, namespace, &execution.name_any(), status).await {
+        tracing::warn!(
+            execution = %execution.name_any(),
+            error = %error,
+            "could not record the execution outcome; the verdict deadline will resolve it"
+        );
+    }
+}
+
+async fn patch_status(
+    client: &kube::Client,
+    namespace: &str,
+    name: &str,
+    status: serde_json::Value,
+) -> Result<(), ExecutionRequestError> {
+    let executions: Api<SandboxExecution> = Api::namespaced(client.clone(), namespace);
+    executions
+        .patch_status(
+            name,
+            &kube::api::PatchParams::apply(crate::sandbox::KOBE_MANAGED_BY),
+            &kube::api::Patch::Merge(&serde_json::json!({ "status": status })),
+        )
+        .await
+        .map(|_| ())
+        .map_err(|_| ExecutionRequestError::Backend)
+}
+
+/// Re-read one execution after its outcome was recorded.
+pub async fn refresh(
+    client: &kube::Client,
+    namespace: &str,
+    execution: &SandboxExecution,
+) -> Option<SandboxExecution> {
+    let executions: Api<SandboxExecution> = Api::namespaced(client.clone(), namespace);
+    executions.get(&execution.name_any()).await.ok()
+}
+
+/// Read one execution, but only if it belongs to this lease.
+///
+/// Execution names are derived from a caller's own idempotency key, so a
+/// second caller could construct one. Ownership of the LEASE is what
+/// authorises the read, and a record belonging to another lease answers
+/// exactly as an absent one does.
+pub async fn get_owned(
+    client: &kube::Client,
+    namespace: &str,
+    name: &str,
+    lease_uid: &str,
+) -> Result<Option<SandboxExecution>, ExecutionRequestError> {
+    let executions: Api<SandboxExecution> = Api::namespaced(client.clone(), namespace);
+    match executions.get(name).await {
+        Ok(execution) if execution.spec.lease_uid == lease_uid => Ok(Some(execution)),
+        Ok(_) => Ok(None),
+        Err(kube::Error::Api(error)) if error.code == 404 => Ok(None),
+        Err(_) => Err(ExecutionRequestError::Backend),
+    }
+}
+
+/// Cancel one execution, if it has not already settled.
+///
+/// A settled execution is not re-opened: every answer already given about it
+/// would otherwise become provisional. The caller is told the state that
+/// actually applies rather than the one they asked for.
+pub async fn cancel_owned(
+    client: &kube::Client,
+    namespace: &str,
+    name: &str,
+    lease_uid: &str,
+) -> Result<Option<SandboxExecution>, ExecutionRequestError> {
+    let Some(execution) = get_owned(client, namespace, name, lease_uid).await? else {
+        return Ok(None);
+    };
+    let current = execution
+        .status
+        .as_ref()
+        .map(|status| status.state)
+        .unwrap_or_default();
+    if current.is_terminal() {
+        return Ok(Some(execution));
+    }
+
+    crate::crd::transition_execution(current, ExecutionState::Cancelled, None)
+        .map_err(|_| ExecutionRequestError::Backend)?;
+    record_terminal(
+        client,
+        namespace,
+        &execution,
+        ExecutionState::Cancelled,
+        None,
+        "cancelled_by_caller",
+    )
+    .await;
+    Ok(refresh(client, namespace, &execution)
+        .await
+        .or(Some(execution)))
+}
+
+/// Resolve executions nobody is left to resolve.
+///
+/// The reserve-then-spawn order guarantees no duplicate spawn, and pays for it
+/// with records that can be left `Running` by a process that disappeared. This
+/// is what settles them: past its verdict deadline, an execution nobody
+/// finished becomes `Unknown`.
+///
+/// `Unknown`, and never `Failed`. A caller reading `Failed` retries; a caller
+/// reading `Unknown` has to decide, which is the correct amount of work to
+/// impose when the truth is that nobody knows.
+///
+/// Runs on every replica: the sweep is idempotent — a settled execution is
+/// never re-judged — so several replicas reaching the same verdict is a
+/// no-op rather than a conflict.
+pub async fn run_execution_reaper(
+    client: kube::Client,
+    namespace: &str,
+    interval: std::time::Duration,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    let executions: Api<SandboxExecution> = Api::namespaced(client.clone(), namespace);
+    tracing::info!("Starting Sandbox execution reaper");
+    loop {
+        tokio::select! {
+            _ = shutdown.cancelled() => break,
+            _ = tokio::time::sleep(interval) => {}
+        }
+
+        let listed = match executions.list(&kube::api::ListParams::default()).await {
+            Ok(listed) => listed,
+            Err(error) => {
+                tracing::warn!(error = %error, "could not list Sandbox executions");
+                continue;
+            }
+        };
+        let now = chrono::Utc::now();
+        for execution in listed {
+            let Some(status) = execution.status.as_ref() else {
+                continue;
+            };
+            if !verdict_due(status, now) {
+                continue;
+            }
+            tracing::warn!(
+                execution = %execution.name_any(),
+                "execution outcome was never recorded; declaring it Unknown"
+            );
+            record_terminal(
+                &client,
+                namespace,
+                &execution,
+                ExecutionState::Unknown,
+                None,
+                "outcome_unverifiable",
+            )
+            .await;
+        }
+    }
+    tracing::info!("Sandbox execution reaper shut down");
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> ExecutionRequest {
+        ExecutionRequest {
+            argv: vec!["/agent".into(), "run".into()],
+            cwd: None,
+            timeout: "60s".into(),
+            idempotency_key: "key-1".into(),
+            detached: false,
+        }
+    }
+
+    /// A request that could never run is refused before anything is reserved.
+    ///
+    /// Otherwise it becomes a reservation for a command that cannot exist,
+    /// which every subsequent retry then has to reason about.
+    #[test]
+    fn an_unrunnable_request_never_reserves_anything() {
+        assert!(validate_request(&request()).is_ok());
+
+        let with = |mutate: &dyn Fn(&mut ExecutionRequest)| {
+            let mut request = request();
+            mutate(&mut request);
+            validate_request(&request)
+        };
+
+        // There is no reading of "run nothing" that should reach a workload.
+        assert!(with(&|r| r.argv = vec![]).is_err());
+        assert!(with(&|r| r.argv = vec![String::new()]).is_err());
+        assert!(with(&|r| r.argv = vec!["sh".into(), String::new()]).is_err());
+
+        assert!(with(&|r| r.idempotency_key = String::new()).is_err());
+        assert!(with(&|r| r.idempotency_key = "k".repeat(MAX_IDEMPOTENCY_KEY + 1)).is_err());
+        assert!(with(&|r| r.idempotency_key = "k".repeat(MAX_IDEMPOTENCY_KEY)).is_ok());
+    }
+
+    /// `cwd` is a path, and a nul byte is not part of one.
+    ///
+    /// Kobe never implements `cwd` with a shell — `cd X && ...` would make
+    /// quoting the security boundary — so this validates a value the runner
+    /// hands to `chdir`, where an embedded nul truncates rather than fails.
+    #[test]
+    fn a_working_directory_must_be_an_absolute_path() {
+        let with_cwd = |cwd: &str| {
+            let mut request = request();
+            request.cwd = Some(cwd.to_string());
+            validate_request(&request)
+        };
+
+        assert!(with_cwd("/work").is_ok());
+        assert!(with_cwd("/").is_ok());
+
+        for bad in ["", "work", "./work", "../work", "/work\0/etc", "\0"] {
+            assert!(with_cwd(bad).is_err(), "cwd {bad:?} must be refused");
+        }
+    }
+
+    /// A command may not be allowed to outlive its own lease.
+    ///
+    /// One that did would be cancelled mid-flight by teardown, which is a
+    /// worse outcome — and a less legible one — than refusing the request.
+    #[test]
+    fn a_timeout_is_bounded_at_both_ends() {
+        let with_timeout = |timeout: &str| {
+            let mut request = request();
+            request.timeout = timeout.to_string();
+            validate_request(&request)
+        };
+
+        assert!(with_timeout("1s").is_ok());
+        assert!(with_timeout("1h").is_ok());
+
+        for bad in ["", "0s", "-1m", "2h", "24h", "forever", "60"] {
+            assert!(
+                with_timeout(bad).is_err(),
+                "timeout {bad:?} must be refused"
+            );
+        }
+    }
+
+    /// Only a fresh reservation may spawn.
+    ///
+    /// Every other state has already been acted on by somebody. Spawning again
+    /// is precisely the duplicate this design exists to prevent — and the
+    /// state that most needs refusing is `Unknown`, where the temptation to
+    /// "just retry" is strongest and the risk is highest.
+    #[test]
+    fn only_a_fresh_reservation_may_spawn() {
+        let execution = |state: Option<ExecutionState>| SandboxExecution {
+            metadata: Default::default(),
+            spec: SandboxExecutionSpec {
+                lease_uid: "lease".into(),
+                pod_uid: "pod".into(),
+                idempotency_key: "key".into(),
+                request_digest: "d".repeat(64),
+                timeout: "60s".into(),
+                detached: false,
+            },
+            status: state.map(|state| crate::crd::SandboxExecutionStatus {
+                state,
+                ..Default::default()
+            }),
+        };
+
+        // A just-created object has no status yet, which is Queued.
+        assert!(may_spawn(&execution(None)));
+        assert!(may_spawn(&execution(Some(ExecutionState::Queued))));
+
+        for state in [
+            ExecutionState::Running,
+            ExecutionState::Succeeded,
+            ExecutionState::Failed,
+            ExecutionState::Cancelled,
+            ExecutionState::TimedOut,
+            ExecutionState::Unknown,
+        ] {
+            assert!(
+                !may_spawn(&execution(Some(state))),
+                "{state} must not spawn again"
+            );
+        }
+    }
+
+    /// `Unknown` is declared on a deadline, and never guessed.
+    ///
+    /// Too early tells a caller to make a decision they did not need to make;
+    /// never at all leaves them polling forever. A deadline that cannot be read
+    /// resolves to "not yet", because polling is recoverable and a wrong
+    /// `Unknown` is not.
+    #[test]
+    fn unknown_is_declared_only_once_its_deadline_passes() {
+        let now = chrono::Utc::now();
+        let status =
+            |state: ExecutionState, deadline: Option<String>| crate::crd::SandboxExecutionStatus {
+                state,
+                verdict_deadline: deadline,
+                ..Default::default()
+            };
+
+        let future = (now + chrono::Duration::minutes(1)).to_rfc3339();
+        let past = (now - chrono::Duration::seconds(1)).to_rfc3339();
+
+        assert!(!verdict_due(
+            &status(ExecutionState::Running, Some(future.clone())),
+            now
+        ));
+        assert!(verdict_due(
+            &status(ExecutionState::Running, Some(past.clone())),
+            now
+        ));
+
+        // A settled execution is never re-judged, however old its deadline.
+        for state in [
+            ExecutionState::Succeeded,
+            ExecutionState::Failed,
+            ExecutionState::Cancelled,
+            ExecutionState::TimedOut,
+            ExecutionState::Unknown,
+            ExecutionState::Queued,
+        ] {
+            assert!(
+                !verdict_due(&status(state, Some(past.clone())), now),
+                "{state} must not be re-judged"
+            );
+        }
+
+        // Unreadable deadlines wait rather than guess.
+        for unreadable in [None, Some(String::new()), Some("soon".into())] {
+            assert!(!verdict_due(
+                &status(ExecutionState::Running, unreadable),
+                now
+            ));
+        }
+    }
+
+    /// The verdict deadline leaves room for the command itself.
+    ///
+    /// A deadline shorter than the timeout would declare `Unknown` about
+    /// executions that are simply still running, which is the fastest way to
+    /// make the state meaningless.
+    #[test]
+    fn the_verdict_deadline_outlasts_the_command() {
+        let started = chrono::Utc::now();
+        let timeout = chrono::Duration::minutes(10);
+        let deadline = verdict_deadline(started, timeout);
+
+        assert!(deadline > started + timeout);
+        assert_eq!(deadline, started + timeout + VERDICT_GRACE);
+    }
+}

--- a/src/crd/execution.rs
+++ b/src/crd/execution.rs
@@ -1,0 +1,558 @@
+//! Durable, idempotent Sandbox command executions (#82).
+//!
+//! # Why plain `exec` is not enough
+//!
+//! A Kubernetes exec is a connection. If it drops, or the process serving it
+//! restarts, there is no way to answer the only question that matters on a
+//! retry: *did my command already run?* An agent that retries a `terraform
+//! apply` because its connection blipped has done something much worse than
+//! fail.
+//!
+//! So an execution is an **object**, reserved before anything is spawned. The
+//! reservation is what makes "already ran" answerable, and the record is what
+//! makes the answer survive a restart.
+//!
+//! # What is deliberately not stored
+//!
+//! Not the argv, not stdin, not the environment, not the output. A command line
+//! carries secrets routinely — a token in a flag, a connection string in an
+//! argument — and Kubernetes object status is readable by anyone with `get` on
+//! the type, replicated to every etcd member, and included in backups.
+//!
+//! What is stored is a **digest** of the request. That is enough to answer "is
+//! this the same command as last time?" without ever holding the command.
+//!
+//! # Unknown is a real outcome
+//!
+//! If Kobe cannot establish what happened — it crashed between spawning and
+//! recording, or the target stopped answering — the execution becomes
+//! `Unknown`. Not failed, which invites a retry; not succeeded, which is a lie.
+//! `Unknown` is the state that tells a caller they must decide, and it exists
+//! precisely because the alternative is a silent duplicate spawn.
+
+use kube::{CustomResource, KubeSchema};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+/// One command's durable record.
+///
+/// Owner-referenced to its `SandboxLease`, so it cannot outlive the lease it
+/// belongs to: #82 requires history to end with the Sandbox, and an execution
+/// record that survived would describe a workload nobody can inspect.
+#[derive(CustomResource, Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[kube(
+    group = "kobe.kunobi.ninja",
+    version = "v1alpha1",
+    kind = "SandboxExecution",
+    plural = "sandboxexecutions",
+    shortname = "sbxe",
+    status = "SandboxExecutionStatus",
+    namespaced,
+    printcolumn = r#"{"name":"State","type":"string","jsonPath":".status.state"}"#,
+    printcolumn = r#"{"name":"Exit","type":"integer","jsonPath":".status.exitCode"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxExecutionSpec {
+    /// The lease this ran under, by UID. An execution never outlives its exact
+    /// lease: a same-named successor is a different Sandbox, and answering its
+    /// caller with this record would describe somebody else's command.
+    #[schemars(length(min = 1))]
+    pub lease_uid: String,
+
+    /// The Pod it ran in, by UID. Recorded so a replaced Pod invalidates the
+    /// record rather than silently re-pointing it.
+    #[schemars(length(min = 1))]
+    pub pod_uid: String,
+
+    /// Caller-supplied key. Two requests with this key are the same request.
+    #[schemars(length(min = 1, max = 253))]
+    pub idempotency_key: String,
+
+    /// SHA-256 over the canonical request. Never the request itself: a command
+    /// line routinely carries secrets, and object status is readable by anyone
+    /// with `get`, replicated to every etcd member, and included in backups.
+    #[schemars(length(min = 64, max = 64))]
+    pub request_digest: String,
+
+    /// Wall-clock bound the runner enforces.
+    #[schemars(length(min = 1))]
+    pub timeout: String,
+
+    /// Whether the caller waited for the result.
+    #[serde(default)]
+    pub detached: bool,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxExecutionStatus {
+    #[serde(default)]
+    pub state: ExecutionState,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub started_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub finished_at: Option<String>,
+    /// The remote process's exact exit code. Absent unless the command actually
+    /// ran to completion — a synthesised zero would be indistinguishable from
+    /// a real success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// Bounded reason code. Never a raw backend message, and never any part of
+    /// the command's own output.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(max = 64))]
+    pub reason: Option<String>,
+    /// Deadline after which a still-`Running` execution becomes `Unknown`.
+    ///
+    /// Persisted rather than derived, so a restarted controller reaches the
+    /// same verdict as the one that started it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub verdict_deadline: Option<String>,
+}
+
+/// Where an execution is.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+pub enum ExecutionState {
+    /// Reserved, not yet spawned. The state that makes a retry answerable.
+    #[default]
+    Queued,
+    Running,
+    Succeeded,
+    /// Ran and exited non-zero.
+    Failed,
+    /// Cancelled by the caller, or by the lease ending.
+    Cancelled,
+    /// The runner's own bound elapsed.
+    TimedOut,
+    /// Kobe cannot establish what happened.
+    ///
+    /// Not `Failed`, which invites a retry of something that may have run; not
+    /// `Succeeded`, which would be a lie. This is the state that tells a caller
+    /// the decision is theirs.
+    Unknown,
+}
+
+impl std::fmt::Display for ExecutionState {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+// `crdgen` and the reaper binary import this module for its schemas without
+// evaluating lifecycle, so these are unused in those builds.
+#[allow(dead_code)]
+impl ExecutionState {
+    /// Whether the outcome is settled.
+    pub fn is_terminal(self) -> bool {
+        matches!(
+            self,
+            Self::Succeeded | Self::Failed | Self::Cancelled | Self::TimedOut | Self::Unknown
+        )
+    }
+
+    /// Whether this state means the command definitely did not run.
+    ///
+    /// Only `Queued` does. Everything else — including `Unknown` — may have
+    /// side effects, and that distinction is the whole reason a caller cannot
+    /// safely retry on their own.
+    pub fn definitely_did_not_run(self) -> bool {
+        self == Self::Queued
+    }
+}
+
+/// Why a state change was refused.
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum ExecutionTransitionError {
+    #[error("an execution in {from} is already settled and cannot become {to}")]
+    AlreadyTerminal {
+        from: ExecutionState,
+        to: ExecutionState,
+    },
+    #[error("{from} cannot become {to}")]
+    Invalid {
+        from: ExecutionState,
+        to: ExecutionState,
+    },
+    #[error("{state} requires an exit code")]
+    ExitCodeRequired { state: ExecutionState },
+    #[error("{state} must not carry an exit code")]
+    ExitCodeForbidden { state: ExecutionState },
+}
+
+/// Validate one execution state change.
+///
+/// Terminal is terminal. A settled execution that could move again would make
+/// every answer Kobe has already given about it provisional — including the
+/// ones a caller acted on.
+#[allow(dead_code)]
+pub fn transition_execution(
+    from: ExecutionState,
+    to: ExecutionState,
+    exit_code: Option<i32>,
+) -> Result<ExecutionState, ExecutionTransitionError> {
+    use ExecutionState::*;
+
+    if from == to {
+        return Ok(from);
+    }
+    if from.is_terminal() {
+        return Err(ExecutionTransitionError::AlreadyTerminal { from, to });
+    }
+
+    let allowed = matches!(
+        (from, to),
+        (Queued, Running)
+            // Cancelled before it ever ran, and timed out while still queued,
+            // are both real: a caller can cancel during the spawn, and a
+            // spawn that never completes still has to end somewhere.
+            | (Queued, Cancelled)
+            | (Queued, TimedOut)
+            | (Queued, Unknown)
+            | (Running, Succeeded)
+            | (Running, Failed)
+            | (Running, Cancelled)
+            | (Running, TimedOut)
+            | (Running, Unknown)
+    );
+    if !allowed {
+        return Err(ExecutionTransitionError::Invalid { from, to });
+    }
+
+    // An exit code is a claim that the process ran to completion. Attaching one
+    // to a cancelled or unknown execution asserts something nobody observed.
+    match to {
+        Succeeded | Failed if exit_code.is_none() => {
+            return Err(ExecutionTransitionError::ExitCodeRequired { state: to });
+        }
+        Cancelled | TimedOut | Unknown | Running | Queued if exit_code.is_some() => {
+            return Err(ExecutionTransitionError::ExitCodeForbidden { state: to });
+        }
+        _ => {}
+    }
+    Ok(to)
+}
+
+/// The terminal state implied by an exit code.
+///
+/// Zero is success; anything else is a command that ran and said no. A
+/// non-zero exit is emphatically not a Kobe failure, and conflating them would
+/// make a caller's own failing test look like an infrastructure fault.
+#[allow(dead_code)]
+pub fn state_for_exit_code(exit_code: i32) -> ExecutionState {
+    if exit_code == 0 {
+        ExecutionState::Succeeded
+    } else {
+        ExecutionState::Failed
+    }
+}
+
+/// Canonical digest of one execution request.
+///
+/// Covers everything that changes what runs. Two requests sharing an
+/// idempotency key must agree on all of it — otherwise the second is a
+/// different command wearing the first one's name, and returning the first
+/// one's result would be a wrong answer rather than a cached one.
+#[allow(dead_code)]
+pub fn request_digest(argv: &[String], cwd: Option<&str>, timeout: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    // Length-prefixed, so ["a","bc"] and ["ab","c"] cannot collide — an
+    // ambiguity here would let a caller substitute a different command under
+    // the same key.
+    hasher.update((argv.len() as u64).to_be_bytes());
+    for argument in argv {
+        hasher.update((argument.len() as u64).to_be_bytes());
+        hasher.update(argument.as_bytes());
+    }
+    match cwd {
+        Some(cwd) => {
+            hasher.update([1u8]);
+            hasher.update((cwd.len() as u64).to_be_bytes());
+            hasher.update(cwd.as_bytes());
+        }
+        None => hasher.update([0u8]),
+    }
+    hasher.update((timeout.len() as u64).to_be_bytes());
+    hasher.update(timeout.as_bytes());
+    format!("{:x}", hasher.finalize())
+}
+
+/// Whether an existing record answers this request.
+///
+/// Same key and same digest: the caller is retrying, and gets the original.
+/// Same key, different digest: a different command under a reused key, which
+/// is a conflict rather than a new execution — silently running it would give
+/// the caller two commands where they asked for one.
+#[allow(dead_code)]
+pub fn reuse_verdict(
+    existing: &SandboxExecutionSpec,
+    lease_uid: &str,
+    request_digest: &str,
+) -> ReuseVerdict {
+    if existing.lease_uid != lease_uid {
+        // A key from another lease is not this caller's to reuse or conflict
+        // with; it is simply not found here.
+        return ReuseVerdict::Foreign;
+    }
+    if existing.request_digest == request_digest {
+        ReuseVerdict::SameRequest
+    } else {
+        ReuseVerdict::Conflict
+    }
+}
+
+#[allow(dead_code)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ReuseVerdict {
+    /// Return the original execution.
+    SameRequest,
+    /// Refuse: the key is taken by a different command.
+    Conflict,
+    /// Belongs to another lease entirely.
+    Foreign,
+}
+
+/// The execution object's name, derived from lease UID and idempotency key.
+///
+/// Derived so the reservation is a `create`, and a `create` is atomic: two
+/// concurrent retries of the same request race for one name and exactly one
+/// wins. A generated name would need a read-then-write, which is precisely the
+/// pattern that produces duplicate spawns under concurrency.
+///
+/// Hashed rather than concatenated because an idempotency key is caller-
+/// supplied: it can be long, contain characters a Kubernetes name forbids, or
+/// be chosen to collide with another lease's.
+#[allow(dead_code)]
+pub fn execution_name(lease_uid: &str, idempotency_key: &str) -> String {
+    use sha2::{Digest, Sha256};
+
+    let mut hasher = Sha256::new();
+    hasher.update((lease_uid.len() as u64).to_be_bytes());
+    hasher.update(lease_uid.as_bytes());
+    hasher.update(idempotency_key.as_bytes());
+    // 128 bits of a SHA-256, which is not a collision anyone can arrange.
+    format!("sbxe-{:x}", hasher.finalize())[..37].to_string()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use ExecutionState::*;
+
+    fn spec(lease_uid: &str, digest: &str) -> SandboxExecutionSpec {
+        SandboxExecutionSpec {
+            lease_uid: lease_uid.into(),
+            pod_uid: "pod-uid".into(),
+            idempotency_key: "key-1".into(),
+            request_digest: digest.into(),
+            timeout: "60s".into(),
+            detached: false,
+        }
+    }
+
+    /// A settled execution never moves again.
+    ///
+    /// Every answer Kobe has already given about it — to a poll, to a retry —
+    /// would otherwise be provisional, including the ones a caller acted on.
+    #[test]
+    fn terminal_states_are_terminal() {
+        for terminal in [Succeeded, Failed, Cancelled, TimedOut, Unknown] {
+            assert!(terminal.is_terminal());
+            for to in [Running, Succeeded, Failed, Cancelled, TimedOut, Unknown] {
+                if to == terminal {
+                    // Idempotent: re-recording the same outcome is not a
+                    // change, and a controller may well do it after a restart.
+                    assert_eq!(transition_execution(terminal, to, None).unwrap(), terminal);
+                    continue;
+                }
+                assert!(
+                    matches!(
+                        transition_execution(terminal, to, None),
+                        Err(ExecutionTransitionError::AlreadyTerminal { .. })
+                    ),
+                    "{terminal} must not become {to}"
+                );
+            }
+        }
+    }
+
+    /// An exit code is a claim that the process ran to completion.
+    ///
+    /// Requiring one for Succeeded/Failed stops a synthesised zero from being
+    /// indistinguishable from a real success; forbidding it elsewhere stops a
+    /// cancelled or unknown execution from asserting an outcome nobody saw.
+    #[test]
+    fn an_exit_code_is_only_ever_an_observed_one() {
+        assert_eq!(
+            transition_execution(Running, Succeeded, Some(0)).unwrap(),
+            Succeeded
+        );
+        assert_eq!(
+            transition_execution(Running, Failed, Some(1)).unwrap(),
+            Failed
+        );
+
+        for state in [Succeeded, Failed] {
+            assert!(matches!(
+                transition_execution(Running, state, None),
+                Err(ExecutionTransitionError::ExitCodeRequired { .. })
+            ));
+        }
+        for state in [Cancelled, TimedOut, Unknown] {
+            assert!(
+                matches!(
+                    transition_execution(Running, state, Some(0)),
+                    Err(ExecutionTransitionError::ExitCodeForbidden { .. })
+                ),
+                "{state} must not carry an exit code"
+            );
+            assert!(transition_execution(Running, state, None).is_ok());
+        }
+    }
+
+    /// A non-zero exit is the caller's result, not Kobe's failure.
+    ///
+    /// Conflating them makes somebody's own failing test look like an
+    /// infrastructure fault — and, worse, look retryable.
+    #[test]
+    fn a_non_zero_exit_is_a_result_not_a_fault() {
+        assert_eq!(state_for_exit_code(0), Succeeded);
+        for code in [1, 2, 127, 130, 255, -1, i32::MAX, i32::MIN] {
+            assert_eq!(state_for_exit_code(code), Failed, "exit {code}");
+        }
+    }
+
+    /// Only `Queued` proves a command did not run.
+    ///
+    /// This is the distinction a caller needs to decide whether retrying is
+    /// safe, and it is why `Unknown` exists at all: everything but `Queued`
+    /// may have had side effects.
+    #[test]
+    fn only_a_queued_execution_definitely_did_not_run() {
+        assert!(Queued.definitely_did_not_run());
+        for state in [Running, Succeeded, Failed, Cancelled, TimedOut, Unknown] {
+            assert!(
+                !state.definitely_did_not_run(),
+                "{state} may have had side effects"
+            );
+        }
+    }
+
+    /// A reused key with different content is a conflict, not a new command.
+    ///
+    /// Running it would give the caller two commands where they asked for one
+    /// — and returning the first one's result would answer a question they did
+    /// not ask.
+    #[test]
+    fn a_reused_key_with_different_content_conflicts() {
+        let original = spec("lease-a", "digest-1");
+
+        assert_eq!(
+            reuse_verdict(&original, "lease-a", "digest-1"),
+            ReuseVerdict::SameRequest
+        );
+        assert_eq!(
+            reuse_verdict(&original, "lease-a", "digest-2"),
+            ReuseVerdict::Conflict
+        );
+        // Another lease's key is not this caller's to reuse OR to conflict
+        // with; leaking the conflict would confirm the other lease exists.
+        assert_eq!(
+            reuse_verdict(&original, "lease-b", "digest-1"),
+            ReuseVerdict::Foreign
+        );
+    }
+
+    /// The digest covers everything that changes what runs, unambiguously.
+    ///
+    /// Length-prefixing matters: without it `["a","bc"]` and `["ab","c"]`
+    /// hash alike, which would let a caller substitute a different command
+    /// under a key whose first use they already got a result for.
+    #[test]
+    fn the_request_digest_cannot_be_made_to_collide() {
+        let base = request_digest(&["/agent".into(), "run".into()], None, "60s");
+
+        assert_eq!(
+            base,
+            request_digest(&["/agent".into(), "run".into()], None, "60s"),
+            "the same request must digest identically"
+        );
+
+        // Argument boundaries.
+        assert_ne!(base, request_digest(&["/agentrun".into()], None, "60s"));
+        assert_ne!(
+            request_digest(&["a".into(), "bc".into()], None, "60s"),
+            request_digest(&["ab".into(), "c".into()], None, "60s")
+        );
+        // Order.
+        assert_ne!(
+            base,
+            request_digest(&["run".into(), "/agent".into()], None, "60s")
+        );
+        // Working directory, including present-but-empty versus absent.
+        assert_ne!(
+            base,
+            request_digest(&["/agent".into(), "run".into()], Some("/work"), "60s")
+        );
+        assert_ne!(
+            base,
+            request_digest(&["/agent".into(), "run".into()], Some(""), "60s")
+        );
+        // Timeout: the same command with a different bound is a different
+        // request, because its outcome can differ.
+        assert_ne!(
+            base,
+            request_digest(&["/agent".into(), "run".into()], None, "600s")
+        );
+
+        assert_eq!(base.len(), 64);
+    }
+
+    /// Names are derived and fenced, so the reservation can be a `create`.
+    ///
+    /// A generated name would need read-then-write, which is exactly the
+    /// pattern that produces duplicate spawns under concurrent retries.
+    #[test]
+    fn execution_names_are_derived_fenced_and_valid() {
+        let name = execution_name("lease-uid-1", "key-1");
+        assert_eq!(name, execution_name("lease-uid-1", "key-1"));
+
+        // One lease's key cannot name another's execution.
+        assert_ne!(name, execution_name("lease-uid-2", "key-1"));
+        assert_ne!(name, execution_name("lease-uid-1", "key-2"));
+
+        // A caller-supplied key can be long, oddly cased, or full of
+        // characters a Kubernetes name forbids. None of that reaches the name.
+        for hostile in [
+            "../../etc/passwd",
+            "UPPER",
+            &"x".repeat(4096),
+            "with spaces",
+            "with/slash",
+            "",
+        ] {
+            let name = execution_name("lease-uid-1", hostile);
+            assert!(name.len() <= 253, "{name} is too long");
+            assert!(
+                name.chars()
+                    .all(|c| c.is_ascii_lowercase() || c.is_ascii_digit() || c == '-'),
+                "{name} is not a valid object name"
+            );
+            assert!(name.starts_with("sbxe-"));
+        }
+
+        // Concatenation would let one lease's key collide with another's by
+        // moving the boundary; the length prefix prevents it.
+        assert_ne!(
+            execution_name("ab", "c"),
+            execution_name("a", "bc"),
+            "the lease/key boundary must be unambiguous"
+        );
+    }
+}

--- a/src/crd/mod.rs
+++ b/src/crd/mod.rs
@@ -3,6 +3,7 @@ pub mod bootstrap_config;
 pub mod cidr;
 #[allow(dead_code)]
 pub mod datastore;
+pub mod execution;
 pub mod instance;
 pub mod lease;
 pub mod profile;
@@ -19,6 +20,7 @@ pub use bootstrap_config::*;
 pub use cidr::*;
 #[allow(unused_imports)]
 pub use datastore::*;
+pub use execution::*;
 pub use instance::*;
 pub use lease::*;
 pub use profile::*;

--- a/src/crdgen.rs
+++ b/src/crdgen.rs
@@ -47,6 +47,10 @@ fn main() {
             "{}",
             serde_yaml_ng::to_string(&crd::SandboxLease::crd()).unwrap()
         ),
+        "sandboxexecutions" => print!(
+            "{}",
+            serde_yaml_ng::to_string(&crd::SandboxExecution::crd()).unwrap()
+        ),
         _ => {
             print!(
                 "{}",
@@ -96,6 +100,11 @@ fn main() {
             print!(
                 "{}",
                 serde_yaml_ng::to_string(&crd::SandboxLease::crd()).unwrap()
+            );
+            println!("---");
+            print!(
+                "{}",
+                serde_yaml_ng::to_string(&crd::SandboxExecution::crd()).unwrap()
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -265,6 +265,24 @@ async fn main() -> anyhow::Result<()> {
         // cancel connections it is holding itself — the socket lives in one
         // process — so a leader-elected revoker would leave live streams on
         // every other replica with nobody watching them.
+        // Executions left Running by a process that disappeared are settled
+        // here. The reserve-then-spawn order buys "never a duplicate spawn"
+        // and pays for it with records nobody is left to finish; this is what
+        // turns those into an honest `Unknown` rather than a poll that never
+        // ends.
+        let execution_reaper_client = client.clone();
+        let execution_reaper_ns = namespace.clone();
+        let execution_reaper_shutdown = shutdown.clone();
+        tokio::spawn(async move {
+            api::sandbox_executions::run_execution_reaper(
+                execution_reaper_client,
+                &execution_reaper_ns,
+                std::time::Duration::from_secs(60),
+                execution_reaper_shutdown,
+            )
+            .await;
+        });
+
         let revoker_client = client.clone();
         let revoker_ns = namespace.clone();
         let revoker_shutdown = shutdown.clone();


### PR DESCRIPTION
Core of #82 · **stacked on #130**
Epic: #70 — Agent Sandbox · Parent: #75

A Kubernetes exec is a *connection*. If it drops, there is no way to answer the only question that matters on a retry: **did my command already run?** An agent that re-runs `terraform apply` because its connection blipped has done something far worse than fail.

## The order is the entire guarantee

```
reserve the idempotency key  →  spawn  →  record the outcome
```

Spawning first and recording afterwards is the obvious implementation, and it is wrong in exactly the case that matters: a crash between the two leaves no trace that anything ran, so the retry runs it again.

Reserving first inverts that. A crash leaves a record saying "this may have run", the retry finds it, and nobody spawns twice. The cost is that some executions end in `Unknown` — which is the honest answer, and the one #82 asks for.

**The reservation is a `create`**, on a name derived from lease UID and key — not a read-then-write. Two concurrent retries race for one object and the API server picks a winner. Read-then-write is the classic way to get two spawns from one idempotency key.

## What is deliberately not stored

Not the argv, not stdin, not the environment, not the output — only a **digest** of the request. Command lines carry secrets routinely (a token in a flag, a connection string in an argument), and Kubernetes object status is readable by anyone with `get` on the type, replicated to every etcd member, and included in backups. The digest still answers "is this the same command as last time?" without ever holding the command.

The digest is **length-prefixed**, so `["a","bc"]` and `["ab","c"]` cannot collide. Without that, a caller could substitute a different command under a key whose first use they already have a result for.

## Conflict, not silent reuse

Same key + same digest → the original execution. Same key + **different** digest → `409`. Running it would give the caller two commands where they asked for one; returning the first one's result would answer a question they did not ask.

A key belonging to **another lease** is simply not found. Reporting a conflict would confirm the other lease exists.

## `Unknown` is a first-class outcome

Declared on a **persisted** deadline — so a restarted controller reaches the same verdict as the one that started the execution — and never guessed. An unreadable deadline waits, because polling is recoverable and a wrong `Unknown` is not.

Not `Failed`, which invites retrying something that may already have had effects. Not `Succeeded`, which would be a lie. `Unknown` is the state that tells a caller the decision is theirs.

**Only `Queued` proves a command did not run.** That is the distinction a caller needs to decide whether retrying is safe, and it is why every other state — including `Unknown` — refuses to spawn again.

## Other decisions

- **Terminal is terminal.** A settled execution that could move again would make every answer Kobe already gave about it provisional, including ones a caller acted on.
- **An exit code is a claim the process ran to completion**: required for `Succeeded`/`Failed`, forbidden for `Cancelled`/`TimedOut`/`Unknown`. A synthesised zero would be indistinguishable from a real success.
- **`cwd` is an absolute path with no nul**, and never implemented with a shell — `cd X && ...` would make quoting the security boundary. The runner validates it too; this is the sanity check, not the enforcement.
- **Execution names are hashed** from lease UID and key, so a caller-supplied key cannot escape into an object name, exceed the length limit, or collide across leases.
- **Records are owner-referenced to their lease**, so history ends with the Sandbox rather than describing a workload nobody can inspect.

An **execution reaper** settles records left `Running` by a process that disappeared. It runs on every replica and is idempotent — a settled execution is never re-judged — so several replicas reaching the same verdict is a no-op.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1509 passed, 0 failed
```

Mutation-checked: ignoring a digest conflict, collapsing the digest's argument boundaries, letting a running execution spawn again, and declaring `Unknown` without a deadline — each fails its tests.

## Two deviations, stated plainly

**The key is reserved in Kobe's API, not in the target.** #82 asks for the target. Doing so needs a writable, durable path inside a container Kobe does not control — the runner contract this issue itself defers — and the difference would only matter if two independent Kobe deployments could drive one Sandbox, which they cannot. Reserving in Kobe is durable, atomic, and available today.

**Detached execution is refused with `501`.** It needs a supervisor inside the container that outlives the connection. A "detached" execution that actually dies with its connection is *worse* than none, because a caller builds on the guarantee it appears to offer. Wait mode is fully implemented and carries every idempotency guarantee above.

## Against #82's acceptance criteria

| Criterion | |
|---|---|
| Wait mode returns distinct stdout/stderr and the exit status | ✅ |
| Reusing one key cannot start a duplicate across retries or restarts | ✅ |
| Conflicting content for one key is rejected | ✅ |
| Lost/unverifiable outcomes report `Unknown`, never success or auto-retry | ✅ |
| `cwd` validated, never an implicit shell | ✅ |
| Output, arguments, stdin, environment, credentials absent from status/events/logs | ✅ |
| Foreign identity, stale UID, release, expiry, quarantine deny | ✅ via #81 |
| Resource/output/concurrency bounds | ✅ output, timeout, concurrency |
| Detached survives disconnect; poll, log tail, cancel | ⚠️ poll and cancel yes; **detach and log tail need the runner** |
| Failure injection across crash-before-spawn / after-spawn / after-ack | ⚠️ the *states* are covered by unit tests; injected crashes need the integration harness in #76 |
| Timeout/cancel terminates the process group | ⚠️ cancel is recorded and the connection dropped; **killing the process group needs the runner** |

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.