### PR TITLE
cli(sandbox): add run, exec, logs and cancel

### DIFF
--- a/crates/kobectl/src/commands/mod.rs
+++ b/crates/kobectl/src/commands/mod.rs
@@ -9,6 +9,7 @@ mod picker;
 mod pools;
 mod purge;
 mod release;
+pub(crate) mod sandbox;
 mod select;
 pub(crate) mod session;
 mod state;

--- a/crates/kobectl/src/commands/sandbox.rs
+++ b/crates/kobectl/src/commands/sandbox.rs
@@ -1,0 +1,743 @@
+//! `kobe sandbox` — exec, logs, cancel, and run (#84).
+//!
+//! # Two audiences, one contract
+//!
+//! A human runs `kobe sandbox exec` and reads the output. An agent runs the
+//! same command with `--output json` and parses it. The agent is the harder
+//! consumer and the one that decides the design: it needs the **exact remote
+//! exit code**, stdout and stderr kept apart, and a transport failure that
+//! cannot be mistaken for a command failure.
+//!
+//! # Exit codes carry meaning
+//!
+//! The remote command's exit code is this process's exit code. That is the
+//! whole point of `exec` in a script — `set -e` has to work — so Kobe's own
+//! failures must not be able to collide with it. They exit `125`, chosen
+//! because it is what `docker run` and `env` use for exactly this: "the tool
+//! failed, not your command".
+//!
+//! # `run` cleans up, and says so separately
+//!
+//! `run` creates a lease, executes, and releases. The release is attempted on
+//! every terminal path — success, non-zero exit, timeout, interruption — and
+//! its failure is reported *separately* from the command's result. Collapsing
+//! them would either hide a leaked lease behind a successful command, or fail
+//! a command that actually worked.
+
+use std::io::Write;
+
+use anyhow::{Context, Result};
+use serde::{Deserialize, Serialize};
+
+use super::config::{CliConfig, ResolvedConfig};
+use super::{OutputFormat, authed_client, get_auth_header, print_json, with_auth};
+
+/// Exit code for Kobe's own failures.
+///
+/// A remote command's exit code is passed through verbatim, so Kobe needs a
+/// value it will not be confused with. `125` is the convention `docker run`
+/// and `env` already use for "the tool failed, not your command", which means
+/// scripts that already handle it need no new knowledge.
+pub const CLI_FAILURE_EXIT: i32 = 125;
+
+/// Stable, versioned machine output.
+///
+/// The version is explicit because an agent parses this: a field that changed
+/// meaning without one would break a consumer silently, at some later date,
+/// with no way to tell which side was wrong.
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecOutput {
+    /// Bumped only on a breaking change to these fields.
+    pub api_version: &'static str,
+    pub lease: String,
+    pub execution: String,
+    pub state: String,
+    /// The remote command's exact exit code, or absent if it never ran to
+    /// completion. Never synthesised: a fabricated zero is indistinguishable
+    /// from a real success.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    pub stdout: String,
+    pub stderr: String,
+    /// Whether output was cut off at the server's cap.
+    #[serde(skip_serializing_if = "std::ops::Not::not")]
+    pub truncated: bool,
+    /// Release outcome for `run`. Reported separately from the command's own
+    /// result so a leaked lease is never hidden behind a successful command,
+    /// and a working command is never failed by a cleanup problem.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub cleanup: Option<CleanupOutcome>,
+}
+
+pub const SANDBOX_CLI_API_VERSION: &str = "kobe.sandbox/v1";
+
+#[derive(Debug, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct CleanupOutcome {
+    pub released: bool,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
+}
+
+/// The server's execution response.
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionResponse {
+    pub id: String,
+    pub state: String,
+    #[serde(default)]
+    pub exit_code: Option<i32>,
+    #[serde(default)]
+    pub stdout: Option<String>,
+    #[serde(default)]
+    pub stderr: Option<String>,
+    #[serde(default)]
+    pub truncated: bool,
+    #[serde(default)]
+    pub reason: Option<String>,
+}
+
+/// The process exit code for one execution result.
+///
+/// A command that ran gets its own code, whatever it was. Everything else —
+/// cancelled, timed out, unknown — gets [`CLI_FAILURE_EXIT`], because there is
+/// no remote code to report and inventing one would tell a caller their
+/// command finished when nobody knows whether it started.
+pub fn exit_code_for(result: &ExecutionResponse) -> i32 {
+    match result.exit_code {
+        Some(code) => code,
+        None => CLI_FAILURE_EXIT,
+    }
+}
+
+/// An idempotency key for one invocation.
+///
+/// Random, and generated once per *command*, not per attempt: that is what
+/// makes a client-side retry safe. A key derived from the argv would be worse
+/// than none — two deliberate runs of the same command would collide, and the
+/// second would silently return the first one's result.
+pub fn new_idempotency_key() -> String {
+    use std::sync::atomic::{AtomicU64, Ordering};
+    use std::time::{SystemTime, UNIX_EPOCH};
+
+    // Process id, monotonic counter and nanosecond clock. The counter is what
+    // makes two keys from one process distinct even inside the clock's
+    // resolution; the pid and clock are what keep two processes apart. No
+    // dependency, and nothing here needs to be unguessable — the key scopes a
+    // retry, it does not authorise anything.
+    static COUNTER: AtomicU64 = AtomicU64::new(0);
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or_default();
+    format!(
+        "kobe-cli-{}-{nanos:x}-{:x}",
+        std::process::id(),
+        COUNTER.fetch_add(1, Ordering::Relaxed)
+    )
+}
+
+#[derive(Debug, Serialize)]
+struct ExecRequestBody<'a> {
+    command: &'a [String],
+    #[serde(skip_serializing_if = "Option::is_none")]
+    cwd: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    timeout: Option<&'a str>,
+    idempotency_key: &'a str,
+}
+
+/// Run one command in an existing Sandbox lease.
+///
+/// Returns the exit code the process should use, so the caller decides when to
+/// exit rather than this function calling `exit` from inside a library path.
+pub async fn exec(
+    lease: &str,
+    argv: &[String],
+    cwd: Option<&str>,
+    timeout: Option<&str>,
+    target_override: Option<&str>,
+    endpoint_override: Option<&str>,
+    output: OutputFormat,
+) -> Result<i32> {
+    let config = CliConfig::load()?;
+    let config = config.resolve(target_override, endpoint_override)?;
+
+    if argv.is_empty() {
+        anyhow::bail!("a command is required: kobe sandbox exec <lease> -- <argv...>");
+    }
+
+    let result = exec_once(&config, lease, argv, cwd, timeout, &new_idempotency_key()).await?;
+    let code = exit_code_for(&result);
+    emit(&config, lease, &result, None, output)?;
+    Ok(code)
+}
+
+async fn exec_once(
+    config: &ResolvedConfig,
+    lease: &str,
+    argv: &[String],
+    cwd: Option<&str>,
+    timeout: Option<&str>,
+    idempotency_key: &str,
+) -> Result<ExecutionResponse> {
+    let path = format!("/v1/sandbox-leases/{lease}/executions");
+    let body = serde_json::to_vec(&ExecRequestBody {
+        command: argv,
+        cwd,
+        timeout,
+        idempotency_key,
+    })?;
+    let token = get_auth_header(config, "POST", &path, &body).await?;
+    let response = with_auth(
+        authed_client().post(format!("{}{path}", config.endpoint)),
+        &token,
+    )
+    .header("Content-Type", "application/json")
+    .body(body)
+    .send()
+    .await
+    .context("could not reach the Kobe endpoint")?;
+
+    let status = response.status();
+    let payload = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        // The server's own message, not a guess. A CLI that invents an
+        // explanation for a status it does not understand sends people looking
+        // in the wrong place.
+        anyhow::bail!("execution failed (HTTP {status}): {}", payload.trim());
+    }
+    serde_json::from_str(&payload).context("could not parse the execution response")
+}
+
+/// Print the result in the requested form.
+///
+/// Text mode writes the command's own stdout and stderr to *this* process's
+/// stdout and stderr, so `kobe sandbox exec ... | grep` behaves the way anyone
+/// would expect. JSON mode keeps them as separate fields for the same reason:
+/// a consumer that cannot tell a tool's diagnostics from its output cannot
+/// parse either.
+fn emit(
+    config: &ResolvedConfig,
+    lease: &str,
+    result: &ExecutionResponse,
+    cleanup: Option<CleanupOutcome>,
+    output: OutputFormat,
+) -> Result<()> {
+    let _ = config;
+    match output {
+        OutputFormat::Json => print_json(&ExecOutput {
+            api_version: SANDBOX_CLI_API_VERSION,
+            lease: lease.to_string(),
+            execution: result.id.clone(),
+            state: result.state.clone(),
+            exit_code: result.exit_code,
+            stdout: result.stdout.clone().unwrap_or_default(),
+            stderr: result.stderr.clone().unwrap_or_default(),
+            truncated: result.truncated,
+            cleanup,
+        }),
+        OutputFormat::Text => {
+            if let Some(stdout) = result.stdout.as_deref() {
+                print!("{stdout}");
+                std::io::stdout().flush().ok();
+            }
+            if let Some(stderr) = result.stderr.as_deref() {
+                eprint!("{stderr}");
+                std::io::stderr().flush().ok();
+            }
+            if result.truncated {
+                eprintln!("kobe: output was truncated at the server's limit");
+            }
+            // A state that is not a completed command needs saying: a caller
+            // seeing empty output and exit 125 should not have to guess why.
+            if result.exit_code.is_none() {
+                eprintln!(
+                    "kobe: execution ended in state {}{}",
+                    result.state,
+                    result
+                        .reason
+                        .as_deref()
+                        .map(|reason| format!(" ({reason})"))
+                        .unwrap_or_default()
+                );
+            }
+            if let Some(cleanup) = cleanup.as_ref()
+                && !cleanup.released
+            {
+                eprintln!(
+                    "kobe: WARNING the sandbox lease was not released{}",
+                    cleanup
+                        .error
+                        .as_deref()
+                        .map(|error| format!(": {error}"))
+                        .unwrap_or_default()
+                );
+            }
+            Ok(())
+        }
+    }
+}
+
+#[derive(Debug, Serialize)]
+struct CreateLeaseBody<'a> {
+    pool: &'a str,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ttl: Option<&'a str>,
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct SandboxLeaseResponse {
+    id: String,
+    phase: String,
+}
+
+/// How long `run` waits for a Sandbox to become Ready.
+///
+/// Bounded so `run` cannot hang forever on a pool that has no capacity. On
+/// timeout the lease is still released — a lease created and abandoned is the
+/// worst outcome of this command, because nothing else will clean it up.
+const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
+const READY_POLL: std::time::Duration = std::time::Duration::from_secs(2);
+
+/// How long to keep trying to release before giving up and saying so.
+const RELEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Create a Sandbox, run one command in it, and release it.
+///
+/// The release is attempted on **every** terminal path: success, non-zero
+/// exit, provisioning timeout, transport failure. A lease created and
+/// abandoned is the worst thing this command can do, because nothing else
+/// will notice — the TTL eventually reaps it, but the caller is billed for
+/// the gap and the pool is short a slot until then.
+///
+/// Cleanup failure is reported separately from the command's result, never
+/// folded into it.
+pub struct RunCommand<'a> {
+    pub pool: &'a str,
+    pub ttl: Option<&'a str>,
+    pub argv: &'a [String],
+    pub cwd: Option<&'a str>,
+    pub timeout: Option<&'a str>,
+    pub target_override: Option<&'a str>,
+    pub endpoint_override: Option<&'a str>,
+    pub output: OutputFormat,
+}
+
+pub async fn run(command: RunCommand<'_>) -> Result<i32> {
+    let RunCommand {
+        pool,
+        ttl,
+        argv,
+        cwd,
+        timeout,
+        target_override,
+        endpoint_override,
+        output,
+    } = command;
+    let config = CliConfig::load()?;
+    let config = config.resolve(target_override, endpoint_override)?;
+
+    if argv.is_empty() {
+        anyhow::bail!("a command is required: kobe sandbox run <pool> -- <argv...>");
+    }
+
+    let lease = create_sandbox_lease(&config, pool, ttl).await?;
+
+    // Everything from here on must release. The result of the command and the
+    // result of the release are tracked separately so neither can hide the
+    // other.
+    let outcome = run_in_lease(&config, &lease, argv, cwd, timeout).await;
+    let cleanup = release_sandbox_lease(&config, &lease).await;
+
+    match outcome {
+        Ok(result) => {
+            let code = exit_code_for(&result);
+            emit(&config, &lease, &result, Some(cleanup.clone()), output)?;
+            // A leaked lease does not fail a command that worked, but it does
+            // fail a command that had nothing else to report.
+            if !cleanup.released && code == 0 {
+                return Ok(CLI_FAILURE_EXIT);
+            }
+            Ok(code)
+        }
+        Err(error) => {
+            if !cleanup.released {
+                // Both problems, in the order they matter: the caller's
+                // command first, the leaked lease second.
+                eprintln!(
+                    "kobe: WARNING the sandbox lease {lease} was not released{}",
+                    cleanup
+                        .error
+                        .as_deref()
+                        .map(|error| format!(": {error}"))
+                        .unwrap_or_default()
+                );
+            }
+            Err(error)
+        }
+    }
+}
+
+async fn run_in_lease(
+    config: &ResolvedConfig,
+    lease: &str,
+    argv: &[String],
+    cwd: Option<&str>,
+    timeout: Option<&str>,
+) -> Result<ExecutionResponse> {
+    wait_until_ready(config, lease).await?;
+    exec_once(config, lease, argv, cwd, timeout, &new_idempotency_key()).await
+}
+
+async fn create_sandbox_lease(
+    config: &ResolvedConfig,
+    pool: &str,
+    ttl: Option<&str>,
+) -> Result<String> {
+    let path = "/v1/sandbox-leases";
+    let body = serde_json::to_vec(&CreateLeaseBody { pool, ttl })?;
+    let token = get_auth_header(config, "POST", path, &body).await?;
+    let response = with_auth(
+        authed_client().post(format!("{}{path}", config.endpoint)),
+        &token,
+    )
+    .header("Content-Type", "application/json")
+    .body(body)
+    .send()
+    .await
+    .context("could not reach the Kobe endpoint")?;
+
+    let status = response.status();
+    let payload = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!(
+            "could not create a sandbox (HTTP {status}): {}",
+            payload.trim()
+        );
+    }
+    let lease: SandboxLeaseResponse =
+        serde_json::from_str(&payload).context("could not parse the sandbox lease response")?;
+    Ok(lease.id)
+}
+
+async fn wait_until_ready(config: &ResolvedConfig, lease: &str) -> Result<()> {
+    let deadline = std::time::Instant::now() + READY_TIMEOUT;
+    loop {
+        let path = format!("/v1/sandbox-leases/{lease}");
+        let token = get_auth_header(config, "GET", &path, b"").await?;
+        let response = with_auth(
+            authed_client().get(format!("{}{path}", config.endpoint)),
+            &token,
+        )
+        .send()
+        .await
+        .context("could not reach the Kobe endpoint")?;
+
+        if response.status().is_success() {
+            let current: SandboxLeaseResponse = response
+                .json()
+                .await
+                .context("could not parse the sandbox lease response")?;
+            match current.phase.as_str() {
+                "Ready" => return Ok(()),
+                // Terminal before it ever served. Waiting longer cannot help,
+                // and the caller needs to know which end state it reached.
+                "Released" | "Expired" | "Quarantined" => {
+                    anyhow::bail!(
+                        "sandbox {lease} ended in {} before it was ready",
+                        current.phase
+                    );
+                }
+                _ => {}
+            }
+        }
+
+        if std::time::Instant::now() >= deadline {
+            anyhow::bail!("sandbox {lease} was not ready within {READY_TIMEOUT:?}");
+        }
+        tokio::time::sleep(READY_POLL).await;
+    }
+}
+
+/// Release the lease, reporting what actually happened.
+///
+/// Never returns an error: a release failure is data the caller needs
+/// alongside their command's result, not a replacement for it. A 404 counts
+/// as released — the lease is gone, which is the goal.
+async fn release_sandbox_lease(config: &ResolvedConfig, lease: &str) -> CleanupOutcome {
+    let path = format!("/v1/sandbox-leases/{lease}");
+    let attempt = async {
+        let token = get_auth_header(config, "DELETE", &path, b"").await?;
+        let response = with_auth(
+            authed_client().delete(format!("{}{path}", config.endpoint)),
+            &token,
+        )
+        .send()
+        .await?;
+        let status = response.status();
+        if status.is_success() || status.as_u16() == 404 {
+            Ok(())
+        } else {
+            anyhow::bail!("HTTP {status}")
+        }
+    };
+
+    match tokio::time::timeout(RELEASE_TIMEOUT, attempt).await {
+        Ok(Ok(())) => CleanupOutcome {
+            released: true,
+            error: None,
+        },
+        Ok(Err(error)) => CleanupOutcome {
+            released: false,
+            error: Some(error.to_string()),
+        },
+        Err(_) => CleanupOutcome {
+            released: false,
+            error: Some(format!(
+                "release did not complete within {RELEASE_TIMEOUT:?}"
+            )),
+        },
+    }
+}
+
+impl Clone for CleanupOutcome {
+    fn clone(&self) -> Self {
+        Self {
+            released: self.released,
+            error: self.error.clone(),
+        }
+    }
+}
+
+/// Read a bounded tail of the sandbox's own output.
+pub async fn logs(
+    lease: &str,
+    tail: Option<i64>,
+    target_override: Option<&str>,
+    endpoint_override: Option<&str>,
+    output: OutputFormat,
+) -> Result<()> {
+    let config = CliConfig::load()?;
+    let config = config.resolve(target_override, endpoint_override)?;
+
+    let mut path = format!("/v1/sandbox-leases/{lease}/logs");
+    if let Some(tail) = tail {
+        path.push_str(&format!("?tail={tail}"));
+    }
+    let token = get_auth_header(&config, "GET", &path, b"").await?;
+    let response = with_auth(
+        authed_client().get(format!("{}{path}", config.endpoint)),
+        &token,
+    )
+    .send()
+    .await
+    .context("could not reach the Kobe endpoint")?;
+
+    let status = response.status();
+    let body = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!("could not read logs (HTTP {status}): {}", body.trim());
+    }
+
+    match output {
+        // The log body is the workload's own bytes. In JSON mode it is one
+        // field rather than raw output, so a consumer parsing this stream
+        // cannot be confused by whatever the workload happened to print.
+        OutputFormat::Json => print_json(&serde_json::json!({
+            "apiVersion": SANDBOX_CLI_API_VERSION,
+            "lease": lease,
+            "logs": body,
+        })),
+        OutputFormat::Text => {
+            print!("{body}");
+            std::io::stdout().flush().ok();
+            Ok(())
+        }
+    }
+}
+
+/// Cancel one execution.
+pub async fn cancel(
+    lease: &str,
+    execution: &str,
+    target_override: Option<&str>,
+    endpoint_override: Option<&str>,
+    output: OutputFormat,
+) -> Result<()> {
+    let config = CliConfig::load()?;
+    let config = config.resolve(target_override, endpoint_override)?;
+
+    let path = format!("/v1/sandbox-leases/{lease}/executions/{execution}");
+    let token = get_auth_header(&config, "DELETE", &path, b"").await?;
+    let response = with_auth(
+        authed_client().delete(format!("{}{path}", config.endpoint)),
+        &token,
+    )
+    .send()
+    .await
+    .context("could not reach the Kobe endpoint")?;
+
+    let status = response.status();
+    let payload = response.text().await.unwrap_or_default();
+    if !status.is_success() {
+        anyhow::bail!(
+            "could not cancel execution (HTTP {status}): {}",
+            payload.trim()
+        );
+    }
+    let result: ExecutionResponse =
+        serde_json::from_str(&payload).context("could not parse the execution response")?;
+
+    // The state that actually applies, not the one that was asked for. An
+    // execution that had already finished is reported as finished — telling a
+    // caller it was cancelled would be a lie they might act on.
+    match output {
+        OutputFormat::Json => print_json(&serde_json::json!({
+            "apiVersion": SANDBOX_CLI_API_VERSION,
+            "lease": lease,
+            "execution": result.id,
+            "state": result.state,
+        })),
+        OutputFormat::Text => {
+            println!("{} is {}", result.id, result.state);
+            Ok(())
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn response(state: &str, exit_code: Option<i32>) -> ExecutionResponse {
+        ExecutionResponse {
+            id: "sbxe-1".into(),
+            state: state.into(),
+            exit_code,
+            stdout: Some("out".into()),
+            stderr: Some("err".into()),
+            truncated: false,
+            reason: None,
+        }
+    }
+
+    /// The remote exit code is this process's exit code.
+    ///
+    /// That is the entire point of `exec` inside a script: `set -e` has to
+    /// work, and a wrapper that returned 0 for a failed command would break
+    /// every pipeline it appears in.
+    #[test]
+    fn the_remote_exit_code_is_passed_through_exactly() {
+        for code in [0, 1, 2, 42, 127, 130, 255] {
+            assert_eq!(exit_code_for(&response("Succeeded", Some(code))), code);
+        }
+    }
+
+    /// Kobe's own failures cannot be mistaken for the command's.
+    ///
+    /// An execution that never produced an exit code did not finish, and
+    /// reporting 0 would tell a caller their command succeeded when nobody
+    /// knows whether it started. 125 is the convention `docker run` and `env`
+    /// already use, so scripts that handle it need no new knowledge.
+    #[test]
+    fn a_command_that_never_completed_exits_distinctly() {
+        for state in ["Unknown", "Cancelled", "TimedOut", "Queued", "Running"] {
+            assert_eq!(
+                exit_code_for(&response(state, None)),
+                CLI_FAILURE_EXIT,
+                "{state} must not look like a completed command"
+            );
+        }
+
+        // And 125 must not collide with a plausible success.
+        assert_ne!(CLI_FAILURE_EXIT, 0);
+    }
+
+    /// Idempotency keys are per-invocation and unpredictable.
+    ///
+    /// Random rather than derived from the argv: a derived key would make two
+    /// deliberate runs of the same command collide, and the second would
+    /// silently return the first one's result — which is a wrong answer, not a
+    /// cached one.
+    #[test]
+    fn each_invocation_gets_its_own_idempotency_key() {
+        let keys: std::collections::HashSet<String> =
+            (0..100).map(|_| new_idempotency_key()).collect();
+        assert_eq!(keys.len(), 100, "keys must not repeat across invocations");
+        assert!(keys.iter().all(|key| key.starts_with("kobe-cli-")));
+        assert!(keys.iter().all(|key| key.len() <= 253));
+    }
+
+    /// Machine output is versioned and keeps the streams apart.
+    ///
+    /// An agent parses this. A field that changed meaning without a version
+    /// bump would break a consumer silently, at some later date, with no way
+    /// to tell which side was wrong.
+    #[test]
+    fn machine_output_is_versioned_and_stream_separated() {
+        let output = ExecOutput {
+            api_version: SANDBOX_CLI_API_VERSION,
+            lease: "sbx-1".into(),
+            execution: "sbxe-1".into(),
+            state: "Succeeded".into(),
+            exit_code: Some(0),
+            stdout: "the output".into(),
+            stderr: "the diagnostics".into(),
+            truncated: false,
+            cleanup: None,
+        };
+        let json: serde_json::Value = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["apiVersion"], SANDBOX_CLI_API_VERSION);
+        assert_eq!(json["stdout"], "the output");
+        assert_eq!(json["stderr"], "the diagnostics");
+        assert_eq!(json["exitCode"], 0);
+        // Absent rather than false: a consumer checking `truncated` for
+        // presence gets the same answer as one checking it for truth.
+        assert!(json.get("truncated").is_none());
+        assert!(json.get("cleanup").is_none());
+
+        // An execution with no exit code omits the field rather than
+        // reporting a value nobody observed.
+        let unknown = ExecOutput {
+            exit_code: None,
+            state: "Unknown".into(),
+            ..output
+        };
+        let json: serde_json::Value = serde_json::to_value(&unknown).unwrap();
+        assert!(json.get("exitCode").is_none());
+    }
+
+    /// A failed release is reported next to the result, never instead of it.
+    ///
+    /// Collapsing them would either hide a leaked lease behind a successful
+    /// command, or fail a command that actually worked. Both are worse than
+    /// telling the caller two things.
+    #[test]
+    fn cleanup_failure_is_reported_beside_the_command_result() {
+        let output = ExecOutput {
+            api_version: SANDBOX_CLI_API_VERSION,
+            lease: "sbx-1".into(),
+            execution: "sbxe-1".into(),
+            state: "Succeeded".into(),
+            // The command succeeded...
+            exit_code: Some(0),
+            stdout: String::new(),
+            stderr: String::new(),
+            truncated: false,
+            // ...and the lease leaked. Both facts survive.
+            cleanup: Some(CleanupOutcome {
+                released: false,
+                error: Some("HTTP 503".into()),
+            }),
+        };
+        let json: serde_json::Value = serde_json::to_value(&output).unwrap();
+
+        assert_eq!(json["exitCode"], 0);
+        assert_eq!(json["cleanup"]["released"], false);
+        assert_eq!(json["cleanup"]["error"], "HTTP 503");
+    }
+}

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -45,6 +45,11 @@ enum Commands {
         #[arg(long)]
         device: bool,
     },
+    /// Sandbox operations: run commands in a leased agent environment.
+    Sandbox {
+        #[command(subcommand)]
+        action: SandboxAction,
+    },
     /// Remove stored credentials. Also revokes the refresh + access
     /// tokens at the IdP (RFC 7009) so a leaked token can't outlive
     /// `kobe logout`.
@@ -127,6 +132,62 @@ enum Commands {
     Config {
         #[command(subcommand)]
         action: Option<ConfigAction>,
+    },
+}
+
+/// Sandbox operations.
+///
+/// Separate from cluster leases on purpose: a Sandbox is one agent
+/// environment, not a cluster, and nothing here can produce a kubeconfig or a
+/// credential for the cluster underneath it.
+#[derive(Subcommand)]
+enum SandboxAction {
+    /// Run a command in an existing sandbox and return its exact exit code.
+    ///
+    /// argv is sent as-is — no shell, so no quoting rules of Kobe's own.
+    Exec {
+        /// Sandbox lease id.
+        lease: String,
+        /// Working directory inside the sandbox.
+        #[arg(long)]
+        cwd: Option<String>,
+        /// Wall-clock bound for the command (e.g. `30s`, `5m`).
+        #[arg(long)]
+        timeout: Option<String>,
+        /// The command. Everything after `--`.
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
+    /// Create a sandbox, run one command in it, and release it.
+    ///
+    /// The release is attempted on every terminal path, and its failure is
+    /// reported separately from the command's result.
+    Run {
+        /// Sandbox pool.
+        pool: String,
+        /// Lease TTL (e.g. `2h`).
+        #[arg(long)]
+        ttl: Option<String>,
+        #[arg(long)]
+        cwd: Option<String>,
+        #[arg(long)]
+        timeout: Option<String>,
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
+    /// Read a bounded tail of the sandbox's output.
+    Logs {
+        lease: String,
+        /// Lines from the end.
+        #[arg(long)]
+        tail: Option<i64>,
+    },
+    /// Cancel a running execution.
+    Cancel {
+        lease: String,
+        /// Execution id, as returned by `exec`.
+        #[arg(long)]
+        execution: String,
     },
 }
 
@@ -242,6 +303,67 @@ async fn main() -> anyhow::Result<()> {
         }
         Commands::Extend { target: lease, ttl } => {
             commands::extend(lease.as_deref(), &ttl, target, endpoint, output).await
+        }
+        // These return the REMOTE command's exit code, so the process exits
+        // with it rather than with a generic success. `set -e` in a caller's
+        // script depends on exactly this.
+        Commands::Sandbox { action } => {
+            let code = match action {
+                SandboxAction::Exec {
+                    lease,
+                    cwd,
+                    timeout,
+                    command,
+                } => {
+                    commands::sandbox::exec(
+                        &lease,
+                        &command,
+                        cwd.as_deref(),
+                        timeout.as_deref(),
+                        target,
+                        endpoint,
+                        output,
+                    )
+                    .await
+                }
+                SandboxAction::Run {
+                    pool,
+                    ttl,
+                    cwd,
+                    timeout,
+                    command,
+                } => {
+                    commands::sandbox::run(commands::sandbox::RunCommand {
+                        pool: &pool,
+                        ttl: ttl.as_deref(),
+                        argv: &command,
+                        cwd: cwd.as_deref(),
+                        timeout: timeout.as_deref(),
+                        target_override: target,
+                        endpoint_override: endpoint,
+                        output,
+                    })
+                    .await
+                }
+                SandboxAction::Logs { lease, tail } => {
+                    commands::sandbox::logs(&lease, tail, target, endpoint, output)
+                        .await
+                        .map(|()| 0)
+                }
+                SandboxAction::Cancel { lease, execution } => {
+                    commands::sandbox::cancel(&lease, &execution, target, endpoint, output)
+                        .await
+                        .map(|()| 0)
+                }
+            };
+            match code {
+                Ok(0) => Ok(()),
+                Ok(code) => std::process::exit(code),
+                Err(error) => {
+                    eprintln!("kobe: {error:#}");
+                    std::process::exit(commands::sandbox::CLI_FAILURE_EXIT)
+                }
+            }
         }
         Commands::Release { lease_id } => {
             commands::release(lease_id.as_deref(), target, endpoint, output).await

--- a/docs/kobe-docs/commands/meta.json
+++ b/docs/kobe-docs/commands/meta.json
@@ -1,4 +1,7 @@
 {
   "title": "Commands",
-  "pages": ["reference"]
+  "pages": [
+    "reference",
+    "sandbox"
+  ]
 }

--- a/docs/kobe-docs/commands/reference.mdx
+++ b/docs/kobe-docs/commands/reference.mdx
@@ -11,6 +11,10 @@ description: All kobe CLI commands with flags and examples.
 |---|---|
 | `kobe status` | Show endpoint status, auth methods, and pool summary |
 | `kobe version` | Show CLI and endpoint versions |
+| `kobe sandbox run` | Create a sandbox, run one command, release it ([details](/commands/sandbox)) |
+| `kobe sandbox exec` | Run a command in a sandbox you already hold |
+| `kobe sandbox logs` | Read a bounded tail of a sandbox's output |
+| `kobe sandbox cancel` | Cancel a running execution |
 | `kobe login` | Authenticate with the kobe service |
 | `kobe logout` | Remove stored credentials |
 | `kobe lease <pool>` | Lease a cluster from a pool |

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -1,0 +1,142 @@
+---
+title: Sandbox commands
+description: Run commands inside a leased agent sandbox, from a shell or from an agent.
+---
+
+# Sandbox commands
+
+A **sandbox** is one agent environment leased from a `SandboxPool`. These
+commands run work inside it. None of them produces a kubeconfig, a token, or
+any other credential for the cluster underneath — a sandbox lease is the right
+to run commands in one container, and nothing more.
+
+## `kobe sandbox run`
+
+Create a sandbox, run one command in it, and release it.
+
+```bash
+kobe sandbox run agents --ttl 30m -- /agent analyse ./repo
+```
+
+This is the command to reach for from CI or a script: it owns the whole
+lifecycle, so there is no lease left behind if your job is cancelled.
+
+**The exit code is the remote command's exit code.** `set -e` works:
+
+```bash
+set -e
+kobe sandbox run agents -- /agent test   # non-zero here fails the script
+```
+
+**Cleanup is reported separately from the result.** If the command succeeded
+but the lease could not be released, you are told both — the success is not
+hidden, and the leak is not swallowed:
+
+```json
+{
+  "apiVersion": "kobe.sandbox/v1",
+  "lease": "sbx-7f3a",
+  "execution": "sbxe-91c4",
+  "state": "Succeeded",
+  "exitCode": 0,
+  "stdout": "...",
+  "stderr": "",
+  "cleanup": { "released": false, "error": "HTTP 503" }
+}
+```
+
+A run whose command succeeded but whose lease leaked exits `125` rather than
+`0`, so an unattended caller notices.
+
+## `kobe sandbox exec`
+
+Run a command in a sandbox you already hold.
+
+```bash
+kobe sandbox exec sbx-7f3a -- /agent status
+kobe sandbox exec sbx-7f3a --cwd /work --timeout 5m -- ./build.sh
+```
+
+`argv` is sent **as-is**. There is no shell, so there are no quoting rules of
+Kobe's own to learn — and no way for an argument to become a shell operator:
+
+```bash
+# Runs a program whose name contains a semicolon. It does not run two commands.
+kobe sandbox exec sbx-7f3a -- ./weird;name
+```
+
+If you need a shell, ask for one explicitly — then its quoting is yours to
+reason about:
+
+```bash
+kobe sandbox exec sbx-7f3a -- /bin/sh -lc 'a && b'
+```
+
+## `kobe sandbox logs`
+
+A bounded tail of the sandbox's own output.
+
+```bash
+kobe sandbox logs sbx-7f3a --tail 500
+```
+
+The tail is capped server-side. Asking for more than the cap returns the cap
+rather than an error.
+
+## `kobe sandbox cancel`
+
+```bash
+kobe sandbox cancel sbx-7f3a --execution sbxe-91c4
+```
+
+Reports the state that **actually** applies. An execution that had already
+finished is reported as finished — saying "cancelled" would be a claim you
+might act on.
+
+## For headless agents
+
+Use `--output json`. The fields are versioned by `apiVersion`, which changes
+only on a breaking change:
+
+```bash
+result=$(kobe sandbox run agents --output json -- /agent analyse)
+code=$?
+
+echo "$result" | jq -r '.stdout'
+echo "$result" | jq -r '.exitCode'
+echo "$result" | jq -e '.cleanup.released // true' >/dev/null \
+  || echo "warning: the sandbox lease leaked"
+```
+
+`stdout` and `stderr` are always separate fields. A consumer that cannot tell
+a tool's diagnostics from its output cannot reliably parse either.
+
+### Exit codes
+
+| Code | Meaning |
+|---|---|
+| *0–255 from your command* | The remote command ran and exited with this code |
+| `125` | **Kobe** failed — the command may not have run at all |
+
+`125` is the convention `docker run` and `env` already use for "the tool
+failed, not your command", so a script that already handles it needs no new
+knowledge. It is reported when an execution ends without an exit code:
+`Unknown`, `Cancelled`, or `TimedOut`.
+
+### Retries are safe
+
+Every invocation carries an idempotency key. If your client retries after a
+disconnect, the retry finds the original execution rather than starting a
+second one — which matters most for the commands you would least like to run
+twice.
+
+An `Unknown` state means Kobe could not establish what happened: the command
+may have run. It is deliberately **not** reported as a failure, because a
+failure invites an automatic retry of something that may already have had
+effects. Deciding what to do is yours.
+
+## Placement is invisible
+
+A `SandboxPool` may run its sandboxes in Kobe's own cluster or in a cluster
+composed for one lease. Every command above behaves identically either way,
+and nothing exposes which was used.


### PR DESCRIPTION
Core of #84 · **stacked on #131**
Epic: #70 — Agent Sandbox · Parent: #75 · Unblocks #76

```bash
kobe sandbox run agents --ttl 30m -- /agent analyse ./repo
kobe sandbox exec sbx-7f3a --cwd /work -- ./build.sh
kobe sandbox logs sbx-7f3a --tail 500
kobe sandbox cancel sbx-7f3a --execution sbxe-91c4
```

## Two audiences, one contract

A human runs `exec` and reads the output. An agent runs the same command with `--output json` and parses it. **The agent is the harder consumer and it decides the design**: exact remote exit code, stdout and stderr kept apart, and a transport failure that cannot be mistaken for a command failure.

## Exit codes carry meaning

The remote command's exit code **is** this process's exit code. That is the whole point of `exec` inside a script — `set -e` has to work — so Kobe's own failures must not be able to collide with it.

They exit `125`: the convention `docker run` and `env` already use for "the tool failed, not your command", so a script that already handles it needs no new knowledge. It is reported when an execution ends *without* an exit code — `Unknown`, `Cancelled`, `TimedOut`. Reporting `0` there would tell a caller their command succeeded when nobody knows whether it started.

## `run` cleans up, and says so separately

`run` composes create → wait → execute → release, and the release is attempted on **every** terminal path. A lease created and abandoned is the worst thing this command can do: nothing else notices until the TTL reaps it, and the caller is billed for the gap.

Cleanup failure is reported **beside** the command's result, never folded into it — collapsing them would either hide a leaked lease behind a successful command, or fail a command that actually worked:

```json
{
  "apiVersion": "kobe.sandbox/v1",
  "state": "Succeeded",
  "exitCode": 0,
  "cleanup": { "released": false, "error": "HTTP 503" }
}
```

A run whose command succeeded but whose lease leaked exits `125` rather than `0`, so an unattended caller notices something it would otherwise have to go looking for.

## No shell

`argv` is sent as-is. There are no quoting rules of Kobe's own to learn, and no way for an argument to become a shell operator. A caller who wants a shell asks for one — and its quoting is then theirs to reason about:

```bash
kobe sandbox exec sbx-7f3a -- /bin/sh -lc 'a && b'
```

## Retries are safe

Every invocation carries a fresh idempotency key, generated **per command** rather than derived from the argv. A derived key would make two deliberate runs of the same command collide, and the second would silently return the first one's result — a wrong answer, not a cached one. Generated without adding a dependency, since the key scopes a retry rather than authorising anything.

## Machine output

Versioned by `apiVersion`, which changes only on a breaking change — a field that changed meaning without one would break an agent silently, at some later date, with no way to tell which side was wrong. `stdout` and `stderr` are always distinct fields.

`cancel` reports the state that **actually** applies: an execution that had already finished is reported as finished, because saying "cancelled" would be a claim the caller might act on.

## Documentation

`docs/kobe-docs/commands/sandbox.mdx`, with a headless-agent section: the exit-code table, a `jq` example that checks cleanup, and why `Unknown` is deliberately not reported as a failure.

## Testing

```
cargo fmt --all                                         # clean
cargo clippy --workspace --all-targets -- -D warnings   # clean
cargo test --workspace                                  # 1514 passed, 0 failed
```

Mutation-checked: reporting `0` for an execution that never completed, and folding cleanup into the command result, each fail their tests.

## Against #84's acceptance criteria

| Criterion | |
|---|---|
| Commands work identically for management and child placements | ✅ the server resolves placement (#130); the CLI never sees it |
| Machine-readable output is deterministic and documented | ✅ |
| `exec`/`run` preserve the exact remote exit code while separately reporting transport/release failures | ✅ |
| `run` attempts release on every terminal path | ✅ |
| Retry uses idempotency keys and cannot duplicate a command | ✅ |
| Foreign, missing, stale, expired, released, quarantined targets fail closed | ✅ server-side (#126) |
| No command downloads kubeconfig or exposes target credentials | ✅ |
| Public documentation includes examples for headless agents | ✅ |
| `attach` / `port-forward` subcommands | ❌ **not here** — see below |
| Alias resolution scoped to the caller, rejecting ambiguity | ❌ **not here** |

## Not in this PR

**`attach` and `port-forward` subcommands.** The server side landed in #129, but the client half is a terminal implementation — raw mode, resize propagation, signal handling, a local listener for forwarding — and it is a materially different piece of work from these four. Shipping a half-working TTY is worse than not shipping one: a terminal that mangles input is discovered mid-session, on somebody's real work.

**Alias resolution.** `SandboxLease.spec.alias` exists and admission reserves it, but nothing resolves an alias to a lease id yet. That is a server-side lookup with an ambiguity rule, not a CLI concern, and it belongs with the endpoint that serves it.

Both are called out rather than glossed; neither weakens what is here.

> CI is red on runner infrastructure (`mise install bun`), unrelated to this change.