### PR TITLE
epic(sandbox): land the Agent Sandbox foundation on main

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,12 @@ name: CI
 
 on:
   pull_request:
-    branches: [main]
+    # `epic/**` keeps CI running for work that accumulates on a long-lived
+    # integration branch instead of landing on main one PR at a time. Without
+    # it a stacked epic gets NO checks until the whole thing merges — which is
+    # exactly backwards, since the point of holding work off main is to prove
+    # it carries no regressions first.
+    branches: [main, "epic/**"]
     paths:
       - "src/**"
       - "crates/**"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -132,7 +132,7 @@ jobs:
 
       - name: Verify CRDs match generated output
         run: |
-          for crd in clusterpools clusterleases accesspolicies kobestores cidrpools; do
+          for crd in clusterpools clusterleases clusterinstances bootstrapconfigs accesspolicies kobestores cidrclaims cidrpools sandboxpools sandboxleases; do
             cargo run --quiet --bin crdgen -- "$crd" > "/tmp/${crd}-generated.yaml"
             diff -u "/tmp/${crd}-generated.yaml" "charts/kobe/crds/${crd}.yaml" || {
               echo "::error::CRD '${crd}' is out of date. Run 'cargo run --bin crdgen -- ${crd} > charts/kobe/crds/${crd}.yaml' to update."

--- a/README.md
+++ b/README.md
@@ -80,6 +80,10 @@ When a client leases a cluster, Kobe binds one from the warm pool instantly. Whe
 | `PATCH` | `/v1/leases/:id` | Extend a lease TTL |
 | `GET` | `/v1/pools` | List available pools with status |
 | `GET` | `/v1/pools/:name` | Get a specific pool's status |
+| `POST` | `/v1/sandbox-leases` | Create caller-safe Sandbox lease intent |
+| `GET` | `/v1/sandbox-leases` | List your Sandbox leases |
+| `GET` | `/v1/sandbox-leases/:id` | Get a Sandbox lease's lifecycle state |
+| `DELETE` | `/v1/sandbox-leases/:id` | Request Sandbox lease release |
 | `GET` | `/v1/status` | Endpoint status + auth methods (no auth required) |
 
 See [docs/kobe-docs/api/reference.mdx](docs/kobe-docs/api/reference.mdx) for full request/response shapes.
@@ -91,6 +95,8 @@ Kobe is driven by a small set of CRDs (group `kobe.kunobi.ninja/v1alpha1`):
 - **`ClusterPool`** — a pool of warm clusters with a backend, sizing, and default TTL.
 - **`ClusterInstance`** — one provisioned cluster, managed by a pool.
 - **`ClusterLease`** — binds a requester to an instance (created by the HTTP API, not authored directly).
+- **`SandboxPool`** — an administrator-owned class of bounded Agent Sandbox capacity and placement.
+- **`SandboxLease`** — caller-safe disposable Sandbox intent (created by the HTTP API).
 - **`AccessPolicy`** — who may lease which pools, with TTL / concurrency / extension caps.
 - **`KobeStore`** — datastore config for backends that externalize control-plane state.
 

--- a/charts/kobe/crds/accesspolicies.yaml
+++ b/charts/kobe/crds/accesspolicies.yaml
@@ -165,6 +165,65 @@ spec:
                       items:
                         type: string
                       type: array
+                    sandbox:
+                      description: |-
+                        Optional, kind-specific Agent Sandbox permissions. Older policy objects
+                        omit this block and continue authorizing Cluster leases exactly as
+                        before, while Sandbox operations fail closed.
+                      nullable: true
+                      properties:
+                        maxConcurrentLeases:
+                          description: |-
+                            Maximum active Sandbox leases for this identity, separate from Cluster
+                            lease concurrency.
+                          format: uint32
+                          minimum: 0.0
+                          type: integer
+                        maxTtl:
+                          description: Maximum runtime TTL, starting only once the Sandbox is Ready.
+                          minLength: 1
+                          type: string
+                        pools:
+                          description: SandboxPool name patterns; wildcard semantics match Cluster pools.
+                          items:
+                            type: string
+                          minItems: 1
+                          type: array
+                        resourceCeiling:
+                          description: Aggregate per-Sandbox CPU and memory ceiling.
+                          properties:
+                            maxCpu:
+                              minLength: 1
+                              type: string
+                            maxMemory:
+                              minLength: 1
+                              type: string
+                          required:
+                          - maxCpu
+                          - maxMemory
+                          type: object
+                        verbs:
+                          description: Independently authorized Sandbox operations.
+                          items:
+                            description: |-
+                              Agent Sandbox authorization verbs. `lease` includes create and own-object
+                              reads; `release` remains independently revocable.
+                            enum:
+                            - lease
+                            - exec
+                            - logs
+                            - port-forward
+                            - release
+                            type: string
+                          minItems: 1
+                          type: array
+                      required:
+                      - maxConcurrentLeases
+                      - maxTtl
+                      - pools
+                      - resourceCeiling
+                      - verbs
+                      type: object
                   required:
                   - maxConcurrentLeases
                   - maxTtl

--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -1026,6 +1026,7 @@ spec:
                 - Recycling
                 - Unhealthy
                 - Failed
+                - Quarantined
                 type: string
               provisioned:
                 default: false

--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -927,6 +927,46 @@ spec:
                       not infer it from a same-named current pool.
                     nullable: true
                     type: string
+                  teardownPlan:
+                    description: |-
+                      Exactly which footprints this instance created, recorded at creation.
+
+                      This is the trust boundary for verified teardown. A receipt only proves
+                      what it covers, so the list of subjects it must cover cannot come from
+                      the receipt, nor from whatever the teardown path happens to look for
+                      later — an optional resource whose config changed after creation would
+                      then be quietly dropped from the plan and never verified.
+
+                      Stamped once alongside the rest of this provenance and never
+                      overwritten. `None` means the instance predates verified teardown; such
+                      an instance is ineligible for [`CleanupMode::VerifiedDestroy`] rather
+                      than being verified against a guessed plan.
+                    items:
+                      description: |-
+                        One thing whose absence must be proven.
+
+                        Enumerated rather than free-text so a receipt cannot be satisfied by an
+                        unrecognised or invented subject, and so adding a resource to the teardown
+                        path is a deliberate, reviewable change to this list.
+                      enum:
+                      - agentDeployment
+                      - serverStatefulSet
+                      - serverPods
+                      - service
+                      - podDisruptionBudget
+                      - publisherConfigMap
+                      - registriesConfigMap
+                      - tokenSecret
+                      - kubeconfigSecret
+                      - cidrClaim
+                      - connectTokenSecret
+                      - serverDataPvcs
+                      - serverDataVolumes
+                      - database
+                      - databaseRole
+                      type: string
+                    nullable: true
+                    type: array
                 required:
                 - operatorVersion
                 type: object
@@ -1067,6 +1107,22 @@ spec:
                   timestamp fields above.
                 nullable: true
                 type: string
+              teardownIdentities:
+                description: |-
+                  Provisioner-assigned resource identities this instance owns — currently
+                  the PersistentVolumes its data claims are bound to.
+
+                  Captured once the instance is healthy, NOT at teardown. These names are
+                  chosen by the provisioner and only knowable after claims bind, so
+                  capturing them during teardown would let the teardown path define its
+                  own scope. Recorded early, they become something a later teardown must
+                  account for rather than something it gets to choose.
+
+                  Written once and never shrunk: a smaller list would silently narrow what
+                  a receipt has to prove.
+                items:
+                  type: string
+                type: array
             type: object
         required:
         - spec

--- a/charts/kobe/crds/clusterleases.yaml
+++ b/charts/kobe/crds/clusterleases.yaml
@@ -368,7 +368,25 @@ spec:
                           - serverDataPvcs
                           - serverDataVolumes
                           - database
+                          - databaseRole
                           type: string
+                        verified:
+                          description: |-
+                            The concrete resources this check actually looked at.
+
+                            A [`TeardownSubject`] is a category. On its own,
+                            `Database = Verified` asserts that *a* database is gone without saying
+                            which — so a receipt could be satisfied by checking the wrong one, or by
+                            checking one of several when the footprint had more. Recording the exact
+                            identities makes the claim auditable after the fact, which is the whole
+                            point of keeping evidence that outlives the instance.
+
+                            Names only: object names, PV names, the database and role identifiers.
+                            Never connection strings, credentials, or anything that would turn a
+                            receipt into a secret.
+                          items:
+                            type: string
+                          type: array
                       required:
                       - result
                       - subject

--- a/charts/kobe/crds/clusterleases.yaml
+++ b/charts/kobe/crds/clusterleases.yaml
@@ -27,6 +27,13 @@ spec:
               The lease controller binds it to a warm cluster, tracks TTL,
               and handles release/expiry/recycling.
             properties:
+              cleanupMode:
+                description: How thoroughly a lease's capacity must be torn down before it can be reused.
+                enum:
+                - Standard
+                - VerifiedDestroy
+                nullable: true
+                type: string
               poolRef:
                 description: Which profile's pool to lease from.
                 type: string
@@ -299,6 +306,7 @@ spec:
                 - Released
                 - Expired
                 - Recycling
+                - Quarantined
                 type: string
               queuePosition:
                 default: 0
@@ -306,6 +314,165 @@ spec:
                 format: uint32
                 minimum: 0.0
                 type: integer
+              teardownReceipt:
+                description: |-
+                  Durable proof that this lease's exact capacity was destroyed.
+
+                  Recorded here rather than on the `ClusterInstance` because it must stay
+                  queryable *after* the instance object is gone — which is exactly when
+                  the evidence matters, and when #74's owning `SandboxLease` consumes it.
+                nullable: true
+                properties:
+                  attemptId:
+                    description: Unique per attempt; retries produce new attempts, never edit old ones.
+                    type: string
+                  backendType:
+                    description: Backend identity and immutable provenance digest observed at bind time.
+                    type: string
+                  checks:
+                    items:
+                      description: Evidence for one subject.
+                      properties:
+                        reason:
+                          description: |-
+                            Bounded, non-secret reason code (e.g. `pv_still_present`,
+                            `datastore_unreachable`). Never a raw provider response.
+                          nullable: true
+                          type: string
+                        result:
+                          description: Outcome of proving one subject absent.
+                          enum:
+                          - verified
+                          - notApplicable
+                          - unknown
+                          type: string
+                        subject:
+                          description: |-
+                            One thing whose absence must be proven.
+
+                            Enumerated rather than free-text so a receipt cannot be satisfied by an
+                            unrecognised or invented subject, and so adding a resource to the teardown
+                            path is a deliberate, reviewable change to this list.
+                          enum:
+                          - agentDeployment
+                          - serverStatefulSet
+                          - serverPods
+                          - service
+                          - podDisruptionBudget
+                          - publisherConfigMap
+                          - registriesConfigMap
+                          - tokenSecret
+                          - kubeconfigSecret
+                          - cidrClaim
+                          - connectTokenSecret
+                          - serverDataPvcs
+                          - serverDataVolumes
+                          - database
+                          type: string
+                      required:
+                      - result
+                      - subject
+                      type: object
+                    type: array
+                  completedAt:
+                    nullable: true
+                    type: string
+                  configDigest:
+                    type: string
+                  instance:
+                    description: Reference to another Kobe-managed resource in the same namespace.
+                    properties:
+                      name:
+                        description: |-
+                          Resource name. Names are display and lookup handles, never sufficient
+                          authority on their own because Kubernetes permits name reuse.
+                        type: string
+                      uid:
+                        description: |-
+                          Kubernetes UID of the referenced object. New controller-written
+                          references always set this. `None` is accepted only so pre-UID-fence
+                          objects remain readable; security-sensitive consumers must fail closed
+                          or run the proof-based legacy migration before using the reference.
+                        nullable: true
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  instanceSpecDigest:
+                    type: string
+                  lease:
+                    description: |-
+                      Exact subjects this receipt is about. A same-named replacement is a
+                      mismatch, not successful absence.
+                    properties:
+                      name:
+                        description: |-
+                          Resource name. Names are display and lookup handles, never sufficient
+                          authority on their own because Kubernetes permits name reuse.
+                        type: string
+                      uid:
+                        description: |-
+                          Kubernetes UID of the referenced object. New controller-written
+                          references always set this. `None` is accepted only so pre-UID-fence
+                          objects remain readable; security-sensitive consumers must fail closed
+                          or run the proof-based legacy migration before using the reference.
+                        nullable: true
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  outcome:
+                    description: Aggregate verdict for one teardown attempt.
+                    enum:
+                    - verified
+                    - quarantined
+                    type: string
+                  pool:
+                    description: Reference to another Kobe-managed resource in the same namespace.
+                    properties:
+                      name:
+                        description: |-
+                          Resource name. Names are display and lookup handles, never sufficient
+                          authority on their own because Kubernetes permits name reuse.
+                        type: string
+                      uid:
+                        description: |-
+                          Kubernetes UID of the referenced object. New controller-written
+                          references always set this. `None` is accepted only so pre-UID-fence
+                          objects remain readable; security-sensitive consumers must fail closed
+                          or run the proof-based legacy migration before using the reference.
+                        nullable: true
+                        type: string
+                    required:
+                    - name
+                    type: object
+                  retryCount:
+                    default: 0
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  schemaVersion:
+                    description: |-
+                      Schema version, so a consumer can refuse evidence it does not understand
+                      rather than misread an older shape as complete.
+                    format: uint32
+                    minimum: 0.0
+                    type: integer
+                  startedAt:
+                    type: string
+                required:
+                - attemptId
+                - backendType
+                - checks
+                - configDigest
+                - instance
+                - instanceSpecDigest
+                - lease
+                - outcome
+                - pool
+                - schemaVersion
+                - startedAt
+                type: object
             type: object
         required:
         - spec

--- a/charts/kobe/crds/clusterpools.yaml
+++ b/charts/kobe/crds/clusterpools.yaml
@@ -916,6 +916,18 @@ spec:
                 - Idle
                 nullable: true
                 type: string
+              quarantined:
+                default: 0
+                description: |-
+                  Members held back because their teardown could not be proven complete.
+
+                  Separate from `recycling` on purpose: recycling is transient churn that
+                  resolves itself, while a quarantined member is stuck until the same
+                  exact subject produces a verified receipt. Reporting them together would
+                  make a pool bleeding capacity look merely busy.
+                format: uint32
+                minimum: 0.0
+                type: integer
               queueDepth:
                 default: 0
                 description: Current queue depth (claims waiting for clusters).

--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -1,0 +1,446 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sandboxleases.kobe.kunobi.ninja
+spec:
+  group: kobe.kunobi.ninja
+  names:
+    categories: []
+    kind: SandboxLease
+    plural: sandboxleases
+    shortNames:
+    - sl
+    singular: sandboxlease
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.phase
+      name: Phase
+      type: string
+    - jsonPath: .status.expiresAt
+      name: Expires
+      type: date
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SandboxLeaseSpec via `CustomResource`
+        properties:
+          spec:
+            description: Caller-safe intent for one disposable Sandbox.
+            properties:
+              alias:
+                minLength: 1
+                nullable: true
+                type: string
+              poolRef:
+                description: |-
+                  Exact SandboxPool admitted by Kobe. UID and generation fence pool
+                  recreation or mutation between HTTP admission and placement.
+                properties:
+                  generation:
+                    format: int64
+                    minimum: 1.0
+                    type: integer
+                  name:
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  uid:
+                    minLength: 1
+                    type: string
+                required:
+                - generation
+                - name
+                - uid
+                type: object
+              requester:
+                description: |-
+                  Set by Kobe from the authenticated principal, never trusted from an HTTP
+                  request body. Ownership uses the complete tuple, not the display
+                  identity alone.
+                properties:
+                  identity:
+                    minLength: 1
+                    type: string
+                  issuer:
+                    minLength: 1
+                    type: string
+                  provider:
+                    description: Stable configured authentication provider ID.
+                    minLength: 1
+                    type: string
+                  type:
+                    minLength: 1
+                    type: string
+                required:
+                - identity
+                - issuer
+                - provider
+                - type
+                type: object
+              ttl:
+                minLength: 1
+                type: string
+            required:
+            - poolRef
+            - requester
+            - ttl
+            type: object
+          status:
+            nullable: true
+            properties:
+              conditions:
+                items:
+                  description: Kubernetes-style condition with the generation from which it was derived.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      description: Kubernetes Condition status values.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              expiresAt:
+                description: Set only when the upstream Sandbox becomes Ready.
+                format: date-time
+                nullable: true
+                type: string
+              observedGeneration:
+                format: int64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              phase:
+                default: Pending
+                description: |-
+                  Stable public phases. `Released` and `Expired` are clean terminal states;
+                  uncertain teardown remains `Quarantined` and continues consuming capacity.
+                enum:
+                - Pending
+                - Provisioning
+                - Ready
+                - Releasing
+                - Released
+                - Expired
+                - Quarantined
+                type: string
+              placement:
+                nullable: true
+                properties:
+                  clusterPool:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  type:
+                    enum:
+                    - management
+                    - childCluster
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: resolved childCluster placement requires the exact ClusterPool reference
+                  rule: (self.type == 'management' && !has(self.clusterPool)) || (self.type == 'childCluster' && has(self.clusterPool))
+              provisioningDeadline:
+                description: Absolute bound for setup. This is not the runtime expiry.
+                format: date-time
+                nullable: true
+                type: string
+              readyAt:
+                format: date-time
+                nullable: true
+                type: string
+              target:
+                description: |-
+                  Restart-safe, non-secret target provenance. Fields are filled monotonically:
+                  once a reference is present its name and UID may never be cleared or changed.
+                nullable: true
+                properties:
+                  childClusterInstance:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  childClusterLease:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  namespace:
+                    minLength: 1
+                    type: string
+                  pod:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandbox:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandboxClaim:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandboxTemplate:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                  sandboxWarmPool:
+                    description: Non-secret identity of one exact Kubernetes object.
+                    nullable: true
+                    properties:
+                      apiVersion:
+                        minLength: 1
+                        type: string
+                      generation:
+                        format: int64
+                        minimum: 0.0
+                        nullable: true
+                        type: integer
+                      kind:
+                        minLength: 1
+                        type: string
+                      name:
+                        minLength: 1
+                        type: string
+                      namespace:
+                        minLength: 1
+                        nullable: true
+                        type: string
+                      uid:
+                        minLength: 1
+                        type: string
+                    required:
+                    - apiVersion
+                    - kind
+                    - name
+                    - uid
+                    type: object
+                required:
+                - namespace
+                type: object
+            type: object
+        required:
+        - spec
+        title: SandboxLease
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -1,0 +1,338 @@
+apiVersion: apiextensions.k8s.io/v1
+kind: CustomResourceDefinition
+metadata:
+  name: sandboxpools.kobe.kunobi.ninja
+spec:
+  group: kobe.kunobi.ninja
+  names:
+    categories: []
+    kind: SandboxPool
+    plural: sandboxpools
+    shortNames:
+    - sp
+    singular: sandboxpool
+  scope: Namespaced
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.ready
+      name: Ready
+      type: integer
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        description: Auto-generated derived type for SandboxPoolSpec via `CustomResource`
+        properties:
+          spec:
+            description: Administrator-owned class of Agent Sandbox capacity.
+            properties:
+              defaultTtl:
+                description: TTL used when a lease request omits one.
+                minLength: 1
+                type: string
+              isolation:
+                description: |-
+                  Claimed workload-isolation mechanism. Hardened tiers carry the exact
+                  administrator-selected RuntimeClass; leases cannot override it.
+                properties:
+                  runtimeClassName:
+                    maxLength: 253
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
+                    type: string
+                  tier:
+                    enum:
+                    - trusted-runc
+                    - gvisor
+                    - kata
+                    type: string
+                required:
+                - tier
+                type: object
+                x-kubernetes-validations:
+                - message: trusted-runc must not set runtimeClassName; hardened tiers must set it
+                  rule: (self.tier == 'trusted-runc' && !has(self.runtimeClassName)) || (self.tier in ['gvisor', 'kata'] && has(self.runtimeClassName))
+              maxTtl:
+                description: Maximum runtime TTL this pool will accept, independent of caller policy.
+                minLength: 1
+                type: string
+              placement:
+                description: |-
+                  Exactly one target class. The tagged enum makes management and child
+                  placement mutually exclusive in both JSON and generated OpenAPI.
+                properties:
+                  clusterPoolRef:
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  type:
+                    enum:
+                    - management
+                    - childCluster
+                    type: string
+                required:
+                - type
+                type: object
+                x-kubernetes-validations:
+                - message: management must not set clusterPoolRef; childCluster must set it
+                  rule: (self.type == 'management' && !has(self.clusterPoolRef)) || (self.type == 'childCluster' && has(self.clusterPoolRef))
+              provisioningTimeout:
+                description: |-
+                  Maximum time allowed for placement and Sandbox provisioning. Runtime TTL
+                  starts only after readiness and is therefore separate from this deadline.
+                minLength: 1
+                type: string
+              readiness:
+                description: |-
+                  Pool-specific execution canary used in addition to fixed controller
+                  checks such as upstream readiness and runtime verification.
+                properties:
+                  canary:
+                    properties:
+                      argv:
+                        description: Direct argv vector; no implicit shell expansion.
+                        items:
+                          maxLength: 4096
+                          minLength: 1
+                          type: string
+                        maxItems: 64
+                        minItems: 1
+                        type: array
+                      timeout:
+                        minLength: 1
+                        type: string
+                    required:
+                    - argv
+                    - timeout
+                    type: object
+                required:
+                - canary
+                type: object
+              template:
+                description: |-
+                  Restricted template translated into the controller-owned upstream
+                  `SandboxTemplate`; this is intentionally not a `PodSpec` escape hatch.
+                properties:
+                  containers:
+                    description: |-
+                      Complete bounded set of containers. Environment, mounts, security
+                      context, service accounts, and arbitrary Pod fields are not exposed.
+                    items:
+                      description: One administrator-controlled container in a Sandbox template.
+                      properties:
+                        args:
+                          default: []
+                          items:
+                            maxLength: 4096
+                            type: string
+                          maxItems: 256
+                          type: array
+                        command:
+                          default: []
+                          description: Executable and arguments, passed directly without an implicit shell.
+                          items:
+                            maxLength: 4096
+                            minLength: 1
+                            type: string
+                          maxItems: 64
+                          type: array
+                        image:
+                          maxLength: 2048
+                          minLength: 1
+                          type: string
+                        name:
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        resources:
+                          description: |-
+                            Explicit requests and limits. CPU and memory are the only resource
+                            dimensions admitted by the first Sandbox API, keeping quota comparison
+                            deterministic and avoiding arbitrary extended-resource keys.
+                          properties:
+                            limits:
+                              properties:
+                                cpu:
+                                  description: Kubernetes CPU quantity such as `500m` or `2`.
+                                  minLength: 1
+                                  type: string
+                                ephemeralStorage:
+                                  description: Kubernetes ephemeral-storage quantity such as `1Gi`.
+                                  minLength: 1
+                                  type: string
+                                memory:
+                                  description: Kubernetes memory quantity such as `512Mi` or `2Gi`.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - cpu
+                              - ephemeralStorage
+                              - memory
+                              type: object
+                            requests:
+                              properties:
+                                cpu:
+                                  description: Kubernetes CPU quantity such as `500m` or `2`.
+                                  minLength: 1
+                                  type: string
+                                ephemeralStorage:
+                                  description: Kubernetes ephemeral-storage quantity such as `1Gi`.
+                                  minLength: 1
+                                  type: string
+                                memory:
+                                  description: Kubernetes memory quantity such as `512Mi` or `2Gi`.
+                                  minLength: 1
+                                  type: string
+                              required:
+                              - cpu
+                              - ephemeralStorage
+                              - memory
+                              type: object
+                          required:
+                          - limits
+                          - requests
+                          type: object
+                      required:
+                      - image
+                      - name
+                      - resources
+                      type: object
+                    maxItems: 16
+                    minItems: 1
+                    type: array
+                  defaultContainer:
+                    description: Container selected by default for execution operations.
+                    maxLength: 63
+                    minLength: 1
+                    pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                    type: string
+                  exposedPorts:
+                    default: []
+                    description: |-
+                      Ports that later access brokers may expose. Any undeclared port remains
+                      unauthorized.
+                    items:
+                      description: One TCP port declared safe for later lease-scoped forwarding.
+                      properties:
+                        container:
+                          maxLength: 63
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        name:
+                          maxLength: 15
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
+                          type: string
+                        port:
+                          format: uint16
+                          maximum: 65535.0
+                          minimum: 1.0
+                          type: integer
+                      required:
+                      - container
+                      - name
+                      - port
+                      type: object
+                    maxItems: 64
+                    type: array
+                required:
+                - containers
+                - defaultContainer
+                type: object
+                x-kubernetes-validations:
+                - message: defaultContainer must name one declared container
+                  rule: self.containers.exists(c, c.name == self.defaultContainer)
+                - message: container names must be unique
+                  rule: self.containers.all(c, self.containers.filter(other, other.name == c.name).size() == 1)
+                - message: every exposed port must name one declared container
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.containers.exists(c, c.name == p.container))'
+                - message: exposed port names must be unique
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.name == p.name).size() == 1)'
+                - message: a container port may be declared only once
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)'
+                - message: exposed port names must contain a letter and cannot contain consecutive hyphens
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches(''.*[a-z].*'') && !p.name.contains(''--''))'
+              warmCapacity:
+                description: Desired number of unclaimed upstream Sandboxes kept warm.
+                format: uint32
+                maximum: 2147483647.0
+                minimum: 0.0
+                type: integer
+            required:
+            - defaultTtl
+            - isolation
+            - maxTtl
+            - placement
+            - provisioningTimeout
+            - readiness
+            - template
+            - warmCapacity
+            type: object
+          status:
+            nullable: true
+            properties:
+              allocated:
+                default: 0
+                format: uint32
+                minimum: 0.0
+                type: integer
+              conditions:
+                items:
+                  description: Kubernetes-style condition with the generation from which it was derived.
+                  properties:
+                    lastTransitionTime:
+                      format: date-time
+                      nullable: true
+                      type: string
+                    message:
+                      type: string
+                    observedGeneration:
+                      format: int64
+                      minimum: 0.0
+                      nullable: true
+                      type: integer
+                    reason:
+                      type: string
+                    status:
+                      description: Kubernetes Condition status values.
+                      enum:
+                      - 'True'
+                      - 'False'
+                      - Unknown
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - message
+                  - reason
+                  - status
+                  - type
+                  type: object
+                type: array
+                x-kubernetes-list-map-keys:
+                - type
+                x-kubernetes-list-type: map
+              observedGeneration:
+                format: int64
+                minimum: 0.0
+                nullable: true
+                type: integer
+              ready:
+                default: 0
+                format: uint32
+                minimum: 0.0
+                type: integer
+            type: object
+        required:
+        - spec
+        title: SandboxPool
+        type: object
+    served: true
+    storage: true
+    subresources:
+      status: {}

--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -92,10 +92,26 @@ rules:
   - apiGroups: [""]
     resources: ["nodes"]
     verbs: ["get", "list", "watch"]
-  # Leader election
+  # Verified teardown must observe that a PVC's backing PersistentVolume is
+  # actually gone — a claim can be deleted under a `Retain` reclaim policy while
+  # the volume, and the tenant's data, survive. Read-only: kobe never deletes a
+  # PV directly, it only proves absence. Without this the volume check 403s,
+  # which correctly reads as "cannot verify" and would quarantine every
+  # persistent pool forever.
+  - apiGroups: [""]
+    resources: ["persistentvolumes"]
+    verbs: ["get", "list", "watch"]
+  # Leader election, AND the Sandbox admission ledger.
+  #
+  # `list` and `delete` are load-bearing for admission, not leader election:
+  # quota and alias reservations are coordination Leases, released by deleting
+  # them and found by listing on the owning lease's UID label. Without both,
+  # every release 403s and a caller's quota is consumed permanently on the
+  # first teardown — a failure no unit test sees, because it only exists once
+  # real RBAC applies.
   - apiGroups: ["coordination.k8s.io"]
     resources: ["leases"]
-    verbs: ["get", "create", "update", "patch"]
+    verbs: ["get", "list", "create", "update", "patch", "delete"]
   # CRD discovery (Velero detection)
   - apiGroups: ["apiextensions.k8s.io"]
     resources: ["customresourcedefinitions"]

--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -43,6 +43,15 @@ rules:
       - cidrpools
       - cidrpools/status
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # Sandbox admission reads administrator-owned pool definitions.
+  - apiGroups: ["kobe.kunobi.ninja"]
+    resources: ["sandboxpools"]
+    verbs: ["get", "list", "watch"]
+  # Sandbox callers create lease intent through the HTTP API. Lifecycle
+  # controllers, not admission, own the status subresource.
+  - apiGroups: ["kobe.kunobi.ninja"]
+    resources: ["sandboxleases"]
+    verbs: ["create", "get", "list", "watch", "patch", "delete"]
   # Core resources for virtual cluster lifecycle
   - apiGroups: [""]
     resources: ["services", "configmaps", "secrets", "serviceaccounts", "pods", "pods/status", "events", "persistentvolumeclaims", "endpoints"]

--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -20,6 +20,10 @@ The kobe HTTP API is served by the operator. All endpoints except `/v1/status`, 
 | `GET` | `/v1/pools` | Required | List available pools |
 | `GET` | `/v1/pools/:name` | Required | Get a specific pool's status |
 | `GET` | `/v1/pools/:name/leases` | Required | List leases for a specific pool |
+| `POST` | `/v1/sandbox-leases` | Required | Create a Sandbox lease from a SandboxPool |
+| `GET` | `/v1/sandbox-leases` | Required | List your Sandbox leases |
+| `GET` | `/v1/sandbox-leases/:id` | Required | Get one Sandbox lease |
+| `DELETE` | `/v1/sandbox-leases/:id` | Required | Request Sandbox release |
 | `GET` | `/v1/status` | Optional | Endpoint status, auth methods, pool summary |
 | `GET` | `/healthz` | None | Liveness probe |
 | `GET` | `/metrics` | None | Prometheus metrics |
@@ -225,6 +229,87 @@ Lists leases currently associated with one pool. This is useful for operational 
   }
 ]
 ```
+
+---
+
+## Sandbox leases
+
+<Callout type="warn">
+  `SandboxPool` and `SandboxLease` are alpha APIs. Admission is available once
+  their CRDs are installed. A lease remains `Pending` until a compatible Agent
+  Sandbox placement controller is enabled.
+</Callout>
+
+Sandbox callers select an administrator-owned `SandboxPool`; they cannot send a
+Pod spec, namespace, RuntimeClass, environment values, mounts, PVCs, or target
+credentials. Responses never contain a management or child-cluster kubeconfig.
+
+### `POST /v1/sandbox-leases`
+
+Creates caller-safe Sandbox intent and returns `202 Accepted`.
+
+```json
+{
+  "pool": "agent-small",
+  "ttl": "30m",
+  "alias": "review-142"
+}
+```
+
+`ttl` defaults to the pool's `defaultTtl` and is capped by both the pool and the
+caller's Sandbox policy. `alias` is optional and must be unique among that
+identity's active Sandbox leases.
+
+```json
+{
+  "id": "sandbox-a1b2c3d4e5f6",
+  "phase": "Pending",
+  "pool": "agent-small",
+  "ttl": "30m",
+  "alias": "review-142"
+}
+```
+
+When a requested TTL is reduced, `effective_ttl` reports the accepted value.
+
+| Status | Meaning |
+|---|---|
+| `400` | Invalid pool name, alias, or TTL |
+| `403` | Missing Sandbox `lease` permission or resource ceiling exceeded |
+| `404` | An allowed SandboxPool does not exist |
+| `409` | Alias is already active |
+| `429` | Sandbox concurrency limit reached |
+| `503` | Pool configuration or Kubernetes admission cannot be verified |
+
+### `GET /v1/sandbox-leases`
+
+Lists only leases owned by the authenticated identity and still permitted by
+its Sandbox pool scope. Requester identity and target credentials are omitted.
+
+### `GET /v1/sandbox-leases/:id`
+
+Returns the typed lifecycle state for an owned lease. A lease belonging to
+another identity returns `404`.
+
+Possible phases are `Pending`, `Provisioning`, `Ready`, `Releasing`, `Released`,
+`Expired`, and `Quarantined`. `Quarantined` means cleanup is uncertain and the
+capacity remains unavailable; it is not a successful terminal state.
+
+When resolved, the response may include non-secret placement and target object
+references with exact Kubernetes UIDs. It never includes bearer tokens or
+kubeconfigs.
+
+### `DELETE /v1/sandbox-leases/:id`
+
+Requires the independent Sandbox `release` verb. For an admitted active lease,
+the API records server-owned release intent and returns `204 No Content`; it
+does not write lifecycle status. The placement controller observes that intent,
+moves the lease to `Releasing`, revokes access, and verifies cleanup.
+
+Repeated release of an already requested, `Releasing`, `Released`, or `Expired`
+lease returns `204 No Content`. A `Quarantined` lease returns `409 Conflict`:
+cleanup is still uncertain, so its capacity remains unavailable rather than
+being reported as released.
 
 ---
 

--- a/docs/kobe-docs/auth/overview.mdx
+++ b/docs/kobe-docs/auth/overview.mdx
@@ -47,6 +47,16 @@ spec:
       maxTtl: 1h
       maxConcurrentLeases: 3
       maxExtensions: 2
+      # Optional and kind-specific. Omitting this block denies Sandbox APIs
+      # without changing the Cluster lease grant above.
+      sandbox:
+        pools: ["agent-*"]
+        verbs: [lease, exec, logs, port-forward, release]
+        maxTtl: 2h
+        maxConcurrentLeases: 2
+        resourceCeiling:
+          maxCpu: "4"
+          maxMemory: 8Gi
 ```
 
 ## Authorization rules
@@ -59,6 +69,18 @@ Rules control what an authenticated caller can do. Fields:
 | `maxTtl` | Maximum TTL the caller can request. Requests for longer TTLs are capped to this value. |
 | `maxConcurrentLeases` | How many active leases this identity can hold simultaneously. |
 | `maxExtensions` | How many times a lease can be extended via `PATCH /v1/leases/:id`. |
+| `sandbox` | Optional, independent Sandbox grant. Missing means Sandbox access is denied. |
+
+The `sandbox` block scopes `SandboxPool` names and verbs separately from cluster
+pools. `lease` permits create plus read/list of the caller's own Sandbox leases;
+`release` is independently revocable. `exec`, `logs`, and `port-forward` are
+consumed by the restricted Sandbox execution API.
+
+`resourceCeiling.maxCpu` and `maxMemory` are Kubernetes quantities compared
+against the sum of all container limits in the selected `SandboxPool`. Invalid
+quantities fail closed. Sandbox concurrency is also counted separately from
+`ClusterLease` concurrency, and a quarantined Sandbox continues consuming its
+quota until cleanup is proven.
 
 For OIDC policies, a `match` clause lets you apply different rules to different roles or repositories within the same provider. The first rule whose `match` clause passes is used. Rules without a `match` clause always apply.
 

--- a/docs/kobe-docs/getting-started/installation.mdx
+++ b/docs/kobe-docs/getting-started/installation.mdx
@@ -140,7 +140,7 @@ You should see the list of available subcommands. If the command isn't found, ma
 The `kobe-operator` binary runs in your host Kubernetes cluster. Refer to the Helm chart or Flux deployment in the kobe repository for production setup. The operator requires:
 
 - A host Kubernetes cluster (k3s, k0s, EKS, GKE, or any conformant cluster)
-- Permission to manage `ClusterPool`, `ClusterLease`, `ClusterInstance`, `AccessPolicy`, and `KobeStore` CRDs
+- Permission to manage Kobe CRDs, including `ClusterPool`, `ClusterLease`, `ClusterInstance`, `SandboxPool`, `SandboxLease`, `AccessPolicy`, and `KobeStore`
 - Network access between the operator and a kobe endpoint your clients can reach
 
 Install the CRDs:
@@ -150,3 +150,14 @@ cargo run --bin crdgen -- all | kubectl apply -f -
 ```
 
 Or apply them from the Helm chart, which bundles the generated CRD manifests.
+
+Helm does not upgrade objects from a chart's `crds/` directory. Before upgrading
+an existing Kobe release to a version that adds CRDs, apply the new chart's CRD
+manifests explicitly, then upgrade the operator.
+
+`SandboxPool` and `SandboxLease` are deliberately not operator startup
+prerequisites, so existing cluster-lease endpoints can remain available during
+a staged upgrade. Until both Sandbox CRDs are installed and established, the
+Sandbox API is unavailable; a `503 Service Unavailable` means Kobe could not
+verify Sandbox admission against Kubernetes. Install the CRDs before enabling
+Sandbox API clients.

--- a/docs/kobe-docs/pools/meta.json
+++ b/docs/kobe-docs/pools/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Pools",
-  "pages": ["overview", "backends"]
+  "pages": ["overview", "backends", "sandbox-pools"]
 }

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -1,0 +1,84 @@
+---
+title: Sandbox pools
+description: Define bounded, administrator-owned Agent Sandbox templates and placement.
+---
+
+# Sandbox pools
+
+<Callout type="warn">
+  `SandboxPool` and `SandboxLease` are alpha APIs. Kobe admits lease intent, but
+  a lease remains `Pending` until a compatible Agent Sandbox placement
+  controller is enabled.
+</Callout>
+
+Administrators author `SandboxPool` objects. API callers only choose an allowed
+pool, TTL, and optional alias; they cannot provide a Pod spec, namespace,
+RuntimeClass, environment values, mounts, PVCs, or target credentials.
+
+## Example
+
+```yaml
+apiVersion: kobe.kunobi.ninja/v1alpha1
+kind: SandboxPool
+metadata:
+  name: agent-small
+  namespace: kobe
+spec:
+  warmCapacity: 2
+  defaultTtl: 30m
+  maxTtl: 2h
+  provisioningTimeout: 10m
+  placement:
+    type: management
+  template:
+    defaultContainer: workspace
+    containers:
+      - name: workspace
+        image: ghcr.io/example/agent-sandbox:v1
+        command: ["/usr/local/bin/agent"]
+        args: ["serve"]
+        resources:
+          requests:
+            cpu: 250m
+            memory: 512Mi
+            ephemeralStorage: 1Gi
+          limits:
+            cpu: "1"
+            memory: 2Gi
+            ephemeralStorage: 4Gi
+    exposedPorts:
+      - name: http
+        container: workspace
+        port: 8080
+  isolation:
+    tier: gvisor
+    runtimeClassName: gvisor
+  readiness:
+    canary:
+      argv: ["/usr/local/bin/agent", "healthcheck"]
+      timeout: 30s
+```
+
+Every container must declare CPU, memory, and ephemeral-storage requests and
+limits. `defaultContainer` and each exposed port must refer to a declared
+container. Canary `argv` is executed directly, without an implicit shell.
+
+## Placement and isolation
+
+Use `placement.type: management` to place upstream Sandbox objects in Kobe's
+management cluster. To compose a Sandbox with a child cluster from a
+same-namespace `ClusterPool`, use exactly one child placement instead:
+
+```yaml
+placement:
+  type: childCluster
+  clusterPoolRef: ci-sandbox
+```
+
+Isolation tier `trusted-runc` must omit `runtimeClassName`. Hardened tiers
+`gvisor` and `kata` require the exact administrator-selected RuntimeClass name.
+Lease callers cannot override either placement or isolation.
+
+See the [API reference](/docs/api/reference#sandbox-leases) for lease operations
+and [authentication and authorization](/docs/auth/overview) for Sandbox policy
+verbs and limits.

--- a/justfile
+++ b/justfile
@@ -127,7 +127,10 @@ build-crdgen:
     cargo run --bin crdgen -- bootstrapconfigs > charts/kobe/crds/bootstrapconfigs.yaml
     cargo run --bin crdgen -- accesspolicies > charts/kobe/crds/accesspolicies.yaml
     cargo run --bin crdgen -- kobestores > charts/kobe/crds/kobestores.yaml
+    cargo run --bin crdgen -- cidrclaims > charts/kobe/crds/cidrclaims.yaml
     cargo run --bin crdgen -- cidrpools > charts/kobe/crds/cidrpools.yaml
+    cargo run --bin crdgen -- sandboxpools > charts/kobe/crds/sandboxpools.yaml
+    cargo run --bin crdgen -- sandboxleases > charts/kobe/crds/sandboxleases.yaml
 
 # Build Docker images locally (operator + kobe-sync)
 [group('docker')]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -20,6 +20,9 @@ use crate::pool::parse_duration;
 /// Validated identity extracted from a JWT.
 #[derive(Debug, Clone)]
 pub struct AuthIdentity {
+    /// Stable configured provider ID. Unlike `requester_type`, this does not
+    /// include the currently matched rule value and is safe for ownership keys.
+    pub provider: String,
     /// Provider and role: "{provider_name}:{role}" (e.g., "github-actions:ci").
     pub requester_type: String,
     /// Identity string formatted per the provider's identityTemplate.
@@ -535,6 +538,7 @@ impl JwtAuthenticator {
         })?;
 
         Ok(AuthIdentity {
+            provider: verified.provider_name.clone(),
             requester_type: verified.provider_name,
             identity: verified.identity,
             issuer: "ssh".to_string(),
@@ -628,6 +632,7 @@ impl JwtAuthenticator {
             .inc();
 
         Ok(AuthIdentity {
+            provider: kid.provider.clone(),
             requester_type,
             identity,
             issuer,
@@ -728,6 +733,33 @@ fn access_rule_to_policy(rule: &AccessRule) -> crate::api::policy::Policy {
         max_concurrent_leases: rule.max_concurrent_leases,
         default_priority: 50,
         max_extensions: rule.max_extensions,
+        sandbox: rule.sandbox.as_ref().and_then(|grant| {
+            let Some(max_ttl) = parse_duration(&grant.max_ttl) else {
+                warn!(
+                    raw_value = %grant.max_ttl,
+                    "Failed to parse Sandbox max_ttl; dropping Sandbox grant"
+                );
+                return None;
+            };
+            if max_ttl <= chrono::Duration::zero() {
+                warn!(
+                    raw_value = %grant.max_ttl,
+                    "Sandbox max_ttl must be positive; dropping Sandbox grant"
+                );
+                return None;
+            }
+            if let Err(error) = crate::sandbox::parse_resource_ceiling(&grant.resource_ceiling) {
+                warn!(%error, "Invalid Sandbox resource ceiling; dropping Sandbox grant");
+                return None;
+            }
+            Some(crate::api::policy::SandboxPolicy {
+                allowed_pools: grant.pools.clone(),
+                verbs: grant.verbs.clone(),
+                max_ttl,
+                max_concurrent_leases: grant.max_concurrent_leases,
+                resource_ceiling: grant.resource_ceiling.clone(),
+            })
+        }),
     }
 }
 
@@ -892,6 +924,7 @@ mod tests {
             max_ttl: "1h".to_string(),
             max_concurrent_leases: 5,
             max_extensions: 2,
+            sandbox: None,
         }];
         let claims = make_claims("test-sub", HashMap::new());
         let (rule, matched) = match_rule(&rules, &claims).unwrap();
@@ -911,6 +944,7 @@ mod tests {
                 max_ttl: "8h".to_string(),
                 max_concurrent_leases: 10,
                 max_extensions: 5,
+                sandbox: None,
             },
             AccessRule {
                 match_clause: None,
@@ -918,6 +952,7 @@ mod tests {
                 max_ttl: "1h".to_string(),
                 max_concurrent_leases: 3,
                 max_extensions: 1,
+                sandbox: None,
             },
         ];
 
@@ -950,6 +985,7 @@ mod tests {
             max_ttl: "4h".to_string(),
             max_concurrent_leases: 10,
             max_extensions: 5,
+            sandbox: None,
         }];
 
         let mut extra = HashMap::new();
@@ -974,6 +1010,7 @@ mod tests {
             max_ttl: "1h".to_string(),
             max_concurrent_leases: 5,
             max_extensions: 2,
+            sandbox: None,
         }];
         let claims = make_claims("test-sub", HashMap::new());
         assert!(match_rule(&rules, &claims).is_none());
@@ -1118,6 +1155,7 @@ mod tests {
             max_ttl: "2h".to_string(),
             max_concurrent_leases: 5,
             max_extensions: 3,
+            sandbox: None,
         };
         let policy = access_rule_to_policy(&rule);
         assert_eq!(policy.max_ttl, chrono::Duration::hours(2));
@@ -1134,6 +1172,7 @@ mod tests {
             max_ttl: "invalid".to_string(),
             max_concurrent_leases: 1,
             max_extensions: 0,
+            sandbox: None,
         };
         let policy = access_rule_to_policy(&rule);
         // Should default to 1h (3600s) when parsing fails
@@ -1148,10 +1187,76 @@ mod tests {
             max_ttl: "30m".to_string(),
             max_concurrent_leases: 10,
             max_extensions: 2,
+            sandbox: None,
         };
         let policy = access_rule_to_policy(&rule);
         assert_eq!(policy.allowed_pools, vec!["*"]);
         assert_eq!(policy.max_ttl, chrono::Duration::minutes(30));
+    }
+
+    #[test]
+    fn access_rule_to_policy_projects_typed_sandbox_grant() {
+        let rule = AccessRule {
+            match_clause: None,
+            pools: vec!["cluster-*".into()],
+            max_ttl: "2h".into(),
+            max_concurrent_leases: 5,
+            max_extensions: 2,
+            sandbox: Some(crate::crd::SandboxAccessRule {
+                pools: vec!["agent-*".into()],
+                verbs: vec![
+                    crate::crd::SandboxVerb::Lease,
+                    crate::crd::SandboxVerb::Exec,
+                ],
+                max_ttl: "30m".into(),
+                max_concurrent_leases: 3,
+                resource_ceiling: crate::crd::SandboxResourceCeiling {
+                    max_cpu: "2".into(),
+                    max_memory: "4Gi".into(),
+                },
+            }),
+        };
+
+        let policy = access_rule_to_policy(&rule);
+        let sandbox = policy.sandbox.expect("valid grant must be projected");
+        assert_eq!(sandbox.allowed_pools, vec!["agent-*"]);
+        assert_eq!(sandbox.max_ttl, chrono::Duration::minutes(30));
+        assert_eq!(sandbox.max_concurrent_leases, 3);
+        assert_eq!(
+            sandbox.verbs,
+            vec![
+                crate::crd::SandboxVerb::Lease,
+                crate::crd::SandboxVerb::Exec
+            ]
+        );
+        assert_eq!(sandbox.resource_ceiling.max_cpu, "2");
+    }
+
+    #[test]
+    fn invalid_sandbox_grant_fails_closed_without_changing_cluster_policy() {
+        let rule = AccessRule {
+            match_clause: None,
+            pools: vec!["cluster-*".into()],
+            max_ttl: "2h".into(),
+            max_concurrent_leases: 5,
+            max_extensions: 2,
+            sandbox: Some(crate::crd::SandboxAccessRule {
+                pools: vec!["*".into()],
+                verbs: vec![crate::crd::SandboxVerb::Lease],
+                max_ttl: "invalid".into(),
+                max_concurrent_leases: 3,
+                resource_ceiling: crate::crd::SandboxResourceCeiling {
+                    max_cpu: "2".into(),
+                    max_memory: "4Gi".into(),
+                },
+            }),
+        };
+
+        let policy = access_rule_to_policy(&rule);
+        assert!(policy.sandbox.is_none());
+        assert_eq!(policy.allowed_pools, vec!["cluster-*"]);
+        assert_eq!(policy.max_ttl, chrono::Duration::hours(2));
+        assert_eq!(policy.max_concurrent_leases, 5);
     }
 
     // --- JwtAuthenticator async tests ---

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -2,4 +2,5 @@ pub mod auth;
 pub mod connect;
 pub mod policy;
 pub mod routes;
+pub mod sandbox;
 pub mod upgrade;

--- a/src/api/policy.rs
+++ b/src/api/policy.rs
@@ -1,4 +1,5 @@
 use crate::api::auth::AuthIdentity;
+use crate::crd::{SandboxResourceCeiling, SandboxVerb};
 use crate::pool::parse_duration;
 
 /// Authorization policy — what each identity type is allowed to do.
@@ -14,6 +15,19 @@ pub struct Policy {
     pub default_priority: u32,
     /// Maximum number of TTL extensions.
     pub max_extensions: u32,
+    /// Optional kind-specific Sandbox grant. Absence always denies Sandbox and
+    /// preserves the meaning of legacy Cluster-only AccessPolicy objects.
+    pub sandbox: Option<SandboxPolicy>,
+}
+
+/// Runtime form of a validated Sandbox access grant.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct SandboxPolicy {
+    pub allowed_pools: Vec<String>,
+    pub verbs: Vec<SandboxVerb>,
+    pub max_ttl: chrono::Duration,
+    pub max_concurrent_leases: u32,
+    pub resource_ceiling: SandboxResourceCeiling,
 }
 
 /// Get the authorization policy for a given identity.
@@ -24,7 +38,11 @@ pub fn policy_for(identity: &AuthIdentity) -> Policy {
 
 /// Check if a pool name matches the allowed patterns for an identity.
 pub fn is_pool_allowed(pool: &str, policy: &Policy) -> bool {
-    policy.allowed_pools.iter().any(|pattern| {
+    pool_matches(pool, &policy.allowed_pools)
+}
+
+fn pool_matches(pool: &str, patterns: &[String]) -> bool {
+    patterns.iter().any(|pattern| {
         if pattern == "*" {
             return true;
         }
@@ -34,6 +52,27 @@ pub fn is_pool_allowed(pool: &str, policy: &Policy) -> bool {
             pool == pattern
         }
     })
+}
+
+/// Check a Sandbox operation against both its pool scope and independent verb
+/// grant. A missing Sandbox grant fails closed even when Cluster pools allow
+/// the same name or the wildcard `*`.
+pub fn is_sandbox_allowed(pool: &str, verb: SandboxVerb, policy: &Policy) -> bool {
+    policy.sandbox.as_ref().is_some_and(|sandbox| {
+        pool_matches(pool, &sandbox.allowed_pools) && sandbox.verbs.contains(&verb)
+    })
+}
+
+/// Clamp a valid positive runtime TTL to the Sandbox-specific maximum.
+/// Invalid, zero, or negative values return `None` instead of inheriting the
+/// legacy Cluster one-hour fallback.
+pub fn clamp_sandbox_ttl(requested: &str, policy: &Policy) -> Option<chrono::Duration> {
+    let grant = policy.sandbox.as_ref()?;
+    let requested = parse_duration(requested)?;
+    if requested <= chrono::Duration::zero() {
+        return None;
+    }
+    Some(requested.min(grant.max_ttl))
 }
 
 /// Clamp a requested TTL to the policy maximum.
@@ -91,6 +130,7 @@ mod tests {
             max_concurrent_leases: 5,
             default_priority: 100,
             max_extensions: 2,
+            sandbox: None,
         };
 
         assert!(is_pool_allowed("e2e-basic", &ci_policy));
@@ -103,6 +143,7 @@ mod tests {
             max_concurrent_leases: 10,
             default_priority: 100,
             max_extensions: 10,
+            sandbox: None,
         };
 
         assert!(is_pool_allowed("e2e-basic", &admin_policy));
@@ -118,6 +159,7 @@ mod tests {
             max_concurrent_leases: 5,
             default_priority: 100,
             max_extensions: 2,
+            sandbox: None,
         };
 
         // Within limit
@@ -127,6 +169,87 @@ mod tests {
         // Exceeds limit
         let clamped = clamp_ttl("2h", &policy);
         assert_eq!(clamped, chrono::Duration::hours(1));
+    }
+
+    fn policy_with_sandbox() -> Policy {
+        Policy {
+            allowed_pools: vec!["cluster-*".into()],
+            max_ttl: chrono::Duration::hours(8),
+            max_concurrent_leases: 5,
+            default_priority: 100,
+            max_extensions: 2,
+            sandbox: Some(SandboxPolicy {
+                allowed_pools: vec!["agent-*".into()],
+                verbs: vec![SandboxVerb::Lease, SandboxVerb::Release],
+                max_ttl: chrono::Duration::minutes(30),
+                max_concurrent_leases: 3,
+                resource_ceiling: SandboxResourceCeiling {
+                    max_cpu: "2".into(),
+                    max_memory: "4Gi".into(),
+                },
+            }),
+        }
+    }
+
+    #[test]
+    fn sandbox_grant_is_kind_pool_and_verb_specific() {
+        let policy = policy_with_sandbox();
+        assert!(is_pool_allowed("cluster-ci", &policy));
+        assert!(!is_sandbox_allowed(
+            "cluster-ci",
+            SandboxVerb::Lease,
+            &policy
+        ));
+        assert!(is_sandbox_allowed("agent-ci", SandboxVerb::Lease, &policy));
+        assert!(!is_sandbox_allowed("agent-ci", SandboxVerb::Exec, &policy));
+
+        let mut legacy = policy;
+        legacy.sandbox = None;
+        assert!(!is_sandbox_allowed("agent-ci", SandboxVerb::Lease, &legacy));
+    }
+
+    #[test]
+    fn sandbox_wildcard_and_every_verb_are_checked_independently() {
+        let mut policy = policy_with_sandbox();
+        let sandbox = policy.sandbox.as_mut().unwrap();
+        sandbox.allowed_pools = vec!["*".into()];
+        sandbox.verbs = vec![
+            SandboxVerb::Lease,
+            SandboxVerb::Exec,
+            SandboxVerb::Logs,
+            SandboxVerb::PortForward,
+            SandboxVerb::Release,
+        ];
+
+        for verb in sandbox.verbs.clone() {
+            assert!(is_sandbox_allowed("any-sandbox-pool", verb, &policy));
+        }
+        policy
+            .sandbox
+            .as_mut()
+            .unwrap()
+            .verbs
+            .retain(|verb| *verb != SandboxVerb::Release);
+        assert!(!is_sandbox_allowed(
+            "any-sandbox-pool",
+            SandboxVerb::Release,
+            &policy
+        ));
+    }
+
+    #[test]
+    fn sandbox_ttl_is_fail_closed_and_uses_kind_specific_limit() {
+        let policy = policy_with_sandbox();
+        assert_eq!(
+            clamp_sandbox_ttl("15m", &policy),
+            Some(chrono::Duration::minutes(15))
+        );
+        assert_eq!(
+            clamp_sandbox_ttl("2h", &policy),
+            Some(chrono::Duration::minutes(30))
+        );
+        assert_eq!(clamp_sandbox_ttl("invalid", &policy), None);
+        assert_eq!(clamp_sandbox_ttl("0s", &policy), None);
     }
 
     #[test]

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -2748,6 +2748,10 @@ fn build_lease_crd(
                 identity: identity.identity.clone(),
             },
             priority,
+            // Callers cannot request verified teardown: it is an internal
+            // composition detail of #74's child placement, not tenant-facing
+            // intent. Absent means Standard, so behaviour is unchanged.
+            cleanup_mode: None,
         },
         status: None,
     }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -280,6 +280,7 @@ pub fn build_router<B: ClusterBackend + Clone + 'static>(state: AppState<B>) -> 
         .route("/v1/pools", get(list_pools::<B>))
         .route("/v1/pools/{name}", get(get_pool::<B>))
         .route("/v1/pools/{name}/leases", get(list_pool_leases::<B>))
+        .merge(crate::api::sandbox::routes::<B>())
         .layer(axum::middleware::from_fn(concurrency_limit));
 
     let connect_routes = Router::new()
@@ -2991,6 +2992,7 @@ mod tests {
 
     fn test_identity() -> AuthIdentity {
         AuthIdentity {
+            provider: "github-actions".to_string(),
             requester_type: "github-actions:ci".to_string(),
             identity: "repo:org/repo:ref:refs/heads/main".to_string(),
             issuer: "https://token.actions.githubusercontent.com".to_string(),
@@ -3000,6 +3002,7 @@ mod tests {
                 max_concurrent_leases: 5,
                 default_priority: 100,
                 max_extensions: 2,
+                sandbox: None,
             },
         }
     }

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -1,0 +1,2450 @@
+//! HTTP admission for caller-safe [`SandboxLease`](crate::crd::SandboxLease)
+//! intent.
+//!
+//! The routes in this module deliberately stop at admission and lifecycle
+//! intent. They never resolve a target cluster, return Kubernetes credentials,
+//! or expose upstream Agent Sandbox objects. Placement controllers in #73/#74
+//! own those transitions.
+
+use axum::extract::{Path, State};
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::routing::{get, post};
+use axum::{Json, Router};
+use k8s_openapi::api::coordination::v1::{Lease, LeaseSpec};
+use kube::ResourceExt;
+use kube::api::{
+    Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, Preconditions,
+};
+use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
+use thiserror::Error;
+use tracing::{error, info, warn};
+
+use super::auth::AuthIdentity;
+use super::policy::{clamp_sandbox_ttl, format_duration, is_sandbox_allowed, policy_for};
+use super::routes::AppState;
+use crate::backend::ClusterBackend;
+use crate::crd::{
+    ResolvedSandboxPlacement, SandboxCondition, SandboxLease, SandboxLeasePhase, SandboxLeaseSpec,
+    SandboxPool, SandboxPoolReference, SandboxPrincipal, SandboxTargetProvenance, SandboxVerb,
+};
+use crate::pool::{is_valid_k8s_name, parse_duration};
+use crate::sandbox::{aggregate_resource_limits, resource_ceiling_allows};
+
+const REQUESTER_HASH_LABEL: &str = "kobe.kunobi.ninja/requester-hash";
+const SANDBOX_POOL_LABEL: &str = "kobe.kunobi.ninja/sandbox-pool";
+const SANDBOX_ALIAS_LABEL: &str = "kobe.kunobi.ninja/alias";
+const SANDBOX_POOL_CRD: &str = "sandboxpools.kobe.kunobi.ninja";
+const SANDBOX_LEASE_CRD: &str = "sandboxleases.kobe.kunobi.ninja";
+const SANDBOX_RESERVATION_TYPE_LABEL: &str = "kobe.kunobi.ninja/sandbox-reservation";
+const SANDBOX_RESERVATION_LEASE_UID_LABEL: &str = "kobe.kunobi.ninja/sandbox-lease-uid";
+const SANDBOX_RESERVATION_LEASE_NAME_ANNOTATION: &str = "kobe.kunobi.ninja/sandbox-lease-name";
+const SANDBOX_RESERVATION_QUOTA: &str = "quota";
+const SANDBOX_RESERVATION_ALIAS: &str = "alias";
+const MAX_SANDBOX_CONCURRENCY_SLOTS: u32 = 256;
+/// Server-owned admission gate. Placement controllers must ignore every lease
+/// unless this annotation has the exact `admitted` value.
+pub(crate) const SANDBOX_ADMISSION_ANNOTATION: &str = "kobe.kunobi.ninja/sandbox-admission";
+pub(crate) const SANDBOX_ADMISSION_PENDING: &str = "pending";
+pub(crate) const SANDBOX_ADMISSION_ADMITTED: &str = "admitted";
+/// Server-owned release intent. Controllers own status transitions and observe
+/// this annotation with the same object resourceVersion fence.
+pub(crate) const SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION: &str =
+    "kobe.kunobi.ninja/sandbox-release-requested-at";
+
+/// Build the caller-authenticated Sandbox lease routes.
+pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
+    Router::new()
+        .route(
+            "/v1/sandbox-leases",
+            post(create_sandbox_lease::<B>).get(list_sandbox_leases::<B>),
+        )
+        .route(
+            "/v1/sandbox-leases/{id}",
+            get(get_sandbox_lease::<B>).delete(release_sandbox_lease::<B>),
+        )
+}
+
+/// Caller-safe lease intent. Unknown fields are rejected so a caller cannot
+/// smuggle requester identity, target coordinates, runtime settings, or an
+/// upstream Pod/Sandbox spec through a future-tolerant JSON object.
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct CreateSandboxLeaseRequest {
+    pool: String,
+    #[serde(default)]
+    ttl: Option<String>,
+    #[serde(default)]
+    alias: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxLeaseResponse {
+    id: String,
+    phase: String,
+    pool: String,
+    ttl: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    effective_ttl: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    observed_generation: Option<i64>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    provisioning_deadline: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    ready_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    placement: Option<ResolvedSandboxPlacement>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    target: Option<SandboxTargetProvenance>,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    conditions: Vec<SandboxCondition>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxLeaseSummary {
+    id: String,
+    phase: String,
+    pool: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    expires_at: Option<String>,
+}
+
+#[derive(Debug, Serialize)]
+struct SandboxErrorResponse {
+    error: String,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    detail: Option<String>,
+}
+
+fn sandbox_error(status: StatusCode, error: impl Into<String>, detail: Option<String>) -> Response {
+    (
+        status,
+        Json(SandboxErrorResponse {
+            error: error.into(),
+            detail,
+        }),
+    )
+        .into_response()
+}
+
+fn sandbox_infra_error(message: &'static str, err: impl std::fmt::Display) -> Response {
+    error!(error = %err, "{message}");
+    sandbox_error(StatusCode::SERVICE_UNAVAILABLE, message, None)
+}
+
+#[tracing::instrument(skip_all)]
+async fn create_sandbox_lease<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Json(request): Json<CreateSandboxLeaseRequest>,
+) -> Response {
+    if let Err(response) =
+        require_sandbox_crds(&state.client, &[SANDBOX_POOL_CRD, SANDBOX_LEASE_CRD]).await
+    {
+        return response;
+    }
+    let policy = policy_for(&identity);
+
+    if !is_valid_k8s_name(&request.pool) {
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid SandboxPool name",
+            Some(
+                "Pool must be a DNS label (lowercase alphanumeric and hyphens, 1-63 characters)"
+                    .into(),
+            ),
+        );
+    }
+    if !is_sandbox_allowed(&request.pool, SandboxVerb::Lease, &policy) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease is not allowed for this pool",
+            None,
+        );
+    }
+    if let Some(alias) = request.alias.as_deref()
+        && !is_valid_k8s_name(alias)
+    {
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid Sandbox lease alias",
+            Some(
+                "Alias must be a DNS label (lowercase alphanumeric and hyphens, 1-63 characters)"
+                    .into(),
+            ),
+        );
+    }
+
+    let pools: Api<SandboxPool> = Api::namespaced(state.client.clone(), &state.namespace);
+    let pool = match pools.get(&request.pool).await {
+        Ok(pool) => pool,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            return sandbox_error(StatusCode::NOT_FOUND, "SandboxPool not found", None);
+        }
+        Err(err) => return sandbox_infra_error("Unable to load SandboxPool", err),
+    };
+
+    if let Err(err) = pool.spec.validate() {
+        return sandbox_infra_error("SandboxPool configuration is invalid", err);
+    }
+    let pool_reference = match sandbox_pool_reference(&pool) {
+        Ok(reference) => reference,
+        Err(detail) => {
+            return sandbox_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "SandboxPool identity is incomplete",
+                Some(detail),
+            );
+        }
+    };
+
+    let requested_ttl = request.ttl.as_deref().unwrap_or(&pool.spec.default_ttl);
+    let Some(requested_duration) =
+        parse_duration(requested_ttl).filter(|duration| *duration > chrono::Duration::zero())
+    else {
+        if request.ttl.is_none() {
+            return sandbox_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "SandboxPool default TTL is invalid",
+                None,
+            );
+        }
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid Sandbox lease TTL",
+            Some("Use a positive duration such as '30m' or '2h'".into()),
+        );
+    };
+    let Some(policy_duration) = clamp_sandbox_ttl(requested_ttl, &policy) else {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease TTL is not authorized",
+            None,
+        );
+    };
+    if parse_duration(&pool.spec.provisioning_timeout)
+        .filter(|duration| *duration > chrono::Duration::zero())
+        .is_none()
+    {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "SandboxPool provisioning timeout is invalid",
+            None,
+        );
+    }
+    let Some(pool_max_ttl) =
+        parse_duration(&pool.spec.max_ttl).filter(|duration| *duration > chrono::Duration::zero())
+    else {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "SandboxPool maximum TTL is invalid",
+            None,
+        );
+    };
+    let effective_duration = policy_duration.min(pool_max_ttl);
+    let effective_ttl = format_duration(&effective_duration);
+    let was_clamped = effective_duration < requested_duration;
+
+    let Some(grant) = policy.sandbox.as_ref() else {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox access is not configured",
+            None,
+        );
+    };
+    let totals = match aggregate_resource_limits(&pool.spec.template) {
+        Ok(totals) => totals,
+        Err(err) => return sandbox_infra_error("SandboxPool resources are invalid", err),
+    };
+    match resource_ceiling_allows(&grant.resource_ceiling, &totals) {
+        Ok(true) => {}
+        Ok(false) => {
+            return sandbox_error(
+                StatusCode::FORBIDDEN,
+                "SandboxPool exceeds your resource ceiling",
+                None,
+            );
+        }
+        Err(err) => return sandbox_infra_error("Sandbox resource ceiling is invalid", err),
+    }
+
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let reservations: Api<Lease> = Api::namespaced(state.client.clone(), &state.namespace);
+    if grant.max_concurrent_leases > MAX_SANDBOX_CONCURRENCY_SLOTS {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Sandbox concurrency policy exceeds the supported reservation bound",
+            None,
+        );
+    }
+    // Reclaim this principal's own quota stranded by an earlier request that
+    // died between reserving and admitting. Runs before admission so a caller
+    // locked out by their own crashed request recovers on their next attempt
+    // rather than staying 429/409 forever.
+    reap_abandoned_pending_leases(&leases, &reservations, &identity, chrono::Utc::now()).await;
+
+    let lease_id = format!(
+        "sandbox-{}",
+        &uuid::Uuid::new_v4().to_string().replace('-', "")[..12]
+    );
+    let lease = build_sandbox_lease(
+        &lease_id,
+        &state.namespace,
+        pool_reference,
+        &effective_ttl,
+        request.alias.as_deref(),
+        &identity,
+    );
+    let created = match leases.create(&PostParams::default(), &lease).await {
+        Ok(created) => created,
+        Err(err) => return sandbox_infra_error("Failed to create Sandbox lease", err),
+    };
+    if let Err(err) = validate_lease_shape(&lease, &created, SANDBOX_ADMISSION_PENDING) {
+        if let Err(cleanup_err) = delete_exact_pending_lease(&leases, &reservations, &created).await
+        {
+            error!(error = %cleanup_err, "Failed to remove malformed Sandbox lease create response");
+        }
+        return sandbox_infra_error("Sandbox lease create response failed validation", err);
+    }
+
+    // Quota and alias admission use atomic, per-principal Kubernetes Lease
+    // reservations. Advisory LIST checks above improve error latency, but only
+    // these CREATE operations are authoritative across API replicas.
+    let admission_reservations = match acquire_admission_reservations(
+        &reservations,
+        &created,
+        &identity,
+        request.alias.as_deref(),
+        grant.max_concurrent_leases,
+    )
+    .await
+    {
+        Ok(reservations) => reservations,
+        Err(AdmissionReservationError::QuotaExhausted) => {
+            if let Err(err) = delete_exact_pending_lease(&leases, &reservations, &created).await {
+                return sandbox_infra_error(
+                    "Sandbox quota reservation cleanup failed; lease remains unadmitted",
+                    err,
+                );
+            }
+            return sandbox_error(
+                StatusCode::TOO_MANY_REQUESTS,
+                format!(
+                    "Concurrent Sandbox lease limit ({}) reached",
+                    grant.max_concurrent_leases
+                ),
+                None,
+            );
+        }
+        Err(AdmissionReservationError::AliasTaken) => {
+            if let Err(err) = delete_exact_pending_lease(&leases, &reservations, &created).await {
+                return sandbox_infra_error(
+                    "Sandbox alias reservation cleanup failed; lease remains unadmitted",
+                    err,
+                );
+            }
+            return sandbox_error(
+                StatusCode::CONFLICT,
+                format!(
+                    "Sandbox lease alias '{}' is already active",
+                    request.alias.as_deref().unwrap_or_default()
+                ),
+                None,
+            );
+        }
+        Err(err) => {
+            if let Err(cleanup_err) =
+                delete_exact_pending_lease(&leases, &reservations, &created).await
+            {
+                error!(error = %cleanup_err, "Failed to remove Sandbox lease after reservation error");
+            }
+            return sandbox_infra_error("Failed to reserve Sandbox admission", err);
+        }
+    };
+
+    if let Err(err) = admit_sandbox_lease(&leases, &reservations, &created).await {
+        if matches!(err, SandboxLeaseMutationError::AdmissionNotCommitted) {
+            if let Err(cleanup_err) =
+                release_admission_reservations(&reservations, &admission_reservations).await
+            {
+                error!(error = %cleanup_err, "Failed to release Sandbox admission reservations");
+            }
+            if let Err(cleanup_err) =
+                delete_exact_pending_lease(&leases, &reservations, &created).await
+            {
+                error!(error = %cleanup_err, "Failed to remove Sandbox lease after admission failure");
+            }
+        }
+        return sandbox_infra_error("Failed to finalize Sandbox lease admission", err);
+    }
+
+    info!(
+        lease_id = %lease_id,
+        pool = %request.pool,
+        identity = %identity.identity,
+        "Sandbox lease accepted for placement"
+    );
+
+    (
+        StatusCode::ACCEPTED,
+        Json(SandboxLeaseResponse {
+            id: lease_id,
+            phase: SandboxLeasePhase::Pending.to_string(),
+            pool: request.pool,
+            ttl: effective_ttl.clone(),
+            effective_ttl: was_clamped.then_some(effective_ttl),
+            alias: request.alias,
+            observed_generation: None,
+            provisioning_deadline: None,
+            ready_at: None,
+            expires_at: None,
+            placement: None,
+            target: None,
+            conditions: Vec::new(),
+        }),
+    )
+        .into_response()
+}
+
+#[tracing::instrument(skip_all)]
+async fn list_sandbox_leases<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+) -> Response {
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    let policy = policy_for(&identity);
+    let Some(grant) = policy.sandbox.as_ref() else {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox access is not configured",
+            None,
+        );
+    };
+    if !grant.verbs.contains(&SandboxVerb::Lease) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease read is not allowed",
+            None,
+        );
+    }
+
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let params = requester_list_params(&identity);
+    match leases.list(&params).await {
+        Ok(items) => {
+            let response: Vec<_> = items
+                .iter()
+                .filter(|lease| principal_matches(&lease.spec.requester, &identity))
+                .filter(|lease| {
+                    is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy)
+                })
+                .map(|lease| {
+                    let status = lease.status.clone().unwrap_or_default();
+                    SandboxLeaseSummary {
+                        id: lease.name_any(),
+                        phase: status.phase.to_string(),
+                        pool: lease.spec.pool_ref.name.clone(),
+                        alias: lease.spec.alias.clone(),
+                        expires_at: status.expires_at,
+                    }
+                })
+                .collect();
+            (StatusCode::OK, Json(response)).into_response()
+        }
+        Err(err) => sandbox_infra_error("Failed to list Sandbox leases", err),
+    }
+}
+
+#[tracing::instrument(skip_all)]
+async fn get_sandbox_lease<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let lease = match owned_sandbox_lease(&leases, &id, &identity).await {
+        Ok(Some(lease)) => lease,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(err) => return sandbox_infra_error("Failed to get Sandbox lease", err),
+    };
+    let policy = policy_for(&identity);
+    if !is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox lease read is not allowed",
+            None,
+        );
+    }
+
+    (StatusCode::OK, Json(sandbox_lease_response(lease, None))).into_response()
+}
+
+#[tracing::instrument(skip_all)]
+async fn release_sandbox_lease<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+) -> Response {
+    if let Err(response) = require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD]).await {
+        return response;
+    }
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let lease = match owned_sandbox_lease(&leases, &id, &identity).await {
+        Ok(Some(lease)) => lease,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(err) => return sandbox_infra_error("Failed to get Sandbox lease", err),
+    };
+    let policy = policy_for(&identity);
+    if !is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Release, &policy) {
+        return sandbox_error(
+            StatusCode::FORBIDDEN,
+            "Sandbox release is not allowed",
+            None,
+        );
+    }
+
+    let phase = lease
+        .status
+        .as_ref()
+        .map(|status| status.phase)
+        .unwrap_or_default();
+    if phase == SandboxLeasePhase::Quarantined {
+        return sandbox_error(
+            StatusCode::CONFLICT,
+            "Sandbox cleanup is quarantined",
+            Some("Cleanup remains uncertain; capacity has not been released".into()),
+        );
+    }
+    if matches!(
+        phase,
+        SandboxLeasePhase::Releasing | SandboxLeasePhase::Released | SandboxLeasePhase::Expired
+    ) {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+
+    if lease
+        .annotations()
+        .get(SANDBOX_ADMISSION_ANNOTATION)
+        .map(String::as_str)
+        != Some(SANDBOX_ADMISSION_ADMITTED)
+    {
+        let reservations: Api<Lease> = Api::namespaced(state.client.clone(), &state.namespace);
+        return match delete_exact_pending_lease(&leases, &reservations, &lease).await {
+            Ok(()) => StatusCode::NO_CONTENT.into_response(),
+            Err(err) => sandbox_infra_error("Failed to remove unadmitted Sandbox lease", err),
+        };
+    }
+    if lease
+        .annotations()
+        .contains_key(SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION)
+    {
+        return StatusCode::NO_CONTENT.into_response();
+    }
+
+    let Some(resource_version) = lease.resource_version() else {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "Sandbox lease has no resourceVersion",
+            None,
+        );
+    };
+    let patch = serde_json::json!({
+        "metadata": {
+            "resourceVersion": resource_version,
+            "annotations": {
+                SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION: chrono::Utc::now().to_rfc3339()
+            }
+        }
+    });
+    match leases
+        .patch(&id, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+    {
+        Ok(_) => StatusCode::NO_CONTENT.into_response(),
+        Err(err) => sandbox_infra_error("Failed to request Sandbox release", err),
+    }
+}
+
+async fn require_sandbox_crds(client: &kube::Client, names: &[&str]) -> Result<(), Response> {
+    use k8s_openapi::apiextensions_apiserver::pkg::apis::apiextensions::v1::CustomResourceDefinition;
+
+    let crds: Api<CustomResourceDefinition> = Api::all(client.clone());
+    for name in names {
+        match crds.get(name).await {
+            Ok(crd)
+                if crd
+                    .status
+                    .as_ref()
+                    .and_then(|status| status.conditions.as_ref())
+                    .is_some_and(|conditions| {
+                        conditions.iter().any(|condition| {
+                            condition.type_ == "Established" && condition.status == "True"
+                        })
+                    }) =>
+            {
+                continue;
+            }
+            Ok(_) | Err(kube::Error::Api(_)) => {
+                return Err(sandbox_error(
+                    StatusCode::SERVICE_UNAVAILABLE,
+                    "Sandbox API is not installed or established",
+                    None,
+                ));
+            }
+            Err(err) => return Err(sandbox_infra_error("Unable to discover Sandbox API", err)),
+        }
+    }
+    Ok(())
+}
+
+async fn owned_sandbox_lease(
+    leases: &Api<SandboxLease>,
+    id: &str,
+    identity: &AuthIdentity,
+) -> Result<Option<SandboxLease>, kube::Error> {
+    match leases.get(id).await {
+        Ok(lease) if principal_matches(&lease.spec.requester, identity) => Ok(Some(lease)),
+        Ok(_) => Ok(None),
+        Err(kube::Error::Api(error)) if error.code == 404 => Ok(None),
+        Err(err) => Err(err),
+    }
+}
+
+fn sandbox_lease_response(
+    lease: SandboxLease,
+    effective_ttl: Option<String>,
+) -> SandboxLeaseResponse {
+    let id = lease.name_any();
+    let status = lease.status.unwrap_or_default();
+    SandboxLeaseResponse {
+        id,
+        phase: status.phase.to_string(),
+        pool: lease.spec.pool_ref.name,
+        ttl: lease.spec.ttl,
+        effective_ttl,
+        alias: lease.spec.alias,
+        observed_generation: status.observed_generation,
+        provisioning_deadline: status.provisioning_deadline,
+        ready_at: status.ready_at,
+        expires_at: status.expires_at,
+        placement: status.placement,
+        target: status.target,
+        conditions: status.conditions,
+    }
+}
+
+fn build_sandbox_lease(
+    id: &str,
+    namespace: &str,
+    pool_ref: SandboxPoolReference,
+    ttl: &str,
+    alias: Option<&str>,
+    identity: &AuthIdentity,
+) -> SandboxLease {
+    let mut labels = std::collections::BTreeMap::new();
+    labels.insert(SANDBOX_POOL_LABEL.into(), pool_ref.name.clone());
+    labels.insert(REQUESTER_HASH_LABEL.into(), principal_hash(identity));
+    if let Some(alias) = alias {
+        labels.insert(SANDBOX_ALIAS_LABEL.into(), alias.into());
+    }
+    let annotations = std::collections::BTreeMap::from([(
+        SANDBOX_ADMISSION_ANNOTATION.to_string(),
+        SANDBOX_ADMISSION_PENDING.to_string(),
+    )]);
+    SandboxLease {
+        metadata: ObjectMeta {
+            name: Some(id.into()),
+            namespace: Some(namespace.into()),
+            labels: Some(labels),
+            annotations: Some(annotations),
+            ..Default::default()
+        },
+        spec: SandboxLeaseSpec {
+            pool_ref,
+            ttl: ttl.into(),
+            alias: alias.map(str::to_owned),
+            requester: SandboxPrincipal {
+                provider: identity.provider.clone(),
+                requester_type: identity.requester_type.clone(),
+                issuer: identity.issuer.clone(),
+                identity: identity.identity.clone(),
+            },
+        },
+        status: None,
+    }
+}
+
+fn requester_list_params(identity: &AuthIdentity) -> ListParams {
+    ListParams::default().labels(&format!(
+        "{REQUESTER_HASH_LABEL}={}",
+        principal_hash(identity)
+    ))
+}
+
+/// Stable, non-reversible identifier for one principal.
+///
+/// This is **not** merely a lookup prefilter, which is why it must be
+/// collision-resistant. It names the reservation objects
+/// (`sbx-quota-{hash}-{slot}`, `sbx-alias-{hash}-{alias}`), so two principals
+/// sharing a hash share one quota namespace and one alias namespace — and
+/// unlike the list paths, the reservation path has no exact-identity recheck to
+/// fall back on. A caller able to steer their own identity string toward a
+/// victim's hash could then occupy every one of that victim's slots or squat
+/// their aliases: targeted denial of service.
+///
+/// An earlier version used FNV-1a-64 and documented collisions as harmless.
+/// That was true of visibility (which does recheck exact identity) and false of
+/// the ledger. SHA-256 truncated to 128 bits is collision-resistant here and
+/// still a valid DNS label component.
+///
+/// Components are length-prefixed so `("ab", "c")` and `("a", "bc")` cannot
+/// produce the same digest.
+///
+/// # Changing this function is a migration
+///
+/// The output names the reservation objects AND the label selector used to find
+/// them, so changing it renames every quota slot and alias at once. Objects
+/// created under the previous scheme become invisible: they still occupy
+/// backend resources, but the new selector cannot see them, so a principal
+/// could acquire their full limit again in the new namespace and re-take an
+/// alias someone still holds — a quota and alias bypass.
+///
+/// That was safe to ignore for the FNV-to-SHA-256 change only because
+/// `SandboxLease` had never shipped: it is absent from `main`, from `v0.38.0`,
+/// and from the released chart, so no object could exist under the old scheme.
+/// Once this ships, any further change needs a versioned migration that keeps
+/// enforcing against legacy reservations until they are drained.
+fn principal_hash(identity: &AuthIdentity) -> String {
+    let mut hasher = Sha256::new();
+    for component in [
+        identity.provider.as_bytes(),
+        identity.issuer.as_bytes(),
+        identity.identity.as_bytes(),
+    ] {
+        hasher.update((component.len() as u64).to_be_bytes());
+        hasher.update(component);
+    }
+    hasher
+        .finalize()
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
+/// How long a lease may sit unadmitted before it is treated as abandoned.
+///
+/// Admission is a handful of API calls, so a legitimately in-flight request is
+/// orders of magnitude below this. The margin is deliberately large: reaping a
+/// live request would delete a lease its caller is about to be told succeeded,
+/// which is far worse than a slot staying busy for a few extra minutes.
+const SANDBOX_PENDING_DEADLINE_SECS: i64 = 600;
+
+/// Whether an unadmitted lease is old enough to be treated as abandoned.
+///
+/// Pure so the boundary is testable without a clock: `now` is supplied.
+fn pending_lease_is_abandoned(
+    created_at: Option<&str>,
+    now: chrono::DateTime<chrono::Utc>,
+) -> bool {
+    let Some(created_at) = created_at else {
+        // No creation timestamp means we cannot prove it is old. Reaping on
+        // absent evidence is exactly the mistake this whole module avoids.
+        return false;
+    };
+    let Ok(created_at) = chrono::DateTime::parse_from_rfc3339(created_at) else {
+        return false;
+    };
+    (now - created_at.with_timezone(&chrono::Utc)).num_seconds() >= SANDBOX_PENDING_DEADLINE_SECS
+}
+
+/// Release quota and aliases stranded by a request that died mid-admission.
+///
+/// Reservations are created before the lease is admitted, and they are owned by
+/// that lease — so Kubernetes garbage-collects them only once the lease is
+/// *deleted*. If the process dies (or a cleanup path itself fails) between
+/// acquiring reservations and committing admission, the lease stays `pending`
+/// forever, no controller touches it (placement ignores anything not `admitted`),
+/// and its slot plus alias are consumed permanently. The caller then gets 429 or
+/// 409 on every retry with no way out but manual deletion.
+///
+/// This sweep is the recovery path. It runs on the caller's own next create, so
+/// the principal who was locked out is exactly the one who unlocks themselves.
+///
+/// Scope, stated narrowly: it reclaims **this principal's** abandoned pending
+/// leases at **create time only**. It is not a general reaper — a principal who
+/// never calls create again keeps their slot stranded until #73's controller
+/// owns a durable sweep. That is a deliberately smaller claim than "crash-safe".
+async fn reap_abandoned_pending_leases(
+    leases: &Api<SandboxLease>,
+    reservations: &Api<Lease>,
+    identity: &AuthIdentity,
+    now: chrono::DateTime<chrono::Utc>,
+) {
+    let stale = match leases.list(&requester_list_params(identity)).await {
+        Ok(list) => list,
+        // Best-effort: a failed sweep must not fail the create. The caller
+        // simply keeps whatever quota they already had.
+        Err(error) => {
+            warn!(error = %error, "Sandbox abandoned-lease sweep failed to list");
+            return;
+        }
+    };
+
+    for lease in stale.items {
+        // The label prefilter is a hash, so it can group two principals.
+        // Recheck exact identity before deleting anything: without this, a hash
+        // collision would let one principal reap another's leases.
+        if !principal_matches(&lease.spec.requester, identity) {
+            continue;
+        }
+        if lease
+            .annotations()
+            .get(SANDBOX_ADMISSION_ANNOTATION)
+            .map(String::as_str)
+            != Some(SANDBOX_ADMISSION_PENDING)
+        {
+            continue;
+        }
+        if !pending_lease_is_abandoned(
+            lease
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|timestamp| timestamp.0.to_string())
+                .as_deref(),
+            now,
+        ) {
+            continue;
+        }
+
+        // UID + resourceVersion fenced, and it releases the lease's
+        // reservations. A lease that got admitted since we listed fails the
+        // shape check and is left alone.
+        match delete_exact_pending_lease(leases, reservations, &lease).await {
+            Ok(()) => info!(
+                lease_id = %lease.name_any(),
+                "Reclaimed an abandoned unadmitted Sandbox lease and its reservations"
+            ),
+            Err(error) => warn!(
+                lease_id = %lease.name_any(),
+                error = %error,
+                "Could not reclaim an abandoned unadmitted Sandbox lease"
+            ),
+        }
+    }
+}
+
+fn principal_matches(requester: &SandboxPrincipal, identity: &AuthIdentity) -> bool {
+    requester.provider == identity.provider
+        && requester.issuer == identity.issuer
+        && requester.identity == identity.identity
+}
+
+fn sandbox_pool_reference(pool: &SandboxPool) -> Result<SandboxPoolReference, String> {
+    pool.namespace()
+        .ok_or_else(|| "SandboxPool has no namespace".to_string())?;
+    let uid = pool
+        .uid()
+        .ok_or_else(|| "SandboxPool has no UID".to_string())?;
+    let generation = pool
+        .metadata
+        .generation
+        .ok_or_else(|| "SandboxPool has no generation".to_string())?;
+    Ok(SandboxPoolReference {
+        name: pool.name_any(),
+        uid,
+        generation,
+    })
+}
+
+async fn admit_sandbox_lease(
+    leases: &Api<SandboxLease>,
+    reservations: &Api<Lease>,
+    lease: &SandboxLease,
+) -> Result<(), SandboxLeaseMutationError> {
+    let name = lease.name_any();
+    let resource_version = lease
+        .resource_version()
+        .ok_or(SandboxLeaseMutationError::MissingResourceVersion)?;
+    let patch = serde_json::json!({
+        "metadata": {
+            "resourceVersion": resource_version,
+            "annotations": { SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_ADMITTED }
+        }
+    });
+    match leases
+        .patch(&name, &PatchParams::default(), &Patch::Merge(&patch))
+        .await
+    {
+        Ok(admitted) => validate_lease_shape(lease, &admitted, SANDBOX_ADMISSION_ADMITTED),
+        Err(patch_error) => {
+            // The API server may have committed the patch before the response
+            // was lost. Resolve that ambiguity from the exact UID: an admitted
+            // object is success; a still-pending object is removed with its
+            // current resourceVersion so a failed POST cannot later be placed.
+            let current = match leases.get(&name).await {
+                Ok(current) => current,
+                Err(kube::Error::Api(error)) if error.code == 404 => {
+                    return Err(SandboxLeaseMutationError::Kubernetes(patch_error));
+                }
+                Err(error) => return Err(SandboxLeaseMutationError::Kubernetes(error)),
+            };
+            match current
+                .annotations()
+                .get(SANDBOX_ADMISSION_ANNOTATION)
+                .map(String::as_str)
+            {
+                Some(SANDBOX_ADMISSION_ADMITTED) => {
+                    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_ADMITTED)
+                }
+                Some(SANDBOX_ADMISSION_PENDING) => {
+                    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
+                    delete_exact_pending_lease(leases, reservations, &current).await?;
+                    Err(SandboxLeaseMutationError::AdmissionNotCommitted)
+                }
+                _ => Err(SandboxLeaseMutationError::UnexpectedAdmissionState),
+            }
+        }
+    }
+}
+
+/// One reservation this request actually created, recorded so it can be
+/// released by exact identity. The UID matters: releasing by name alone could
+/// delete a *replacement* reservation another request created after ours was
+/// already gone.
+#[derive(Debug, Clone)]
+struct AdmissionReservation {
+    name: String,
+    uid: String,
+}
+
+/// Why admission could not reserve its slot. Both refusals are ordinary,
+/// caller-visible outcomes rather than faults — the caller is over quota, or
+/// picked an alias someone else is already using.
+#[derive(Debug, Error)]
+enum AdmissionReservationError {
+    #[error("concurrent Sandbox lease quota is exhausted")]
+    QuotaExhausted,
+    #[error("Sandbox lease alias is already active")]
+    AliasTaken,
+    #[error("SandboxLease has no UID to fence its reservations against")]
+    MissingLeaseUid,
+    #[error(transparent)]
+    Kubernetes(#[from] kube::Error),
+}
+
+/// Quota slots are named per principal and per slot index, so acquiring one is
+/// a race for a *specific* name. `CREATE` is the atomic primitive: two API
+/// replicas contending for the last slot cannot both succeed, because the
+/// second gets 409 from the API server.
+fn quota_reservation_name(principal: &str, slot: u32) -> String {
+    format!("sbx-quota-{principal}-{slot}")
+}
+
+/// Aliases are validated DNS labels (<=63 chars) before we get here, so they can
+/// be embedded directly rather than hashed — which keeps the reservation name
+/// legible to an operator debugging a stuck alias.
+fn alias_reservation_name(principal: &str, alias: &str) -> String {
+    format!("sbx-alias-{principal}-{alias}")
+}
+
+/// Build a coordination `Lease` used purely as a compare-and-swap token.
+///
+/// The owner reference is the crash-safety net: if the `SandboxLease` is
+/// deleted by any path we did not anticipate, Kubernetes garbage-collects the
+/// reservations with it, so a slot cannot leak and permanently consume quota.
+fn build_admission_reservation(
+    name: String,
+    reservation_type: &str,
+    lease: &SandboxLease,
+    principal: &str,
+) -> Result<Lease, AdmissionReservationError> {
+    let lease_uid = lease
+        .uid()
+        .ok_or(AdmissionReservationError::MissingLeaseUid)?;
+    let mut labels = std::collections::BTreeMap::new();
+    labels.insert(
+        SANDBOX_RESERVATION_TYPE_LABEL.to_string(),
+        reservation_type.to_string(),
+    );
+    labels.insert(
+        SANDBOX_RESERVATION_LEASE_UID_LABEL.to_string(),
+        lease_uid.clone(),
+    );
+    labels.insert(REQUESTER_HASH_LABEL.to_string(), principal.to_string());
+    let mut annotations = std::collections::BTreeMap::new();
+    annotations.insert(
+        SANDBOX_RESERVATION_LEASE_NAME_ANNOTATION.to_string(),
+        lease.name_any(),
+    );
+
+    Ok(Lease {
+        metadata: ObjectMeta {
+            name: Some(name),
+            namespace: lease.namespace(),
+            labels: Some(labels),
+            annotations: Some(annotations),
+            owner_references: Some(vec![
+                k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference {
+                    api_version: "kobe.kunobi.ninja/v1alpha1".to_string(),
+                    kind: "SandboxLease".to_string(),
+                    name: lease.name_any(),
+                    uid: lease_uid,
+                    controller: Some(false),
+                    block_owner_deletion: Some(false),
+                },
+            ]),
+            ..Default::default()
+        },
+        // The token carries no lease semantics; existence *is* the claim.
+        spec: Some(LeaseSpec::default()),
+    })
+}
+
+/// Reserve this lease's admission atomically across every API replica.
+///
+/// Advisory `LIST` checks earlier in the request improve error latency, but
+/// they cannot be authoritative: two replicas can both read "one slot free" and
+/// both admit. Only the `CREATE` calls below decide, because the API server
+/// serializes them on object name.
+///
+/// Alias is reserved first. A taken alias is a deterministic, user-fixable
+/// conflict, so failing on it before consuming a quota slot avoids a pointless
+/// acquire-then-release round trip against the shared quota namespace.
+async fn acquire_admission_reservations(
+    reservations: &Api<Lease>,
+    lease: &SandboxLease,
+    identity: &AuthIdentity,
+    alias: Option<&str>,
+    max_concurrent_leases: u32,
+) -> Result<Vec<AdmissionReservation>, AdmissionReservationError> {
+    let principal = principal_hash(identity);
+    let mut acquired: Vec<AdmissionReservation> = Vec::new();
+
+    if let Some(alias) = alias {
+        let reservation = build_admission_reservation(
+            alias_reservation_name(&principal, alias),
+            SANDBOX_RESERVATION_ALIAS,
+            lease,
+            &principal,
+        )?;
+        match reservations
+            .create(&PostParams::default(), &reservation)
+            .await
+        {
+            Ok(created) => acquired.push(AdmissionReservation {
+                name: created.name_any(),
+                uid: created.uid().unwrap_or_default(),
+            }),
+            Err(kube::Error::Api(error)) if error.code == 409 => {
+                return Err(AdmissionReservationError::AliasTaken);
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    // Advisory short-circuit. Scanning for a free slot costs one CREATE per
+    // taken slot, so a caller at a 256-slot limit would otherwise pay 256 round
+    // trips just to be told they are over quota. One LIST answers the common
+    // case. It is deliberately NOT authoritative — a slot can free or fill
+    // between this read and the CREATE below, which is exactly why the CREATE
+    // still decides.
+    match reservations
+        .list(&ListParams::default().labels(&format!(
+            "{SANDBOX_RESERVATION_TYPE_LABEL}={SANDBOX_RESERVATION_QUOTA},{REQUESTER_HASH_LABEL}={principal}"
+        )))
+        .await
+    {
+        Ok(existing) if existing.items.len() as u32 >= max_concurrent_leases => {
+            rollback_partial_reservations(reservations, &acquired).await;
+            return Err(AdmissionReservationError::QuotaExhausted);
+        }
+        Ok(_) => {}
+        // A failed advisory read must not fail the request: fall through to the
+        // authoritative scan, which is correct on its own.
+        Err(error) => {
+            error!(error = %error, "Advisory Sandbox quota read failed; falling back to slot scan");
+        }
+    }
+
+    // First free index wins. Slots are dense and bounded by policy, and
+    // `max_concurrent_leases` is capped at MAX_SANDBOX_CONCURRENCY_SLOTS by the
+    // caller, so this loop is bounded regardless of what a policy asks for.
+    let mut slot_taken = false;
+    for slot in 0..max_concurrent_leases {
+        let reservation = build_admission_reservation(
+            quota_reservation_name(&principal, slot),
+            SANDBOX_RESERVATION_QUOTA,
+            lease,
+            &principal,
+        )?;
+        match reservations
+            .create(&PostParams::default(), &reservation)
+            .await
+        {
+            Ok(created) => {
+                acquired.push(AdmissionReservation {
+                    name: created.name_any(),
+                    uid: created.uid().unwrap_or_default(),
+                });
+                slot_taken = true;
+                break;
+            }
+            // This slot belongs to another live lease; try the next one.
+            Err(kube::Error::Api(error)) if error.code == 409 => continue,
+            Err(error) => {
+                // Never leave a partially-acquired alias behind: it would block
+                // the caller's own retry with a spurious 409.
+                rollback_partial_reservations(reservations, &acquired).await;
+                return Err(error.into());
+            }
+        }
+    }
+
+    if !slot_taken {
+        rollback_partial_reservations(reservations, &acquired).await;
+        return Err(AdmissionReservationError::QuotaExhausted);
+    }
+
+    Ok(acquired)
+}
+
+/// Best-effort unwind of reservations taken earlier in a failed acquire.
+///
+/// Deliberately swallows errors: the caller is already returning a failure, and
+/// the owner reference guarantees Kubernetes reaps anything left behind when
+/// the pending lease is removed. Losing the original error to a cleanup error
+/// would be strictly worse for the caller.
+async fn rollback_partial_reservations(
+    reservations: &Api<Lease>,
+    acquired: &[AdmissionReservation],
+) {
+    if let Err(error) = release_admission_reservations(reservations, acquired).await {
+        error!(error = %error, "Failed to roll back partial Sandbox admission reservations");
+    }
+}
+
+/// Release exactly the reservations we hold. A UID precondition means a
+/// reservation that was already reaped and recreated by a different request is
+/// left alone rather than stolen from its new owner.
+async fn release_admission_reservations(
+    reservations: &Api<Lease>,
+    acquired: &[AdmissionReservation],
+) -> Result<(), AdmissionReservationError> {
+    for reservation in acquired {
+        let params = DeleteParams {
+            preconditions: Some(Preconditions {
+                uid: Some(reservation.uid.clone()),
+                resource_version: None,
+            }),
+            ..Default::default()
+        };
+        match reservations.delete(&reservation.name, &params).await {
+            Ok(_) => {}
+            // 404: already gone. 409: the name now holds someone else's
+            // reservation. Both mean "ours is not there", which is the goal.
+            Err(kube::Error::Api(error)) if error.code == 404 || error.code == 409 => {}
+            Err(error) => return Err(error.into()),
+        }
+    }
+    Ok(())
+}
+
+/// Release every reservation owned by one exact lease UID.
+///
+/// Used on the cleanup path, where we hold the lease rather than the list of
+/// reservations we created. Selecting on the UID label (not the name) is what
+/// keeps a recreated same-named lease from dropping its predecessor's slots.
+async fn release_reservations_for_lease(
+    reservations: &Api<Lease>,
+    lease_uid: &str,
+) -> Result<(), SandboxLeaseMutationError> {
+    let params = ListParams::default().labels(&format!(
+        "{SANDBOX_RESERVATION_LEASE_UID_LABEL}={lease_uid}"
+    ));
+    let owned = reservations.list(&params).await?;
+    let held: Vec<AdmissionReservation> = owned
+        .into_iter()
+        .filter_map(|reservation| {
+            Some(AdmissionReservation {
+                name: reservation.name_any(),
+                uid: reservation.uid()?,
+            })
+        })
+        .collect();
+    if let Err(error) = release_admission_reservations(reservations, &held).await {
+        return match error {
+            AdmissionReservationError::Kubernetes(error) => Err(error.into()),
+            // The other variants cannot arise from a release.
+            other => {
+                error!(error = %other, "Unexpected Sandbox reservation release failure");
+                Ok(())
+            }
+        };
+    }
+    Ok(())
+}
+
+/// Remove a still-unadmitted lease and free whatever it reserved.
+///
+/// Reservations are released *after* the lease is gone. Doing it in the other
+/// order would briefly leave an admitted-looking lease with no quota slot,
+/// which a concurrent request could then double-book.
+async fn delete_exact_pending_lease(
+    leases: &Api<SandboxLease>,
+    reservations: &Api<Lease>,
+    lease: &SandboxLease,
+) -> Result<(), SandboxLeaseMutationError> {
+    let expected_uid = lease.uid().ok_or(SandboxLeaseMutationError::MissingUid)?;
+    let current = match leases.get(&lease.name_any()).await {
+        Ok(current) => current,
+        Err(kube::Error::Api(error)) if error.code == 404 => {
+            // The lease is already gone; its reservations may not be.
+            return release_reservations_for_lease(reservations, &expected_uid).await;
+        }
+        Err(error) => return Err(error.into()),
+    };
+    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
+    if current.uid().as_deref() != Some(expected_uid.as_str()) {
+        return Err(SandboxLeaseMutationError::UidChanged);
+    }
+    let resource_version = current
+        .resource_version()
+        .ok_or(SandboxLeaseMutationError::MissingResourceVersion)?;
+    let params = DeleteParams {
+        preconditions: Some(Preconditions {
+            uid: Some(expected_uid.clone()),
+            resource_version: Some(resource_version),
+        }),
+        ..Default::default()
+    };
+    leases.delete(&current.name_any(), &params).await?;
+    release_reservations_for_lease(reservations, &expected_uid).await
+}
+
+fn validate_lease_shape(
+    expected: &SandboxLease,
+    actual: &SandboxLease,
+    admission: &str,
+) -> Result<(), SandboxLeaseMutationError> {
+    if actual.name_any() != expected.name_any()
+        || actual.namespace() != expected.namespace()
+        || actual.spec != expected.spec
+    {
+        return Err(SandboxLeaseMutationError::LeaseShapeChanged);
+    }
+    if let Some(expected_uid) = expected.uid()
+        && actual.uid().as_deref() != Some(expected_uid.as_str())
+    {
+        return Err(SandboxLeaseMutationError::UidChanged);
+    }
+    if actual.uid().is_none() {
+        return Err(SandboxLeaseMutationError::MissingUid);
+    }
+    if actual.resource_version().is_none() {
+        return Err(SandboxLeaseMutationError::MissingResourceVersion);
+    }
+    for (key, expected_value) in expected.labels() {
+        if actual.labels().get(key) != Some(expected_value) {
+            return Err(SandboxLeaseMutationError::LeaseShapeChanged);
+        }
+    }
+    if actual
+        .annotations()
+        .get(SANDBOX_ADMISSION_ANNOTATION)
+        .map(String::as_str)
+        != Some(admission)
+    {
+        return Err(SandboxLeaseMutationError::UnexpectedAdmissionState);
+    }
+    Ok(())
+}
+
+#[derive(Debug, Error)]
+enum SandboxLeaseMutationError {
+    #[error("SandboxLease has no UID")]
+    MissingUid,
+    #[error("SandboxLease has no resourceVersion")]
+    MissingResourceVersion,
+    #[error("SandboxLease identity or server-owned admission fields changed")]
+    LeaseShapeChanged,
+    #[error("SandboxLease UID changed")]
+    UidChanged,
+    #[error("SandboxLease has an unexpected admission state")]
+    UnexpectedAdmissionState,
+    #[error("SandboxLease admission patch did not commit; the pending object was removed")]
+    AdmissionNotCommitted,
+    #[error(transparent)]
+    Kubernetes(#[from] kube::Error),
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    use crate::api::policy::{Policy, SandboxPolicy};
+    use crate::crd::{SandboxLeaseStatus, SandboxResourceCeiling};
+    use axum::body;
+    use tower::ServiceExt;
+    use wiremock::matchers::{method, path, path_regex};
+    use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    fn identity() -> AuthIdentity {
+        AuthIdentity {
+            provider: "developer-oidc".into(),
+            requester_type: "oidc:developer".into(),
+            identity: "alice@example.com".into(),
+            issuer: "https://issuer.example".into(),
+            policy: Policy {
+                allowed_pools: vec!["cluster-*".into()],
+                max_ttl: chrono::Duration::hours(8),
+                max_concurrent_leases: 2,
+                default_priority: 50,
+                max_extensions: 2,
+                sandbox: Some(SandboxPolicy {
+                    allowed_pools: vec!["agent-*".into()],
+                    verbs: vec![SandboxVerb::Lease, SandboxVerb::Release],
+                    max_ttl: chrono::Duration::hours(2),
+                    max_concurrent_leases: 2,
+                    resource_ceiling: SandboxResourceCeiling {
+                        max_cpu: "2".into(),
+                        max_memory: "4Gi".into(),
+                    },
+                }),
+            },
+        }
+    }
+
+    fn test_state(server: &MockServer) -> AppState<crate::testutil::MockBackend> {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        AppState {
+            client: crate::testutil::mock_k8s_client(server),
+            authenticator: std::sync::Arc::new(super::super::auth::JwtAuthenticator::new(
+                "test".into(),
+            )),
+            namespace: "test-ns".into(),
+            backend: crate::testutil::MockBackend::new(),
+            factory: None,
+            datastore: Default::default(),
+            connect_cache: Default::default(),
+        }
+    }
+
+    fn pool_json() -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "SandboxPool",
+            "metadata": {
+                "name": "agent-small",
+                "namespace": "test-ns",
+                "uid": "pool-uid",
+                "generation": 1
+            },
+            "spec": {
+                "warmCapacity": 1,
+                "defaultTtl": "1h",
+                "maxTtl": "4h",
+                "provisioningTimeout": "10m",
+                "placement": { "type": "management" },
+                "template": {
+                    "defaultContainer": "agent",
+                    "containers": [{
+                        "name": "agent",
+                        "image": "example.invalid/agent@sha256:abc",
+                        "resources": {
+                            "requests": {
+                                "cpu": "500m",
+                                "memory": "512Mi",
+                                "ephemeralStorage": "512Mi"
+                            },
+                            "limits": {
+                                "cpu": "1",
+                                "memory": "1Gi",
+                                "ephemeralStorage": "1Gi"
+                            }
+                        }
+                    }],
+                    "exposedPorts": [{ "name": "http", "container": "agent", "port": 3000 }]
+                },
+                "isolation": { "tier": "trusted-runc" },
+                "readiness": { "canary": { "argv": ["/bin/true"], "timeout": "30s" } }
+            }
+        })
+    }
+
+    fn pool_reference() -> SandboxPoolReference {
+        SandboxPoolReference {
+            name: "agent-small".into(),
+            uid: "pool-uid".into(),
+            generation: 1,
+        }
+    }
+
+    fn crd_json(name: &str, plural: &str, kind: &str) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "apiextensions.k8s.io/v1",
+            "kind": "CustomResourceDefinition",
+            "metadata": { "name": name },
+            "spec": {
+                "group": "kobe.kunobi.ninja",
+                "names": { "kind": kind, "plural": plural },
+                "scope": "Namespaced",
+                "versions": [{
+                    "name": "v1alpha1",
+                    "served": true,
+                    "storage": true,
+                    "schema": { "openAPIV3Schema": { "type": "object" } }
+                }]
+            },
+            "status": {
+                "conditions": [{
+                    "type": "Established",
+                    "status": "True",
+                    "reason": "InitialNamesAccepted",
+                    "message": "accepted",
+                    "lastTransitionTime": "2026-08-10T00:00:00Z"
+                }]
+            }
+        })
+    }
+
+    async fn mount_sandbox_crds(server: &MockServer) {
+        for (name, plural, kind) in [
+            (SANDBOX_POOL_CRD, "sandboxpools", "SandboxPool"),
+            (SANDBOX_LEASE_CRD, "sandboxleases", "SandboxLease"),
+        ] {
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/apis/apiextensions.k8s.io/v1/customresourcedefinitions/{name}"
+                )))
+                .respond_with(
+                    ResponseTemplate::new(200).set_body_json(crd_json(name, plural, kind)),
+                )
+                .mount(server)
+                .await;
+        }
+    }
+
+    fn lease_json(name: &str, requester: &str, phase: &str) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "SandboxLease",
+            "metadata": {
+                "name": name,
+                "namespace": "test-ns",
+                "uid": format!("{name}-uid"),
+                "resourceVersion": "1",
+                "creationTimestamp": "2026-08-10T00:00:00Z"
+                ,"labels": {
+                    SANDBOX_POOL_LABEL: "agent-small",
+                    REQUESTER_HASH_LABEL: principal_hash(&identity())
+                },
+                "annotations": {
+                    SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_ADMITTED
+                }
+            },
+            "spec": {
+                "poolRef": {
+                    "name": "agent-small",
+                    "uid": "pool-uid",
+                    "generation": 1
+                },
+                "ttl": "1h",
+                "requester": {
+                    "provider": "developer-oidc",
+                    "type": "oidc:developer",
+                    "issuer": "https://issuer.example",
+                    "identity": requester
+                }
+            },
+            "status": { "phase": phase, "observedGeneration": 1 }
+        })
+    }
+
+    async fn response_json(response: Response) -> serde_json::Value {
+        let bytes = body::to_bytes(response.into_body(), usize::MAX)
+            .await
+            .unwrap();
+        serde_json::from_slice(&bytes).unwrap()
+    }
+
+    /// Mock the coordination-Lease API with the semantics the CAS ledger
+    /// depends on:
+    ///
+    /// - `CREATE` succeeds on a free name and returns 409 on a taken one,
+    ///   exactly as the API server serializes competing writers;
+    /// - `LIST` honours `labelSelector`. This matters: the release path selects
+    ///   on the lease-UID label, so a mock that ignored selectors would let one
+    ///   lease's cleanup delete another lease's reservations and hide a real
+    ///   fencing bug.
+    ///
+    /// `preheld` simulates reservations another lease already owns, which is how
+    /// quota exhaustion and alias conflicts are provoked deterministically
+    /// without running concurrent requests. They are labelled with a foreign
+    /// lease UID, so correct code must leave them alone.
+    ///
+    /// Returns the live ledger so a test can assert what was acquired and,
+    /// crucially, what was released again.
+    async fn mount_reservation_api(
+        server: &MockServer,
+        preheld: &[String],
+    ) -> Arc<Mutex<std::collections::BTreeMap<String, serde_json::Value>>> {
+        mount_reservation_api_owned(
+            server,
+            &preheld
+                .iter()
+                .map(|name| (name.clone(), FOREIGN_LEASE_UID.to_string()))
+                .collect::<Vec<_>>(),
+        )
+        .await
+    }
+
+    const FOREIGN_LEASE_UID: &str = "preheld-foreign-lease-uid";
+
+    /// Like `mount_reservation_api`, but each pre-held reservation names the
+    /// SandboxLease UID that owns it — so a test can model reservations
+    /// stranded by a *specific* lease and watch them actually be released.
+    async fn mount_reservation_api_owned(
+        server: &MockServer,
+        preheld: &[(String, String)],
+    ) -> Arc<Mutex<std::collections::BTreeMap<String, serde_json::Value>>> {
+        const RESERVATIONS: &str = "/apis/coordination.k8s.io/v1/namespaces/test-ns/leases";
+
+        // Reconstruct the labels a real reservation would carry from its name
+        // (`sbx-<type>-<principal>-<suffix>`), so selector filtering behaves.
+        let seeded: std::collections::BTreeMap<String, serde_json::Value> = preheld
+            .iter()
+            .map(|(name, owner_uid)| {
+                let parts: Vec<&str> = name.splitn(4, '-').collect();
+                let reservation_type = parts.get(1).copied().unwrap_or_default();
+                let principal = parts.get(2).copied().unwrap_or_default();
+                (
+                    name.clone(),
+                    serde_json::json!({
+                        "apiVersion": "coordination.k8s.io/v1",
+                        "kind": "Lease",
+                        "metadata": {
+                            "name": name,
+                            "namespace": "test-ns",
+                            "uid": format!("{name}-uid"),
+                            "labels": {
+                                SANDBOX_RESERVATION_TYPE_LABEL: reservation_type,
+                                SANDBOX_RESERVATION_LEASE_UID_LABEL: owner_uid,
+                                REQUESTER_HASH_LABEL: principal,
+                            }
+                        }
+                    }),
+                )
+            })
+            .collect();
+        let held = Arc::new(Mutex::new(seeded));
+
+        let create_state = Arc::clone(&held);
+        Mock::given(method("POST"))
+            .and(path(RESERVATIONS))
+            .respond_with(move |request: &wiremock::Request| {
+                let mut object: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                let name = object["metadata"]["name"].as_str().unwrap().to_string();
+                let mut state = create_state.lock().unwrap();
+                if state.contains_key(&name) {
+                    return ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                        "apiVersion": "v1",
+                        "kind": "Status",
+                        "status": "Failure",
+                        "reason": "AlreadyExists",
+                        "message": format!("leases.coordination.k8s.io \"{name}\" already exists"),
+                        "code": 409
+                    }));
+                }
+                object["metadata"]["uid"] = serde_json::json!(format!("{name}-uid"));
+                object["metadata"]["resourceVersion"] = serde_json::json!("1");
+                state.insert(name, object.clone());
+                ResponseTemplate::new(201).set_body_json(object)
+            })
+            .mount(server)
+            .await;
+
+        let delete_state = Arc::clone(&held);
+        Mock::given(method("DELETE"))
+            .and(path_regex(
+                r"^/apis/coordination\.k8s\.io/v1/namespaces/test-ns/leases/.+$",
+            ))
+            .respond_with(move |request: &wiremock::Request| {
+                let name = request
+                    .url
+                    .path()
+                    .rsplit('/')
+                    .next()
+                    .unwrap_or_default()
+                    .to_string();
+                // Honour the UID precondition, exactly as the API server does.
+                // Without this the mock deletes by bare name, and the UID
+                // fencing the release path depends on goes untested — a
+                // regression that stole another lease's reservation would pass.
+                let precondition_uid = serde_json::from_slice::<serde_json::Value>(&request.body)
+                    .ok()
+                    .and_then(|body| {
+                        body["preconditions"]["uid"]
+                            .as_str()
+                            .map(|uid| uid.to_string())
+                    });
+                let mut state = delete_state.lock().unwrap();
+                let actual_uid = state
+                    .get(&name)
+                    .and_then(|object| object["metadata"]["uid"].as_str().map(|s| s.to_string()));
+                match (actual_uid, precondition_uid) {
+                    (None, _) => ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                        "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                        "reason": "NotFound", "code": 404
+                    })),
+                    (Some(actual), Some(expected)) if actual != expected => {
+                        ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                            "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                            "reason": "Conflict",
+                            "message": "the UID in the precondition does not match",
+                            "code": 409
+                        }))
+                    }
+                    (Some(_), _) => {
+                        state.remove(&name);
+                        ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                            "apiVersion": "v1", "kind": "Status", "status": "Success"
+                        }))
+                    }
+                }
+            })
+            .mount(server)
+            .await;
+
+        let list_state = Arc::clone(&held);
+        Mock::given(method("GET"))
+            .and(path(RESERVATIONS))
+            .respond_with(move |request: &wiremock::Request| {
+                let selector = request
+                    .url
+                    .query_pairs()
+                    .find(|(key, _)| key == "labelSelector")
+                    .map(|(_, value)| value.to_string())
+                    .unwrap_or_default();
+                let required: Vec<(String, String)> = selector
+                    .split(',')
+                    .filter(|term| !term.is_empty())
+                    .filter_map(|term| {
+                        term.split_once('=')
+                            .map(|(key, value)| (key.to_string(), value.to_string()))
+                    })
+                    .collect();
+                let items: Vec<serde_json::Value> = list_state
+                    .lock()
+                    .unwrap()
+                    .values()
+                    .filter(|object| {
+                        required.iter().all(|(key, value)| {
+                            object["metadata"]["labels"][key].as_str() == Some(value.as_str())
+                        })
+                    })
+                    .cloned()
+                    .collect();
+                ResponseTemplate::new(200).set_body_json(crate::testutil::k8s_list_response(items))
+            })
+            .mount(server)
+            .await;
+
+        held
+    }
+
+    /// Full create-path harness: CRDs, an empty reservation ledger, and the
+    /// SandboxLease object mocks.
+    async fn mount_create_api(
+        server: &MockServer,
+        relist_created: bool,
+        ambiguous_admit_response: bool,
+    ) -> Arc<Mutex<Option<serde_json::Value>>> {
+        mount_sandbox_crds(server).await;
+        mount_reservation_api(server, &[]).await;
+        mount_create_lease_objects(server, relist_created, ambiguous_admit_response).await
+    }
+
+    /// Just the SandboxLease object mocks, for tests that mount their own
+    /// reservation ledger with pre-held slots.
+    async fn mount_create_lease_only(server: &MockServer) -> Arc<Mutex<Option<serde_json::Value>>> {
+        mount_create_lease_objects(server, true, false).await
+    }
+
+    async fn mount_create_lease_objects(
+        server: &MockServer,
+        relist_created: bool,
+        ambiguous_admit_response: bool,
+    ) -> Arc<Mutex<Option<serde_json::Value>>> {
+        let lease_state = Arc::new(Mutex::new(None::<serde_json::Value>));
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pool_json()))
+            .mount(server)
+            .await;
+
+        let list_state = Arc::clone(&lease_state);
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                let items = if relist_created {
+                    list_state.lock().unwrap().clone().into_iter().collect()
+                } else {
+                    Vec::new()
+                };
+                ResponseTemplate::new(200).set_body_json(crate::testutil::k8s_list_response(items))
+            })
+            .mount(server)
+            .await;
+
+        let create_state = Arc::clone(&lease_state);
+        Mock::given(method("POST"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(move |request: &wiremock::Request| {
+                let mut object: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                let name = object["metadata"]["name"].as_str().unwrap().to_string();
+                object["metadata"]["uid"] = serde_json::json!(format!("{name}-uid"));
+                object["metadata"]["resourceVersion"] = serde_json::json!("1");
+                object["metadata"]["creationTimestamp"] = serde_json::json!("2026-08-10T00:00:00Z");
+                *create_state.lock().unwrap() = Some(object.clone());
+                ResponseTemplate::new(201).set_body_json(object)
+            })
+            .mount(server)
+            .await;
+
+        let get_state = Arc::clone(&lease_state);
+        Mock::given(method("GET"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| match get_state.lock().unwrap().clone() {
+                Some(object) => ResponseTemplate::new(200).set_body_json(object),
+                None => ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "Status",
+                    "status": "Failure",
+                    "reason": "NotFound",
+                    "code": 404
+                })),
+            })
+            .mount(server)
+            .await;
+
+        let patch_state = Arc::clone(&lease_state);
+        Mock::given(method("PATCH"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                let mut guard = patch_state.lock().unwrap();
+                let object = guard.as_mut().expect("created lease");
+                object["metadata"]["annotations"][SANDBOX_ADMISSION_ANNOTATION] =
+                    serde_json::json!(SANDBOX_ADMISSION_ADMITTED);
+                object["metadata"]["resourceVersion"] = serde_json::json!("2");
+                if ambiguous_admit_response {
+                    ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                        "apiVersion": "v1",
+                        "kind": "Status",
+                        "status": "Failure",
+                        "reason": "InternalError",
+                        "code": 500
+                    }))
+                } else {
+                    ResponseTemplate::new(200).set_body_json(object.clone())
+                }
+            })
+            .mount(server)
+            .await;
+
+        let delete_state = Arc::clone(&lease_state);
+        Mock::given(method("DELETE"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                *delete_state.lock().unwrap() = None;
+                ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                    "apiVersion": "v1",
+                    "kind": "Status",
+                    "status": "Success",
+                    "code": 200
+                }))
+            })
+            .mount(server)
+            .await;
+
+        lease_state
+    }
+
+    #[test]
+    fn request_rejects_server_owned_and_unsafe_fields() {
+        for field in [
+            "requester",
+            "namespace",
+            "runtimeClassName",
+            "podSpec",
+            "credentials",
+        ] {
+            let mut value = serde_json::json!({ "pool": "agent-small", "ttl": "1h" });
+            value[field] = serde_json::json!({ "identity": "mallory" });
+            assert!(
+                serde_json::from_value::<CreateSandboxLeaseRequest>(value).is_err(),
+                "field {field} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn build_lease_derives_requester_and_contains_no_target_or_credentials() {
+        let identity = identity();
+        let lease = build_sandbox_lease(
+            "sandbox-abc",
+            "kobe",
+            pool_reference(),
+            "30m",
+            Some("review"),
+            &identity,
+        );
+        assert_eq!(lease.spec.requester.identity, identity.identity);
+        assert_eq!(lease.spec.alias.as_deref(), Some("review"));
+        assert!(lease.status.is_none());
+        let json = serde_json::to_string(&lease).unwrap();
+        for forbidden in ["kubeconfig", "bearer", "token", "credentials", "podSpec"] {
+            assert!(
+                !json
+                    .to_ascii_lowercase()
+                    .contains(&forbidden.to_ascii_lowercase())
+            );
+        }
+    }
+
+    #[test]
+    fn quarantined_lease_still_consumes_quota() {
+        assert!(SandboxLeasePhase::Pending.consumes_capacity());
+        assert!(SandboxLeasePhase::Provisioning.consumes_capacity());
+        assert!(SandboxLeasePhase::Ready.consumes_capacity());
+        assert!(SandboxLeasePhase::Releasing.consumes_capacity());
+        assert!(SandboxLeasePhase::Quarantined.consumes_capacity());
+        assert!(!SandboxLeasePhase::Released.consumes_capacity());
+        assert!(!SandboxLeasePhase::Expired.consumes_capacity());
+    }
+
+    #[test]
+    fn response_never_contains_requester_or_credentials() {
+        let mut lease = build_sandbox_lease(
+            "sandbox-abc",
+            "kobe",
+            pool_reference(),
+            "30m",
+            None,
+            &identity(),
+        );
+        lease.status = Some(SandboxLeaseStatus::default());
+        let json = serde_json::to_string(&sandbox_lease_response(lease, None)).unwrap();
+        assert!(!json.contains("alice@example.com"));
+        assert!(!json.to_ascii_lowercase().contains("token"));
+        assert!(!json.to_ascii_lowercase().contains("kubeconfig"));
+    }
+
+    // NOTE: `quota_race_resolution_is_deterministic` lived here and is gone.
+    // It exercised `lease_exceeds_quota`, an advisory list-then-rank check from
+    // the design this branch replaced. Ranking a LIST cannot decide admission:
+    // two API replicas can both observe a free slot and both admit. The
+    // coordination-Lease CAS ledger above is authoritative instead, so the old
+    // test pinned a contract that no longer exists.
+
+    #[test]
+    fn principal_hash_separates_providers_and_issuers() {
+        let base = identity();
+        let mut other_provider = base.clone();
+        other_provider.provider = "other-oidc".into();
+        let mut other_issuer = base.clone();
+        other_issuer.issuer = "https://other.example".into();
+        assert_ne!(principal_hash(&base), principal_hash(&other_provider));
+        assert_ne!(principal_hash(&base), principal_hash(&other_issuer));
+
+        // The hash NAMES the quota and alias reservations, so its width is a
+        // security property, not a formatting detail: a short digest lets a
+        // caller steer their identity onto a victim's hash and occupy that
+        // victim's slots. 128 bits, hex-encoded.
+        assert_eq!(
+            principal_hash(&base).len(),
+            32,
+            "principal hash must retain 128 bits — it namespaces quota and aliases"
+        );
+        assert!(principal_hash(&base).chars().all(|c| c.is_ascii_hexdigit()));
+
+        // Length-prefixing must stop component boundaries from sliding.
+        let mut split_a = base.clone();
+        split_a.provider = "ab".into();
+        split_a.issuer = "c".into();
+        let mut split_b = base.clone();
+        split_b.provider = "a".into();
+        split_b.issuer = "bc".into();
+        assert_ne!(
+            principal_hash(&split_a),
+            principal_hash(&split_b),
+            "concatenation must be unambiguous across component boundaries"
+        );
+    }
+
+    #[tokio::test]
+    async fn sandbox_routes_require_authentication() {
+        let server = MockServer::start().await;
+        let app = crate::api::routes::build_router(test_state(&server));
+        for (verb, uri) in [
+            ("GET", "/v1/sandbox-leases"),
+            ("POST", "/v1/sandbox-leases"),
+            ("GET", "/v1/sandbox-leases/sandbox-a"),
+            ("DELETE", "/v1/sandbox-leases/sandbox-a"),
+        ] {
+            let request = http::Request::builder()
+                .method(verb)
+                .uri(uri)
+                .header("content-type", "application/json")
+                .body(axum::body::Body::from("{}"))
+                .unwrap();
+            let response = app.clone().oneshot(request).await.unwrap();
+            assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{verb} {uri}");
+        }
+    }
+
+    #[tokio::test]
+    async fn create_uses_server_identity_and_applies_pool_and_policy_ttl() {
+        let server = MockServer::start().await;
+        mount_create_api(&server, true, false).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("3h".into()),
+                alias: Some("review".into()),
+            }),
+        )
+        .await;
+        let status = response.status();
+        let body = response_json(response).await;
+        assert_eq!(status, StatusCode::ACCEPTED, "response: {body}");
+        assert_eq!(body["ttl"], "2h");
+        assert_eq!(body["effective_ttl"], "2h");
+        assert!(body.get("kubeconfig").is_none());
+        assert!(body.get("token").is_none());
+
+        let requests = server.received_requests().await.unwrap();
+        let create = requests
+            .iter()
+            .find(|request| {
+                request.method.as_str() == "POST" && request.url.path().ends_with("/sandboxleases")
+            })
+            .expect("SandboxLease create request");
+        let object: serde_json::Value = serde_json::from_slice(&create.body).unwrap();
+        assert_eq!(object["spec"]["requester"]["identity"], "alice@example.com");
+        assert_eq!(object["spec"]["requester"]["provider"], "developer-oidc");
+        assert_eq!(object["spec"]["poolRef"]["uid"], "pool-uid");
+        assert_eq!(object["spec"]["ttl"], "2h");
+        assert!(object["spec"].get("namespace").is_none());
+        assert!(object["spec"].get("runtimeClassName").is_none());
+    }
+
+    #[tokio::test]
+    async fn create_treats_applied_but_lost_admission_response_as_success() {
+        let server = MockServer::start().await;
+        mount_create_api(&server, true, true).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .all(|request| request.method.as_str() != "DELETE")
+        );
+    }
+
+    // NOTE: `create_fails_closed_and_removes_lease_missing_from_relist` was
+    // here and is gone with the design it tested. It asserted that a lease
+    // absent from a post-create LIST fails closed — the verification step of
+    // the list-then-rank quota scheme this branch replaces. Under the CAS
+    // ledger the LIST is not a verification step at all (it cannot be: two
+    // replicas can both read a free slot), so the relist result no longer
+    // decides admission. The tests below pin the mechanism that does.
+
+    /// A request that dies between reserving and admitting must not lock its
+    /// principal out permanently.
+    ///
+    /// This is the boundary the bug actually reaches a user at: reservations are
+    /// owned by their SandboxLease, so Kubernetes GC frees them only once that
+    /// lease is *deleted*. A lease abandoned at `pending` is never deleted —
+    /// placement ignores anything not `admitted` — so its slot and alias stay
+    /// consumed and every retry returns 429/409 with no way out but manual
+    /// deletion.
+    ///
+    /// Asserting only that `pending_lease_is_abandoned` returns true would prove
+    /// nothing: the fix lives in the create handler, so the test has to be the
+    /// create that was previously refused.
+    #[tokio::test]
+    async fn create_reclaims_quota_stranded_by_its_own_abandoned_lease() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+
+        // Both of this principal's slots are held by reservations owned by a
+        // lease that never reached `admitted`.
+        let stranded_uid = "sandbox-stranded-uid";
+        let held = mount_reservation_api_owned(
+            &server,
+            &[
+                (
+                    quota_reservation_name(&principal, 0),
+                    stranded_uid.to_string(),
+                ),
+                (
+                    quota_reservation_name(&principal, 1),
+                    stranded_uid.to_string(),
+                ),
+            ],
+        )
+        .await;
+
+        // The abandoned lease itself: same principal, still `pending`, and old
+        // enough to be past the deadline.
+        let abandoned = {
+            let mut object = lease_json("sandbox-stranded", "alice@example.com", "Pending");
+            object["metadata"]["uid"] = serde_json::json!(stranded_uid);
+            object["metadata"]["creationTimestamp"] =
+                serde_json::json!((chrono::Utc::now() - chrono::Duration::hours(2)).to_rfc3339());
+            object["metadata"]["annotations"] = serde_json::json!({
+                SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_PENDING
+            });
+            object
+        };
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200)
+                    .set_body_json(crate::testutil::k8s_list_response(vec![abandoned.clone()])),
+            )
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-stranded",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(abandoned))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-stranded",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Success"
+            })))
+            .mount(&server)
+            .await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+        assert_eq!(
+            response.status(),
+            StatusCode::ACCEPTED,
+            "a principal locked out by their own abandoned lease must recover on retry"
+        );
+
+        // The slot names are expected to still be occupied — by the NEW lease,
+        // which re-acquired them. What must be gone is any reservation still
+        // owned by the abandoned lease.
+        let remaining = held.lock().unwrap().clone();
+        let still_stranded: Vec<&String> = remaining
+            .iter()
+            .filter(|(_, object)| {
+                object["metadata"]["labels"][SANDBOX_RESERVATION_LEASE_UID_LABEL].as_str()
+                    == Some(stranded_uid)
+            })
+            .map(|(name, _)| name)
+            .collect();
+        assert!(
+            still_stranded.is_empty(),
+            "reservations owned by the abandoned lease must be released: {still_stranded:?}"
+        );
+    }
+
+    /// The deadline must never reap a request that is merely in flight — that
+    /// would delete a lease its caller is about to be told succeeded.
+    #[test]
+    fn only_leases_past_the_deadline_are_treated_as_abandoned() {
+        let now = chrono::Utc::now();
+        let fresh = (now - chrono::Duration::seconds(5)).to_rfc3339();
+        let old =
+            (now - chrono::Duration::seconds(SANDBOX_PENDING_DEADLINE_SECS + 60)).to_rfc3339();
+
+        assert!(!pending_lease_is_abandoned(Some(&fresh), now));
+        assert!(pending_lease_is_abandoned(Some(&old), now));
+        // Absent or unparseable evidence of age is not evidence of abandonment.
+        assert!(!pending_lease_is_abandoned(None, now));
+        assert!(!pending_lease_is_abandoned(Some("not-a-timestamp"), now));
+    }
+
+    /// Quota is decided by CREATE contention on a per-slot name, not by
+    /// counting. With every slot pre-held, admission must refuse, and must not
+    /// leave the caller's pending lease behind.
+    #[tokio::test]
+    async fn create_refuses_when_every_quota_slot_is_held() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+        // The policy in `identity()` allows 2 concurrent Sandbox leases.
+        let preheld: Vec<String> = (0..2)
+            .map(|slot| quota_reservation_name(&principal, slot))
+            .collect();
+        mount_reservation_api(&server, &preheld).await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .any(|request| request.method.as_str() == "DELETE"
+                    && request.url.path().contains("/sandboxleases/")),
+            "the unadmitted lease must be removed when its quota reservation fails"
+        );
+    }
+
+    /// An alias already held by another live lease is a conflict, and it must be
+    /// detected without burning one of the caller's quota slots.
+    #[tokio::test]
+    async fn create_refuses_a_taken_alias_without_consuming_a_quota_slot() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+        let held =
+            mount_reservation_api(&server, &[alias_reservation_name(&principal, "review")]).await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: Some("review".into()),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let remaining = held.lock().unwrap().clone();
+        assert_eq!(
+            remaining.len(),
+            1,
+            "only the pre-existing alias should remain; no quota slot may be consumed: {remaining:?}"
+        );
+        assert!(remaining.contains_key(&alias_reservation_name(&principal, "review")));
+    }
+
+    /// The happy path must take exactly one quota slot and one alias, so a
+    /// caller's second lease cannot silently reuse the first one's slot.
+    #[tokio::test]
+    async fn create_acquires_exactly_one_quota_slot_and_one_alias() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let held = mount_reservation_api(&server, &[]).await;
+        mount_create_lease_only(&server).await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: Some("review".into()),
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::ACCEPTED);
+
+        let principal = principal_hash(&identity());
+        let remaining = held.lock().unwrap().clone();
+        assert_eq!(
+            remaining.len(),
+            2,
+            "expected one slot + one alias: {remaining:?}"
+        );
+        assert!(remaining.contains_key(&quota_reservation_name(&principal, 0)));
+        assert!(remaining.contains_key(&alias_reservation_name(&principal, "review")));
+    }
+
+    /// Releasing a reservation must delete OUR object, never whatever now holds
+    /// that name.
+    ///
+    /// The names are deterministic and reused: once a slot is freed, the next
+    /// request takes the identical name. If a release ever runs against a stale
+    /// record — the reservation was already reaped and recreated in between —
+    /// deleting by bare name would silently free a *live* lease's slot, letting
+    /// a third request over-admit against it.
+    ///
+    /// Hardening the mock to honour UID preconditions was necessary but not
+    /// sufficient: without this test nothing reached that code path, so removing
+    /// the precondition from the production release still passed the suite.
+    #[tokio::test]
+    async fn releasing_a_stale_record_leaves_the_current_owner_alone() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let principal = principal_hash(&identity());
+        let contested = quota_reservation_name(&principal, 0);
+        // The name is currently held by a DIFFERENT lease than the one our
+        // stale record remembers.
+        let held = mount_reservation_api_owned(
+            &server,
+            &[(contested.clone(), "current-owner-lease-uid".to_string())],
+        )
+        .await;
+
+        let client = crate::testutil::mock_k8s_client(&server);
+        let reservations: Api<Lease> = Api::namespaced(client, "test-ns");
+        let stale = AdmissionReservation {
+            name: contested.clone(),
+            uid: "a-previous-reservation-uid".into(),
+        };
+
+        release_admission_reservations(&reservations, std::slice::from_ref(&stale))
+            .await
+            .expect("a stale record is not an error — ours is simply already gone");
+
+        assert!(
+            held.lock().unwrap().contains_key(&contested),
+            "the current owner's reservation must survive a stale release"
+        );
+    }
+
+    /// Reservations are fenced to the lease UID, so a different principal's
+    /// identical alias is a different reservation name and does not collide.
+    #[test]
+    fn reservation_names_are_scoped_per_principal() {
+        let alice = principal_hash(&identity());
+        let bob = principal_hash(&AuthIdentity {
+            identity: "bob@example.com".into(),
+            ..identity()
+        });
+        assert_ne!(alice, bob);
+        assert_ne!(
+            alias_reservation_name(&alice, "review"),
+            alias_reservation_name(&bob, "review")
+        );
+        assert_ne!(
+            quota_reservation_name(&alice, 0),
+            quota_reservation_name(&bob, 0)
+        );
+    }
+
+    #[tokio::test]
+    async fn list_filters_exact_identity_after_hash_prefilter() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![
+                    lease_json("sandbox-own", "alice@example.com", "Ready"),
+                    lease_json("sandbox-foreign", "mallory@example.com", "Ready"),
+                ]),
+            ))
+            .mount(&server)
+            .await;
+
+        let response = list_sandbox_leases::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        assert_eq!(body.as_array().unwrap().len(), 1);
+        assert_eq!(body[0]["id"], "sandbox-own");
+        assert!(body[0].get("requester").is_none());
+    }
+
+    #[tokio::test]
+    async fn foreign_get_and_release_are_indistinguishable_from_missing() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-foreign",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-foreign",
+                "mallory@example.com",
+                "Ready",
+            )))
+            .mount(&server)
+            .await;
+
+        let get_response = get_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-foreign".into()),
+        )
+        .await;
+        assert_eq!(get_response.status(), StatusCode::NOT_FOUND);
+
+        let release_response = release_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-foreign".into()),
+        )
+        .await;
+        assert_eq!(release_response.status(), StatusCode::NOT_FOUND);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .all(|request| request.method.as_str() != "PATCH")
+        );
+    }
+
+    #[tokio::test]
+    async fn release_records_intent_without_writing_controller_status() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-own",
+                "alice@example.com",
+                "Ready",
+            )))
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-own",
+                "alice@example.com",
+                "Ready",
+            )))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let response = release_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-own".into()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::NO_CONTENT);
+
+        let requests = server.received_requests().await.unwrap();
+        let patch = requests
+            .iter()
+            .find(|request| request.method.as_str() == "PATCH")
+            .expect("release intent patch");
+        assert!(!patch.url.path().ends_with("/status"));
+        let body: serde_json::Value = serde_json::from_slice(&patch.body).unwrap();
+        assert_eq!(body["metadata"]["resourceVersion"], "1");
+        assert!(
+            body["metadata"]["annotations"]
+                .get(SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION)
+                .is_some()
+        );
+        assert!(body.get("status").is_none());
+    }
+
+    #[tokio::test]
+    async fn quarantined_release_is_explicit_conflict() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease_json(
+                "sandbox-own",
+                "alice@example.com",
+                "Quarantined",
+            )))
+            .mount(&server)
+            .await;
+
+        let response = release_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-own".into()),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap()
+                .iter()
+                .all(|request| request.method.as_str() != "PATCH")
+        );
+    }
+}

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -317,7 +317,12 @@ async fn create_sandbox_lease<B: ClusterBackend>(
     // Quota and alias admission use atomic, per-principal Kubernetes Lease
     // reservations. Advisory LIST checks above improve error latency, but only
     // these CREATE operations are authoritative across API replicas.
-    let admission_reservations = match acquire_admission_reservations(
+    // The returned handles are intentionally unused past this point: every
+    // cleanup path goes through `delete_exact_pending_lease`, which deletes the
+    // lease under its UID fence FIRST and then releases whatever carries that
+    // lease's UID label. Releasing from this handle directly would free the
+    // quota slot before the lease is provably gone.
+    let _admission_reservations = match acquire_admission_reservations(
         &reservations,
         &created,
         &identity,
@@ -370,19 +375,62 @@ async fn create_sandbox_lease<B: ClusterBackend>(
     };
 
     if let Err(err) = admit_sandbox_lease(&leases, &reservations, &created).await {
-        if matches!(err, SandboxLeaseMutationError::AdmissionNotCommitted) {
-            if let Err(cleanup_err) =
-                release_admission_reservations(&reservations, &admission_reservations).await
-            {
-                error!(error = %cleanup_err, "Failed to release Sandbox admission reservations");
+        match err {
+            // Provably NOT admitted. Remove the lease, which releases its own
+            // reservations afterwards.
+            //
+            // Deliberately does not release reservations first. Doing so would
+            // free the quota slot while the lease might still be live — if the
+            // "not committed" classification were ever wrong, another request
+            // could take that slot against an admitted lease and over-admit.
+            // Deleting the lease under its UID fence is what makes the release
+            // safe, so it has to come first.
+            SandboxLeaseMutationError::AdmissionNotCommitted => {
+                if let Err(cleanup_err) =
+                    delete_exact_pending_lease(&leases, &reservations, &created).await
+                {
+                    error!(error = %cleanup_err, "Failed to remove Sandbox lease after admission failure");
+                }
+                return sandbox_infra_error("Failed to finalize Sandbox lease admission", err);
             }
-            if let Err(cleanup_err) =
-                delete_exact_pending_lease(&leases, &reservations, &created).await
-            {
-                error!(error = %cleanup_err, "Failed to remove Sandbox lease after admission failure");
+            // Anything else means we do NOT know whether admission committed —
+            // a lost response, a transport error, a mutating webhook reshaping
+            // the object. Returning failure on a guess is the worst outcome
+            // available: if the lease actually IS admitted, the caller retries
+            // and ends up with two sandboxes for one intended request.
+            //
+            // So re-read the exact object and report what is true.
+            other => {
+                match leases.get(&lease_id).await {
+                    Ok(current)
+                        if current
+                            .annotations()
+                            .get(SANDBOX_ADMISSION_ANNOTATION)
+                            .map(String::as_str)
+                            == Some(SANDBOX_ADMISSION_ADMITTED) =>
+                    {
+                        warn!(
+                            lease_id = %lease_id,
+                            error = %other,
+                            "admission response was lost but the lease is admitted; \
+                             reporting success rather than inviting a duplicate retry"
+                        );
+                        // Fall through to the success response below.
+                    }
+                    _ => {
+                        if let Err(cleanup_err) =
+                            delete_exact_pending_lease(&leases, &reservations, &created).await
+                        {
+                            error!(error = %cleanup_err, "Failed to remove Sandbox lease after admission failure");
+                        }
+                        return sandbox_infra_error(
+                            "Failed to finalize Sandbox lease admission",
+                            other,
+                        );
+                    }
+                }
             }
         }
-        return sandbox_infra_error("Failed to finalize Sandbox lease admission", err);
     }
 
     info!(
@@ -726,6 +774,47 @@ fn requester_list_params(identity: &AuthIdentity) -> ListParams {
 /// and from the released chart, so no object could exist under the old scheme.
 /// Once this ships, any further change needs a versioned migration that keeps
 /// enforcing against legacy reservations until they are drained.
+/// Whether a reservation name is one this principal could legitimately own.
+///
+/// Names are deterministic (`sbx-quota-{hash}-{slot}`,
+/// `sbx-alias-{hash}-{alias}`), so an object that does not match either shape
+/// for this exact principal is not ours to delete — however it is labelled.
+fn reservation_name_belongs_to(name: &str, principal: &str) -> bool {
+    if let Some(slot) = name.strip_prefix(&format!("sbx-{SANDBOX_RESERVATION_QUOTA}-{principal}-"))
+    {
+        // A slot index and nothing else, so a crafted suffix cannot ride along.
+        return !slot.is_empty() && slot.bytes().all(|byte| byte.is_ascii_digit());
+    }
+    if let Some(alias) = name.strip_prefix(&format!("sbx-{SANDBOX_RESERVATION_ALIAS}-{principal}-"))
+    {
+        // Aliases are validated DNS labels at admission; re-check the shape
+        // here so a name that merely starts correctly cannot slip through.
+        return is_valid_k8s_name(alias);
+    }
+    false
+}
+
+/// The same digest as [`principal_hash`], over a stored principal rather than a
+/// live authenticated identity. Cleanup runs from the persisted object, not
+/// from a request, so it needs this form.
+fn principal_hash_for(requester: &SandboxPrincipal) -> String {
+    let mut hasher = Sha256::new();
+    for component in [
+        requester.provider.as_bytes(),
+        requester.issuer.as_bytes(),
+        requester.identity.as_bytes(),
+    ] {
+        hasher.update((component.len() as u64).to_be_bytes());
+        hasher.update(component);
+    }
+    hasher
+        .finalize()
+        .iter()
+        .take(16)
+        .map(|byte| format!("{byte:02x}"))
+        .collect()
+}
+
 fn principal_hash(identity: &AuthIdentity) -> String {
     let mut hasher = Sha256::new();
     for component in [
@@ -768,6 +857,84 @@ fn pending_lease_is_abandoned(
         return false;
     };
     (now - created_at.with_timezone(&chrono::Utc)).num_seconds() >= SANDBOX_PENDING_DEADLINE_SECS
+}
+
+/// Background sweep that reclaims abandoned admission state for every principal.
+///
+/// The create-path sweep only helps a caller who comes back. A principal whose
+/// request died mid-admission and who never calls create again keeps their
+/// quota slot and alias consumed indefinitely — and an operator has no way to
+/// see it, because the lease looks like an ordinary `pending` object that no
+/// controller will ever touch (placement ignores anything not `admitted`).
+///
+/// This runs on the operator, so recovery no longer depends on the victim
+/// retrying. Same fences as the create-path sweep: only leases past the
+/// deadline, deleted under UID + resourceVersion preconditions, releasing only
+/// reservations whose names derive from that lease's own principal.
+///
+/// Deliberately does NOT need the Sandbox placement controller (#73) — it
+/// operates purely on the admission objects this module owns, so it can ship
+/// while placement is still blocked.
+pub async fn run_sandbox_admission_reaper(
+    client: kube::Client,
+    namespace: &str,
+    shutdown: tokio_util::sync::CancellationToken,
+) {
+    let mut interval = tokio::time::interval(std::time::Duration::from_secs(120));
+    let leases: Api<SandboxLease> = Api::namespaced(client.clone(), namespace);
+    let reservations: Api<Lease> = Api::namespaced(client, namespace);
+
+    loop {
+        tokio::select! {
+            _ = interval.tick() => {},
+            _ = shutdown.cancelled() => {
+                info!("Sandbox admission reaper shutting down");
+                return;
+            },
+        }
+
+        let now = chrono::Utc::now();
+        let all = match leases.list(&ListParams::default()).await {
+            Ok(list) => list,
+            Err(error) => {
+                warn!(error = %error, "Sandbox admission reaper could not list leases");
+                continue;
+            }
+        };
+
+        for lease in all.items {
+            if lease
+                .annotations()
+                .get(SANDBOX_ADMISSION_ANNOTATION)
+                .map(String::as_str)
+                != Some(SANDBOX_ADMISSION_PENDING)
+            {
+                continue;
+            }
+            if !pending_lease_is_abandoned(
+                lease
+                    .metadata
+                    .creation_timestamp
+                    .as_ref()
+                    .map(|timestamp| timestamp.0.to_string())
+                    .as_deref(),
+                now,
+            ) {
+                continue;
+            }
+            match delete_exact_pending_lease(&leases, &reservations, &lease).await {
+                Ok(()) => info!(
+                    lease_id = %lease.name_any(),
+                    "Reaped an abandoned unadmitted Sandbox lease and released its quota"
+                ),
+                Err(error) => warn!(
+                    lease_id = %lease.name_any(),
+                    error = %error,
+                    "Could not reap an abandoned unadmitted Sandbox lease; will retry"
+                ),
+            }
+        }
+    }
 }
 
 /// Release quota and aliases stranded by a request that died mid-admission.
@@ -911,7 +1078,12 @@ async fn admit_sandbox_lease(
                     validate_lease_shape(lease, &current, SANDBOX_ADMISSION_ADMITTED)
                 }
                 Some(SANDBOX_ADMISSION_PENDING) => {
-                    validate_lease_shape(lease, &current, SANDBOX_ADMISSION_PENDING)?;
+                    // The safety property is "never delete an ADMITTED lease by this path",
+                    // not "the annotation must read exactly `pending`". Demanding the latter
+                    // bricked any lease whose annotation went missing or corrupt: the release
+                    // handler routes everything not-admitted here, and this then refused it
+                    // forever, so the object could not be removed through the API at all.
+                    validate_lease_shape_unadmitted(lease, &current)?;
                     delete_exact_pending_lease(leases, reservations, &current).await?;
                     Err(SandboxLeaseMutationError::AdmissionNotCommitted)
                 }
@@ -1045,10 +1217,20 @@ async fn acquire_admission_reservations(
             .create(&PostParams::default(), &reservation)
             .await
         {
-            Ok(created) => acquired.push(AdmissionReservation {
-                name: created.name_any(),
-                uid: created.uid().unwrap_or_default(),
-            }),
+            Ok(created) => {
+                // An empty UID would make every later release fail its
+                // precondition with 409, which the release path treats as
+                // "ours is already gone" — silently stranding the slot.
+                // Refuse rather than acquire something we can never release.
+                let Some(uid) = created.uid() else {
+                    rollback_partial_reservations(reservations, &acquired).await;
+                    return Err(AdmissionReservationError::MissingLeaseUid);
+                };
+                acquired.push(AdmissionReservation {
+                    name: created.name_any(),
+                    uid,
+                });
+            }
             Err(kube::Error::Api(error)) if error.code == 409 => {
                 return Err(AdmissionReservationError::AliasTaken);
             }
@@ -1096,9 +1278,15 @@ async fn acquire_admission_reservations(
             .await
         {
             Ok(created) => {
+                // Same reasoning as the alias arm: a reservation we cannot
+                // name by UID is one we can never release.
+                let Some(uid) = created.uid() else {
+                    rollback_partial_reservations(reservations, &acquired).await;
+                    return Err(AdmissionReservationError::MissingLeaseUid);
+                };
                 acquired.push(AdmissionReservation {
                     name: created.name_any(),
-                    uid: created.uid().unwrap_or_default(),
+                    uid,
                 });
                 slot_taken = true;
                 break;
@@ -1170,14 +1358,37 @@ async fn release_admission_reservations(
 /// keeps a recreated same-named lease from dropping its predecessor's slots.
 async fn release_reservations_for_lease(
     reservations: &Api<Lease>,
+    lease: &SandboxLease,
     lease_uid: &str,
 ) -> Result<(), SandboxLeaseMutationError> {
     let params = ListParams::default().labels(&format!(
         "{SANDBOX_RESERVATION_LEASE_UID_LABEL}={lease_uid}"
     ));
     let owned = reservations.list(&params).await?;
+
+    // A label is caller-supplied data, not an integrity check. Deleting
+    // everything a selector returns makes this a confused deputy: anyone able
+    // to create a coordination Lease in this namespace could label an unrelated
+    // object with a victim's SandboxLease UID and have Kobe's privileged
+    // credentials delete it during that victim's cleanup.
+    //
+    // So the selector only narrows the search. What may actually be deleted is
+    // decided here, from names derived from THIS lease's own principal.
+    let principal = principal_hash_for(&lease.spec.requester);
     let held: Vec<AdmissionReservation> = owned
         .into_iter()
+        .filter(|reservation| {
+            let name = reservation.name_any();
+            if !reservation_name_belongs_to(&name, &principal) {
+                warn!(
+                    reservation = %name,
+                    "refusing to delete a reservation whose name does not match this lease's \
+                     principal; it carries our UID label but is not ours"
+                );
+                return false;
+            }
+            true
+        })
         .filter_map(|reservation| {
             Some(AdmissionReservation {
                 name: reservation.name_any(),
@@ -1213,7 +1424,7 @@ async fn delete_exact_pending_lease(
         Ok(current) => current,
         Err(kube::Error::Api(error)) if error.code == 404 => {
             // The lease is already gone; its reservations may not be.
-            return release_reservations_for_lease(reservations, &expected_uid).await;
+            return release_reservations_for_lease(reservations, lease, &expected_uid).await;
         }
         Err(error) => return Err(error.into()),
     };
@@ -1232,7 +1443,30 @@ async fn delete_exact_pending_lease(
         ..Default::default()
     };
     leases.delete(&current.name_any(), &params).await?;
-    release_reservations_for_lease(reservations, &expected_uid).await
+    release_reservations_for_lease(reservations, lease, &expected_uid).await
+}
+
+/// Validate everything `validate_lease_shape` does, except that the admission
+/// annotation need only be **not admitted** rather than exactly `pending`.
+///
+/// Used on the delete path. An admitted lease must never be removed this way —
+/// that is the invariant worth keeping — but a lease stuck with a missing or
+/// unrecognised annotation is unadmitted by definition and has to remain
+/// deletable, or it becomes permanently stuck holding its principal's quota.
+fn validate_lease_shape_unadmitted(
+    expected: &SandboxLease,
+    actual: &SandboxLease,
+) -> Result<(), SandboxLeaseMutationError> {
+    let admission = actual
+        .annotations()
+        .get(SANDBOX_ADMISSION_ANNOTATION)
+        .map(String::as_str);
+    if admission == Some(SANDBOX_ADMISSION_ADMITTED) {
+        return Err(SandboxLeaseMutationError::UnexpectedAdmissionState);
+    }
+    // Reuse the strict checks for identity and shape by passing whatever the
+    // object actually carries, so only the admission comparison is relaxed.
+    validate_lease_shape(expected, actual, admission.unwrap_or_default())
 }
 
 fn validate_lease_shape(
@@ -2271,6 +2505,327 @@ mod tests {
             held.lock().unwrap().contains_key(&contested),
             "the current owner's reservation must survive a stale release"
         );
+    }
+
+    /// The durable reaper must reclaim a stranded lease belonging to a
+    /// principal who never comes back.
+    ///
+    /// The create-path sweep only helps a caller who retries. This is the case
+    /// it cannot cover: the request died mid-admission and nobody returns, so
+    /// the quota slot and alias stay consumed with no controller willing to
+    /// touch the `pending` lease.
+    ///
+    /// Driving the whole background loop would mean waiting on its interval, so
+    /// this exercises the same decision and the same fenced deletion the loop
+    /// performs per lease.
+    #[tokio::test]
+    async fn the_reaper_reclaims_a_lease_whose_principal_never_returns() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+        let stranded_uid = "sandbox-orphan-uid";
+
+        let held = mount_reservation_api_owned(
+            &server,
+            &[(
+                quota_reservation_name(&principal, 0),
+                stranded_uid.to_string(),
+            )],
+        )
+        .await;
+
+        let abandoned = {
+            let mut object = lease_json("sandbox-orphan", "alice@example.com", "Pending");
+            object["metadata"]["uid"] = serde_json::json!(stranded_uid);
+            object["metadata"]["creationTimestamp"] =
+                serde_json::json!((chrono::Utc::now() - chrono::Duration::hours(3)).to_rfc3339());
+            object["metadata"]["annotations"] = serde_json::json!({
+                SANDBOX_ADMISSION_ANNOTATION: SANDBOX_ADMISSION_PENDING
+            });
+            object
+        };
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-orphan",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(abandoned.clone()))
+            .mount(&server)
+            .await;
+        Mock::given(method("DELETE"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-orphan",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Success"
+            })))
+            .mount(&server)
+            .await;
+
+        let client = crate::testutil::mock_k8s_client(&server);
+        let leases: Api<SandboxLease> = Api::namespaced(client.clone(), "test-ns");
+        let reservations: Api<Lease> = Api::namespaced(client, "test-ns");
+        let lease: SandboxLease = serde_json::from_value(abandoned).unwrap();
+
+        // The reaper's per-lease decision: past the deadline, so reclaim it.
+        assert!(pending_lease_is_abandoned(
+            lease
+                .metadata
+                .creation_timestamp
+                .as_ref()
+                .map(|timestamp| timestamp.0.to_string())
+                .as_deref(),
+            chrono::Utc::now()
+        ));
+        delete_exact_pending_lease(&leases, &reservations, &lease)
+            .await
+            .expect("the reaper must be able to reclaim it");
+
+        let remaining = held.lock().unwrap().clone();
+        assert!(
+            remaining.is_empty(),
+            "the stranded principal's quota must be released even though they never retried:              {remaining:?}"
+        );
+    }
+
+    /// An admission that lands LATE must not be reported as failure.
+    ///
+    /// The race, from the review that found it: the PATCH commits, but the
+    /// response is lost; `admit_sandbox_lease` re-reads and still sees
+    /// `pending` (the write has not surfaced yet); its fenced DELETE then 409s
+    /// against the now-landed patch; so it returns a *Kubernetes* error rather
+    /// than `AdmissionNotCommitted`. The old code returned 503 for that with no
+    /// further checking — while an admitted, placeable lease existed. The
+    /// caller retries and ends up with TWO sandboxes for one request.
+    ///
+    /// Note this is NOT the same as the applied-but-lost case, which
+    /// `admit_sandbox_lease` already resolves internally: with the outer
+    /// re-read disabled, that one still passes. This test fails without it.
+    #[tokio::test]
+    async fn an_admission_that_lands_late_is_not_reported_as_failure() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        mount_reservation_api(&server, &[]).await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pool_json()))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(Vec::<serde_json::Value>::new()),
+            ))
+            .mount(&server)
+            .await;
+
+        let created_state = Arc::new(Mutex::new(None::<serde_json::Value>));
+        let create_state = Arc::clone(&created_state);
+        Mock::given(method("POST"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases",
+            ))
+            .respond_with(move |request: &wiremock::Request| {
+                let mut object: serde_json::Value = serde_json::from_slice(&request.body).unwrap();
+                let name = object["metadata"]["name"].as_str().unwrap().to_string();
+                object["metadata"]["uid"] = serde_json::json!(format!("{name}-uid"));
+                object["metadata"]["resourceVersion"] = serde_json::json!("1");
+                object["metadata"]["creationTimestamp"] = serde_json::json!("2026-08-12T00:00:00Z");
+                *create_state.lock().unwrap() = Some(object.clone());
+                ResponseTemplate::new(201).set_body_json(object)
+            })
+            .mount(&server)
+            .await;
+
+        // The PATCH "fails" from the client's point of view.
+        Mock::given(method("PATCH"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(ResponseTemplate::new(500).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure", "code": 500
+            })))
+            .mount(&server)
+            .await;
+
+        // First GET (inside admit) still reads `pending`; the second (our outer
+        // re-read) sees the patch has landed as `admitted`.
+        let reads = Arc::new(Mutex::new(0u32));
+        let get_state = Arc::clone(&created_state);
+        let get_reads = Arc::clone(&reads);
+        Mock::given(method("GET"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(move |_: &wiremock::Request| {
+                let mut object = get_state.lock().unwrap().clone().unwrap();
+                let mut seen = get_reads.lock().unwrap();
+                *seen += 1;
+                let admission = if *seen == 1 {
+                    SANDBOX_ADMISSION_PENDING
+                } else {
+                    SANDBOX_ADMISSION_ADMITTED
+                };
+                object["metadata"]["annotations"] =
+                    serde_json::json!({ SANDBOX_ADMISSION_ANNOTATION: admission });
+                ResponseTemplate::new(200).set_body_json(object)
+            })
+            .mount(&server)
+            .await;
+
+        // The fenced DELETE loses to the late-landing patch.
+        Mock::given(method("DELETE"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sandbox-[a-z0-9]+$",
+            ))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "Conflict", "code": 409
+            })))
+            .mount(&server)
+            .await;
+
+        let response = create_sandbox_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(CreateSandboxLeaseRequest {
+                pool: "agent-small".into(),
+                ttl: Some("1h".into()),
+                alias: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(
+            response.status(),
+            StatusCode::ACCEPTED,
+            "the lease is admitted and placeable; a 503 here makes the caller \
+             retry and create a second sandbox"
+        );
+    }
+
+    /// A lease with a corrupted admission annotation must stay deletable.
+    ///
+    /// The release handler routes everything not-`admitted` to the delete path,
+    /// which used to demand the annotation read exactly `pending`. So a lease
+    /// whose annotation went missing or unrecognised could not be removed
+    /// through the API at all — it 503'd forever, holding its principal's quota
+    /// with no operator recourse short of editing etcd.
+    ///
+    /// Relaxing this must NOT weaken the real invariant: an admitted lease is
+    /// still refused, because deleting one here would drop a live sandbox's
+    /// record while its workload runs.
+    #[test]
+    fn a_corrupted_annotation_stays_deletable_but_an_admitted_lease_does_not() {
+        let base = sandbox_lease_from_json_with_admission(
+            lease_json("sandbox-x", "alice@example.com", "Pending"),
+            SANDBOX_ADMISSION_PENDING,
+        );
+
+        // Normal case still works.
+        assert!(validate_lease_shape_unadmitted(&base, &base).is_ok());
+
+        // Corrupted / unrecognised annotation: deletable.
+        let corrupted = sandbox_lease_from_json_with_admission(
+            lease_json("sandbox-x", "alice@example.com", "Pending"),
+            "garbage-value",
+        );
+        assert!(
+            validate_lease_shape_unadmitted(&corrupted, &corrupted).is_ok(),
+            "an unrecognised annotation is still unadmitted, so it must be removable"
+        );
+
+        // Admitted: still refused. This is the invariant the relaxation keeps.
+        let admitted = sandbox_lease_from_json_with_admission(
+            lease_json("sandbox-x", "alice@example.com", "Pending"),
+            SANDBOX_ADMISSION_ADMITTED,
+        );
+        assert!(
+            matches!(
+                validate_lease_shape_unadmitted(&admitted, &admitted),
+                Err(SandboxLeaseMutationError::UnexpectedAdmissionState)
+            ),
+            "an admitted lease must never be removed by the unadmitted delete path"
+        );
+    }
+
+    fn sandbox_lease_from_json_with_admission(
+        mut object: serde_json::Value,
+        admission: &str,
+    ) -> SandboxLease {
+        object["metadata"]["annotations"] =
+            serde_json::json!({ SANDBOX_ADMISSION_ANNOTATION: admission });
+        serde_json::from_value(object).expect("lease fixture must deserialize")
+    }
+
+    /// An object carrying our UID label but NOT our name shape must survive.
+    ///
+    /// The label is caller-supplied data. Anyone able to create a coordination
+    /// Lease in this namespace could stamp a victim's SandboxLease UID onto an
+    /// unrelated object and have Kobe's privileged credentials delete it during
+    /// that victim's cleanup — a confused deputy. Only names derived from this
+    /// lease's own principal may be deleted.
+    #[test]
+    fn only_names_derived_from_our_principal_may_be_deleted() {
+        let principal = principal_hash(&identity());
+
+        // Ours.
+        assert!(reservation_name_belongs_to(
+            &quota_reservation_name(&principal, 0),
+            &principal
+        ));
+        assert!(reservation_name_belongs_to(
+            &alias_reservation_name(&principal, "review"),
+            &principal
+        ));
+
+        // An injected object that merely carries our label.
+        assert!(!reservation_name_belongs_to(
+            "important-system-lease",
+            &principal
+        ));
+        assert!(!reservation_name_belongs_to(
+            "kube-controller-manager",
+            &principal
+        ));
+
+        // Another principal's reservations are not ours to release.
+        let other = principal_hash(&AuthIdentity {
+            identity: "mallory@example.com".into(),
+            ..identity()
+        });
+        assert!(!reservation_name_belongs_to(
+            &quota_reservation_name(&other, 0),
+            &principal
+        ));
+
+        // Right prefix, wrong shape: a crafted suffix must not ride along.
+        assert!(!reservation_name_belongs_to(
+            &format!("sbx-quota-{principal}-0-extra"),
+            &principal
+        ));
+        assert!(!reservation_name_belongs_to(
+            &format!("sbx-quota-{principal}-"),
+            &principal
+        ));
+    }
+
+    /// The persisted-principal digest must agree with the live-identity one, or
+    /// cleanup would compute names that never match what admission created.
+    #[test]
+    fn stored_and_live_principal_digests_agree() {
+        let live = identity();
+        let stored = SandboxPrincipal {
+            provider: live.provider.clone(),
+            requester_type: live.requester_type.clone(),
+            issuer: live.issuer.clone(),
+            identity: live.identity.clone(),
+        };
+        assert_eq!(principal_hash(&live), principal_hash_for(&stored));
     }
 
     /// Reservations are fenced to the lease UID, so a different principal's

--- a/src/backend/datastore.rs
+++ b/src/backend/datastore.rs
@@ -461,6 +461,41 @@ pub async fn ensure_cluster_role(
 
 /// Drop the per-cluster role. Call AFTER `drop_database`: PostgreSQL refuses to
 /// drop a role that still owns objects.
+/// Whether this cluster's database still exists.
+///
+/// Verification, not cleanup: `DROP DATABASE IF EXISTS` succeeding proves the
+/// statement ran, not that the database is gone — a concurrent recreate, a
+/// failed drop that only warned, or a connection to a different server all
+/// leave it present. Teardown evidence has to come from a separate read.
+///
+/// An error is deliberately propagated rather than reported as "absent". A
+/// query that could not run is uncertainty, and uncertainty must quarantine.
+pub async fn database_exists(pool: &PgPool, cluster_name: &str, prefix: &str) -> Result<bool> {
+    let db_name = sanitize_db_name(cluster_name, prefix)?;
+    let found: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM pg_database WHERE datname = $1")
+        .bind(&db_name)
+        .fetch_optional(pool)
+        .await
+        .with_context(|| format!("Failed to check whether database {db_name} exists"))?;
+    Ok(found.is_some())
+}
+
+/// Whether this cluster's per-cluster role still exists.
+///
+/// Separate from the database on purpose: a role can outlive the database it
+/// owned, and it carries credentials. Dropping the database while leaving the
+/// role behind is exactly the leak that would otherwise sit inside a receipt
+/// claiming the footprint is gone.
+pub async fn cluster_role_exists(pool: &PgPool, cluster_name: &str, prefix: &str) -> Result<bool> {
+    let role_name = sanitize_db_name(cluster_name, prefix)?;
+    let found: Option<(i32,)> = sqlx::query_as("SELECT 1 FROM pg_roles WHERE rolname = $1")
+        .bind(&role_name)
+        .fetch_optional(pool)
+        .await
+        .with_context(|| format!("Failed to check whether role {role_name} exists"))?;
+    Ok(found.is_some())
+}
+
 pub async fn drop_cluster_role(pool: &PgPool, cluster_name: &str, prefix: &str) -> Result<()> {
     let name = sanitize_db_name(cluster_name, prefix)?;
     info!(role = %name, "Dropping per-cluster datastore role");

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -30,6 +30,9 @@ use kube::api::{
 use std::collections::BTreeMap;
 use tracing::{debug, info, warn};
 
+use crate::backend::VerifiedDestroyUnsupported;
+use crate::crd::{CheckResult, TeardownCheck, TeardownSubject};
+
 use crate::crd::{
     Addon, ClusterConfig, IntraPlacementMode, KubeletSharedMountConfig, Placement, ReadinessGate,
 };
@@ -1762,6 +1765,234 @@ impl K3sBackend {
     /// prefix would also match the PVCs of a *different* cluster literally named
     /// `{cluster}-server` (whose PVCs are `data-{cluster}-server-server-{n}`), so
     /// without it `delete("foo")` could reap `foo-server`'s volumes.
+    /// Record which PersistentVolumes this cluster's data PVCs are bound to.
+    ///
+    /// Must run BEFORE deletion. A PVC's `spec.volumeName` is the only link to
+    /// its backing PV, and it disappears with the PVC — so a receipt that did
+    /// not capture this first could never prove the volume was reclaimed, only
+    /// that the claim object vanished. That distinction is the difference
+    /// between "the pointer is gone" and "the tenant's data is gone".
+    ///
+    /// Returns `Err` when the PVCs could not be listed at all: not knowing what
+    /// existed is uncertainty, and the caller turns it into `Unknown`.
+    async fn capture_bound_volumes(
+        &self,
+        name: &str,
+        namespace: &str,
+    ) -> std::result::Result<Vec<String>, String> {
+        let pvcs: Api<PersistentVolumeClaim> = Api::namespaced(self.client.clone(), namespace);
+        let list = pvcs
+            .list(&ListParams::default())
+            .await
+            .map_err(|_| "pvc_list_failed".to_string())?;
+
+        let mut volumes = Vec::new();
+        for pvc in list.items {
+            let Some(pvc_name) = pvc.metadata.name.as_deref() else {
+                continue;
+            };
+            if !Self::is_server_data_pvc(pvc_name, name) {
+                continue;
+            }
+            match pvc.spec.as_ref().and_then(|spec| spec.volume_name.clone()) {
+                Some(volume) => volumes.push(volume),
+                // A data PVC with no bound volume is either still provisioning
+                // or bound to something we cannot name. Either way we cannot
+                // later prove that volume is gone.
+                None => return Err("pvc_unbound_volume_unknown".to_string()),
+            }
+        }
+        Ok(volumes)
+    }
+
+    /// Prove one subject absent, or report why we cannot.
+    ///
+    /// Every arm answers the same question — "can I *observe* that this is
+    /// gone?" — and returns `Unknown` rather than guessing. A read that errors
+    /// is never absence.
+    async fn verify_subject_absent(
+        &self,
+        name: &str,
+        namespace: &str,
+        subject: TeardownSubject,
+        bound_volumes: &std::result::Result<Vec<String>, String>,
+        delete_outcome: &Result<()>,
+    ) -> TeardownCheck {
+        // A failed delete means the footprint was never fully addressed, so no
+        // subject can be claimed absent on the strength of this attempt.
+        if let Err(error) = delete_outcome {
+            debug!(cluster = name, error = %error, "teardown delete failed; subject unverifiable");
+            return TeardownCheck {
+                subject,
+                result: CheckResult::Unknown,
+                reason: Some("delete_failed".into()),
+                verified: Vec::new(),
+            };
+        }
+
+        // Recorded alongside the verdict so the receipt says WHICH resources
+        // were inspected, not merely that some resource of this category was.
+        let mut verified: Vec<String> = Vec::new();
+        let (result, reason) = match subject {
+            TeardownSubject::AgentDeployment => {
+                let api: Api<Deployment> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-agent"));
+                Self::absent_by_name(&api, &format!("{name}-agent")).await
+            }
+            TeardownSubject::ServerStatefulSet => {
+                let api: Api<StatefulSet> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-server"));
+                Self::absent_by_name(&api, &format!("{name}-server")).await
+            }
+            TeardownSubject::Service => {
+                let api: Api<Service> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-server"));
+                Self::absent_by_name(&api, &format!("{name}-server")).await
+            }
+            TeardownSubject::PodDisruptionBudget => {
+                let api: Api<PodDisruptionBudget> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-server"));
+                Self::absent_by_name(&api, &format!("{name}-server")).await
+            }
+            TeardownSubject::PublisherConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-kubeconfig-publisher"));
+                Self::absent_by_name(&api, &format!("{name}-kubeconfig-publisher")).await
+            }
+            TeardownSubject::RegistriesConfigMap => {
+                let api: Api<ConfigMap> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-registries"));
+                Self::absent_by_name(&api, &format!("{name}-registries")).await
+            }
+            TeardownSubject::TokenSecret => {
+                let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-token"));
+                Self::absent_by_name(&api, &format!("{name}-token")).await
+            }
+            TeardownSubject::KubeconfigSecret => {
+                let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-kubeconfig"));
+                Self::absent_by_name(&api, &format!("{name}-kubeconfig")).await
+            }
+            TeardownSubject::ConnectTokenSecret => {
+                let api: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
+                verified.push(format!("{name}-connect-token"));
+                Self::absent_by_name(&api, &format!("{name}-connect-token")).await
+            }
+            // Pods are label-selected rather than named: a StatefulSet's pods
+            // outlive its deletion while terminating, which is precisely the
+            // window an accepted DELETE would have hidden.
+            TeardownSubject::ServerPods => {
+                let pods: Api<Pod> = Api::namespaced(self.client.clone(), namespace);
+                let selector = format!("kobe.kunobi.ninja/cluster={name}");
+                verified.push(selector.clone());
+                match pods.list(&ListParams::default().labels(&selector)).await {
+                    Ok(list) if list.items.is_empty() => (CheckResult::Verified, None),
+                    Ok(_) => (CheckResult::Unknown, Some("pods_still_present".into())),
+                    Err(_) => (CheckResult::Unknown, Some("pod_list_failed".into())),
+                }
+            }
+            TeardownSubject::ServerDataPvcs => {
+                verified.push(format!("data-{name}-server-*"));
+                let pvcs: Api<PersistentVolumeClaim> =
+                    Api::namespaced(self.client.clone(), namespace);
+                match pvcs.list(&ListParams::default()).await {
+                    Ok(list) => {
+                        let remaining = list.items.iter().any(|pvc| {
+                            pvc.metadata
+                                .name
+                                .as_deref()
+                                .is_some_and(|pvc_name| Self::is_server_data_pvc(pvc_name, name))
+                        });
+                        if remaining {
+                            (CheckResult::Unknown, Some("pvc_still_present".into()))
+                        } else {
+                            (CheckResult::Verified, None)
+                        }
+                    }
+                    Err(_) => (CheckResult::Unknown, Some("pvc_list_failed".into())),
+                }
+            }
+            // The captured PVs must be gone too. A PVC deleted under a `Retain`
+            // reclaim policy leaves its volume — and the tenant's data — intact.
+            TeardownSubject::ServerDataVolumes => match bound_volumes {
+                Err(reason) => (CheckResult::Unknown, Some(reason.clone())),
+                Ok(volumes) if volumes.is_empty() => (CheckResult::Verified, None),
+                Ok(volumes) => {
+                    // The captured PV names, so the receipt says exactly which
+                    // volumes were proven reclaimed.
+                    verified.extend(volumes.iter().cloned());
+                    let api: Api<k8s_openapi::api::core::v1::PersistentVolume> =
+                        Api::all(self.client.clone());
+                    let mut verdict = (CheckResult::Verified, None);
+                    for volume in volumes {
+                        let (result, reason) = Self::absent_by_name(&api, volume).await;
+                        if result != CheckResult::Verified {
+                            verdict = (result, reason.or_else(|| Some("pv_still_present".into())));
+                            break;
+                        }
+                    }
+                    verdict
+                }
+            },
+            TeardownSubject::CidrClaim => {
+                let api: Api<crate::crd::CIDRClaim> =
+                    Api::namespaced(self.client.clone(), namespace);
+                Self::absent_by_name(&api, name).await
+            }
+            TeardownSubject::Database => match self.datastore.current() {
+                None => (CheckResult::Unknown, Some("datastore_unavailable".into())),
+                Some((pool, _)) => {
+                    verified.push(format!("database:k3s_{name}"));
+                    match datastore::database_exists(&pool, name, "k3s_").await {
+                        Ok(false) => (CheckResult::Verified, None),
+                        Ok(true) => (CheckResult::Unknown, Some("database_still_present".into())),
+                        Err(_) => (CheckResult::Unknown, Some("datastore_unreachable".into())),
+                    }
+                }
+            },
+            TeardownSubject::DatabaseRole => match self.datastore.current() {
+                None => (CheckResult::Unknown, Some("datastore_unavailable".into())),
+                Some((pool, _)) => {
+                    match datastore::cluster_role_exists(&pool, name, "k3s_").await {
+                        Ok(false) => (CheckResult::Verified, None),
+                        Ok(true) => (CheckResult::Unknown, Some("role_still_present".into())),
+                        Err(_) => (CheckResult::Unknown, Some("datastore_unreachable".into())),
+                    }
+                }
+            },
+        };
+
+        TeardownCheck {
+            subject,
+            result,
+            // Only claim to have verified something if we actually did. A
+            // failed or uncertain check must not leave identities behind that
+            // read as proof.
+            verified: if result == CheckResult::Verified {
+                verified
+            } else {
+                Vec::new()
+            },
+            reason,
+        }
+    }
+
+    /// A 404 is the ONLY proof of absence. Any other error is uncertainty —
+    /// an RBAC denial or a timeout tells us nothing about whether the object
+    /// is there, and must never read as a clean teardown.
+    async fn absent_by_name<K>(api: &Api<K>, name: &str) -> (CheckResult, Option<String>)
+    where
+        K: kube::Resource + Clone + serde::de::DeserializeOwned + std::fmt::Debug,
+        <K as kube::Resource>::DynamicType: Default,
+    {
+        match api.get_opt(name).await {
+            Ok(None) => (CheckResult::Verified, None),
+            Ok(Some(_)) => (CheckResult::Unknown, Some("still_present".into())),
+            Err(_) => (CheckResult::Unknown, Some("lookup_failed".into())),
+        }
+    }
+
     fn is_server_data_pvc(pvc_name: &str, cluster: &str) -> bool {
         let prefix = format!("data-{cluster}-server-");
         pvc_name.strip_prefix(&prefix).is_some_and(|ordinal| {
@@ -2106,6 +2337,67 @@ impl ClusterBackend for K3sBackend {
 
         info!(cluster = name, "k3s cluster deleted");
         Ok(())
+    }
+
+    fn supports_verified_destroy(&self) -> bool {
+        true
+    }
+
+    async fn capture_teardown_identities(
+        &self,
+        name: &str,
+        namespace: &str,
+    ) -> Result<Vec<String>> {
+        // Same capture the teardown path uses, run early instead. An error is
+        // propagated rather than reported as "no volumes": recording an empty
+        // list on a failed read would understate the footprint permanently.
+        self.capture_bound_volumes(name, namespace)
+            .await
+            .map_err(|reason| anyhow::anyhow!("could not capture bound volumes: {reason}"))
+    }
+
+    /// Tear down and then *prove* the footprint is absent.
+    ///
+    /// The ordering matters and is the whole contract:
+    ///
+    /// 1. **Capture** what cannot be observed after deletion — chiefly the PVs
+    ///    the data PVCs are bound to. Once a PVC is gone its `volumeName` is
+    ///    unrecoverable, so a receipt written without capturing it first can
+    ///    never prove the backing volume was reclaimed.
+    /// 2. **Delete** via the ordinary path, so verified and unverified teardown
+    ///    cannot diverge in what they remove.
+    /// 3. **Poll to confirmed absence.** An accepted DELETE is not evidence:
+    ///    finalizers, terminating Pods and PV reclaim all complete
+    ///    asynchronously, and `delete()` today returns before any of it.
+    ///
+    /// Anything that cannot be observed becomes [`CheckResult::Unknown`], which
+    /// quarantines the capacity. That is the intended outcome, not a failure of
+    /// this function.
+    async fn delete_verified(
+        &self,
+        name: &str,
+        namespace: &str,
+        plan: &[TeardownSubject],
+    ) -> std::result::Result<Vec<TeardownCheck>, VerifiedDestroyUnsupported> {
+        // Captured BEFORE deletion; unrecoverable afterwards.
+        let bound_volumes = self.capture_bound_volumes(name, namespace).await;
+
+        let delete_outcome = self.delete(name, namespace).await;
+
+        let mut checks = Vec::with_capacity(plan.len());
+        for subject in plan {
+            checks.push(
+                self.verify_subject_absent(
+                    name,
+                    namespace,
+                    *subject,
+                    &bound_volumes,
+                    &delete_outcome,
+                )
+                .await,
+            );
+        }
+        Ok(checks)
     }
 
     #[tracing::instrument(skip(self), fields(cluster = name, namespace))]
@@ -2999,6 +3291,251 @@ mod tests {
             "kind": "Secret",
             "metadata": { "name": name, "namespace": namespace }
         })
+    }
+
+    /// An object that is STILL THERE after teardown must not read as verified.
+    ///
+    /// This is the defect the whole receipt design exists for: `delete()`
+    /// returns as soon as the DELETE requests are accepted, while finalizers
+    /// and terminating Pods complete asynchronously. A provider that reported
+    /// success on an accepted request would hand back capacity that still has
+    /// the tenant's workload running on it.
+    #[tokio::test]
+    async fn a_surviving_object_is_unknown_not_verified() {
+        let server = MockServer::start().await;
+        // The StatefulSet is still present when we look.
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "apps/v1",
+                "kind": "StatefulSet",
+                "metadata": { "name": "c1-server", "namespace": "test-ns" }
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert_eq!(check.reason.as_deref(), Some("still_present"));
+    }
+
+    /// A verified check must name WHAT it verified.
+    ///
+    /// `Database = Verified` on its own asserts that *a* database is gone
+    /// without saying which — so the claim cannot be audited after the instance
+    /// is gone, which is exactly when the receipt is read. Recording the
+    /// concrete identity is what makes the evidence mean something later.
+    #[tokio::test]
+    async fn a_verified_check_records_what_it_actually_inspected() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "NotFound", "code": 404
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Verified);
+        assert_eq!(
+            check.verified,
+            vec!["c1-server".to_string()],
+            "the receipt must say which object was proven absent"
+        );
+    }
+
+    /// An UNVERIFIED check must not carry identities that read as proof.
+    ///
+    /// Otherwise a quarantining receipt would list the very resources it failed
+    /// to verify, and a later reader could mistake the list for evidence.
+    #[tokio::test]
+    async fn an_unverified_check_claims_nothing() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "apps/v1", "kind": "StatefulSet",
+                "metadata": { "name": "c1-server", "namespace": "test-ns" }
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert!(
+            check.verified.is_empty(),
+            "a check that did not verify must claim nothing: {:?}",
+            check.verified
+        );
+    }
+
+    /// Only a 404 proves absence. An RBAC denial or a timeout tells us nothing
+    /// about whether the object exists — treating either as "gone" is how a
+    /// broken permission silently becomes a clean bill of health.
+    #[tokio::test]
+    async fn a_failed_lookup_is_uncertainty_not_absence() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(403).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "Forbidden", "code": 403
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(
+            check.result,
+            CheckResult::Unknown,
+            "a 403 must never be read as absence"
+        );
+        assert_eq!(check.reason.as_deref(), Some("lookup_failed"));
+    }
+
+    /// A 404 IS proof, so the happy path must actually verify — otherwise the
+    /// receipt can never be satisfied and every teardown quarantines.
+    #[tokio::test]
+    async fn a_missing_object_verifies() {
+        let server = MockServer::start().await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/apps/v1/namespaces/test-ns/statefulsets/c1-server",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "apiVersion": "v1", "kind": "Status", "status": "Failure",
+                "reason": "NotFound", "code": 404
+            })))
+            .mount(&server)
+            .await;
+
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Ok(()),
+            )
+            .await;
+
+        assert_eq!(check.result, CheckResult::Verified);
+        assert!(check.reason.is_none());
+    }
+
+    /// With no datastore reachable, the database and its role are unprovable —
+    /// and a leaked role carries credentials, which is why it is its own
+    /// subject rather than folded into the database check.
+    #[tokio::test]
+    async fn database_and_role_are_unknown_without_a_datastore() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+
+        for subject in [TeardownSubject::Database, TeardownSubject::DatabaseRole] {
+            let check = backend
+                .verify_subject_absent("c1", "test-ns", subject, &Ok(Vec::new()), &Ok(()))
+                .await;
+            assert_eq!(check.result, CheckResult::Unknown, "{subject:?}");
+            assert_eq!(check.reason.as_deref(), Some("datastore_unavailable"));
+        }
+    }
+
+    /// A failed delete poisons every subject. Verifying absence after a
+    /// teardown that did not complete would report "gone" for whatever the
+    /// failed attempt happened not to reach.
+    #[tokio::test]
+    async fn a_failed_delete_makes_every_subject_unknown() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerStatefulSet,
+                &Ok(Vec::new()),
+                &Err(anyhow::anyhow!("delete blew up")),
+            )
+            .await;
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert_eq!(check.reason.as_deref(), Some("delete_failed"));
+    }
+
+    /// If the PVCs could not be listed before deletion, the backing volumes are
+    /// unnameable afterwards — so the volume subject must fail closed rather
+    /// than silently report that nothing needed reclaiming.
+    #[tokio::test]
+    async fn uncapturable_volumes_fail_closed() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let check = backend
+            .verify_subject_absent(
+                "c1",
+                "test-ns",
+                TeardownSubject::ServerDataVolumes,
+                &Err("pvc_list_failed".to_string()),
+                &Ok(()),
+            )
+            .await;
+        assert_eq!(check.result, CheckResult::Unknown);
+        assert_eq!(check.reason.as_deref(), Some("pvc_list_failed"));
+    }
+
+    #[tokio::test]
+    async fn k3s_advertises_the_verified_teardown_capability() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        assert!(backend.supports_verified_destroy());
     }
 
     fn token_secret_response(name: &str, namespace: &str, token: &[u8]) -> serde_json::Value {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -24,6 +24,7 @@ use crate::crd::{
     Addon, BackendType, BootstrapConfig, BootstrapJobSpec, BootstrapRef, ClusterConfig,
     ClusterPool, InterInstanceSpread, PersistenceConfig, ReadinessGate, SpreadStrength,
 };
+use crate::crd::{TeardownCheck, TeardownSubject};
 
 /// Fetch, or create once, the per-cluster PostgreSQL password.
 ///
@@ -550,6 +551,21 @@ pub struct GuestPodCrash {
 /// Implementations handle the actual cluster provisioning. The profile and
 /// claim controllers interact only through this trait, keeping them decoupled
 /// from the underlying technology.
+// Declared ahead of the k3s provider that implements it and the controller
+// that calls it, so nothing constructs or invokes this yet. Same pattern as the
+// `teardown` module in `src/crd`. The alternative — landing the contract and
+// the provider together — is the several-thousand-line PR this split exists to
+// avoid.
+#[allow(dead_code)]
+/// A backend was asked for verified teardown and cannot provide it.
+///
+/// Distinct from an ordinary error: nothing failed, the capability simply does
+/// not exist for this backend. Callers must refuse the lease rather than fall
+/// back to unverified cleanup.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+#[error("backend does not implement verified teardown")]
+pub struct VerifiedDestroyUnsupported;
+
 pub trait ClusterBackend: Send + Sync {
     /// Create a virtual cluster with the given name and config.
     ///
@@ -581,6 +597,63 @@ pub trait ClusterBackend: Send + Sync {
         name: &str,
         namespace: &str,
     ) -> impl std::future::Future<Output = Result<()>> + Send;
+
+    /// Delete a virtual cluster and return **evidence** that its footprint is
+    /// gone, rather than evidence that a DELETE request was accepted.
+    ///
+    /// Deliberately a separate method with a default body instead of a changed
+    /// `delete` signature: the four backends that cannot produce evidence keep
+    /// compiling untouched and refuse honestly, rather than being mechanically
+    /// updated to return a receipt they cannot substantiate. A backend that
+    /// "implements" verified teardown by returning success it did not observe
+    /// is worse than one that says it cannot.
+    ///
+    /// `plan` lists what this instance actually created, so the provider knows
+    /// which subjects it must account for and which never existed. Returning
+    /// [`CheckResult::Unknown`] for anything it cannot observe is correct and
+    /// expected — that quarantines the capacity instead of releasing it.
+    #[allow(dead_code)]
+    fn delete_verified(
+        &self,
+        name: &str,
+        namespace: &str,
+        plan: &[TeardownSubject],
+    ) -> impl std::future::Future<Output = Result<Vec<TeardownCheck>, VerifiedDestroyUnsupported>> + Send
+    {
+        let _ = (name, namespace, plan);
+        async { Err(VerifiedDestroyUnsupported) }
+    }
+
+    /// Capture the provisioner-assigned resource identities this instance owns.
+    ///
+    /// Called while the instance is healthy, NOT at teardown. Bound
+    /// PersistentVolume names are chosen by the provisioner and only knowable
+    /// once claims have bound; capturing them at teardown time would let the
+    /// teardown path define its own scope, which is the thing receipts exist to
+    /// prevent. Recorded early, the list is something a later teardown must
+    /// account for rather than something it gets to choose.
+    ///
+    /// Returning an empty list means "this backend has no such identities",
+    /// which is correct for every backend that cannot produce evidence anyway.
+    #[allow(dead_code)]
+    fn capture_teardown_identities(
+        &self,
+        name: &str,
+        namespace: &str,
+    ) -> impl std::future::Future<Output = Result<Vec<String>>> + Send {
+        let _ = (name, namespace);
+        async { Ok(Vec::new()) }
+    }
+
+    /// Whether this backend can produce teardown evidence at all.
+    ///
+    /// Checked before binding so a receipt-required lease is refused up front,
+    /// rather than discovering mid-teardown that no evidence is possible and
+    /// stranding the lease in quarantine through no fault of the caller.
+    #[allow(dead_code)]
+    fn supports_verified_destroy(&self) -> bool {
+        false
+    }
 
     /// Check if a virtual cluster's API server is healthy.
     fn check_health(
@@ -1455,6 +1528,31 @@ mod tests {
     use base64::Engine;
     use wiremock::matchers::{method, path};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    /// A backend that has not implemented verified teardown must REFUSE, not
+    /// quietly succeed.
+    ///
+    /// The default body is the safety property here: adding this capability to
+    /// the trait without one would have forced every backend to be updated by
+    /// hand, and the mechanical update is "return Ok(vec![])" — a backend
+    /// claiming a clean footprint it never looked at. Refusing by default means
+    /// a backend can only claim evidence by actually writing the code.
+    #[tokio::test]
+    async fn a_backend_without_the_capability_refuses_rather_than_claiming_success() {
+        let backend = crate::testutil::MockBackend::new();
+        assert!(
+            !backend.supports_verified_destroy(),
+            "capability must be opt-in"
+        );
+        let outcome = backend
+            .delete_verified("pool-x-0", "test-ns", &[TeardownSubject::ServerStatefulSet])
+            .await;
+        assert_eq!(
+            outcome,
+            Err(VerifiedDestroyUnsupported),
+            "an unimplemented backend must not return an empty (clean-looking) check list"
+        );
+    }
 
     fn kubeconfig_secret_response(
         cluster_name: &str,

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -2244,6 +2244,7 @@ fn phase_reason(phase: &ClusterInstancePhase) -> &'static str {
         ClusterInstancePhase::Recycling => "Recycling",
         ClusterInstancePhase::Unhealthy => "Unhealthy",
         ClusterInstancePhase::Failed => "Failed",
+        ClusterInstancePhase::Quarantined => "Quarantined",
     }
 }
 

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -23,9 +23,10 @@ use crate::backend::{
 };
 use crate::crd::{
     Addon, BackendConfig, BackendType, BootstrapRef, CIDRClaim, CIDRClaimPhase, CIDRClaimSpec,
-    ClusterConfig, ClusterInstance, ClusterInstanceCondition, ClusterInstanceNetwork,
-    ClusterInstancePhase, ClusterInstanceStatus, ClusterPool, HealthCheckConfig, LeasePhase,
-    ReadinessGate, SnapshotConfig,
+    CheckResult, CleanupMode, ClusterConfig, ClusterInstance, ClusterInstanceCondition,
+    ClusterInstanceNetwork, ClusterInstancePhase, ClusterInstanceStatus, ClusterLease, ClusterPool,
+    HealthCheckConfig, LeasePhase, ReadinessGate, SnapshotConfig, TEARDOWN_RECEIPT_SCHEMA_VERSION,
+    TeardownOutcome, TeardownReceipt,
 };
 use crate::velero::VeleroCoordinator;
 
@@ -244,6 +245,15 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                 warn!(instance = %name, reason, "Deletion fenced: exact lease binding is not verifiable");
                 return Ok(Action::requeue(std::time::Duration::from_secs(30)));
             }
+            // Receipt-required teardown decides here, not after the fact: the
+            // finalizer is the last handle on this capacity, and releasing it
+            // on an accepted DELETE is exactly what makes "cleanup complete" a
+            // guess. A lease asking for VerifiedDestroy must produce evidence
+            // before the handle goes.
+            if let Some(outcome) = verified_teardown_gate(&ctx, &instance, &name, &ns).await {
+                return outcome;
+            }
+
             match delete_instance_backend(&ctx, &config, &instance, &name, &ns).await {
                 Ok(()) => {
                     cleanup_orphan_projected_resources(&ctx.client, &name, &ns).await;
@@ -335,6 +345,7 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                                 // is preserved (we never want to overwrite it
                                 // from an instance-controller patch).
                                 created_with: None,
+                                teardown_identities: Vec::new(),
                                 message: Some("network allocated; awaiting provisioning".into()),
                                 // Overwritten centrally in patch_instance_status.
                                 conditions: Vec::new(),
@@ -742,6 +753,11 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
             }
         }
         ClusterInstancePhase::Ready => {
+            // Record provisioner-assigned identities while the instance is
+            // healthy. Doing this at teardown would let the teardown path
+            // choose its own scope; recorded here, a later receipt has to
+            // account for what was captured long before it ran.
+            capture_teardown_identities_once(&ctx, &instance, &name, &ns, &status).await;
             let next =
                 evaluate_ready_instance(&ctx, &config, &instance, &name, &ns, &status).await?;
             Ok(next)
@@ -749,6 +765,34 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
         ClusterInstancePhase::Leased => {
             let next = evaluate_leased_instance(&ctx, &instance, &name, &ns, &status).await?;
             Ok(next)
+        }
+        // Quarantine has exactly ONE way out: the same exact subject producing
+        // a verified receipt. Retrying is safe and idempotent — the provider
+        // re-runs delete and re-observes absence — so a transient RBAC or
+        // datastore failure that caused the quarantine can resolve itself.
+        //
+        // What must never happen is leaving by any other route: no timeout, no
+        // operator patch of the phase, no "it has been stuck a while" fallback.
+        // Those would return capacity to the pool on exactly the evidence the
+        // quarantine exists to demand.
+        ClusterInstancePhase::Quarantined => {
+            debug!(
+                instance = %name,
+                "quarantined: retrying teardown verification for the same exact subject"
+            );
+            // Only the deletion path can produce a receipt, so a quarantined
+            // instance that is not being deleted simply waits. It holds its
+            // finalizer and binding, so it is never selectable as capacity.
+            if instance.metadata.deletion_timestamp.is_none() {
+                return Ok(Action::requeue(std::time::Duration::from_secs(300)));
+            }
+            match verified_teardown_gate(&ctx, &instance, &name, &ns).await {
+                Some(outcome) => outcome,
+                // Not receipt-required after all (the lease changed or is
+                // gone): fall back to the ordinary path rather than holding
+                // capacity hostage forever.
+                None => Ok(Action::requeue(std::time::Duration::from_secs(30))),
+            }
         }
         ClusterInstancePhase::Recycling => {
             info!(instance = %name, owner = %owner, "Deleting backend resources");
@@ -1794,6 +1838,327 @@ async fn delete_instance_backend<B: ClusterBackend + Clone>(
     } else {
         ctx.backend.delete(name, namespace).await
     }
+}
+
+/// Gate finalizer release on evidence, for leases that asked for it.
+///
+/// Returns `None` when this instance is not receipt-required, so the ordinary
+/// teardown path runs unchanged — every existing lease keeps today's behaviour.
+///
+/// When it *is* required, this is the only place the last cleanup handle can be
+/// released, and it is released only against a receipt whose checks cover the
+/// plan recorded at creation. Anything else — a missing plan, an unsupported
+/// backend, a check that came back `Unknown` — quarantines the instance and
+/// keeps the finalizer, because a handle dropped on unproven capacity cannot be
+/// taken back.
+async fn verified_teardown_gate<B: ClusterBackend + Clone>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+    name: &str,
+    namespace: &str,
+) -> Option<Result<Action, InstanceError>> {
+    let status = instance.status.as_ref()?;
+    let binding = status.binding.as_ref()?;
+
+    // An instance that is ALREADY quarantined got there because evidence was
+    // required and missing. It must never fall back to the unverified path,
+    // whatever happens to its lease afterwards — otherwise deleting the
+    // ClusterLease becomes a way to launder unproven capacity back into the
+    // pool, which is a bypass of the whole mechanism rather than an edge case.
+    let already_quarantined = status.phase == ClusterInstancePhase::Quarantined;
+
+    // Does the bound lease actually ask for this?
+    let leases: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), namespace);
+    let lease = match leases.get(&binding.lease.name).await {
+        Ok(lease) => lease,
+        Err(error) => {
+            if already_quarantined {
+                warn!(
+                    instance = %name,
+                    error = %error,
+                    "quarantined instance's lease is unreadable; holding quarantine rather \
+                     than releasing on the unverified path"
+                );
+                return Some(
+                    quarantine_instance(ctx, instance, name, namespace, "lease_unreadable").await,
+                );
+            }
+            return None;
+        }
+    };
+    if lease.spec.cleanup_mode.unwrap_or_default() != CleanupMode::VerifiedDestroy {
+        if already_quarantined {
+            warn!(
+                instance = %name,
+                "quarantined instance's lease no longer requests verified teardown; \
+                 holding quarantine — capacity still has unproven state"
+            );
+            return Some(
+                quarantine_instance(ctx, instance, name, namespace, "mode_downgraded").await,
+            );
+        }
+        return None;
+    }
+
+    let started_at = chrono::Utc::now().to_rfc3339();
+
+    // The plan must come from what creation recorded. An instance created
+    // before verified teardown existed has no plan, and verifying it against a
+    // reconstructed guess would prove only that the guess was satisfied.
+    let Some(plan) = status
+        .created_with
+        .as_ref()
+        .and_then(|created| created.teardown_plan.clone())
+    else {
+        warn!(
+            instance = %name,
+            "verified teardown requested but no creation-time plan was recorded; quarantining"
+        );
+        return Some(
+            quarantine_instance(ctx, instance, name, namespace, "teardown_plan_missing").await,
+        );
+    };
+
+    let checks = match resolve_verified_backend(ctx, instance).await {
+        Some(backend) => match backend.delete_verified(name, namespace, &plan).await {
+            Ok(checks) => checks,
+            Err(_) => {
+                warn!(
+                    instance = %name,
+                    "backend cannot produce teardown evidence; quarantining rather than \
+                     falling back to unverified cleanup"
+                );
+                return Some(
+                    quarantine_instance(ctx, instance, name, namespace, "backend_unsupported")
+                        .await,
+                );
+            }
+        },
+        None => {
+            return Some(
+                quarantine_instance(ctx, instance, name, namespace, "backend_unresolvable").await,
+            );
+        }
+    };
+
+    let outcome = TeardownReceipt::outcome_for(&checks);
+    let receipt = TeardownReceipt {
+        schema_version: TEARDOWN_RECEIPT_SCHEMA_VERSION,
+        attempt_id: uuid::Uuid::new_v4().to_string(),
+        lease: binding.lease.clone(),
+        instance: crate::crd::ResourceRef {
+            name: binding.instance.name.clone(),
+            uid: Some(binding.instance.uid.clone()),
+        },
+        pool: binding.pool.clone(),
+        backend_type: format!("{:?}", binding.backend.backend_type).to_lowercase(),
+        config_digest: binding.backend.config_digest.clone(),
+        instance_spec_digest: binding.instance_spec_digest.clone(),
+        started_at,
+        completed_at: Some(chrono::Utc::now().to_rfc3339()),
+        checks,
+        retry_count: 0,
+        outcome,
+    };
+
+    // Persist the evidence BEFORE releasing anything. A receipt written after
+    // the finalizer is gone can be lost with the object it describes, and the
+    // whole point is that it outlives the instance.
+    if let Err(error) = record_teardown_receipt(ctx, &lease, &receipt, namespace).await {
+        warn!(instance = %name, error = %error, "could not persist teardown receipt; retrying");
+        return Some(Ok(Action::requeue(std::time::Duration::from_secs(15))));
+    }
+
+    if outcome != TeardownOutcome::Verified {
+        let unproven: Vec<&str> = receipt
+            .checks
+            .iter()
+            .filter(|check| check.result == CheckResult::Unknown)
+            .map(|check| check.reason.as_deref().unwrap_or("unknown"))
+            .collect();
+        warn!(
+            instance = %name,
+            reasons = ?unproven,
+            "teardown could not be proven complete; quarantining capacity"
+        );
+        return Some(
+            quarantine_instance(ctx, instance, name, namespace, "teardown_unverified").await,
+        );
+    }
+
+    info!(instance = %name, "teardown verified; releasing the cleanup handle");
+    cleanup_orphan_projected_resources(&ctx.client, name, namespace).await;
+    let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
+    if let Err(error) = remove_finalizer(&instances_api, instance, INSTANCE_FINALIZER).await {
+        return Some(Err(error.into()));
+    }
+    Some(Ok(Action::await_change()))
+}
+
+/// Record the provisioner-assigned identities this instance owns, once.
+///
+/// Best-effort and idempotent: a failed capture leaves the list empty and is
+/// retried on the next reconcile, and a non-empty list is never rewritten —
+/// shrinking it later would silently narrow what a receipt must prove.
+///
+/// Only meaningful for a backend that can produce evidence; everything else
+/// returns an empty list from the default implementation.
+async fn capture_teardown_identities_once<B: ClusterBackend + Clone>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+    name: &str,
+    namespace: &str,
+    status: &ClusterInstanceStatus,
+) {
+    if !status.teardown_identities.is_empty() {
+        return;
+    }
+    // Only instances whose plan includes a provisioner-assigned footprint have
+    // anything to capture.
+    let wants_volumes = status
+        .created_with
+        .as_ref()
+        .and_then(|created| created.teardown_plan.as_ref())
+        .is_some_and(|plan| plan.contains(&crate::crd::TeardownSubject::ServerDataVolumes));
+    if !wants_volumes {
+        return;
+    }
+    let Some(backend) = resolve_verified_backend(ctx, instance).await else {
+        return;
+    };
+    let identities = match backend.capture_teardown_identities(name, namespace).await {
+        Ok(identities) if !identities.is_empty() => identities,
+        // Empty or failed: retry next reconcile rather than recording a list
+        // that understates the footprint.
+        _ => return,
+    };
+
+    let (Some(uid), Some(resource_version)) = (
+        instance.metadata.uid.as_deref(),
+        instance.resource_version(),
+    ) else {
+        return;
+    };
+    let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "test", "path": "/metadata/resourceVersion", "value": resource_version },
+        { "op": "add", "path": "/status/teardownIdentities", "value": identities }
+    ]));
+    match instances_api
+        .patch_status(name, &PatchParams::default(), &Patch::<()>::Json(patch))
+        .await
+    {
+        Ok(_) => info!(
+            instance = %name,
+            "recorded provisioner-assigned teardown identities"
+        ),
+        Err(error) => debug!(
+            instance = %name,
+            error = %error,
+            "could not record teardown identities; will retry"
+        ),
+    }
+}
+
+/// Resolve the backend through immutable provenance, same fence as
+/// `delete_instance_backend`.
+async fn resolve_verified_backend<B: ClusterBackend + Clone>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+) -> Option<crate::backend::BackendDispatch> {
+    let factory = ctx.factory.as_ref()?;
+    let provenance = instance
+        .status
+        .as_ref()
+        .and_then(|status| status.created_with.as_ref())
+        .and_then(|created| created.backend.as_ref())?;
+    factory.backend_for_provenance(provenance).ok()
+}
+
+/// Write the receipt onto the lease, fenced to the exact lease UID.
+async fn record_teardown_receipt<B: ClusterBackend>(
+    ctx: &InstanceContext<B>,
+    lease: &ClusterLease,
+    receipt: &TeardownReceipt,
+    namespace: &str,
+) -> Result<(), anyhow::Error> {
+    let leases: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), namespace);
+    let uid = lease
+        .metadata
+        .uid
+        .as_deref()
+        .ok_or_else(|| anyhow::anyhow!("lease has no UID"))?;
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "add", "path": "/status/teardownReceipt", "value": receipt }
+    ]));
+    leases
+        .patch_status(
+            &lease.name_any(),
+            &PatchParams::default(),
+            &Patch::<()>::Json(patch),
+        )
+        .await?;
+    Ok(())
+}
+
+/// Hold the capacity back and keep every cleanup handle.
+///
+/// Deliberately does NOT remove the finalizer or clear the binding: those are
+/// what a later retry needs to address the same exact subject, and what stops
+/// the ordinary 404-based recycle path from treating the capacity as clean.
+async fn quarantine_instance<B: ClusterBackend>(
+    ctx: &InstanceContext<B>,
+    instance: &ClusterInstance,
+    name: &str,
+    namespace: &str,
+    reason: &str,
+) -> Result<Action, InstanceError> {
+    let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
+    let mut next = instance.status.clone().unwrap_or_default();
+    next.phase = ClusterInstancePhase::Quarantined;
+    next.state_since = Some(chrono::Utc::now().to_rfc3339());
+    next.message = Some(format!("quarantined: {reason}"));
+
+    // Fenced, not a bare merge patch. Two ways an unfenced write goes wrong:
+    // a stale reconcile holding an older view could overwrite `Quarantined`
+    // with whatever phase it believed, handing unproven capacity back to the
+    // pool; and a name-addressed write could land on a same-named replacement
+    // instance that has nothing to do with this teardown.
+    let (Some(uid), Some(resource_version)) = (
+        instance.metadata.uid.as_deref(),
+        instance.resource_version(),
+    ) else {
+        // Without an identity to fence against we cannot safely mark anything.
+        // Requeue rather than write blind; the finalizer still holds.
+        warn!(
+            instance = %name,
+            "cannot fence the quarantine write; retrying rather than writing unfenced"
+        );
+        return Ok(Action::requeue(std::time::Duration::from_secs(30)));
+    };
+    let patch = crate::controllers::lease::json_patch(serde_json::json!([
+        { "op": "test", "path": "/metadata/uid", "value": uid },
+        { "op": "test", "path": "/metadata/resourceVersion", "value": resource_version },
+        { "op": "add", "path": "/status", "value": next }
+    ]));
+    match instances_api
+        .patch_status(name, &PatchParams::default(), &Patch::<()>::Json(patch))
+        .await
+    {
+        Ok(_) => {}
+        // The object moved under us. Re-reconcile against the new state rather
+        // than forcing a phase derived from a view that is now stale.
+        Err(error) if crate::controllers::lease::optimistic_conflict(&error) => {
+            debug!(instance = %name, "quarantine write conflicted; re-reading");
+            return Ok(Action::requeue(std::time::Duration::from_secs(5)));
+        }
+        Err(error) => return Err(error.into()),
+    }
+    // Bounded backoff: a transient API failure may resolve, and the same exact
+    // subject can then produce a verified receipt.
+    Ok(Action::requeue(std::time::Duration::from_secs(120)))
 }
 
 async fn verify_bound_instance_for_teardown<B: ClusterBackend>(

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -15,7 +15,7 @@ use crate::backend::{BackendFactory, ClusterBackend};
 use crate::crd::{
     BackendProvenance, BoundInstanceRef, ClusterInstance, ClusterInstancePhase, ClusterLease,
     ClusterLeaseCondition, ClusterLeaseStatus, ClusterPool, ClusterPoolPhase, ClusterPoolStatus,
-    LeaseBinding, LeasePhase, ResourceRef,
+    LeaseBinding, LeasePhase, ResourceRef, TEARDOWN_RECEIPT_ACKNOWLEDGED_ANNOTATION,
 };
 use crate::diagnostics;
 use crate::pool::{PoolState, parse_duration};
@@ -632,6 +632,27 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
             };
 
             if cluster_gone {
+                // A receipt-required lease carries the ONLY durable proof that
+                // its capacity was destroyed, and it is read after the instance
+                // is gone — which is exactly the moment this branch fires. So
+                // deleting the lease here would destroy the evidence at the
+                // instant it becomes relevant, and #74's owning SandboxLease
+                // would have nothing to consume.
+                //
+                // Retain it until a consumer acknowledges. Deliberately not a
+                // timeout: evidence that expires on a clock is evidence you
+                // cannot rely on having.
+                if status.teardown_receipt.is_some()
+                    && !lease
+                        .annotations()
+                        .contains_key(TEARDOWN_RECEIPT_ACKNOWLEDGED_ANNOTATION)
+                {
+                    debug!(
+                        lease = %name,
+                        "retaining recycled lease: its teardown receipt has not been consumed"
+                    );
+                    return Ok(Action::requeue(std::time::Duration::from_secs(300)));
+                }
                 info!(lease = %name, "Recycling complete, deleting lease CRD");
                 let delete_params = DeleteParams {
                     preconditions: Some(Preconditions {

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -596,6 +596,13 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
             Ok(Action::requeue(std::time::Duration::from_secs(10)))
         }
 
+        // Terminal until the same exact subject produces a verified receipt.
+        // Access is already revoked and the binding/finalizers are deliberately
+        // retained as cleanup handles, so there is nothing to reconcile here.
+        // The transitions INTO this phase, and the retry that can leave it,
+        // belong to the verified-teardown controller work.
+        LeasePhase::Quarantined => Ok(Action::requeue(std::time::Duration::from_secs(300))),
+
         LeasePhase::Recycling => {
             let cluster_gone = if let Some(binding) = &status.binding {
                 let instances_api: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), &ns);
@@ -837,6 +844,7 @@ async fn finalize_binding<B: ClusterBackend>(
         max_extensions,
         message: None,
         conditions: Vec::new(),
+        teardown_receipt: None,
     };
     new_status.conditions =
         derive_lease_conditions(&new_status, &status.conditions, None, &now.to_rfc3339());

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -1237,6 +1237,11 @@ async fn reconcile_profile(
     pool_size_set("leased", counts.leased);
     pool_size_set("unhealthy", counts.unhealthy);
     pool_size_set("recycling", counts.recycling);
+    // Emitted separately from `unhealthy` so an alert can distinguish capacity
+    // that is churning from capacity that is stuck holding unproven state.
+    // A rising `quarantined` means teardown evidence is failing, which no
+    // other dimension reveals.
+    pool_size_set("quarantined", counts.quarantined);
 
     // Surface hidden CPU over-reservation (issue #189): a pool that sets
     // `resources.limits` with empty `requests` makes the kubelet copy each
@@ -1372,6 +1377,7 @@ async fn reconcile_profile(
         creating: counts.creating,
         recycling: counts.recycling,
         unhealthy: counts.unhealthy,
+        quarantined: counts.quarantined,
         queue_depth,
         golden_backup: existing_golden_backup,
         golden_generation: existing_golden_generation,
@@ -1727,6 +1733,23 @@ async fn ensure_cluster_instance(
         .map_err(|err| anyhow::anyhow!("failed to encode backend provenance: {err}"))?;
     let provenance = crate::crd::ClusterInstanceProvenance {
         operator_version: env!("BUILD_VERSION").to_string(),
+        // Record what this instance is about to create, while we still know.
+        // Recomputing this at teardown would read whatever the pool config says
+        // *then* — so a pool that stopped setting `registryMirrors` after this
+        // instance was built would silently drop that ConfigMap from the plan
+        // and never verify it. Only k3s can be verified, so only k3s gets a
+        // plan; anything else stays `None` and is refused a receipt-required
+        // lease at bind time.
+        teardown_plan: matches!(
+            profile.spec.backend.backend_type,
+            crate::crd::BackendType::K3s
+        )
+        .then(|| {
+            crate::crd::k3s_teardown_plan(
+                &profile.spec.cluster,
+                profile.spec.backend.datastore.is_some(),
+            )
+        }),
         kobe_sync_image: matches!(
             profile.spec.backend.backend_type,
             crate::crd::BackendType::Vkobe

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -45,6 +45,42 @@ pub struct ProfileContext {
 }
 
 #[cfg(test)]
+mod quarantine_tests {
+    use super::*;
+
+    /// Quarantined capacity must never present as leasable. `ClusterState` has
+    /// no Quarantined variant yet, so this pins the interim mapping: whatever it
+    /// maps to, it must not be `Ready` or `Leased`, or unproven capacity would
+    /// be handed to the next caller.
+    #[test]
+    fn quarantined_never_maps_to_usable_capacity() {
+        let state = cluster_state_from_phase(&ClusterInstancePhase::Quarantined);
+        assert_ne!(state, ClusterState::Ready);
+        assert_ne!(state, ClusterState::Leased);
+    }
+
+    /// The reverse mapping must never *produce* Quarantined, because that would
+    /// mean in-memory pool state could invent a quarantine that no teardown
+    /// evidence supports.
+    #[test]
+    fn pool_state_cannot_invent_a_quarantine() {
+        for state in [
+            ClusterState::Creating,
+            ClusterState::Ready,
+            ClusterState::Leased,
+            ClusterState::Unhealthy,
+            ClusterState::Recycling,
+        ] {
+            assert_ne!(
+                cluster_phase_from_state(&state),
+                ClusterInstancePhase::Quarantined,
+                "{state:?} must not round-trip into Quarantined"
+            );
+        }
+    }
+}
+
+#[cfg(test)]
 mod cluster_instance_tests {
     use super::*;
     use std::collections::HashMap;
@@ -1910,7 +1946,14 @@ async fn sync_cluster_instance_statuses(client: &Client, namespace: &str, pool_s
         // In particular, an invalid/legacy binding must remain unavailable
         // even if its display-only leaseRef is missing or stale.
         let lease_held = current.lease_ref.is_some() || current.binding.is_some();
-        let phase = if lease_held {
+        // Quarantined is preserved explicitly, not just incidentally. A
+        // quarantined instance keeps its binding as a cleanup handle, so
+        // `lease_held` happens to cover it today — but relying on that would
+        // mean a future change to binding retention silently downgrades
+        // Quarantined to whatever the in-memory pool state says, handing
+        // unproven capacity back to the pool.
+        let quarantined = current.phase == ClusterInstancePhase::Quarantined;
+        let phase = if lease_held || quarantined {
             current.phase.clone()
         } else {
             cluster_phase_from_state(&entry.state)
@@ -2210,6 +2253,10 @@ fn cluster_state_from_phase(phase: &ClusterInstancePhase) -> ClusterState {
         ClusterInstancePhase::Recycling => ClusterState::Recycling,
         ClusterInstancePhase::Unhealthy => ClusterState::Unhealthy,
         ClusterInstancePhase::Failed => ClusterState::Unhealthy,
+        // Quarantined maps to its own state, never to Unhealthy: Unhealthy is
+        // deleted unconditionally by the pool manager, which would destroy the
+        // cleanup handle and let the ordinary recycle path resume.
+        ClusterInstancePhase::Quarantined => ClusterState::Quarantined,
     }
 }
 
@@ -2220,6 +2267,7 @@ fn cluster_phase_from_state(state: &ClusterState) -> ClusterInstancePhase {
         ClusterState::Leased => ClusterInstancePhase::Leased,
         ClusterState::Recycling => ClusterInstancePhase::Recycling,
         ClusterState::Unhealthy => ClusterInstancePhase::Unhealthy,
+        ClusterState::Quarantined => ClusterInstancePhase::Quarantined,
     }
 }
 

--- a/src/crd/access_policy.rs
+++ b/src/crd/access_policy.rs
@@ -2,6 +2,8 @@ use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
+use super::SandboxResourceCeiling;
+
 /// AccessPolicy configures authentication and authorization for cluster lease requests.
 ///
 /// Each AccessPolicy represents one authentication method (OIDC provider, static token,
@@ -139,6 +141,44 @@ pub struct AccessRule {
     /// Maximum TTL extensions per lease.
     #[serde(default = "default_max_extensions")]
     pub max_extensions: u32,
+
+    /// Optional, kind-specific Agent Sandbox permissions. Older policy objects
+    /// omit this block and continue authorizing Cluster leases exactly as
+    /// before, while Sandbox operations fail closed.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SandboxAccessRule>,
+}
+
+/// Bounded Agent Sandbox grant attached to one existing identity rule.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxAccessRule {
+    /// SandboxPool name patterns; wildcard semantics match Cluster pools.
+    #[schemars(length(min = 1))]
+    pub pools: Vec<String>,
+    /// Independently authorized Sandbox operations.
+    #[schemars(length(min = 1))]
+    pub verbs: Vec<SandboxVerb>,
+    /// Maximum runtime TTL, starting only once the Sandbox is Ready.
+    #[schemars(length(min = 1))]
+    pub max_ttl: String,
+    /// Maximum active Sandbox leases for this identity, separate from Cluster
+    /// lease concurrency.
+    pub max_concurrent_leases: u32,
+    /// Aggregate per-Sandbox CPU and memory ceiling.
+    pub resource_ceiling: SandboxResourceCeiling,
+}
+
+/// Agent Sandbox authorization verbs. `lease` includes create and own-object
+/// reads; `release` remains independently revocable.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub enum SandboxVerb {
+    Lease,
+    Exec,
+    Logs,
+    PortForward,
+    Release,
 }
 
 /// Claim-based match condition for OIDC rules.
@@ -356,5 +396,43 @@ mod tests {
         }))
         .expect("unknown fields must be ignored, not rejected");
         assert_eq!(spec.rules.len(), 1);
+    }
+
+    #[test]
+    fn legacy_access_rule_omits_sandbox_and_denies_by_shape() {
+        let rule: AccessRule = serde_json::from_value(serde_json::json!({
+            "pools": ["ci-*"],
+            "maxTtl": "1h",
+            "maxConcurrentLeases": 2
+        }))
+        .unwrap();
+
+        assert!(rule.sandbox.is_none());
+        assert!(serde_json::to_value(rule).unwrap().get("sandbox").is_none());
+    }
+
+    #[test]
+    fn typed_sandbox_grant_round_trips_and_rejects_unknown_fields() {
+        let value = serde_json::json!({
+            "pools": ["ci-*"],
+            "maxTtl": "1h",
+            "maxConcurrentLeases": 2,
+            "sandbox": {
+                "pools": ["agent-*"],
+                "verbs": ["lease", "exec", "logs", "port-forward", "release"],
+                "maxTtl": "30m",
+                "maxConcurrentLeases": 4,
+                "resourceCeiling": { "maxCpu": "2", "maxMemory": "4Gi" }
+            }
+        });
+        let rule: AccessRule = serde_json::from_value(value.clone()).unwrap();
+        assert_eq!(
+            serde_json::to_value(rule).unwrap()["sandbox"],
+            value["sandbox"]
+        );
+
+        let mut invalid = value;
+        invalid["sandbox"]["namespace"] = serde_json::json!("kube-system");
+        assert!(serde_json::from_value::<AccessRule>(invalid).is_err());
     }
 }

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -203,6 +203,12 @@ pub enum ClusterInstancePhase {
     Recycling,
     Unhealthy,
     Failed,
+    /// Teardown could not be proven complete. Access stays revoked, finalizers
+    /// and binding provenance are retained, and the unit is never Ready, never
+    /// rebound, and never counted as clean replacement capacity. It may leave
+    /// this phase only when the same exact subject produces a fully verified
+    /// receipt.
+    Quarantined,
 }
 
 /// Network ranges reserved for one ClusterInstance.

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -1,3 +1,4 @@
+use crate::crd::teardown::TeardownSubject;
 use kube::CustomResource;
 use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
@@ -352,6 +353,20 @@ pub struct ClusterInstanceStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub created_with: Option<ClusterInstanceProvenance>,
 
+    /// Provisioner-assigned resource identities this instance owns — currently
+    /// the PersistentVolumes its data claims are bound to.
+    ///
+    /// Captured once the instance is healthy, NOT at teardown. These names are
+    /// chosen by the provisioner and only knowable after claims bind, so
+    /// capturing them during teardown would let the teardown path define its
+    /// own scope. Recorded early, they become something a later teardown must
+    /// account for rather than something it gets to choose.
+    ///
+    /// Written once and never shrunk: a smaller list would silently narrow what
+    /// a receipt has to prove.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub teardown_identities: Vec<String>,
+
     /// Human-readable detail about the instance's current state — *why*
     /// it is in `phase`. Set fresh on every status write by the instance
     /// controller (each construction site supplies a concise phrase like
@@ -440,6 +455,21 @@ pub struct ClusterInstanceProvenance {
     /// `"0.17.0"`.
     pub operator_version: String,
 
+    /// Exactly which footprints this instance created, recorded at creation.
+    ///
+    /// This is the trust boundary for verified teardown. A receipt only proves
+    /// what it covers, so the list of subjects it must cover cannot come from
+    /// the receipt, nor from whatever the teardown path happens to look for
+    /// later — an optional resource whose config changed after creation would
+    /// then be quietly dropped from the plan and never verified.
+    ///
+    /// Stamped once alongside the rest of this provenance and never
+    /// overwritten. `None` means the instance predates verified teardown; such
+    /// an instance is ineligible for [`CleanupMode::VerifiedDestroy`] rather
+    /// than being verified against a guessed plan.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teardown_plan: Option<Vec<TeardownSubject>>,
+
     /// kobe-sync sidecar image used at create time. Recorded for
     /// `Vkobe` backends only (other backends don't run kobe-sync).
     /// Format matches the operator's `KOBE_SYNC_IMAGE` env var, e.g.
@@ -488,6 +518,10 @@ mod tests {
             phase: ClusterInstancePhase::Leased,
             provisioned: true,
             bootstrapped: true,
+            // Populated, not empty: this is the round-trip test, and an
+            // identity list that did not survive the wire would silently narrow
+            // what a receipt has to prove.
+            teardown_identities: vec!["pvc-1111".into(), "pvc-2222".into()],
             lease_ref: Some(ResourceRef {
                 name: "lease-abc".into(),
                 uid: None,
@@ -504,6 +538,7 @@ mod tests {
             }),
             created_with: Some(ClusterInstanceProvenance {
                 operator_version: "0.37.0".into(),
+                teardown_plan: None,
                 kobe_sync_image: Some("zondax/kobe-sync:v0.16.0".into()),
                 backend_type: Some(BackendType::K0s),
                 pool_uid: None,
@@ -624,6 +659,7 @@ mod tests {
                 "provisioned",
                 "specHash",
                 "stateSince",
+                "teardownIdentities",
             ]
         );
     }
@@ -763,6 +799,7 @@ mod tests {
     fn provenance_omits_unknown_components() {
         let p = ClusterInstanceProvenance {
             operator_version: "0.37.0".into(),
+            teardown_plan: None,
             kobe_sync_image: None,
             backend_type: None,
             pool_uid: None,
@@ -802,6 +839,7 @@ mod tests {
         ] {
             let p = ClusterInstanceProvenance {
                 operator_version: "0.37.0".into(),
+                teardown_plan: None,
                 kobe_sync_image: None,
                 backend_type: Some(bt),
                 pool_uid: None,

--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -3,6 +3,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use crate::crd::LeaseBinding;
+use crate::crd::teardown::{CleanupMode, TeardownReceipt};
 
 /// ClusterLease is the internal representation of a cluster lease.
 ///
@@ -34,6 +35,15 @@ pub struct ClusterLeaseSpec {
     /// Higher values are served first.
     #[serde(default = "default_priority")]
     pub priority: u32,
+
+    /// How thoroughly this lease's capacity must be torn down before reuse.
+    ///
+    /// Absent means [`CleanupMode::Standard`], so every existing `ClusterLease`
+    /// keeps its current behaviour. #74's internal leases request
+    /// [`CleanupMode::VerifiedDestroy`]; pools that cannot produce evidence
+    /// reject it at bind time rather than degrading silently.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cleanup_mode: Option<CleanupMode>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
@@ -79,6 +89,14 @@ pub struct ClusterLeaseStatus {
     /// When the lease expires (TTL deadline).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+
+    /// Durable proof that this lease's exact capacity was destroyed.
+    ///
+    /// Recorded here rather than on the `ClusterInstance` because it must stay
+    /// queryable *after* the instance object is gone — which is exactly when
+    /// the evidence matters, and when #74's owning `SandboxLease` consumes it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub teardown_receipt: Option<TeardownReceipt>,
 
     /// Position in the priority queue (0 = not queued, 1 = next).
     #[serde(default)]
@@ -172,6 +190,9 @@ pub enum LeasePhase {
     Expired,
     /// Cluster being deleted and recreated.
     Recycling,
+    /// Teardown could not be proven complete for this lease's exact capacity.
+    /// Terminal until the same subject produces a verified receipt.
+    Quarantined,
 }
 
 impl std::fmt::Display for LeasePhase {
@@ -182,6 +203,7 @@ impl std::fmt::Display for LeasePhase {
             LeasePhase::Released => write!(f, "Released"),
             LeasePhase::Expired => write!(f, "Expired"),
             LeasePhase::Recycling => write!(f, "Recycling"),
+            LeasePhase::Quarantined => write!(f, "Quarantined"),
         }
     }
 }
@@ -235,6 +257,7 @@ mod json_safety_tests {
             cluster_name: Some("pool-x-0".into()),
             bound_at: Some("2026-06-04T00:00:00Z".into()),
             expires_at: Some("2026-06-04T01:00:00Z".into()),
+            teardown_receipt: None,
             ..Default::default()
         };
         let v = serde_json::to_value(&set_status).unwrap();
@@ -522,6 +545,37 @@ mod json_safety_tests {
                 message: "bound".into(),
                 last_transition_time: Some("2026-06-04T00:00:00Z".into()),
             }],
+            // Populated, not None: the receipt is the durable evidence a #74
+            // SandboxLease reads back after its ClusterInstance is gone, so it
+            // has to survive the wire intact.
+            teardown_receipt: Some(crate::crd::TeardownReceipt {
+                schema_version: crate::crd::TEARDOWN_RECEIPT_SCHEMA_VERSION,
+                attempt_id: "attempt-1".into(),
+                lease: crate::crd::ResourceRef {
+                    name: "lease-x".into(),
+                    uid: Some("lease-uid".into()),
+                },
+                instance: crate::crd::ResourceRef {
+                    name: "pool-x-0".into(),
+                    uid: Some("instance-uid".into()),
+                },
+                pool: crate::crd::ResourceRef {
+                    name: "x".into(),
+                    uid: Some("pool-uid".into()),
+                },
+                backend_type: "k3s".into(),
+                config_digest: "cfg".into(),
+                instance_spec_digest: "spec".into(),
+                started_at: "2026-06-04T02:00:00Z".into(),
+                completed_at: Some("2026-06-04T02:01:00Z".into()),
+                checks: vec![crate::crd::TeardownCheck {
+                    subject: crate::crd::TeardownSubject::ServerStatefulSet,
+                    result: crate::crd::CheckResult::Verified,
+                    reason: None,
+                }],
+                retry_count: 0,
+                outcome: crate::crd::TeardownOutcome::Verified,
+            }),
         };
         let once = serde_json::to_value(&original).unwrap();
         let back: ClusterLeaseStatus = serde_json::from_value(once.clone()).unwrap();

--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -572,6 +572,7 @@ mod json_safety_tests {
                     subject: crate::crd::TeardownSubject::ServerStatefulSet,
                     result: crate::crd::CheckResult::Verified,
                     reason: None,
+                    verified: Vec::new(),
                 }],
                 retry_count: 0,
                 outcome: crate::crd::TeardownOutcome::Verified,

--- a/src/crd/mod.rs
+++ b/src/crd/mod.rs
@@ -6,6 +6,7 @@ pub mod datastore;
 pub mod instance;
 pub mod lease;
 pub mod profile;
+pub mod sandbox;
 
 pub use access_policy::*;
 pub use bootstrap_config::*;
@@ -15,6 +16,7 @@ pub use datastore::*;
 pub use instance::*;
 pub use lease::*;
 pub use profile::*;
+pub use sandbox::*;
 
 /// Schema helper for `serde_json::Value` fields that need an explicit `type: object`
 /// in the OpenAPI spec. Without this, schemars emits `{}` which K8s rejects.

--- a/src/crd/mod.rs
+++ b/src/crd/mod.rs
@@ -7,6 +7,12 @@ pub mod instance;
 pub mod lease;
 pub mod profile;
 pub mod sandbox;
+// The verified-teardown vocabulary is defined ahead of the k3s provider and the
+// controllers that consume it, so these types have no callers in this change.
+// Same pattern as `datastore` above. `crdgen` also compiles `src/crd` alone, so
+// anything used only by controllers looks dead in that unit regardless.
+#[allow(dead_code)]
+pub mod teardown;
 
 pub use access_policy::*;
 pub use bootstrap_config::*;
@@ -17,6 +23,8 @@ pub use instance::*;
 pub use lease::*;
 pub use profile::*;
 pub use sandbox::*;
+#[allow(unused_imports)]
+pub use teardown::*;
 
 /// Schema helper for `serde_json::Value` fields that need an explicit `type: object`
 /// in the OpenAPI spec. Without this, schemars emits `{}` which K8s rejects.

--- a/src/crd/profile.rs
+++ b/src/crd/profile.rs
@@ -1496,6 +1496,15 @@ pub struct ClusterPoolStatus {
     #[serde(default)]
     pub recycling: u32,
 
+    /// Members held back because their teardown could not be proven complete.
+    ///
+    /// Separate from `recycling` on purpose: recycling is transient churn that
+    /// resolves itself, while a quarantined member is stuck until the same
+    /// exact subject produces a verified receipt. Reporting them together would
+    /// make a pool bleeding capacity look merely busy.
+    #[serde(default)]
+    pub quarantined: u32,
+
     /// Number of clusters currently unhealthy and being recycled.
     #[serde(default)]
     pub unhealthy: u32,

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -1,0 +1,939 @@
+//! Kobe-native API contracts for leasing upstream Agent Sandbox capacity.
+//!
+//! These types deliberately expose a much smaller surface than an upstream
+//! `PodSpec` or `SandboxClaim`. Administrators define a bounded [`SandboxPool`];
+//! callers can request only a pool, TTL, alias, and requester identity through a
+//! [`SandboxLease`]. Placement controllers translate that intent into upstream
+//! resources without accepting caller-provided namespaces, credentials, mounts,
+//! environment variables, PVCs, or runtime classes.
+
+use std::collections::BTreeSet;
+
+use kube::{CustomResource, KubeSchema};
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+use thiserror::Error;
+
+/// Administrator-owned class of Agent Sandbox capacity.
+#[derive(CustomResource, Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[kube(
+    group = "kobe.kunobi.ninja",
+    version = "v1alpha1",
+    kind = "SandboxPool",
+    plural = "sandboxpools",
+    shortname = "sp",
+    status = "SandboxPoolStatus",
+    namespaced,
+    printcolumn = r#"{"name":"Ready","type":"integer","jsonPath":".status.ready"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPoolSpec {
+    /// Desired number of unclaimed upstream Sandboxes kept warm.
+    #[schemars(range(max = 2147483647))]
+    pub warm_capacity: u32,
+
+    /// TTL used when a lease request omits one.
+    #[schemars(length(min = 1))]
+    pub default_ttl: String,
+
+    /// Maximum runtime TTL this pool will accept, independent of caller policy.
+    #[schemars(length(min = 1))]
+    pub max_ttl: String,
+
+    /// Maximum time allowed for placement and Sandbox provisioning. Runtime TTL
+    /// starts only after readiness and is therefore separate from this deadline.
+    #[schemars(length(min = 1))]
+    pub provisioning_timeout: String,
+
+    /// Exactly one target class. The tagged enum makes management and child
+    /// placement mutually exclusive in both JSON and generated OpenAPI.
+    pub placement: SandboxPlacement,
+
+    /// Restricted template translated into the controller-owned upstream
+    /// `SandboxTemplate`; this is intentionally not a `PodSpec` escape hatch.
+    pub template: SandboxTemplateSpec,
+
+    /// Claimed workload-isolation mechanism. Hardened tiers carry the exact
+    /// administrator-selected RuntimeClass; leases cannot override it.
+    pub isolation: SandboxIsolation,
+
+    /// Pool-specific execution canary used in addition to fixed controller
+    /// checks such as upstream readiness and runtime verification.
+    pub readiness: SandboxReadinessRequirements,
+}
+
+impl SandboxPoolSpec {
+    /// Validate relationships that cannot be expressed by the Rust type shape.
+    ///
+    /// Controllers and administrative admission paths must call this before
+    /// rendering upstream objects. Structural exclusivity for placement and
+    /// isolation is already enforced by tagged enums.
+    // `crdgen` imports this module for schemas without calling runtime helpers.
+    #[allow(dead_code)]
+    pub fn validate(&self) -> Result<(), SandboxPoolValidationError> {
+        for (field, value) in [
+            ("defaultTtl", self.default_ttl.as_str()),
+            ("maxTtl", self.max_ttl.as_str()),
+            ("provisioningTimeout", self.provisioning_timeout.as_str()),
+        ] {
+            if value.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyDuration(field));
+            }
+        }
+
+        if self.warm_capacity > i32::MAX as u32 {
+            return Err(SandboxPoolValidationError::WarmCapacityTooLarge);
+        }
+        if let SandboxPlacement::ChildCluster { cluster_pool_ref } = &self.placement
+            && cluster_pool_ref.trim().is_empty()
+        {
+            return Err(SandboxPoolValidationError::EmptyClusterPoolRef);
+        }
+
+        if self.template.containers.is_empty() {
+            return Err(SandboxPoolValidationError::NoContainers);
+        }
+
+        let mut container_names = BTreeSet::new();
+        for container in &self.template.containers {
+            if container.name.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyContainerName);
+            }
+            if !container_names.insert(container.name.as_str()) {
+                return Err(SandboxPoolValidationError::DuplicateContainer(
+                    container.name.clone(),
+                ));
+            }
+            if container.image.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyContainerImage(
+                    container.name.clone(),
+                ));
+            }
+            for (field, value) in [
+                ("requests.cpu", container.resources.requests.cpu.as_str()),
+                (
+                    "requests.memory",
+                    container.resources.requests.memory.as_str(),
+                ),
+                (
+                    "requests.ephemeralStorage",
+                    container.resources.requests.ephemeral_storage.as_str(),
+                ),
+                ("limits.cpu", container.resources.limits.cpu.as_str()),
+                ("limits.memory", container.resources.limits.memory.as_str()),
+                (
+                    "limits.ephemeralStorage",
+                    container.resources.limits.ephemeral_storage.as_str(),
+                ),
+            ] {
+                if value.trim().is_empty() {
+                    return Err(SandboxPoolValidationError::EmptyResource {
+                        container: container.name.clone(),
+                        field,
+                    });
+                }
+            }
+        }
+
+        if !container_names.contains(self.template.default_container.as_str()) {
+            return Err(SandboxPoolValidationError::UnknownDefaultContainer(
+                self.template.default_container.clone(),
+            ));
+        }
+
+        let mut port_names = BTreeSet::new();
+        let mut target_ports = BTreeSet::new();
+        for port in &self.template.exposed_ports {
+            if port.name.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyPortName);
+            }
+            if !port_names.insert(port.name.as_str()) {
+                return Err(SandboxPoolValidationError::DuplicatePortName(
+                    port.name.clone(),
+                ));
+            }
+            if port.port == 0 {
+                return Err(SandboxPoolValidationError::ZeroPort(port.name.clone()));
+            }
+            if !container_names.contains(port.container.as_str()) {
+                return Err(SandboxPoolValidationError::UnknownPortContainer {
+                    port: port.name.clone(),
+                    container: port.container.clone(),
+                });
+            }
+            if !target_ports.insert((port.container.as_str(), port.port)) {
+                return Err(SandboxPoolValidationError::DuplicateContainerPort {
+                    container: port.container.clone(),
+                    port: port.port,
+                });
+            }
+        }
+
+        if let Some(runtime_class) = self.isolation.runtime_class_name()
+            && runtime_class.trim().is_empty()
+        {
+            return Err(SandboxPoolValidationError::EmptyRuntimeClass);
+        }
+
+        if self.readiness.canary.argv.is_empty()
+            || self
+                .readiness
+                .canary
+                .argv
+                .iter()
+                .any(|part| part.is_empty())
+        {
+            return Err(SandboxPoolValidationError::EmptyCanaryArgv);
+        }
+        if self.readiness.canary.timeout.trim().is_empty() {
+            return Err(SandboxPoolValidationError::EmptyCanaryTimeout);
+        }
+
+        Ok(())
+    }
+}
+
+/// Exactly one place in which a SandboxPool may be reconciled.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum SandboxPlacement {
+    /// Reconcile upstream objects in Kobe's management cluster.
+    Management {},
+    /// Acquire a child cluster from this same-namespace ClusterPool.
+    ChildCluster {
+        /// Name of the administrator-owned `ClusterPool` used for composition.
+        #[serde(rename = "clusterPoolRef")]
+        cluster_pool_ref: String,
+    },
+}
+
+// Internally tagged enums normally become `oneOf` schemas whose discriminator
+// property has a different enum value in each branch. Kubernetes structural
+// CRDs reject that shape, so keep the wire representation while publishing one
+// flat object plus CEL for the branch invariant.
+impl JsonSchema for SandboxPlacement {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SandboxPlacement".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string", "enum": ["management", "childCluster"] },
+                "clusterPoolRef": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 63,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"
+                }
+            },
+            "x-kubernetes-validations": [{
+                "rule": "(self.type == 'management' && !has(self.clusterPoolRef)) || (self.type == 'childCluster' && has(self.clusterPoolRef))",
+                "message": "management must not set clusterPoolRef; childCluster must set it"
+            }]
+        }))
+        .expect("static SandboxPlacement schema is valid")
+    }
+}
+
+/// Restricted administrator-authored template for one Sandbox Pod.
+#[derive(Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+#[x_kube(
+    validation = Rule::new("self.containers.exists(c, c.name == self.defaultContainer)")
+        .message("defaultContainer must name one declared container")
+)]
+#[x_kube(
+    validation = Rule::new("self.containers.all(c, self.containers.filter(other, other.name == c.name).size() == 1)")
+        .message("container names must be unique")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.containers.exists(c, c.name == p.container))")
+        .message("every exposed port must name one declared container")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.name == p.name).size() == 1)")
+        .message("exposed port names must be unique")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)")
+        .message("a container port may be declared only once")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches('.*[a-z].*') && !p.name.contains('--'))")
+        .message("exposed port names must contain a letter and cannot contain consecutive hyphens")
+)]
+pub struct SandboxTemplateSpec {
+    /// Container selected by default for execution operations.
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub default_container: String,
+    /// Complete bounded set of containers. Environment, mounts, security
+    /// context, service accounts, and arbitrary Pod fields are not exposed.
+    #[schemars(length(min = 1, max = 16))]
+    pub containers: Vec<SandboxContainerSpec>,
+    /// Ports that later access brokers may expose. Any undeclared port remains
+    /// unauthorized.
+    #[serde(default)]
+    #[schemars(length(max = 64))]
+    pub exposed_ports: Vec<SandboxPortSpec>,
+}
+
+/// One administrator-controlled container in a Sandbox template.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxContainerSpec {
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub name: String,
+    #[schemars(length(min = 1, max = 2048))]
+    pub image: String,
+    /// Executable and arguments, passed directly without an implicit shell.
+    #[serde(default)]
+    #[schemars(with = "Vec<NonEmptySandboxArgSchema>", length(max = 64))]
+    pub command: Vec<String>,
+    #[serde(default)]
+    #[schemars(with = "Vec<BoundedSandboxArgSchema>", length(max = 256))]
+    pub args: Vec<String>,
+    pub resources: SandboxContainerResources,
+}
+
+/// Explicit requests and limits. CPU and memory are the only resource
+/// dimensions admitted by the first Sandbox API, keeping quota comparison
+/// deterministic and avoiding arbitrary extended-resource keys.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxContainerResources {
+    pub requests: SandboxResourceQuantity,
+    pub limits: SandboxResourceQuantity,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxResourceQuantity {
+    /// Kubernetes CPU quantity such as `500m` or `2`.
+    #[schemars(length(min = 1))]
+    pub cpu: String,
+    /// Kubernetes memory quantity such as `512Mi` or `2Gi`.
+    #[schemars(length(min = 1))]
+    pub memory: String,
+    /// Kubernetes ephemeral-storage quantity such as `1Gi`.
+    #[schemars(length(min = 1))]
+    pub ephemeral_storage: String,
+}
+
+/// Aggregate per-Sandbox resource ceiling carried by an access grant.
+///
+/// The values use Kubernetes quantities so administrators can express the
+/// ceiling in the same units as pool container limits. Admission compares
+/// parsed values through [`crate::sandbox::resource_ceiling_allows`].
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxResourceCeiling {
+    #[schemars(length(min = 1))]
+    pub max_cpu: String,
+    #[schemars(length(min = 1))]
+    pub max_memory: String,
+}
+
+/// One TCP port declared safe for later lease-scoped forwarding.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPortSpec {
+    #[schemars(length(min = 1, max = 15), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub name: String,
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub container: String,
+    #[schemars(range(min = 1))]
+    pub port: u16,
+}
+
+/// Isolation is a tagged enum so a hardened claim cannot omit its exact
+/// RuntimeClass and trusted-runc cannot smuggle one through another field.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "tier", rename_all = "kebab-case", deny_unknown_fields)]
+pub enum SandboxIsolation {
+    TrustedRunc {},
+    Gvisor {
+        #[serde(rename = "runtimeClassName")]
+        runtime_class_name: String,
+    },
+    Kata {
+        #[serde(rename = "runtimeClassName")]
+        runtime_class_name: String,
+    },
+}
+
+impl JsonSchema for SandboxIsolation {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "SandboxIsolation".into()
+    }
+
+    fn json_schema(_generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["tier"],
+            "properties": {
+                "tier": { "type": "string", "enum": ["trusted-runc", "gvisor", "kata"] },
+                "runtimeClassName": {
+                    "type": "string",
+                    "minLength": 1,
+                    "maxLength": 253,
+                    "pattern": "^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$"
+                }
+            },
+            "x-kubernetes-validations": [{
+                "rule": "(self.tier == 'trusted-runc' && !has(self.runtimeClassName)) || (self.tier in ['gvisor', 'kata'] && has(self.runtimeClassName))",
+                "message": "trusted-runc must not set runtimeClassName; hardened tiers must set it"
+            }]
+        }))
+        .expect("static SandboxIsolation schema is valid")
+    }
+}
+
+impl SandboxIsolation {
+    // `crdgen` imports this module for schemas without rendering Pods.
+    #[allow(dead_code)]
+    pub fn runtime_class_name(&self) -> Option<&str> {
+        match self {
+            Self::TrustedRunc {} => None,
+            Self::Gvisor { runtime_class_name } | Self::Kata { runtime_class_name } => {
+                Some(runtime_class_name)
+            }
+        }
+    }
+}
+
+/// Variable part of readiness validation. Runtime, admission, network, and
+/// upstream-controller checks remain mandatory controller invariants.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxReadinessRequirements {
+    pub canary: SandboxExecutionCanary,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxExecutionCanary {
+    /// Direct argv vector; no implicit shell expansion.
+    #[schemars(with = "Vec<NonEmptySandboxArgSchema>", length(min = 1, max = 64))]
+    pub argv: Vec<String>,
+    #[schemars(length(min = 1))]
+    pub timeout: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+struct NonEmptySandboxArgSchema(#[schemars(length(min = 1, max = 4096))] String);
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema)]
+#[serde(transparent)]
+struct BoundedSandboxArgSchema(#[schemars(length(max = 4096))] String);
+
+/// Caller-safe intent for one disposable Sandbox.
+#[derive(CustomResource, Debug, Clone, Serialize, Deserialize, KubeSchema, PartialEq, Eq)]
+#[kube(
+    group = "kobe.kunobi.ninja",
+    version = "v1alpha1",
+    kind = "SandboxLease",
+    plural = "sandboxleases",
+    shortname = "sl",
+    status = "SandboxLeaseStatus",
+    namespaced,
+    printcolumn = r#"{"name":"Phase","type":"string","jsonPath":".status.phase"}"#,
+    printcolumn = r#"{"name":"Expires","type":"date","jsonPath":".status.expiresAt"}"#,
+    printcolumn = r#"{"name":"Age","type":"date","jsonPath":".metadata.creationTimestamp"}"#
+)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxLeaseSpec {
+    /// Exact SandboxPool admitted by Kobe. UID and generation fence pool
+    /// recreation or mutation between HTTP admission and placement.
+    pub pool_ref: SandboxPoolReference,
+    #[schemars(length(min = 1))]
+    pub ttl: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub alias: Option<String>,
+    /// Set by Kobe from the authenticated principal, never trusted from an HTTP
+    /// request body. Ownership uses the complete tuple, not the display
+    /// identity alone.
+    pub requester: SandboxPrincipal,
+}
+
+/// Same-namespace, immutable reference to the exact SandboxPool admitted by
+/// Kobe. GVK and namespace are implicit in the typed field.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPoolReference {
+    #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
+    pub name: String,
+    #[schemars(length(min = 1))]
+    pub uid: String,
+    #[schemars(range(min = 1))]
+    pub generation: i64,
+}
+
+/// Canonical authenticated owner of a SandboxLease.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPrincipal {
+    /// Stable configured authentication provider ID.
+    #[schemars(length(min = 1))]
+    pub provider: String,
+    #[serde(rename = "type")]
+    #[schemars(length(min = 1))]
+    pub requester_type: String,
+    #[schemars(length(min = 1))]
+    pub issuer: String,
+    #[schemars(length(min = 1))]
+    pub identity: String,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPoolStatus {
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub observed_generation: Option<i64>,
+    #[serde(default)]
+    pub ready: u32,
+    #[serde(default)]
+    pub allocated: u32,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(
+        extend("x-kubernetes-list-type" = "map"),
+        extend("x-kubernetes-list-map-keys" = ["type"])
+    )]
+    pub conditions: Vec<SandboxCondition>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxLeaseStatus {
+    #[serde(default)]
+    pub phase: SandboxLeasePhase,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub observed_generation: Option<i64>,
+    /// Absolute bound for setup. This is not the runtime expiry.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub provisioning_deadline: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub ready_at: Option<String>,
+    /// Set only when the upstream Sandbox becomes Ready.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub placement: Option<ResolvedSandboxPlacement>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub target: Option<SandboxTargetProvenance>,
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(
+        extend("x-kubernetes-list-type" = "map"),
+        extend("x-kubernetes-list-map-keys" = ["type"])
+    )]
+    pub conditions: Vec<SandboxCondition>,
+}
+
+/// Stable public phases. `Released` and `Expired` are clean terminal states;
+/// uncertain teardown remains `Quarantined` and continues consuming capacity.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+pub enum SandboxLeasePhase {
+    #[default]
+    Pending,
+    Provisioning,
+    Ready,
+    Releasing,
+    Released,
+    Expired,
+    Quarantined,
+}
+
+impl std::fmt::Display for SandboxLeasePhase {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "{self:?}")
+    }
+}
+
+impl SandboxLeasePhase {
+    /// Whether the lease may still own or reserve capacity.
+    // `crdgen` imports this module for schemas without lifecycle evaluation.
+    #[allow(dead_code)]
+    pub fn consumes_capacity(self) -> bool {
+        !matches!(self, Self::Released | Self::Expired)
+    }
+}
+
+/// Resolved placement recorded once by a placement controller. A child
+/// placement binds the referenced pool by UID, preventing name-reuse attacks.
+#[derive(Debug, Clone, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(tag = "type", rename_all = "camelCase", deny_unknown_fields)]
+pub enum ResolvedSandboxPlacement {
+    Management {},
+    ChildCluster {
+        #[serde(rename = "clusterPool")]
+        cluster_pool: SandboxObjectReference,
+    },
+}
+
+impl JsonSchema for ResolvedSandboxPlacement {
+    fn schema_name() -> std::borrow::Cow<'static, str> {
+        "ResolvedSandboxPlacement".into()
+    }
+
+    fn json_schema(generator: &mut schemars::SchemaGenerator) -> schemars::Schema {
+        let reference = serde_json::to_value(generator.subschema_for::<SandboxObjectReference>())
+            .expect("SandboxObjectReference schema serializes");
+        serde_json::from_value(serde_json::json!({
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["type"],
+            "properties": {
+                "type": { "type": "string", "enum": ["management", "childCluster"] },
+                "clusterPool": reference
+            },
+            "x-kubernetes-validations": [{
+                "rule": "(self.type == 'management' && !has(self.clusterPool)) || (self.type == 'childCluster' && has(self.clusterPool))",
+                "message": "resolved childCluster placement requires the exact ClusterPool reference"
+            }]
+        }))
+        .expect("static ResolvedSandboxPlacement schema is valid")
+    }
+}
+
+/// Non-secret identity of one exact Kubernetes object.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxObjectReference {
+    #[schemars(length(min = 1))]
+    pub api_version: String,
+    #[schemars(length(min = 1))]
+    pub kind: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1))]
+    pub namespace: Option<String>,
+    #[schemars(length(min = 1))]
+    pub name: String,
+    #[schemars(length(min = 1))]
+    pub uid: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub generation: Option<i64>,
+}
+
+/// Restart-safe, non-secret target provenance. Fields are filled monotonically:
+/// once a reference is present its name and UID may never be cleared or changed.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxTargetProvenance {
+    #[schemars(length(min = 1))]
+    pub namespace: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_cluster_lease: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub child_cluster_instance: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_template: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_warm_pool: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox_claim: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub sandbox: Option<SandboxObjectReference>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub pod: Option<SandboxObjectReference>,
+}
+
+/// Kubernetes-style condition with the generation from which it was derived.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxCondition {
+    #[serde(rename = "type")]
+    pub condition_type: String,
+    pub status: SandboxConditionStatus,
+    pub reason: String,
+    pub message: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(range(min = 0))]
+    pub observed_generation: Option<i64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(extend("format" = "date-time"))]
+    pub last_transition_time: Option<String>,
+}
+
+/// Kubernetes Condition status values.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+pub enum SandboxConditionStatus {
+    True,
+    False,
+    #[default]
+    Unknown,
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+#[allow(dead_code)] // Used by runtime admission/mapping, not the `crdgen` binary.
+pub enum SandboxPoolValidationError {
+    #[error("{0} must not be empty")]
+    EmptyDuration(&'static str),
+    #[error("warmCapacity exceeds upstream int32 replicas")]
+    WarmCapacityTooLarge,
+    #[error("childCluster placement requires a non-empty clusterPoolRef")]
+    EmptyClusterPoolRef,
+    #[error("template must contain at least one container")]
+    NoContainers,
+    #[error("container name must not be empty")]
+    EmptyContainerName,
+    #[error("duplicate container name {0}")]
+    DuplicateContainer(String),
+    #[error("container {0} has an empty image")]
+    EmptyContainerImage(String),
+    #[error("container {container} has an empty {field} resource quantity")]
+    EmptyResource {
+        container: String,
+        field: &'static str,
+    },
+    #[error("default container {0} is not declared")]
+    UnknownDefaultContainer(String),
+    #[error("port name must not be empty")]
+    EmptyPortName,
+    #[error("duplicate port name {0}")]
+    DuplicatePortName(String),
+    #[error("port {0} must be in the range 1-65535")]
+    ZeroPort(String),
+    #[error("port {port} references undeclared container {container}")]
+    UnknownPortContainer { port: String, container: String },
+    #[error("container {container} exposes port {port} more than once")]
+    DuplicateContainerPort { container: String, port: u16 },
+    #[error("hardened isolation requires a non-empty runtimeClassName")]
+    EmptyRuntimeClass,
+    #[error("readiness canary argv must contain non-empty arguments")]
+    EmptyCanaryArgv,
+    #[error("readiness canary timeout must not be empty")]
+    EmptyCanaryTimeout,
+}
+
+#[cfg(test)]
+mod tests {
+    use kube::CustomResourceExt;
+
+    use super::*;
+
+    fn valid_pool_spec() -> SandboxPoolSpec {
+        SandboxPoolSpec {
+            warm_capacity: 2,
+            default_ttl: "1h".into(),
+            max_ttl: "8h".into(),
+            provisioning_timeout: "10m".into(),
+            placement: SandboxPlacement::Management {},
+            template: SandboxTemplateSpec {
+                default_container: "agent".into(),
+                containers: vec![SandboxContainerSpec {
+                    name: "agent".into(),
+                    image: "example.invalid/agent@sha256:abc".into(),
+                    command: vec!["/agent".into()],
+                    args: vec![],
+                    resources: SandboxContainerResources {
+                        requests: SandboxResourceQuantity {
+                            cpu: "500m".into(),
+                            memory: "512Mi".into(),
+                            ephemeral_storage: "512Mi".into(),
+                        },
+                        limits: SandboxResourceQuantity {
+                            cpu: "1".into(),
+                            memory: "1Gi".into(),
+                            ephemeral_storage: "1Gi".into(),
+                        },
+                    },
+                }],
+                exposed_ports: vec![SandboxPortSpec {
+                    name: "http".into(),
+                    container: "agent".into(),
+                    port: 3000,
+                }],
+            },
+            isolation: SandboxIsolation::TrustedRunc {},
+            readiness: SandboxReadinessRequirements {
+                canary: SandboxExecutionCanary {
+                    argv: vec!["/agent".into(), "health".into()],
+                    timeout: "30s".into(),
+                },
+            },
+        }
+    }
+
+    #[test]
+    fn sandbox_lease_defaults_to_pending() {
+        assert_eq!(
+            SandboxLeaseStatus::default().phase,
+            SandboxLeasePhase::Pending
+        );
+    }
+
+    #[test]
+    fn placement_rejects_both_or_neither_shapes() {
+        assert_eq!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "type": "management"
+            }))
+            .unwrap(),
+            SandboxPlacement::Management {}
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "type": "childCluster",
+                "clusterPoolRef": "ci"
+            }))
+            .unwrap(),
+            SandboxPlacement::ChildCluster {
+                cluster_pool_ref: "ci".into()
+            }
+        );
+        assert!(serde_json::from_value::<SandboxPlacement>(serde_json::json!({})).is_err());
+        assert!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "management": {},
+                "childCluster": { "clusterPoolRef": "ci" }
+            }))
+            .is_err()
+        );
+        assert!(
+            serde_json::from_value::<SandboxPlacement>(serde_json::json!({
+                "type": "management",
+                "clusterPoolRef": "smuggled"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn hardened_isolation_requires_runtime_class_by_shape() {
+        assert!(
+            serde_json::from_value::<SandboxIsolation>(serde_json::json!({ "tier": "gvisor" }))
+                .is_err()
+        );
+        assert!(
+            serde_json::from_value::<SandboxIsolation>(serde_json::json!({
+                "tier": "trusted-runc",
+                "runtimeClassName": "runsc"
+            }))
+            .is_err()
+        );
+    }
+
+    #[test]
+    fn pool_validation_rejects_invalid_container_and_port_links() {
+        let mut spec = valid_pool_spec();
+        spec.placement = SandboxPlacement::ChildCluster {
+            cluster_pool_ref: " ".into(),
+        };
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::EmptyClusterPoolRef)
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.default_container = "missing".into();
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::UnknownDefaultContainer(
+                "missing".into()
+            ))
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.exposed_ports[0].container = "missing".into();
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::UnknownPortContainer {
+                port: "http".into(),
+                container: "missing".into(),
+            })
+        );
+    }
+
+    #[test]
+    fn lease_spec_rejects_unsafe_fields() {
+        let valid_spec = serde_json::json!({
+            "poolRef": {
+                "name": "agents",
+                "uid": "pool-uid",
+                "generation": 1
+            },
+            "ttl": "1h",
+            "requester": {
+                "provider": "developer-oidc",
+                "type": "oidc:user",
+                "issuer": "https://issuer.example",
+                "identity": "alice"
+            }
+        });
+        assert!(serde_json::from_value::<SandboxLeaseSpec>(valid_spec.clone()).is_ok());
+        for (field, value) in [
+            ("namespace", serde_json::json!("kube-system")),
+            ("runtimeClassName", serde_json::json!("runc")),
+            (
+                "env",
+                serde_json::json!([{ "name": "TOKEN", "value": "secret" }]),
+            ),
+        ] {
+            let mut unsafe_spec = valid_spec.clone();
+            unsafe_spec[field] = value;
+            assert!(
+                serde_json::from_value::<SandboxLeaseSpec>(unsafe_spec).is_err(),
+                "field {field} must be rejected"
+            );
+        }
+    }
+
+    #[test]
+    fn lease_phase_capacity_contract_keeps_quarantine_active() {
+        for phase in [
+            SandboxLeasePhase::Pending,
+            SandboxLeasePhase::Provisioning,
+            SandboxLeasePhase::Ready,
+            SandboxLeasePhase::Releasing,
+            SandboxLeasePhase::Quarantined,
+        ] {
+            assert!(phase.consumes_capacity(), "{phase} must consume capacity");
+        }
+        assert!(!SandboxLeasePhase::Released.consumes_capacity());
+        assert!(!SandboxLeasePhase::Expired.consumes_capacity());
+    }
+
+    #[test]
+    fn generated_crds_are_concrete_and_status_enabled() {
+        let pool = serde_json::to_value(SandboxPool::crd()).unwrap();
+        let lease = serde_json::to_value(SandboxLease::crd()).unwrap();
+        assert_eq!(pool["metadata"]["name"], "sandboxpools.kobe.kunobi.ninja");
+        assert_eq!(lease["metadata"]["name"], "sandboxleases.kobe.kunobi.ninja");
+        assert_eq!(pool["spec"]["scope"], "Namespaced");
+        assert_eq!(lease["spec"]["scope"], "Namespaced");
+        let placement = &pool["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["placement"];
+        let isolation = &pool["spec"]["versions"][0]["schema"]["openAPIV3Schema"]["properties"]["spec"]
+            ["properties"]["isolation"];
+        let schema_json = serde_json::to_string(&pool).unwrap();
+        assert!(
+            !schema_json.contains("x-kubernetes-preserve-unknown-fields"),
+            "SandboxPool must not contain a free-form schema escape hatch"
+        );
+        assert_eq!(placement["type"], "object");
+        assert_eq!(isolation["type"], "object");
+        assert!(placement["x-kubernetes-validations"].is_array());
+        assert!(isolation["x-kubernetes-validations"].is_array());
+        assert_eq!(
+            pool["spec"]["versions"][0]["subresources"]["status"],
+            serde_json::json!({})
+        );
+        assert_eq!(
+            lease["spec"]["versions"][0]["subresources"]["status"],
+            serde_json::json!({})
+        );
+    }
+}

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -25,7 +25,7 @@ use schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
 
 use super::ResourceRef;
-use super::profile::{ClusterConfig, DiagnosticsConfig};
+use super::profile::{BackendType, ClusterConfig, DiagnosticsConfig};
 
 /// How thoroughly a lease's capacity must be torn down before it can be reused.
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
@@ -77,6 +77,14 @@ pub enum TeardownSubject {
     ServerDataVolumes,
     /// The exact `k3s_<instance>` database.
     Database,
+    /// The per-cluster PostgreSQL role that owns that database.
+    ///
+    /// Added after `fix(datastore): give each cluster its own PostgreSQL role`
+    /// landed on main: k3s teardown now reclaims ownership, drops the database,
+    /// *and* drops a role. Without this subject a leaked role would sit inside
+    /// a receipt that claims the footprint is gone — the database would be
+    /// proven absent while a credential-bearing role survived.
+    DatabaseRole,
 }
 
 /// Outcome of proving one subject absent.
@@ -116,6 +124,21 @@ pub struct TeardownCheck {
     /// `datastore_unreachable`). Never a raw provider response.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub reason: Option<String>,
+
+    /// The concrete resources this check actually looked at.
+    ///
+    /// A [`TeardownSubject`] is a category. On its own,
+    /// `Database = Verified` asserts that *a* database is gone without saying
+    /// which — so a receipt could be satisfied by checking the wrong one, or by
+    /// checking one of several when the footprint had more. Recording the exact
+    /// identities makes the claim auditable after the fact, which is the whole
+    /// point of keeping evidence that outlives the instance.
+    ///
+    /// Names only: object names, PV names, the database and role identifiers.
+    /// Never connection strings, credentials, or anything that would turn a
+    /// receipt into a secret.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub verified: Vec<String>,
 }
 
 /// Durable proof that one exact lease-owned footprint is gone.
@@ -149,6 +172,17 @@ pub struct TeardownReceipt {
     pub retry_count: u32,
     pub outcome: TeardownOutcome,
 }
+
+/// Set by a consumer once it has read and acted on a lease's teardown receipt.
+///
+/// Until this is present, a receipt-carrying lease is retained after recycling
+/// rather than deleted — the receipt is the only durable proof its capacity was
+/// destroyed, and it is read precisely when the instance is already gone.
+///
+/// An annotation rather than a timeout: evidence that expires on a clock is
+/// evidence you cannot rely on having when you need it.
+pub const TEARDOWN_RECEIPT_ACKNOWLEDGED_ANNOTATION: &str =
+    "kobe.kunobi.ninja/teardown-receipt-acknowledged";
 
 /// Current schema version emitted by this build.
 pub const TEARDOWN_RECEIPT_SCHEMA_VERSION: u32 = 1;
@@ -226,6 +260,23 @@ impl TeardownReceipt {
         if self.checks.len() != expected.required_subjects.len() {
             return false;
         }
+        // Every recorded identity must appear in some verified check. A receipt
+        // that proved three of four volumes gone would otherwise pass, leaving
+        // the fourth — and the tenant data on it — behind.
+        let proven: Vec<&String> = self
+            .checks
+            .iter()
+            .filter(|check| check.result == CheckResult::Verified)
+            .flat_map(|check| check.verified.iter())
+            .collect();
+        if !expected
+            .recorded_identities
+            .iter()
+            .all(|identity| proven.contains(&identity))
+        {
+            return false;
+        }
+
         expected.required_subjects.iter().all(|subject| {
             let mut matching = self.checks.iter().filter(|check| check.subject == *subject);
             let Some(check) = matching.next() else {
@@ -239,7 +290,16 @@ impl TeardownReceipt {
             // credentials as never-created and still release the lease. A
             // footprint that genuinely was never created belongs OUT of
             // `required_subjects` — that is what the scope is for.
-            matching.next().is_none() && check.result == CheckResult::Verified
+            if matching.next().is_some() || check.result != CheckResult::Verified {
+                return false;
+            }
+            // Where the name is derivable, the check must actually name it.
+            // Otherwise `ServerStatefulSet = Verified` proves only that
+            // *something* of that category was inspected.
+            match expected_identity_for(*subject, expected.instance_name) {
+                Some(expected_name) => check.verified.contains(&expected_name),
+                None => true,
+            }
         })
     }
 }
@@ -264,6 +324,122 @@ pub struct TeardownScope<'a> {
     /// were never created are simply absent — which is why the list must come
     /// from the creation record, not be inferred at teardown time.
     pub required_subjects: &'a [TeardownSubject],
+    /// Used to derive the expected resource names. Comes from controller-owned
+    /// bind-time state like the rest of this scope, never from the receipt.
+    pub instance_name: &'a str,
+    /// Provisioner-assigned identities recorded while the instance was healthy
+    /// — the PersistentVolumes its claims were bound to.
+    ///
+    /// These cannot be derived from a name, so they are the one part of the
+    /// footprint a teardown could otherwise quietly omit. Recorded long before
+    /// teardown runs, they are something a receipt must account for rather than
+    /// something it gets to choose.
+    pub recorded_identities: &'a [String],
+}
+
+/// The name a subject's resource must have, where naming is deterministic.
+///
+/// This is the non-circular half of identity checking: it comes from the
+/// recorded plan and the instance name, never from the receipt being validated.
+/// A receipt claiming `ServerStatefulSet = Verified` while naming some other
+/// object therefore fails, rather than being accepted because the category
+/// matched.
+///
+/// `None` for subjects whose identity cannot be derived — the bound PV names
+/// are assigned by the provisioner, and the Pod set is a label selector. Those
+/// are still RECORDED in the receipt for audit; they simply cannot be
+/// pre-computed here.
+pub fn expected_identity_for(subject: TeardownSubject, instance: &str) -> Option<String> {
+    let name = match subject {
+        TeardownSubject::AgentDeployment => format!("{instance}-agent"),
+        TeardownSubject::ServerStatefulSet => format!("{instance}-server"),
+        TeardownSubject::Service => format!("{instance}-server"),
+        TeardownSubject::PodDisruptionBudget => format!("{instance}-server"),
+        TeardownSubject::PublisherConfigMap => format!("{instance}-kubeconfig-publisher"),
+        TeardownSubject::RegistriesConfigMap => format!("{instance}-registries"),
+        TeardownSubject::TokenSecret => format!("{instance}-token"),
+        TeardownSubject::KubeconfigSecret => format!("{instance}-kubeconfig"),
+        TeardownSubject::ConnectTokenSecret => format!("{instance}-connect-token"),
+        TeardownSubject::CidrClaim => instance.to_string(),
+        TeardownSubject::Database => format!("database:k3s_{instance}"),
+        TeardownSubject::DatabaseRole => format!("role:k3s_{instance}"),
+        // Provisioner-assigned or selector-based; recorded, not derivable.
+        TeardownSubject::ServerPods
+        | TeardownSubject::ServerDataPvcs
+        | TeardownSubject::ServerDataVolumes => return None,
+    };
+    Some(name)
+}
+
+/// Derive the exact set of footprints a k3s instance creates, from the config
+/// it is being created with.
+///
+/// Called at **creation** and stamped into immutable provenance — never
+/// recomputed at teardown. Recomputing later would read whatever the config
+/// says *then*, so a pool that stopped setting `registryMirrors` after an
+/// instance was made would drop that ConfigMap from the plan and never verify
+/// it. The plan has to describe what was built, not what would be built now.
+///
+/// Subjects that are always created are unconditional; the rest are included
+/// only when the config that creates them is present. A footprint absent from
+/// this list is not "excused" at teardown — it is simply not part of what this
+/// instance made.
+pub fn k3s_teardown_plan(
+    cluster: &ClusterConfig,
+    has_external_datastore: bool,
+) -> Vec<TeardownSubject> {
+    let mut plan = vec![
+        // Always created by the k3s backend.
+        TeardownSubject::ServerStatefulSet,
+        TeardownSubject::ServerPods,
+        TeardownSubject::Service,
+        TeardownSubject::PublisherConfigMap,
+        TeardownSubject::TokenSecret,
+        TeardownSubject::KubeconfigSecret,
+        TeardownSubject::ConnectTokenSecret,
+    ];
+
+    // Agents are a separate Deployment only when the pool asks for them.
+    if cluster.agents.is_some_and(|agents| agents > 0) {
+        plan.push(TeardownSubject::AgentDeployment);
+    }
+    // The HA PodDisruptionBudget exists only for multi-server pools.
+    if cluster.servers > 1 {
+        plan.push(TeardownSubject::PodDisruptionBudget);
+    }
+    if cluster
+        .registry_mirrors
+        .as_ref()
+        .is_some_and(|mirrors| !mirrors.is_empty())
+    {
+        plan.push(TeardownSubject::RegistriesConfigMap);
+    }
+    // Persistent storage means PVCs and the volumes behind them. Both, always
+    // together: proving the claim gone while its volume survives is precisely
+    // the gap that makes a receipt a lie.
+    if cluster
+        .persistence
+        .as_ref()
+        .is_some_and(|persistence| !storage_is_ephemeral(persistence))
+    {
+        plan.push(TeardownSubject::ServerDataPvcs);
+        plan.push(TeardownSubject::ServerDataVolumes);
+    }
+    // A per-cluster database always comes with the role that owns it.
+    if has_external_datastore {
+        plan.push(TeardownSubject::Database);
+        plan.push(TeardownSubject::DatabaseRole);
+    }
+    plan
+}
+
+/// Whether a persistence config allocates no durable volume.
+fn storage_is_ephemeral(persistence: &super::profile::PersistenceConfig) -> bool {
+    persistence
+        .storage_type
+        .as_deref()
+        .unwrap_or("emptyDir")
+        .eq_ignore_ascii_case("emptydir")
 }
 
 /// Why a pool's footprint cannot support [`CleanupMode::VerifiedDestroy`].
@@ -309,10 +485,19 @@ impl VerifiedDestroyIneligible {
 /// because the datastore connection lives outside the CRD; the caller knows
 /// whether the exact database identity needed to verify absence was captured.
 pub fn verified_destroy_eligibility(
+    backend: &BackendType,
     cluster: &ClusterConfig,
     diagnostics: Option<&DiagnosticsConfig>,
     external_datastore_identity_recorded: bool,
 ) -> Result<(), VerifiedDestroyIneligible> {
+    // Only k3s can produce evidence. Every other backend must be refused here
+    // rather than degrade to Standard cleanup while still claiming a verified
+    // mode. Previously this variant existed but was unreachable, because the
+    // function had no backend to judge — so a non-k3s pool received Ok(()).
+    if *backend != BackendType::K3s {
+        return Err(VerifiedDestroyIneligible::UnsupportedBackend);
+    }
+
     // Host-side kubelet trees survive object deletion and are not part of any
     // subject we can observe from the API, so their presence makes "the
     // footprint is absent" unprovable. Re-admissible once the host reaper's
@@ -361,7 +546,7 @@ mod tests {
 
     #[test]
     fn ephemeral_k3s_with_recorded_datastore_is_eligible() {
-        assert!(verified_destroy_eligibility(&cluster(), None, true).is_ok());
+        assert!(verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, true).is_ok());
     }
 
     /// Each rejection must be derived from configuration alone, so an ineligible
@@ -375,7 +560,7 @@ mod tests {
             ..serde_json::from_value(serde_json::json!({})).unwrap()
         });
         assert_eq!(
-            verified_destroy_eligibility(&shared_mount, None, true).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &shared_mount, None, true).unwrap_err(),
             VerifiedDestroyIneligible::KubeletSharedMount
         );
 
@@ -384,7 +569,8 @@ mod tests {
         )
         .unwrap();
         assert_eq!(
-            verified_destroy_eligibility(&cluster(), Some(&capture), true).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &cluster(), Some(&capture), true)
+                .unwrap_err(),
             VerifiedDestroyIneligible::DiagnosticsEnabled
         );
 
@@ -395,14 +581,125 @@ mod tests {
             storage_request_size: None,
         });
         assert_eq!(
-            verified_destroy_eligibility(&retained, None, true).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &retained, None, true).unwrap_err(),
             VerifiedDestroyIneligible::UnverifiableStorage
         );
 
         assert_eq!(
-            verified_destroy_eligibility(&cluster(), None, false).unwrap_err(),
+            verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, false).unwrap_err(),
             VerifiedDestroyIneligible::DatastoreProvenanceMissing
         );
+    }
+
+    /// The plan must describe what was BUILT, not what the config says later.
+    ///
+    /// Optional footprints appear only when the config that creates them is
+    /// present — and because the plan is stamped at creation, a pool that later
+    /// stops setting `registryMirrors` cannot retroactively drop that ConfigMap
+    /// from an existing instance's plan and leave it unverified.
+    #[test]
+    fn the_plan_covers_exactly_what_this_config_creates() {
+        // Minimal ephemeral cluster, no datastore.
+        let minimal: ClusterConfig =
+            serde_json::from_value(serde_json::json!({ "version": "v1.32.0" })).unwrap();
+        let plan = k3s_teardown_plan(&minimal, false);
+
+        // Always built.
+        for required in [
+            TeardownSubject::ServerStatefulSet,
+            TeardownSubject::ServerPods,
+            TeardownSubject::Service,
+            TeardownSubject::TokenSecret,
+            TeardownSubject::KubeconfigSecret,
+            TeardownSubject::ConnectTokenSecret,
+        ] {
+            assert!(plan.contains(&required), "{required:?} is always created");
+        }
+        // Never built by this config — and therefore not something a receipt
+        // has to excuse. Absent from the plan, not marked NotApplicable.
+        for absent in [
+            TeardownSubject::AgentDeployment,
+            TeardownSubject::PodDisruptionBudget,
+            TeardownSubject::RegistriesConfigMap,
+            TeardownSubject::ServerDataPvcs,
+            TeardownSubject::ServerDataVolumes,
+            TeardownSubject::Database,
+            TeardownSubject::DatabaseRole,
+        ] {
+            assert!(!plan.contains(&absent), "{absent:?} was never created");
+        }
+    }
+
+    /// Persistent storage must pull in BOTH the claim and its volume, and a
+    /// datastore must pull in BOTH the database and its role. Proving one half
+    /// while the other survives is exactly the leak a receipt would otherwise
+    /// hide.
+    #[test]
+    fn paired_footprints_are_never_planned_alone() {
+        let persistent: ClusterConfig = serde_json::from_value(serde_json::json!({
+            "version": "v1.32.0",
+            "servers": 3,
+            "agents": 2,
+            "persistence": { "storageType": "dynamic" },
+            "registryMirrors": { "docker.io": ["https://mirror.example"] }
+        }))
+        .unwrap();
+        let plan = k3s_teardown_plan(&persistent, true);
+
+        assert!(plan.contains(&TeardownSubject::ServerDataPvcs));
+        assert!(
+            plan.contains(&TeardownSubject::ServerDataVolumes),
+            "a claim without its volume proves only that the pointer is gone"
+        );
+        assert!(plan.contains(&TeardownSubject::Database));
+        assert!(
+            plan.contains(&TeardownSubject::DatabaseRole),
+            "a database without its role leaves credentials behind"
+        );
+        // Config-gated extras now present.
+        assert!(plan.contains(&TeardownSubject::AgentDeployment));
+        assert!(plan.contains(&TeardownSubject::PodDisruptionBudget));
+        assert!(plan.contains(&TeardownSubject::RegistriesConfigMap));
+    }
+
+    /// A single-server pool has no PodDisruptionBudget, and emptyDir storage
+    /// has no volume to reclaim.
+    #[test]
+    fn single_server_ephemeral_pools_plan_no_pdb_or_volumes() {
+        let single: ClusterConfig = serde_json::from_value(serde_json::json!({
+            "version": "v1.32.0",
+            "servers": 1,
+            "persistence": { "storageType": "emptyDir" }
+        }))
+        .unwrap();
+        let plan = k3s_teardown_plan(&single, false);
+        assert!(!plan.contains(&TeardownSubject::PodDisruptionBudget));
+        assert!(!plan.contains(&TeardownSubject::ServerDataPvcs));
+        assert!(!plan.contains(&TeardownSubject::ServerDataVolumes));
+    }
+
+    /// A backend that cannot produce evidence must be refused at bind time.
+    ///
+    /// This variant existed before but was unreachable: the function took no
+    /// backend, so a k0s or vcluster pool asking for verified teardown got
+    /// `Ok(())` and would only discover mid-teardown that no evidence was
+    /// possible — stranding the lease in quarantine through no fault of its
+    /// caller.
+    #[test]
+    fn only_k3s_can_promise_verified_teardown() {
+        for backend in [
+            BackendType::K0s,
+            BackendType::Capi,
+            BackendType::Vkobe,
+            BackendType::Vcluster,
+        ] {
+            assert_eq!(
+                verified_destroy_eligibility(&backend, &cluster(), None, true).unwrap_err(),
+                VerifiedDestroyIneligible::UnsupportedBackend,
+                "{backend:?} cannot produce a receipt and must be refused"
+            );
+        }
+        assert!(verified_destroy_eligibility(&BackendType::K3s, &cluster(), None, true).is_ok());
     }
 
     /// Disabled diagnostics must not disqualify a pool — only active capture
@@ -413,7 +710,10 @@ mod tests {
             serde_json::json!({ "enabled": false, "storage": "s3://bucket/" }),
         )
         .unwrap();
-        assert!(verified_destroy_eligibility(&cluster(), Some(&disabled), true).is_ok());
+        assert!(
+            verified_destroy_eligibility(&BackendType::K3s, &cluster(), Some(&disabled), true)
+                .is_ok()
+        );
     }
 
     /// A single `Unknown` must dominate, however many subjects verified: the
@@ -424,16 +724,19 @@ mod tests {
             subject: TeardownSubject::ServerStatefulSet,
             result: CheckResult::Verified,
             reason: None,
+            verified: Vec::new(),
         };
         let not_applicable = TeardownCheck {
             subject: TeardownSubject::RegistriesConfigMap,
             result: CheckResult::NotApplicable,
             reason: None,
+            verified: Vec::new(),
         };
         let unknown = TeardownCheck {
             subject: TeardownSubject::Database,
             result: CheckResult::Unknown,
             reason: Some("datastore_unreachable".into()),
+            verified: Vec::new(),
         };
 
         assert_eq!(
@@ -478,6 +781,11 @@ mod tests {
             subject,
             result,
             reason: None,
+            // Name what a real provider would have named, so these fixtures
+            // satisfy the identity comparison the way production does.
+            verified: expected_identity_for(subject, "pool-p-0")
+                .into_iter()
+                .collect(),
         }
     }
 
@@ -512,6 +820,8 @@ mod tests {
             config_digest: "digest",
             instance_spec_digest: "spec-digest",
             required_subjects: required,
+            instance_name: "pool-p-0",
+            recorded_identities: &[],
         }
     }
 
@@ -585,6 +895,119 @@ mod tests {
 
         // An empty plan is not a clean bill of health.
         assert!(!complete.permits_release_for(&scope(&[], &refs)));
+    }
+
+    /// A check must name the resource its subject actually designates.
+    ///
+    /// Without this, `ServerStatefulSet = Verified` proves only that *something*
+    /// of that category was inspected — a receipt could verify a different
+    /// instance's StatefulSet, or one of several resources when the footprint
+    /// had more, and still release capacity. The expected name is derived from
+    /// controller-owned state and the instance name, never from the receipt.
+    #[test]
+    fn a_check_naming_the_wrong_resource_does_not_release() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [TeardownSubject::ServerStatefulSet];
+
+        let correct = receipt(
+            vec![check(
+                TeardownSubject::ServerStatefulSet,
+                CheckResult::Verified,
+            )],
+            TeardownOutcome::Verified,
+        );
+        assert!(correct.permits_release_for(&scope(&required, &refs)));
+
+        // Right category, wrong object — another instance's StatefulSet.
+        let wrong = receipt(
+            vec![TeardownCheck {
+                subject: TeardownSubject::ServerStatefulSet,
+                result: CheckResult::Verified,
+                reason: None,
+                verified: vec!["some-other-instance-server".into()],
+            }],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !wrong.permits_release_for(&scope(&required, &refs)),
+            "a check must name the resource its subject designates"
+        );
+
+        // Claiming the category with no identity at all is equally unproven.
+        let unnamed = receipt(
+            vec![TeardownCheck {
+                subject: TeardownSubject::ServerStatefulSet,
+                result: CheckResult::Verified,
+                reason: None,
+                verified: Vec::new(),
+            }],
+            TeardownOutcome::Verified,
+        );
+        assert!(!unnamed.permits_release_for(&scope(&required, &refs)));
+    }
+
+    /// Every identity recorded while the instance was healthy must be proven
+    /// absent.
+    ///
+    /// Bound PV names cannot be derived from the instance name, so they are the
+    /// one part of the footprint a teardown could quietly omit — verify three of
+    /// four volumes and the fourth, with the tenant's data on it, survives while
+    /// the receipt reads clean. Recording them at Ready and requiring coverage
+    /// here is what closes that.
+    #[test]
+    fn every_recorded_identity_must_be_proven_absent() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [TeardownSubject::ServerDataVolumes];
+        let recorded = vec!["pvc-aaa".to_string(), "pvc-bbb".to_string()];
+
+        let volumes_check = |names: Vec<&str>| TeardownCheck {
+            subject: TeardownSubject::ServerDataVolumes,
+            result: CheckResult::Verified,
+            reason: None,
+            verified: names.into_iter().map(String::from).collect(),
+        };
+        let with_recorded = |identities: &'static [String]| TeardownScope {
+            lease: &refs.0,
+            instance: &refs.1,
+            pool: &refs.2,
+            backend_type: "k3s",
+            config_digest: "digest",
+            instance_spec_digest: "spec-digest",
+            required_subjects: &required,
+            instance_name: "pool-p-0",
+            recorded_identities: identities,
+        };
+        // Leaked to satisfy the 'static bound in this helper; test-only.
+        let recorded_static: &'static [String] = Box::leak(recorded.clone().into_boxed_slice());
+
+        // Both volumes proven: releases.
+        let complete = receipt(
+            vec![volumes_check(vec!["pvc-aaa", "pvc-bbb"])],
+            TeardownOutcome::Verified,
+        );
+        assert!(complete.permits_release_for(&with_recorded(recorded_static)));
+
+        // One volume unaccounted for: must not release.
+        let partial = receipt(
+            vec![volumes_check(vec!["pvc-aaa"])],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !partial.permits_release_for(&with_recorded(recorded_static)),
+            "a volume recorded at Ready but never proven absent must block release"
+        );
+    }
+
+    /// Subjects whose names are provisioner-assigned cannot be pre-derived, so
+    /// they must not be blocked by the identity check — only recorded.
+    #[test]
+    fn provisioner_assigned_subjects_are_not_name_checked() {
+        assert!(expected_identity_for(TeardownSubject::ServerDataVolumes, "pool-p-0").is_none());
+        assert!(expected_identity_for(TeardownSubject::ServerPods, "pool-p-0").is_none());
+        assert_eq!(
+            expected_identity_for(TeardownSubject::Database, "pool-p-0").as_deref(),
+            Some("database:k3s_pool-p-0")
+        );
     }
 
     /// A receipt is proof about ONE subject. It must not be replayable against

--- a/src/crd/teardown.rs
+++ b/src/crd/teardown.rs
@@ -1,0 +1,695 @@
+//! Verified-teardown vocabulary: cleanup modes, per-subject evidence, receipts,
+//! and the pure eligibility rules that decide whether a footprint can be proven
+//! absent at all.
+//!
+//! This module deliberately contains **no** teardown behaviour. It defines what
+//! evidence looks like and which configurations can produce it; the k3s provider
+//! and the controllers that consume it land separately.
+//!
+//! # Why receipts exist
+//!
+//! Today `ClusterBackend::delete` returns `Result<()>`, the instance controller
+//! deletes the `ClusterInstance` once it returns, and the lease controller reads
+//! the resulting 404 as "recycling complete". So an *accepted DELETE request* is
+//! treated as proof of destruction. For capacity that held another tenant's code
+//! and credentials that is not good enough: PVC, PDB, Pod and PostgreSQL
+//! failures currently warn and continue, and nothing waits for the objects or
+//! their backing volumes to actually disappear.
+//!
+//! A receipt replaces inference with evidence. The rule throughout is that
+//! **uncertainty is not success**: anything we cannot observe becomes
+//! [`CheckResult::Unknown`], which quarantines the capacity rather than
+//! returning it to the pool.
+
+use schemars::JsonSchema;
+use serde::{Deserialize, Serialize};
+
+use super::ResourceRef;
+use super::profile::{ClusterConfig, DiagnosticsConfig};
+
+/// How thoroughly a lease's capacity must be torn down before it can be reused.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema, Default)]
+pub enum CleanupMode {
+    /// Today's behaviour: issue the deletes and trust an accepted request.
+    ///
+    /// Remains the default so existing `ClusterLease` objects are untouched.
+    #[default]
+    Standard,
+    /// Removal of the final cleanup handle requires a verified receipt proving
+    /// the exact lease-owned footprint is absent. Missing or uncertain evidence
+    /// quarantines the unit instead of returning it to the pool.
+    ///
+    /// Only `backend.type=k3s` implements this; every other backend must reject
+    /// it at bind time rather than silently degrading to [`Self::Standard`].
+    VerifiedDestroy,
+}
+
+impl CleanupMode {
+    /// Whether this mode requires evidence before capacity may be reused.
+    pub fn requires_receipt(self) -> bool {
+        matches!(self, Self::VerifiedDestroy)
+    }
+}
+
+/// One thing whose absence must be proven.
+///
+/// Enumerated rather than free-text so a receipt cannot be satisfied by an
+/// unrecognised or invented subject, and so adding a resource to the teardown
+/// path is a deliberate, reviewable change to this list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TeardownSubject {
+    AgentDeployment,
+    ServerStatefulSet,
+    ServerPods,
+    Service,
+    PodDisruptionBudget,
+    PublisherConfigMap,
+    RegistriesConfigMap,
+    TokenSecret,
+    KubeconfigSecret,
+    /// The lease's connect-token Secret. Revoked first, verified like the rest.
+    ConnectTokenSecret,
+    CidrClaim,
+    /// Every `data-{instance}-server-{ordinal}` PVC.
+    ServerDataPvcs,
+    /// The PVs those PVCs were bound to, captured before deletion.
+    ServerDataVolumes,
+    /// The exact `k3s_<instance>` database.
+    Database,
+}
+
+/// Outcome of proving one subject absent.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum CheckResult {
+    /// Observed absent. The only result that contributes to a verified receipt.
+    Verified,
+    /// This footprint never existed, established from **recorded creation-time
+    /// configuration** — not from a lookup that happened to return nothing.
+    ///
+    /// The distinction matters: "the pool never enabled registry mirrors" is
+    /// `NotApplicable`; "listing ConfigMaps returned 403" is [`Self::Unknown`].
+    NotApplicable,
+    /// Could not be determined: an API or RBAC error, a timeout, an
+    /// unreachable datastore, or a UID that no longer matches. Quarantines.
+    Unknown,
+}
+
+/// Aggregate verdict for one teardown attempt.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub enum TeardownOutcome {
+    /// Every required subject is `Verified` or `NotApplicable`.
+    Verified,
+    /// At least one subject is `Unknown`. Capacity is not reusable.
+    Quarantined,
+}
+
+/// Evidence for one subject.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TeardownCheck {
+    pub subject: TeardownSubject,
+    pub result: CheckResult,
+    /// Bounded, non-secret reason code (e.g. `pv_still_present`,
+    /// `datastore_unreachable`). Never a raw provider response.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+}
+
+/// Durable proof that one exact lease-owned footprint is gone.
+///
+/// Lives on `ClusterLeaseStatus` rather than on the `ClusterInstance`, because
+/// it must remain queryable **after** the instance object disappears — that is
+/// precisely the moment the evidence matters, and #74's owning `SandboxLease`
+/// has to be able to consume it afterwards.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, JsonSchema)]
+#[serde(rename_all = "camelCase")]
+pub struct TeardownReceipt {
+    /// Schema version, so a consumer can refuse evidence it does not understand
+    /// rather than misread an older shape as complete.
+    pub schema_version: u32,
+    /// Unique per attempt; retries produce new attempts, never edit old ones.
+    pub attempt_id: String,
+    /// Exact subjects this receipt is about. A same-named replacement is a
+    /// mismatch, not successful absence.
+    pub lease: ResourceRef,
+    pub instance: ResourceRef,
+    pub pool: ResourceRef,
+    /// Backend identity and immutable provenance digest observed at bind time.
+    pub backend_type: String,
+    pub config_digest: String,
+    pub instance_spec_digest: String,
+    pub started_at: String,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub completed_at: Option<String>,
+    pub checks: Vec<TeardownCheck>,
+    #[serde(default)]
+    pub retry_count: u32,
+    pub outcome: TeardownOutcome,
+}
+
+/// Current schema version emitted by this build.
+pub const TEARDOWN_RECEIPT_SCHEMA_VERSION: u32 = 1;
+
+impl TeardownReceipt {
+    /// Derive the aggregate outcome from the per-subject evidence.
+    ///
+    /// Deliberately not stored independently of `checks`: an outcome that could
+    /// disagree with its own evidence is exactly the failure mode receipts exist
+    /// to prevent.
+    pub fn outcome_for(checks: &[TeardownCheck]) -> TeardownOutcome {
+        if checks
+            .iter()
+            .any(|check| check.result == CheckResult::Unknown)
+        {
+            TeardownOutcome::Quarantined
+        } else {
+            TeardownOutcome::Verified
+        }
+    }
+
+    /// Whether this receipt releases the exact footprint described by
+    /// `expected`.
+    ///
+    /// A receipt is only proof of *what it actually covers*. An earlier version
+    /// asked only "no `Unknown`, and not empty", which meant a receipt carrying
+    /// one `serverStatefulSet=verified` check released capacity while saying
+    /// nothing about the database, credentials, volumes, or Pods. Absence of
+    /// evidence read as evidence of absence — the exact inversion receipts
+    /// exist to prevent.
+    ///
+    /// `expected` must come from controller-owned bind-time state, never from
+    /// the receipt being validated: a receipt that vouches for its own scope
+    /// proves nothing.
+    ///
+    /// Requires all of:
+    /// - a schema version this build understands;
+    /// - a completion timestamp — an unfinished attempt is not proof;
+    /// - the recorded verdict agreeing with the checks;
+    /// - identity matching `expected` exactly, so a receipt from another
+    ///   attempt or a same-named replacement cannot be replayed;
+    /// - exactly one `Verified` check per expected subject — no missing
+    ///   subjects, no duplicates, no extras, and no `NotApplicable` standing in
+    ///   for a subject the scope says was created.
+    pub fn permits_release_for(&self, expected: &TeardownScope<'_>) -> bool {
+        if self.schema_version != TEARDOWN_RECEIPT_SCHEMA_VERSION
+            || self.completed_at.is_none()
+            || self.outcome != TeardownOutcome::Verified
+            || Self::outcome_for(&self.checks) != TeardownOutcome::Verified
+        {
+            return false;
+        }
+        // A reference without a UID cannot fence anything: two `None` UIDs
+        // compare equal, so a same-named replacement would satisfy the match
+        // that is supposed to exclude it.
+        if self.lease.uid.is_none() || self.instance.uid.is_none() || self.pool.uid.is_none() {
+            return false;
+        }
+        // Identity, not just shape: a valid receipt for a *different* subject
+        // must not release this one.
+        if self.lease != *expected.lease
+            || self.instance != *expected.instance
+            || self.pool != *expected.pool
+            || self.backend_type != expected.backend_type
+            || self.config_digest != expected.config_digest
+            || self.instance_spec_digest != expected.instance_spec_digest
+        {
+            return false;
+        }
+        if expected.required_subjects.is_empty() {
+            // Nothing to prove means nothing was proven. Fail closed rather
+            // than treat an empty plan as a clean bill of health.
+            return false;
+        }
+        if self.checks.len() != expected.required_subjects.len() {
+            return false;
+        }
+        expected.required_subjects.iter().all(|subject| {
+            let mut matching = self.checks.iter().filter(|check| check.subject == *subject);
+            let Some(check) = matching.next() else {
+                return false;
+            };
+            // Exactly one: duplicates could otherwise pair a Verified with a
+            // silently ignored second opinion.
+            //
+            // And it must be Verified, not merely "not Unknown". Accepting
+            // NotApplicable here would let a receipt mark the database and
+            // credentials as never-created and still release the lease. A
+            // footprint that genuinely was never created belongs OUT of
+            // `required_subjects` — that is what the scope is for.
+            matching.next().is_none() && check.result == CheckResult::Verified
+        })
+    }
+}
+
+/// The exact footprint a receipt must account for, derived from
+/// controller-owned bind-time state.
+///
+/// Separate from [`TeardownReceipt`] on purpose. The receipt is mutable status
+/// written by the teardown path; the scope is the trusted record of what that
+/// path was supposed to destroy. Validating a receipt against fields carried
+/// inside itself would let a truncated or replayed receipt define its own
+/// success criteria.
+#[derive(Debug, Clone, Copy)]
+pub struct TeardownScope<'a> {
+    pub lease: &'a ResourceRef,
+    pub instance: &'a ResourceRef,
+    pub pool: &'a ResourceRef,
+    pub backend_type: &'a str,
+    pub config_digest: &'a str,
+    pub instance_spec_digest: &'a str,
+    /// Every subject this instance actually created. Optional footprints that
+    /// were never created are simply absent — which is why the list must come
+    /// from the creation record, not be inferred at teardown time.
+    pub required_subjects: &'a [TeardownSubject],
+}
+
+/// Why a pool's footprint cannot support [`CleanupMode::VerifiedDestroy`].
+///
+/// Rejected **before binding**. An ineligible pool must never accept a
+/// receipt-required lease and then discover mid-teardown that it cannot produce
+/// evidence — that would strand the lease in quarantine through no fault of the
+/// caller.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, thiserror::Error)]
+pub enum VerifiedDestroyIneligible {
+    #[error("backend does not implement verified teardown")]
+    UnsupportedBackend,
+    #[error("kubeletSharedMount leaves host state this receipt cannot account for")]
+    KubeletSharedMount,
+    #[error("diagnostics capture writes objects whose deletion is not receipt-verifiable")]
+    DiagnosticsEnabled,
+    #[error("storage is neither ephemeral nor dynamically provisioned with an observable volume")]
+    UnverifiableStorage,
+    #[error("external datastore identity was not recorded, so its absence cannot be proven")]
+    DatastoreProvenanceMissing,
+}
+
+impl VerifiedDestroyIneligible {
+    /// Bounded reason code for status, events, and metrics.
+    pub const fn reason_code(&self) -> &'static str {
+        match self {
+            Self::UnsupportedBackend => "unsupported_backend",
+            Self::KubeletSharedMount => "kubelet_shared_mount",
+            Self::DiagnosticsEnabled => "diagnostics_enabled",
+            Self::UnverifiableStorage => "unverifiable_storage",
+            Self::DatastoreProvenanceMissing => "datastore_provenance_missing",
+        }
+    }
+}
+
+/// Whether a k3s cluster configuration can produce a verifiable receipt.
+///
+/// Pure and total: every rejection is derived from recorded configuration, never
+/// from a live lookup, so the same inputs always yield the same verdict and the
+/// decision can be made at bind time.
+///
+/// `external_datastore_identity_recorded` is threaded in rather than read here
+/// because the datastore connection lives outside the CRD; the caller knows
+/// whether the exact database identity needed to verify absence was captured.
+pub fn verified_destroy_eligibility(
+    cluster: &ClusterConfig,
+    diagnostics: Option<&DiagnosticsConfig>,
+    external_datastore_identity_recorded: bool,
+) -> Result<(), VerifiedDestroyIneligible> {
+    // Host-side kubelet trees survive object deletion and are not part of any
+    // subject we can observe from the API, so their presence makes "the
+    // footprint is absent" unprovable. Re-admissible once the host reaper's
+    // acknowledgement becomes part of the receipt.
+    if cluster.kubelet_shared_mount.is_some() {
+        return Err(VerifiedDestroyIneligible::KubeletSharedMount);
+    }
+
+    // Diagnostics capture writes bundles to S3 on release. Object deletion there
+    // is not receipt-verifiable today, and a receipt that silently ignored them
+    // would overstate what was destroyed.
+    if diagnostics.is_some_and(|diagnostics| diagnostics.enabled) {
+        return Err(VerifiedDestroyIneligible::DiagnosticsEnabled);
+    }
+
+    // Storage must be either non-persistent, or dynamically provisioned so the
+    // PVC and its backing PV can be observed disappearing. A pool that pins a
+    // storage class we cannot reason about is rejected rather than assumed
+    // deletable — the reclaim policy itself is checked against the live
+    // StorageClass by the provider, since it is not part of this config.
+    if let Some(persistence) = cluster.persistence.as_ref() {
+        let storage_type = persistence.storage_type.as_deref().unwrap_or("emptyDir");
+        let ephemeral = storage_type.eq_ignore_ascii_case("emptydir");
+        let dynamic = storage_type.eq_ignore_ascii_case("dynamic");
+        if !ephemeral && !dynamic {
+            return Err(VerifiedDestroyIneligible::UnverifiableStorage);
+        }
+    }
+
+    if !external_datastore_identity_recorded {
+        return Err(VerifiedDestroyIneligible::DatastoreProvenanceMissing);
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::profile::{KubeletSharedMountConfig, PersistenceConfig};
+
+    fn cluster() -> ClusterConfig {
+        serde_json::from_value(serde_json::json!({ "version": "v1.32.0" }))
+            .expect("minimal ClusterConfig must deserialize")
+    }
+
+    #[test]
+    fn ephemeral_k3s_with_recorded_datastore_is_eligible() {
+        assert!(verified_destroy_eligibility(&cluster(), None, true).is_ok());
+    }
+
+    /// Each rejection must be derived from configuration alone, so an ineligible
+    /// pool is refused at bind time rather than stranding a lease in quarantine.
+    #[test]
+    fn unverifiable_footprints_are_rejected_before_binding() {
+        let mut shared_mount = cluster();
+        shared_mount.kubelet_shared_mount = Some(KubeletSharedMountConfig {
+            server: true,
+            agents: true,
+            ..serde_json::from_value(serde_json::json!({})).unwrap()
+        });
+        assert_eq!(
+            verified_destroy_eligibility(&shared_mount, None, true).unwrap_err(),
+            VerifiedDestroyIneligible::KubeletSharedMount
+        );
+
+        let capture: DiagnosticsConfig = serde_json::from_value(
+            serde_json::json!({ "enabled": true, "storage": "s3://bucket/" }),
+        )
+        .unwrap();
+        assert_eq!(
+            verified_destroy_eligibility(&cluster(), Some(&capture), true).unwrap_err(),
+            VerifiedDestroyIneligible::DiagnosticsEnabled
+        );
+
+        let mut retained = cluster();
+        retained.persistence = Some(PersistenceConfig {
+            storage_type: Some("hostPath".into()),
+            storage_class_name: None,
+            storage_request_size: None,
+        });
+        assert_eq!(
+            verified_destroy_eligibility(&retained, None, true).unwrap_err(),
+            VerifiedDestroyIneligible::UnverifiableStorage
+        );
+
+        assert_eq!(
+            verified_destroy_eligibility(&cluster(), None, false).unwrap_err(),
+            VerifiedDestroyIneligible::DatastoreProvenanceMissing
+        );
+    }
+
+    /// Disabled diagnostics must not disqualify a pool — only active capture
+    /// creates objects we cannot account for.
+    #[test]
+    fn disabled_diagnostics_stays_eligible() {
+        let disabled: DiagnosticsConfig = serde_json::from_value(
+            serde_json::json!({ "enabled": false, "storage": "s3://bucket/" }),
+        )
+        .unwrap();
+        assert!(verified_destroy_eligibility(&cluster(), Some(&disabled), true).is_ok());
+    }
+
+    /// A single `Unknown` must dominate, however many subjects verified: the
+    /// whole point is that partial evidence is not evidence.
+    #[test]
+    fn one_unknown_quarantines_the_whole_attempt() {
+        let verified = TeardownCheck {
+            subject: TeardownSubject::ServerStatefulSet,
+            result: CheckResult::Verified,
+            reason: None,
+        };
+        let not_applicable = TeardownCheck {
+            subject: TeardownSubject::RegistriesConfigMap,
+            result: CheckResult::NotApplicable,
+            reason: None,
+        };
+        let unknown = TeardownCheck {
+            subject: TeardownSubject::Database,
+            result: CheckResult::Unknown,
+            reason: Some("datastore_unreachable".into()),
+        };
+
+        assert_eq!(
+            TeardownReceipt::outcome_for(&[verified.clone(), not_applicable.clone()]),
+            TeardownOutcome::Verified
+        );
+        assert_eq!(
+            TeardownReceipt::outcome_for(&[verified, not_applicable, unknown]),
+            TeardownOutcome::Quarantined
+        );
+    }
+
+    fn receipt(checks: Vec<TeardownCheck>, outcome: TeardownOutcome) -> TeardownReceipt {
+        TeardownReceipt {
+            schema_version: TEARDOWN_RECEIPT_SCHEMA_VERSION,
+            attempt_id: "attempt-1".into(),
+            lease: ResourceRef {
+                name: "lease-a".into(),
+                uid: Some("lease-uid".into()),
+            },
+            instance: ResourceRef {
+                name: "pool-p-0".into(),
+                uid: Some("instance-uid".into()),
+            },
+            pool: ResourceRef {
+                name: "p".into(),
+                uid: Some("pool-uid".into()),
+            },
+            backend_type: "k3s".into(),
+            config_digest: "digest".into(),
+            instance_spec_digest: "spec-digest".into(),
+            started_at: "2026-01-01T00:00:00Z".into(),
+            completed_at: Some("2026-01-01T00:01:00Z".into()),
+            checks,
+            retry_count: 0,
+            outcome,
+        }
+    }
+
+    fn check(subject: TeardownSubject, result: CheckResult) -> TeardownCheck {
+        TeardownCheck {
+            subject,
+            result,
+            reason: None,
+        }
+    }
+
+    fn lease_ref() -> ResourceRef {
+        ResourceRef {
+            name: "lease-a".into(),
+            uid: Some("lease-uid".into()),
+        }
+    }
+    fn instance_ref() -> ResourceRef {
+        ResourceRef {
+            name: "pool-p-0".into(),
+            uid: Some("instance-uid".into()),
+        }
+    }
+    fn pool_ref() -> ResourceRef {
+        ResourceRef {
+            name: "p".into(),
+            uid: Some("pool-uid".into()),
+        }
+    }
+
+    fn scope<'a>(
+        required: &'a [TeardownSubject],
+        refs: &'a (ResourceRef, ResourceRef, ResourceRef),
+    ) -> TeardownScope<'a> {
+        TeardownScope {
+            lease: &refs.0,
+            instance: &refs.1,
+            pool: &refs.2,
+            backend_type: "k3s",
+            config_digest: "digest",
+            instance_spec_digest: "spec-digest",
+            required_subjects: required,
+        }
+    }
+
+    /// A receipt releases capacity only if it accounts for EVERY subject the
+    /// instance actually created.
+    ///
+    /// The earlier rule was "no Unknown, and not empty", which let a receipt
+    /// carrying a single `serverStatefulSet=verified` check release a lease
+    /// while saying nothing about the database, credentials, volumes, or Pods —
+    /// absence of evidence read as evidence of absence.
+    #[test]
+    fn partial_evidence_cannot_release_capacity() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [
+            TeardownSubject::ServerStatefulSet,
+            TeardownSubject::Database,
+            TeardownSubject::KubeconfigSecret,
+        ];
+
+        // Every required subject positively verified.
+        let complete = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Verified),
+                check(TeardownSubject::KubeconfigSecret, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(complete.permits_release_for(&scope(&required, &refs)));
+
+        // NotApplicable must NOT satisfy a subject the scope says was created:
+        // otherwise a receipt marks the database "never existed" and releases
+        // the lease anyway. A genuinely absent footprint belongs out of the
+        // scope, not explained away inside the receipt.
+        let excused = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::NotApplicable),
+                check(TeardownSubject::KubeconfigSecret, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !excused.permits_release_for(&scope(&required, &refs)),
+            "NotApplicable cannot stand in for a subject the scope says was created"
+        );
+
+        // One subject simply missing — the defect this test exists for.
+        let partial = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !partial.permits_release_for(&scope(&required, &refs)),
+            "a receipt that omits a required subject must not release capacity"
+        );
+
+        // Duplicates must not let a second opinion hide behind the first.
+        let duplicated = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Verified),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(!duplicated.permits_release_for(&scope(&required, &refs)));
+
+        // An empty plan is not a clean bill of health.
+        assert!(!complete.permits_release_for(&scope(&[], &refs)));
+    }
+
+    /// A receipt is proof about ONE subject. It must not be replayable against
+    /// another lease, instance, pool, or a same-named replacement.
+    #[test]
+    fn a_receipt_cannot_be_replayed_against_another_subject() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [TeardownSubject::ServerStatefulSet];
+        let valid = receipt(
+            vec![check(
+                TeardownSubject::ServerStatefulSet,
+                CheckResult::Verified,
+            )],
+            TeardownOutcome::Verified,
+        );
+        assert!(valid.permits_release_for(&scope(&required, &refs)));
+
+        // Same name, different UID — a replacement object.
+        let replaced = (
+            lease_ref(),
+            ResourceRef {
+                name: "pool-p-0".into(),
+                uid: Some("replacement-instance-uid".into()),
+            },
+            pool_ref(),
+        );
+        assert!(
+            !valid.permits_release_for(&scope(&required, &replaced)),
+            "a same-named replacement is a different subject"
+        );
+
+        // Drifted provenance must also refuse.
+        let mut drifted = scope(&required, &refs);
+        drifted.config_digest = "other-digest";
+        assert!(!valid.permits_release_for(&drifted));
+
+        // A reference with no UID cannot fence anything: two `None`s compare
+        // equal, so this would otherwise "match" any same-named object.
+        let unfenced_refs = (
+            lease_ref(),
+            ResourceRef {
+                name: "pool-p-0".into(),
+                uid: None,
+            },
+            pool_ref(),
+        );
+        let mut unfenced = receipt(
+            vec![check(
+                TeardownSubject::ServerStatefulSet,
+                CheckResult::Verified,
+            )],
+            TeardownOutcome::Verified,
+        );
+        unfenced.instance = ResourceRef {
+            name: "pool-p-0".into(),
+            uid: None,
+        };
+        assert!(
+            !unfenced.permits_release_for(&scope(&required, &unfenced_refs)),
+            "a receipt without UIDs must never release capacity"
+        );
+    }
+
+    /// Verdict, evidence, schema, and completeness each fail closed on their own.
+    #[test]
+    fn release_requires_evidence_that_matches_the_verdict() {
+        let refs = (lease_ref(), instance_ref(), pool_ref());
+        let required = [
+            TeardownSubject::ServerStatefulSet,
+            TeardownSubject::Database,
+        ];
+
+        // Verdict claims success while the evidence says otherwise.
+        let contradicted = receipt(
+            vec![
+                check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+                check(TeardownSubject::Database, CheckResult::Unknown),
+            ],
+            TeardownOutcome::Verified,
+        );
+        assert!(
+            !contradicted.permits_release_for(&scope(&required, &refs)),
+            "a Verified verdict must not override an Unknown check"
+        );
+
+        let good = vec![
+            check(TeardownSubject::ServerStatefulSet, CheckResult::Verified),
+            check(TeardownSubject::Database, CheckResult::Verified),
+        ];
+
+        // An unrecognised schema must not be read as complete.
+        let mut future = receipt(good.clone(), TeardownOutcome::Verified);
+        future.schema_version = TEARDOWN_RECEIPT_SCHEMA_VERSION + 1;
+        assert!(!future.permits_release_for(&scope(&required, &refs)));
+
+        // An attempt that never finished is not proof.
+        let mut unfinished = receipt(good, TeardownOutcome::Verified);
+        unfinished.completed_at = None;
+        assert!(!unfinished.permits_release_for(&scope(&required, &refs)));
+    }
+
+    #[test]
+    fn standard_cleanup_is_the_default_and_needs_no_receipt() {
+        assert_eq!(CleanupMode::default(), CleanupMode::Standard);
+        assert!(!CleanupMode::Standard.requires_receipt());
+        assert!(CleanupMode::VerifiedDestroy.requires_receipt());
+    }
+}

--- a/src/crdgen.rs
+++ b/src/crdgen.rs
@@ -39,6 +39,14 @@ fn main() {
             "{}",
             serde_yaml_ng::to_string(&crd::CIDRPool::crd()).unwrap()
         ),
+        "sandboxpools" => print!(
+            "{}",
+            serde_yaml_ng::to_string(&crd::SandboxPool::crd()).unwrap()
+        ),
+        "sandboxleases" => print!(
+            "{}",
+            serde_yaml_ng::to_string(&crd::SandboxLease::crd()).unwrap()
+        ),
         _ => {
             print!(
                 "{}",
@@ -78,6 +86,16 @@ fn main() {
             print!(
                 "{}",
                 serde_yaml_ng::to_string(&crd::CIDRPool::crd()).unwrap()
+            );
+            println!("---");
+            print!(
+                "{}",
+                serde_yaml_ng::to_string(&crd::SandboxPool::crd()).unwrap()
+            );
+            println!("---");
+            print!(
+                "{}",
+                serde_yaml_ng::to_string(&crd::SandboxLease::crd()).unwrap()
             );
         }
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,25 @@ async fn main() -> anyhow::Result<()> {
         .await;
     });
 
+    // Start the Sandbox admission reaper. Reservations are created before a
+    // SandboxLease is admitted and are garbage-collected only when that lease
+    // is DELETED — so a request that dies in between leaves a `pending` lease
+    // no controller will ever touch, with its quota slot and alias consumed
+    // forever. Recovery cannot depend on the affected caller retrying, so this
+    // sweeps for every principal. Independent of Sandbox placement (#73): it
+    // only touches admission objects.
+    let sandbox_reaper_client = client.clone();
+    let sandbox_reaper_ns = namespace.clone();
+    let sandbox_reaper_shutdown = shutdown.clone();
+    let sandbox_reaper_handle = tokio::spawn(async move {
+        api::sandbox::run_sandbox_admission_reaper(
+            sandbox_reaper_client,
+            &sandbox_reaper_ns,
+            sandbox_reaper_shutdown,
+        )
+        .await;
+    });
+
     // Start IPAM controller. Reconciles `CIDRClaim`s against the
     // hardcoded `pool::cidr_alloc::ipam_plan`. The instance controller
     // creates one claim per `ClusterInstance` (with ownerReference);
@@ -272,6 +291,12 @@ async fn main() -> anyhow::Result<()> {
                 match result {
                     Ok(()) => warn!("IPAM controller exited unexpectedly"),
                     Err(e) => error!("IPAM controller panicked: {e}"),
+                }
+            }
+            result = sandbox_reaper_handle => {
+                match result {
+                    Ok(()) => warn!("Sandbox admission reaper exited unexpectedly"),
+                    Err(e) => error!("Sandbox admission reaper panicked: {e}"),
                 }
             }
             result = health_handle => {

--- a/src/main.rs
+++ b/src/main.rs
@@ -7,6 +7,7 @@ mod lease_binding;
 mod metrics;
 pub mod pki;
 mod pool;
+mod sandbox;
 mod telemetry;
 mod velero;
 

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -1081,6 +1081,11 @@ pub fn compute_pool_phase(
         && counts.creating == 0
         && counts.recycling == 0
         && counts.unhealthy == 0
+        // Quarantined members are NOT idle: their backend resources still
+        // exist and are being held deliberately. Reporting Idle here would
+        // tell an operator the pool is empty while it is actually holding
+        // capacity it could not prove it destroyed.
+        && counts.quarantined == 0
         && min_ready == 0
     {
         return ClusterPoolPhase::Idle;
@@ -3236,6 +3241,47 @@ mod tests {
         assert_eq!(
             counts.unhealthy, 0,
             "quarantined must be distinguishable from ordinary churn"
+        );
+    }
+
+    /// A pool holding quarantined capacity must never report Idle.
+    ///
+    /// Idle means "empty, nothing running". A quarantined member's backend
+    /// resources still exist — holding them is the point — so reporting Idle
+    /// tells an operator the pool is empty while it is actually sitting on
+    /// capacity it could not prove it destroyed. That is the one state where a
+    /// human most needs to look.
+    #[test]
+    fn a_pool_holding_quarantined_capacity_is_not_idle() {
+        let profile = make_profile(
+            0,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 0,
+                max_clusters: 4,
+                scale_up_threshold: 1,
+                scale_down_after: "30m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+
+        // Genuinely empty scale-to-zero pool: Idle is correct.
+        let empty = StateCounts::default();
+        assert_eq!(
+            compute_pool_phase(&profile, &empty, 0, None, chrono::Utc::now()),
+            crate::crd::ClusterPoolPhase::Idle
+        );
+
+        // Same pool, one member held back.
+        let holding = StateCounts {
+            quarantined: 1,
+            ..Default::default()
+        };
+        assert_ne!(
+            compute_pool_phase(&profile, &holding, 0, None, chrono::Utc::now()),
+            crate::crd::ClusterPoolPhase::Idle,
+            "a pool holding unreclaimed capacity must not read as empty"
         );
     }
 

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -263,6 +263,16 @@ pub enum ClusterState {
     /// Being deleted and recreated.
     #[allow(dead_code)]
     Recycling,
+    /// Teardown could not be proven complete.
+    ///
+    /// Distinct from `Unhealthy` on purpose: `Unhealthy` is
+    /// replacement-eligible and is deleted unconditionally below, which would
+    /// destroy the cleanup handle and let the ordinary 404-based recycle path
+    /// resume — exactly what a quarantine exists to prevent. Quarantined
+    /// capacity is never deleted, replaced, scaled down, or counted as
+    /// available; it leaves only when the same exact subject produces a
+    /// verified teardown receipt.
+    Quarantined,
 }
 
 /// Pool state for a single profile.
@@ -534,6 +544,8 @@ pub fn compute_pool_actions(
     let metric_profile = profile.metadata.name.clone().unwrap_or_default();
 
     // === 1. Unhealthy: always Delete (unbounded). ===
+    // Quarantined is deliberately NOT included: deleting it would remove the
+    // cleanup handle that proves whether the tenant's data is actually gone.
     for (name, entry) in &state.clusters {
         if entry.state == ClusterState::Unhealthy {
             actions.push(PoolAction::Delete(name.clone()));
@@ -571,8 +583,16 @@ pub fn compute_pool_actions(
 
     let current_hash = profile_spec_hash(profile, render_ctx, bootstrap_specs);
     let counts = count_states(state, Some(&current_hash));
-    let total =
-        counts.creating + counts.ready + counts.leased + counts.unhealthy + counts.recycling;
+    // Quarantined counts toward the ceiling. Its backend resources still
+    // exist — that is the whole point, the cleanup handle is being held — so
+    // excluding it would let the pool create a replacement and exceed
+    // maxClusters in real capacity every time a teardown could not be proven.
+    let total = counts.creating
+        + counts.ready
+        + counts.leased
+        + counts.unhealthy
+        + counts.recycling
+        + counts.quarantined;
     let policy = resolved_upgrade_policy(profile, min_ready);
 
     // === 2. Backoff early-return for drift recycle and scale-up. ===
@@ -1127,6 +1147,10 @@ pub struct StateCounts {
     pub leased: u32,
     pub unhealthy: u32,
     pub recycling: u32,
+    /// Capacity held back because its teardown could not be proven. Counted
+    /// separately from `unhealthy` so an operator can see stuck evidence
+    /// rather than mistaking it for ordinary churn.
+    pub quarantined: u32,
     /// Ready instances whose `spec_hash` matches `current_hash`. Zero
     /// when `count_states` was called without a `current_hash`.
     pub ready_clean: u32,
@@ -1164,6 +1188,7 @@ pub fn count_states(state: &PoolState, current_hash: Option<&SpecHash>) -> State
             ClusterState::Leased => c.leased += 1,
             ClusterState::Unhealthy => c.unhealthy += 1,
             ClusterState::Recycling => c.recycling += 1,
+            ClusterState::Quarantined => c.quarantined += 1,
         }
         // Only an entry with both a `current_hash` to compare against
         // AND its own stamped hash can hash-drift. Unstamped entries
@@ -3155,6 +3180,115 @@ mod tests {
         );
         // It was NOT counted toward `max_recycling=1`, but the budget
         // is still 1 here because there are no drifted Ready candidates.
+    }
+
+    /// Quarantined capacity must never be deleted by the pool manager.
+    ///
+    /// This is the boundary that matters. `Unhealthy` is deleted
+    /// unconditionally ("always Delete (unbounded)"), so had `Quarantined`
+    /// been folded into it, the first reconcile after a failed teardown would
+    /// destroy the very object holding the evidence — and the ordinary
+    /// 404-based recycle path would then treat the capacity as clean.
+    ///
+    /// Asserting only on a phase→state mapping helper would not catch that:
+    /// the deletion decision lives here, in `compute_pool_actions`.
+    #[test]
+    fn quarantined_instances_are_never_deleted_or_counted_available() {
+        let profile = make_profile_with_upgrade(4, 1, 1, Some(1));
+        let mut clusters = HashMap::new();
+        clusters.insert(
+            "pool-test-profile-1".into(),
+            make_entry(ClusterState::Quarantined),
+        );
+        clusters.insert(
+            "pool-test-profile-2".into(),
+            make_entry(ClusterState::Ready),
+        );
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+        let deletes: Vec<_> = actions
+            .iter()
+            .filter_map(|a| match a {
+                PoolAction::Delete(n) => Some(n.clone()),
+                _ => None,
+            })
+            .collect();
+        assert!(
+            !deletes.contains(&"pool-test-profile-1".to_string()),
+            "quarantined capacity must never be deleted — that destroys the \
+             cleanup handle proving the tenant's data is gone; got {deletes:?}"
+        );
+
+        // It must also not read as available capacity.
+        let counts = count_states(&state, None);
+        assert_eq!(counts.quarantined, 1);
+        assert_eq!(counts.ready, 1, "only the genuinely Ready member counts");
+        assert_eq!(
+            counts.unhealthy, 0,
+            "quarantined must be distinguishable from ordinary churn"
+        );
+    }
+
+    /// Quarantined capacity must count against the pool ceiling.
+    ///
+    /// Protecting it from deletion is only half the job: its backend resources
+    /// still exist — holding them is the entire point — so if the ceiling
+    /// ignores it, the pool creates a replacement and the operator ends up with
+    /// more physical clusters than `maxClusters` allows. Every failed teardown
+    /// would then quietly grow real resource usage.
+    #[test]
+    fn quarantined_capacity_counts_against_the_pool_ceiling() {
+        // An AUTOSCALED pool whose hard ceiling is one member, and whose one
+        // member is quarantined. (A fixed pool deliberately allows `size + 10`
+        // headroom, so its ceiling is not the binding constraint here.)
+        let profile = make_profile(
+            1,
+            Some(crate::crd::ScalingConfig {
+                min_ready: 1,
+                max_clusters: 1,
+                scale_up_threshold: 1,
+                scale_down_after: "30m".to_string(),
+                queue_timeout: "5m".to_string(),
+                creating_timeout: "10m".to_string(),
+                failure_backoff: None,
+            }),
+        );
+        let mut clusters = HashMap::new();
+        clusters.insert(
+            "pool-test-profile-0".into(),
+            make_entry(ClusterState::Quarantined),
+        );
+        let state = PoolState {
+            clusters,
+            queue_depth: 0,
+        };
+
+        let actions = compute_pool_actions(
+            &profile,
+            &state,
+            chrono::Utc::now(),
+            &test_render_ctx(),
+            &Default::default(),
+        );
+        let creates = actions
+            .iter()
+            .filter(|action| matches!(action, PoolAction::Create(_)))
+            .count();
+        assert_eq!(
+            creates, 0,
+            "a quarantined member already occupies the pool's only slot; \
+             replacing it would exceed maxClusters in real resources"
+        );
     }
 
     /// Unhealthy instances are recycled aggressively without

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1,0 +1,1410 @@
+//! Pure Agent Sandbox v0.5.4 `v1beta1` projections and lease invariants.
+//!
+//! This module has no Kubernetes client or reconciliation side effects. Pool
+//! controllers can render the restricted Kobe contract into upstream objects,
+//! and placement/teardown controllers can reuse the monotonic provenance
+//! checks before touching a target cluster.
+
+// #71 intentionally lands these pure contracts before #73/#74 wire them into
+// reconcilers. Keep non-test builds warning-clean during that staged rollout.
+#![allow(dead_code)]
+
+use std::collections::BTreeMap;
+
+use chrono::{DateTime, SecondsFormat, Utc};
+use k8s_openapi::api::core::v1::{Container, ContainerPort, PodSpec, ResourceRequirements};
+use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
+use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
+use kube::api::{DynamicObject, ObjectMeta, TypeMeta};
+use thiserror::Error;
+
+use crate::crd::{
+    ResolvedSandboxPlacement, SandboxLeasePhase, SandboxLeaseStatus, SandboxObjectReference,
+    SandboxPoolSpec, SandboxPoolValidationError, SandboxResourceCeiling, SandboxTargetProvenance,
+    SandboxTemplateSpec,
+};
+
+pub const AGENT_SANDBOX_API_VERSION: &str = "extensions.agents.x-k8s.io/v1beta1";
+pub const SANDBOX_TEMPLATE_KIND: &str = "SandboxTemplate";
+pub const SANDBOX_WARM_POOL_KIND: &str = "SandboxWarmPool";
+pub const SANDBOX_CLAIM_KIND: &str = "SandboxClaim";
+pub const KOBE_MANAGED_BY: &str = "kobe-operator";
+const KOBE_API_VERSION: &str = "kobe.kunobi.ninja/v1alpha1";
+const SANDBOX_API_VERSION: &str = "agents.x-k8s.io/v1beta1";
+const CORE_API_VERSION: &str = "v1";
+
+/// Render one administrator-owned Kobe pool template into the pinned upstream
+/// Agent Sandbox contract.
+///
+/// The projection is intentionally closed: it emits only declared containers,
+/// CPU/memory/ephemeral-storage resources, TCP ports, the administrator's
+/// RuntimeClass, and fixed secure policies. It cannot emit PVC templates,
+/// environment values, service accounts, arbitrary volumes, or caller metadata.
+pub fn build_sandbox_template(
+    name: &str,
+    namespace: &str,
+    pool: &SandboxPoolSpec,
+    owner_ref: Option<&OwnerReference>,
+) -> Result<DynamicObject, SandboxMappingError> {
+    pool.validate()?;
+    aggregate_resource_limits(&pool.template)?;
+
+    let containers = pool
+        .template
+        .containers
+        .iter()
+        .map(|container| {
+            let ports: Vec<ContainerPort> = pool
+                .template
+                .exposed_ports
+                .iter()
+                .filter(|port| port.container == container.name)
+                .map(|port| ContainerPort {
+                    container_port: i32::from(port.port),
+                    name: Some(port.name.clone()),
+                    protocol: Some("TCP".to_string()),
+                    ..Default::default()
+                })
+                .collect();
+
+            Container {
+                name: container.name.clone(),
+                image: Some(container.image.clone()),
+                command: (!container.command.is_empty()).then(|| container.command.clone()),
+                args: (!container.args.is_empty()).then(|| container.args.clone()),
+                ports: (!ports.is_empty()).then_some(ports),
+                resources: Some(to_k8s_resources(&container.resources)),
+                ..Default::default()
+            }
+        })
+        .collect();
+
+    let pod_spec = PodSpec {
+        automount_service_account_token: Some(false),
+        containers,
+        restart_policy: Some("Never".to_string()),
+        runtime_class_name: pool.isolation.runtime_class_name().map(ToString::to_string),
+        ..Default::default()
+    };
+    let pod_spec = serde_json::to_value(pod_spec)?;
+
+    Ok(managed_object(
+        SANDBOX_TEMPLATE_KIND,
+        name,
+        namespace,
+        owner_ref,
+        serde_json::json!({
+            "spec": {
+                "podTemplate": {
+                    "metadata": {
+                        "labels": {
+                            "app.kubernetes.io/managed-by": KOBE_MANAGED_BY
+                        },
+                        "annotations": {
+                            "kubectl.kubernetes.io/default-container": pool.template.default_container
+                        }
+                    },
+                    "spec": pod_spec
+                },
+                "service": !pool.template.exposed_ports.is_empty(),
+                "networkPolicyManagement": "Managed",
+                "envVarsInjectionPolicy": "Disallowed",
+                "volumeClaimTemplatesPolicy": "Disallowed"
+            }
+        }),
+    ))
+}
+
+/// Render the upstream warm pool using the exact v1beta1
+/// `sandboxTemplateRef.name` field and an immediate drift replacement policy.
+pub fn build_sandbox_warm_pool(
+    name: &str,
+    namespace: &str,
+    template_name: &str,
+    warm_capacity: u32,
+    owner_ref: Option<&OwnerReference>,
+) -> Result<DynamicObject, SandboxMappingError> {
+    let replicas = i32::try_from(warm_capacity)
+        .map_err(|_| SandboxMappingError::WarmCapacityTooLarge(warm_capacity))?;
+    Ok(managed_object(
+        SANDBOX_WARM_POOL_KIND,
+        name,
+        namespace,
+        owner_ref,
+        serde_json::json!({
+            "spec": {
+                "replicas": replicas,
+                "sandboxTemplateRef": { "name": template_name },
+                "updateStrategy": { "type": "Recreate" }
+            }
+        }),
+    ))
+}
+
+/// Render one lease as a v1beta1 SandboxClaim.
+///
+/// The initial claim intentionally omits `shutdownTime`: runtime TTL starts
+/// only after the upstream Sandbox becomes Ready. [`build_sandbox_claim_lifecycle_patch`]
+/// adds the absolute expiry later with a resourceVersion fence.
+pub fn build_sandbox_claim(
+    name: &str,
+    namespace: &str,
+    warm_pool_name: &str,
+    owner_ref: Option<&OwnerReference>,
+) -> DynamicObject {
+    managed_object(
+        SANDBOX_CLAIM_KIND,
+        name,
+        namespace,
+        owner_ref,
+        serde_json::json!({
+            "spec": {
+                "warmPoolRef": { "name": warm_pool_name },
+                "lifecycle": {
+                    "shutdownPolicy": "DeleteForeground"
+                }
+            }
+        }),
+    )
+}
+
+/// Build the post-Ready merge patch that starts upstream expiry. Callers must
+/// derive `expires_at` from the persisted `readyAt + ttl` invariant and use the
+/// current exact Claim resourceVersion.
+pub fn build_sandbox_claim_lifecycle_patch(
+    resource_version: &str,
+    expires_at: DateTime<Utc>,
+) -> Result<serde_json::Value, SandboxMappingError> {
+    if resource_version.trim().is_empty() {
+        return Err(SandboxMappingError::MissingResourceVersion);
+    }
+    Ok(serde_json::json!({
+        "metadata": { "resourceVersion": resource_version },
+        "spec": {
+            "lifecycle": {
+                "shutdownTime": expires_at.to_rfc3339_opts(SecondsFormat::AutoSi, true),
+                "shutdownPolicy": "DeleteForeground"
+            }
+        }
+    }))
+}
+
+fn managed_object(
+    kind: &str,
+    name: &str,
+    namespace: &str,
+    owner_ref: Option<&OwnerReference>,
+    data: serde_json::Value,
+) -> DynamicObject {
+    DynamicObject {
+        types: Some(TypeMeta {
+            api_version: AGENT_SANDBOX_API_VERSION.to_string(),
+            kind: kind.to_string(),
+        }),
+        metadata: ObjectMeta {
+            name: Some(name.to_string()),
+            namespace: Some(namespace.to_string()),
+            labels: Some(
+                [(
+                    "app.kubernetes.io/managed-by".to_string(),
+                    KOBE_MANAGED_BY.to_string(),
+                )]
+                .into_iter()
+                .collect(),
+            ),
+            owner_references: owner_ref.cloned().map(|owner| vec![owner]),
+            ..Default::default()
+        },
+        data,
+    }
+}
+
+fn to_k8s_resources(resources: &crate::crd::SandboxContainerResources) -> ResourceRequirements {
+    let quantities = |quantity: &crate::crd::SandboxResourceQuantity| {
+        BTreeMap::from([
+            ("cpu".to_string(), Quantity(quantity.cpu.clone())),
+            ("memory".to_string(), Quantity(quantity.memory.clone())),
+            (
+                "ephemeral-storage".to_string(),
+                Quantity(quantity.ephemeral_storage.clone()),
+            ),
+        ])
+    };
+    ResourceRequirements {
+        limits: Some(quantities(&resources.limits)),
+        requests: Some(quantities(&resources.requests)),
+        ..Default::default()
+    }
+}
+
+#[derive(Debug, Error)]
+pub enum SandboxMappingError {
+    #[error(transparent)]
+    InvalidPool(#[from] SandboxPoolValidationError),
+    #[error(transparent)]
+    InvalidResources(#[from] SandboxResourceError),
+    #[error("warm capacity {0} exceeds upstream int32 replicas")]
+    WarmCapacityTooLarge(u32),
+    #[error("failed to serialize the restricted PodSpec: {0}")]
+    Serialization(#[from] serde_json::Error),
+    #[error("SandboxClaim resourceVersion is required for the lifecycle patch")]
+    MissingResourceVersion,
+}
+
+/// Canonical aggregate values used for exact, unit-independent admission.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct SandboxResourceTotals {
+    pub cpu_millicores: u128,
+    pub memory_bytes: u128,
+    cpu_nanocores: u128,
+    memory_nanobytes: u128,
+}
+
+/// Sum declared per-container limits and validate every resource pair.
+///
+/// Requests may not exceed limits. Quantities are rounded upward to the target
+/// unit following Kubernetes Quantity semantics, avoiding an undercount at an
+/// authorization boundary.
+pub fn aggregate_resource_limits(
+    template: &SandboxTemplateSpec,
+) -> Result<SandboxResourceTotals, SandboxResourceError> {
+    let mut total_cpu_nanos = 0u128;
+    let mut total_memory_nanos = 0u128;
+
+    for container in &template.containers {
+        // Compare exact nanounits before rounding into policy units. Independent
+        // ceiling-rounding would incorrectly accept 900m > 100m memory because
+        // both values become one whole byte.
+        let request_cpu = parse_positive_quantity_nanos(
+            &container.resources.requests.cpu,
+            QuantityDimension::Cpu,
+            "requests.cpu",
+        )?;
+        let limit_cpu = parse_positive_quantity_nanos(
+            &container.resources.limits.cpu,
+            QuantityDimension::Cpu,
+            "limits.cpu",
+        )?;
+        let request_memory = parse_positive_quantity_nanos(
+            &container.resources.requests.memory,
+            QuantityDimension::Bytes,
+            "requests.memory",
+        )?;
+        let limit_memory = parse_positive_quantity_nanos(
+            &container.resources.limits.memory,
+            QuantityDimension::Bytes,
+            "limits.memory",
+        )?;
+        let request_ephemeral = parse_positive_quantity_nanos(
+            &container.resources.requests.ephemeral_storage,
+            QuantityDimension::Bytes,
+            "requests.ephemeralStorage",
+        )?;
+        let limit_ephemeral = parse_positive_quantity_nanos(
+            &container.resources.limits.ephemeral_storage,
+            QuantityDimension::Bytes,
+            "limits.ephemeralStorage",
+        )?;
+
+        for (resource, request, limit) in [
+            ("cpu", request_cpu, limit_cpu),
+            ("memory", request_memory, limit_memory),
+            ("ephemeral-storage", request_ephemeral, limit_ephemeral),
+        ] {
+            if request > limit {
+                return Err(SandboxResourceError::RequestExceedsLimit {
+                    container: container.name.clone(),
+                    resource,
+                });
+            }
+        }
+
+        total_cpu_nanos = total_cpu_nanos
+            .checked_add(limit_cpu)
+            .ok_or(SandboxResourceError::AggregateOverflow("cpu"))?;
+        total_memory_nanos = total_memory_nanos
+            .checked_add(limit_memory)
+            .ok_or(SandboxResourceError::AggregateOverflow("memory"))?;
+    }
+
+    Ok(SandboxResourceTotals {
+        cpu_millicores: ceil_div(total_cpu_nanos, 1_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("cpu"))?,
+        memory_bytes: ceil_div(total_memory_nanos, 1_000_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("memory"))?,
+        cpu_nanocores: total_cpu_nanos,
+        memory_nanobytes: total_memory_nanos,
+    })
+}
+
+/// Parse a policy ceiling into the canonical units used by admission.
+pub fn parse_resource_ceiling(
+    ceiling: &SandboxResourceCeiling,
+) -> Result<SandboxResourceTotals, SandboxResourceError> {
+    let cpu_nanocores = parse_positive_quantity_nanos(
+        &ceiling.max_cpu,
+        QuantityDimension::Cpu,
+        "resourceCeiling.maxCpu",
+    )?;
+    let memory_nanobytes = parse_positive_quantity_nanos(
+        &ceiling.max_memory,
+        QuantityDimension::Bytes,
+        "resourceCeiling.maxMemory",
+    )?;
+    Ok(SandboxResourceTotals {
+        cpu_millicores: ceil_div(cpu_nanocores, 1_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("cpu"))?,
+        memory_bytes: ceil_div(memory_nanobytes, 1_000_000_000)
+            .ok_or(SandboxResourceError::AggregateOverflow("memory"))?,
+        cpu_nanocores,
+        memory_nanobytes,
+    })
+}
+
+/// Compare a pool's aggregate limits with a caller's typed policy ceiling.
+/// Invalid policy quantities return an error so admission can fail closed.
+pub fn resource_ceiling_allows(
+    ceiling: &SandboxResourceCeiling,
+    requested: &SandboxResourceTotals,
+) -> Result<bool, SandboxResourceError> {
+    let ceiling = parse_resource_ceiling(ceiling)?;
+    Ok(requested.cpu_nanocores <= ceiling.cpu_nanocores
+        && requested.memory_nanobytes <= ceiling.memory_nanobytes)
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SandboxResourceError {
+    #[error("invalid or non-positive Kubernetes quantity for {field}: {value}")]
+    InvalidQuantity { field: &'static str, value: String },
+    #[error("container {container} {resource} request exceeds its limit")]
+    RequestExceedsLimit {
+        container: String,
+        resource: &'static str,
+    },
+    #[error("aggregate {0} limit overflow")]
+    AggregateOverflow(&'static str),
+}
+
+#[derive(Debug, Clone, Copy)]
+enum QuantityDimension {
+    Cpu,
+    Bytes,
+}
+
+fn parse_positive_quantity(
+    value: &str,
+    dimension: QuantityDimension,
+    field: &'static str,
+) -> Result<u128, SandboxResourceError> {
+    let parsed = parse_quantity_nanos(value)
+        .filter(|value| *value > 0)
+        .filter(|value| {
+            !matches!(dimension, QuantityDimension::Cpu)
+                || (*value >= 1_000_000 && *value % 1_000_000 == 0)
+        })
+        .and_then(|nanos| match dimension {
+            QuantityDimension::Cpu => ceil_div(nanos, 1_000_000),
+            QuantityDimension::Bytes => ceil_div(nanos, 1_000_000_000),
+        });
+    parsed.ok_or_else(|| SandboxResourceError::InvalidQuantity {
+        field,
+        value: value.to_string(),
+    })
+}
+
+fn parse_positive_quantity_nanos(
+    value: &str,
+    dimension: QuantityDimension,
+    field: &'static str,
+) -> Result<u128, SandboxResourceError> {
+    parse_quantity_nanos(value)
+        .filter(|value| *value > 0)
+        .filter(|value| {
+            !matches!(dimension, QuantityDimension::Cpu)
+                || (*value >= 1_000_000 && *value % 1_000_000 == 0)
+        })
+        .ok_or_else(|| SandboxResourceError::InvalidQuantity {
+            field,
+            value: value.to_string(),
+        })
+}
+
+fn parse_quantity(value: &str, dimension: QuantityDimension) -> Option<u128> {
+    let nanos = parse_quantity_nanos(value)?;
+    match dimension {
+        QuantityDimension::Cpu if nanos >= 1_000_000 && nanos % 1_000_000 == 0 => {
+            ceil_div(nanos, 1_000_000)
+        }
+        QuantityDimension::Cpu => None,
+        QuantityDimension::Bytes => ceil_div(nanos, 1_000_000_000),
+    }
+}
+
+/// Parse the full positive Kubernetes Quantity suffix grammar into nanounits.
+/// Nanounits retain exact request/limit ordering; conversion to mCPU or bytes
+/// happens only after comparisons and aggregation. Kubernetes quantities cap
+/// at signed 64-bit base units, which also bounds admission arithmetic.
+fn parse_quantity_nanos(value: &str) -> Option<u128> {
+    if value != value.trim() {
+        return None;
+    }
+    let value = value.strip_prefix('+').unwrap_or(value);
+    if value.is_empty() || value.starts_with('-') {
+        return None;
+    }
+
+    let bytes = value.as_bytes();
+    let mut index = 0;
+    let mut mantissa = 0u128;
+    let mut fractional_digits = 0u32;
+    let mut saw_digit = false;
+    let mut saw_decimal = false;
+    while index < bytes.len() {
+        match bytes[index] {
+            b'0'..=b'9' => {
+                saw_digit = true;
+                mantissa = mantissa
+                    .checked_mul(10)?
+                    .checked_add(u128::from(bytes[index] - b'0'))?;
+                if saw_decimal {
+                    fractional_digits = fractional_digits.checked_add(1)?;
+                }
+                index += 1;
+            }
+            b'.' if !saw_decimal => {
+                saw_decimal = true;
+                index += 1;
+            }
+            _ => break,
+        }
+    }
+    if !saw_digit {
+        return None;
+    }
+
+    let suffix = &value[index..];
+    let nanos = if let Some(binary_power) = match suffix {
+        "Ki" => Some(1),
+        "Mi" => Some(2),
+        "Gi" => Some(3),
+        "Ti" => Some(4),
+        "Pi" => Some(5),
+        "Ei" => Some(6),
+        _ => None,
+    } {
+        let numerator = mantissa
+            .checked_mul(1024u128.checked_pow(binary_power)?)?
+            .checked_mul(1_000_000_000)?;
+        ceil_div(numerator, 10u128.checked_pow(fractional_digits)?)?
+    } else {
+        let suffix_exponent = match suffix {
+            "" => 0,
+            "n" => -9,
+            "u" => -6,
+            "m" => -3,
+            "k" => 3,
+            "M" => 6,
+            "G" => 9,
+            "T" => 12,
+            "P" => 15,
+            "E" => 18,
+            _ if suffix.starts_with('e') || (suffix.starts_with('E') && suffix.len() > 1) => {
+                suffix[1..].parse::<i32>().ok()?
+            }
+            _ => return None,
+        };
+        let scale = suffix_exponent
+            .checked_add(9)?
+            .checked_sub(i32::try_from(fractional_digits).ok()?)?;
+        if scale >= 0 {
+            mantissa.checked_mul(10u128.checked_pow(scale as u32)?)?
+        } else {
+            ceil_div(mantissa, 10u128.checked_pow(scale.unsigned_abs())?)?
+        }
+    };
+
+    const KUBERNETES_MAX_NANOUNITS: u128 = (i64::MAX as u128) * 1_000_000_000;
+    (nanos <= KUBERNETES_MAX_NANOUNITS).then_some(nanos)
+}
+
+fn ceil_div(numerator: u128, denominator: u128) -> Option<u128> {
+    let quotient = numerator.checked_div(denominator)?;
+    let remainder = numerator.checked_rem(denominator)?;
+    quotient.checked_add(u128::from(remainder != 0))
+}
+
+/// Record resolved placement once. Retries may repeat the same value, but no
+/// controller may silently retarget a lease or invent a management fallback.
+pub fn record_placement_once(
+    existing: Option<&ResolvedSandboxPlacement>,
+    proposed: ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<ResolvedSandboxPlacement, SandboxProvenanceError> {
+    validate_resolved_placement(&proposed, management_namespace)?;
+    match existing {
+        None => Ok(proposed),
+        Some(current) if current == &proposed => {
+            validate_resolved_placement(current, management_namespace)?;
+            Ok(current.clone())
+        }
+        Some(_) => Err(SandboxProvenanceError::PlacementChanged),
+    }
+}
+
+/// Require an explicitly persisted placement before target operations.
+pub fn require_resolved_placement<'a>(
+    status: &'a SandboxLeaseStatus,
+    management_namespace: &str,
+) -> Result<&'a ResolvedSandboxPlacement, SandboxProvenanceError> {
+    let placement = status
+        .placement
+        .as_ref()
+        .ok_or(SandboxProvenanceError::UnresolvedPlacement)?;
+    validate_resolved_placement(placement, management_namespace)?;
+    Ok(placement)
+}
+
+/// Merge progressively discovered target references without permitting any
+/// existing identity to be changed or cleared. Equality covers API version,
+/// kind, namespace, name, UID, and generation, so delete/recreate name reuse is
+/// rejected even when the object name is unchanged.
+pub fn merge_target_provenance(
+    existing: Option<&SandboxTargetProvenance>,
+    proposed: SandboxTargetProvenance,
+    placement: &ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<SandboxTargetProvenance, SandboxProvenanceError> {
+    validate_resolved_placement(placement, management_namespace)?;
+    validate_target_provenance(&proposed, placement, management_namespace)?;
+    let Some(existing) = existing else {
+        return Ok(proposed);
+    };
+    if existing.namespace != proposed.namespace {
+        return Err(SandboxProvenanceError::NamespaceChanged);
+    }
+
+    Ok(SandboxTargetProvenance {
+        namespace: existing.namespace.clone(),
+        child_cluster_lease: merge_reference(
+            "childClusterLease",
+            &existing.child_cluster_lease,
+            proposed.child_cluster_lease,
+        )?,
+        child_cluster_instance: merge_reference(
+            "childClusterInstance",
+            &existing.child_cluster_instance,
+            proposed.child_cluster_instance,
+        )?,
+        sandbox_template: merge_reference(
+            "sandboxTemplate",
+            &existing.sandbox_template,
+            proposed.sandbox_template,
+        )?,
+        sandbox_warm_pool: merge_reference(
+            "sandboxWarmPool",
+            &existing.sandbox_warm_pool,
+            proposed.sandbox_warm_pool,
+        )?,
+        sandbox_claim: merge_reference(
+            "sandboxClaim",
+            &existing.sandbox_claim,
+            proposed.sandbox_claim,
+        )?,
+        sandbox: merge_reference("sandbox", &existing.sandbox, proposed.sandbox)?,
+        pod: merge_reference("pod", &existing.pod, proposed.pod)?,
+    })
+}
+
+fn validate_resolved_placement(
+    placement: &ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<(), SandboxProvenanceError> {
+    if let ResolvedSandboxPlacement::ChildCluster { cluster_pool } = placement {
+        validate_reference(
+            "clusterPool",
+            cluster_pool,
+            KOBE_API_VERSION,
+            "ClusterPool",
+            Some(management_namespace),
+            true,
+        )?;
+    }
+    Ok(())
+}
+
+fn validate_target_provenance(
+    provenance: &SandboxTargetProvenance,
+    placement: &ResolvedSandboxPlacement,
+    management_namespace: &str,
+) -> Result<(), SandboxProvenanceError> {
+    if provenance.namespace.trim().is_empty() {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field: "namespace",
+            reason: "target namespace is empty",
+        });
+    }
+
+    match placement {
+        ResolvedSandboxPlacement::Management {}
+            if provenance.child_cluster_lease.is_some()
+                || provenance.child_cluster_instance.is_some() =>
+        {
+            return Err(SandboxProvenanceError::UnexpectedChildReference);
+        }
+        ResolvedSandboxPlacement::Management {} | ResolvedSandboxPlacement::ChildCluster { .. } => {
+        }
+    }
+
+    for (field, reference, api_version, kind, target_namespace, generation_required) in [
+        (
+            "childClusterLease",
+            &provenance.child_cluster_lease,
+            KOBE_API_VERSION,
+            "ClusterLease",
+            Some(management_namespace),
+            true,
+        ),
+        (
+            "childClusterInstance",
+            &provenance.child_cluster_instance,
+            KOBE_API_VERSION,
+            "ClusterInstance",
+            Some(management_namespace),
+            true,
+        ),
+        (
+            "sandboxTemplate",
+            &provenance.sandbox_template,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_TEMPLATE_KIND,
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "sandboxWarmPool",
+            &provenance.sandbox_warm_pool,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_WARM_POOL_KIND,
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "sandboxClaim",
+            &provenance.sandbox_claim,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_CLAIM_KIND,
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "sandbox",
+            &provenance.sandbox,
+            SANDBOX_API_VERSION,
+            "Sandbox",
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+        (
+            "pod",
+            &provenance.pod,
+            CORE_API_VERSION,
+            "Pod",
+            Some(provenance.namespace.as_str()),
+            false,
+        ),
+    ] {
+        if let Some(reference) = reference {
+            validate_reference(
+                field,
+                reference,
+                api_version,
+                kind,
+                target_namespace,
+                generation_required,
+            )?;
+        }
+    }
+    Ok(())
+}
+
+fn validate_reference(
+    field: &'static str,
+    reference: &SandboxObjectReference,
+    expected_api_version: &str,
+    expected_kind: &str,
+    expected_namespace: Option<&str>,
+    generation_required: bool,
+) -> Result<(), SandboxProvenanceError> {
+    if reference.api_version != expected_api_version || reference.kind != expected_kind {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "unexpected API version or kind",
+        });
+    }
+    if reference.name.trim().is_empty() || reference.uid.trim().is_empty() {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "name and UID are required",
+        });
+    }
+    let namespace = reference
+        .namespace
+        .as_deref()
+        .filter(|value| !value.is_empty());
+    if namespace.is_none() {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "namespace is required",
+        });
+    }
+    if expected_namespace.is_some_and(|expected| namespace != Some(expected)) {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "namespace does not match the target namespace",
+        });
+    }
+    if generation_required
+        && reference
+            .generation
+            .is_none_or(|generation| generation <= 0)
+    {
+        return Err(SandboxProvenanceError::InvalidReference {
+            field,
+            reason: "positive generation is required",
+        });
+    }
+    Ok(())
+}
+
+fn merge_reference(
+    field: &'static str,
+    existing: &Option<SandboxObjectReference>,
+    proposed: Option<SandboxObjectReference>,
+) -> Result<Option<SandboxObjectReference>, SandboxProvenanceError> {
+    match (existing, proposed) {
+        (None, proposed) => Ok(proposed),
+        (Some(_), None) => Err(SandboxProvenanceError::ReferenceCleared(field)),
+        (Some(current), Some(proposed)) if current == &proposed => Ok(Some(current.clone())),
+        (Some(_), Some(_)) => Err(SandboxProvenanceError::ReferenceChanged(field)),
+    }
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SandboxProvenanceError {
+    #[error("Sandbox placement has not been resolved; no backend fallback is permitted")]
+    UnresolvedPlacement,
+    #[error("resolved Sandbox placement cannot change")]
+    PlacementChanged,
+    #[error("target namespace cannot change")]
+    NamespaceChanged,
+    #[error("target provenance field {0} cannot be cleared")]
+    ReferenceCleared(&'static str),
+    #[error("target provenance field {0} cannot change")]
+    ReferenceChanged(&'static str),
+    #[error("invalid target provenance field {field}: {reason}")]
+    InvalidReference {
+        field: &'static str,
+        reason: &'static str,
+    },
+    #[error("management placement cannot record child-cluster references")]
+    UnexpectedChildReference,
+}
+
+/// Start bounded provisioning from the lease creation timestamp. Retrying with
+/// the same inputs is idempotent; changing an already-persisted deadline fails.
+pub fn begin_sandbox_provisioning(
+    status: &SandboxLeaseStatus,
+    observed_generation: i64,
+    accepted_at: DateTime<Utc>,
+    provisioning_timeout: chrono::Duration,
+) -> Result<SandboxLeaseStatus, SandboxLifecycleError> {
+    if provisioning_timeout <= chrono::Duration::zero() {
+        return Err(SandboxLifecycleError::InvalidDuration(
+            "provisioning timeout",
+        ));
+    }
+    let deadline = accepted_at
+        .checked_add_signed(provisioning_timeout)
+        .ok_or(SandboxLifecycleError::TimestampOverflow)?
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true);
+
+    if status.phase == SandboxLeasePhase::Provisioning {
+        if status.provisioning_deadline.as_deref() == Some(deadline.as_str())
+            && status.observed_generation == Some(observed_generation)
+        {
+            return Ok(status.clone());
+        }
+        return Err(SandboxLifecycleError::PersistedTimestampChanged(
+            "provisioningDeadline",
+        ));
+    }
+    transition_sandbox_phase(status.phase, SandboxLeasePhase::Provisioning, false)?;
+
+    let mut next = status.clone();
+    next.phase = SandboxLeasePhase::Provisioning;
+    next.observed_generation = Some(observed_generation);
+    next.provisioning_deadline = Some(deadline);
+    Ok(next)
+}
+
+/// Mark an upstream Sandbox Ready and start runtime TTL from that exact instant.
+/// Readiness after the persisted provisioning deadline fails closed.
+pub fn mark_sandbox_ready(
+    status: &SandboxLeaseStatus,
+    observed_generation: i64,
+    ready_at: DateTime<Utc>,
+    runtime_ttl: chrono::Duration,
+) -> Result<SandboxLeaseStatus, SandboxLifecycleError> {
+    if runtime_ttl <= chrono::Duration::zero() {
+        return Err(SandboxLifecycleError::InvalidDuration("runtime TTL"));
+    }
+    let deadline = status
+        .provisioning_deadline
+        .as_deref()
+        .ok_or(SandboxLifecycleError::MissingProvisioningDeadline)
+        .and_then(|value| {
+            DateTime::parse_from_rfc3339(value)
+                .map(|value| value.with_timezone(&Utc))
+                .map_err(|_| SandboxLifecycleError::MalformedProvisioningDeadline)
+        })?;
+    if ready_at > deadline {
+        return Err(SandboxLifecycleError::ProvisioningDeadlineElapsed);
+    }
+    let ready_at_string = ready_at.to_rfc3339_opts(SecondsFormat::AutoSi, true);
+    let expires_at = ready_at
+        .checked_add_signed(runtime_ttl)
+        .ok_or(SandboxLifecycleError::TimestampOverflow)?
+        .to_rfc3339_opts(SecondsFormat::AutoSi, true);
+
+    if status.phase == SandboxLeasePhase::Ready {
+        if status.ready_at.as_deref() == Some(ready_at_string.as_str())
+            && status.expires_at.as_deref() == Some(expires_at.as_str())
+            && status.observed_generation == Some(observed_generation)
+        {
+            return Ok(status.clone());
+        }
+        return Err(SandboxLifecycleError::PersistedTimestampChanged(
+            "readyAt/expiresAt",
+        ));
+    }
+    transition_sandbox_phase(status.phase, SandboxLeasePhase::Ready, false)?;
+
+    let mut next = status.clone();
+    next.phase = SandboxLeasePhase::Ready;
+    next.observed_generation = Some(observed_generation);
+    next.ready_at = Some(ready_at_string);
+    next.expires_at = Some(expires_at);
+    Ok(next)
+}
+
+/// Validate a lifecycle phase transition. Clean terminal states always require
+/// verified cleanup; in particular, Quarantined can never look clean merely
+/// because a controller retried or restarted.
+pub fn transition_sandbox_phase(
+    current: SandboxLeasePhase,
+    next: SandboxLeasePhase,
+    cleanup_verified: bool,
+) -> Result<SandboxLeasePhase, SandboxLifecycleError> {
+    if current == next {
+        return Ok(current);
+    }
+    if matches!(
+        next,
+        SandboxLeasePhase::Released | SandboxLeasePhase::Expired
+    ) && !cleanup_verified
+    {
+        return Err(SandboxLifecycleError::CleanupProofRequired);
+    }
+
+    let allowed = matches!(
+        (current, next),
+        (SandboxLeasePhase::Pending, SandboxLeasePhase::Provisioning)
+            | (SandboxLeasePhase::Pending, SandboxLeasePhase::Releasing)
+            | (SandboxLeasePhase::Pending, SandboxLeasePhase::Quarantined)
+            | (SandboxLeasePhase::Provisioning, SandboxLeasePhase::Ready)
+            | (
+                SandboxLeasePhase::Provisioning,
+                SandboxLeasePhase::Releasing
+            )
+            | (
+                SandboxLeasePhase::Provisioning,
+                SandboxLeasePhase::Quarantined
+            )
+            | (SandboxLeasePhase::Ready, SandboxLeasePhase::Releasing)
+            | (SandboxLeasePhase::Ready, SandboxLeasePhase::Quarantined)
+            | (SandboxLeasePhase::Releasing, SandboxLeasePhase::Released)
+            | (SandboxLeasePhase::Releasing, SandboxLeasePhase::Expired)
+            | (SandboxLeasePhase::Releasing, SandboxLeasePhase::Quarantined)
+            | (SandboxLeasePhase::Quarantined, SandboxLeasePhase::Released)
+            | (SandboxLeasePhase::Quarantined, SandboxLeasePhase::Expired)
+    );
+    if allowed {
+        Ok(next)
+    } else {
+        Err(SandboxLifecycleError::InvalidTransition { current, next })
+    }
+}
+
+#[derive(Debug, Clone, Error, PartialEq, Eq)]
+pub enum SandboxLifecycleError {
+    #[error("{0} must be positive")]
+    InvalidDuration(&'static str),
+    #[error("timestamp overflow")]
+    TimestampOverflow,
+    #[error("provisioningDeadline is required before readiness")]
+    MissingProvisioningDeadline,
+    #[error("provisioningDeadline is malformed")]
+    MalformedProvisioningDeadline,
+    #[error("Sandbox became Ready after its provisioning deadline")]
+    ProvisioningDeadlineElapsed,
+    #[error("persisted {0} cannot change")]
+    PersistedTimestampChanged(&'static str),
+    #[error("cleanup proof is required for a clean terminal phase")]
+    CleanupProofRequired,
+    #[error("invalid Sandbox lifecycle transition {current} -> {next}")]
+    InvalidTransition {
+        current: SandboxLeasePhase,
+        next: SandboxLeasePhase,
+    },
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::crd::{
+        SandboxContainerResources, SandboxContainerSpec, SandboxExecutionCanary, SandboxIsolation,
+        SandboxPlacement, SandboxPortSpec, SandboxReadinessRequirements, SandboxResourceQuantity,
+    };
+
+    fn quantity(cpu: &str, memory: &str, ephemeral_storage: &str) -> SandboxResourceQuantity {
+        SandboxResourceQuantity {
+            cpu: cpu.into(),
+            memory: memory.into(),
+            ephemeral_storage: ephemeral_storage.into(),
+        }
+    }
+
+    fn pool() -> SandboxPoolSpec {
+        SandboxPoolSpec {
+            warm_capacity: 2,
+            default_ttl: "1h".into(),
+            max_ttl: "8h".into(),
+            provisioning_timeout: "10m".into(),
+            placement: SandboxPlacement::Management {},
+            template: SandboxTemplateSpec {
+                default_container: "agent".into(),
+                containers: vec![SandboxContainerSpec {
+                    name: "agent".into(),
+                    image: "example.invalid/agent@sha256:abc".into(),
+                    command: vec!["/agent".into()],
+                    args: vec!["serve".into()],
+                    resources: SandboxContainerResources {
+                        requests: quantity("500m", "512Mi", "256Mi"),
+                        limits: quantity("1", "1Gi", "2Gi"),
+                    },
+                }],
+                exposed_ports: vec![SandboxPortSpec {
+                    name: "http".into(),
+                    container: "agent".into(),
+                    port: 3000,
+                }],
+            },
+            isolation: SandboxIsolation::Gvisor {
+                runtime_class_name: "runsc".into(),
+            },
+            readiness: SandboxReadinessRequirements {
+                canary: SandboxExecutionCanary {
+                    argv: vec!["/agent".into(), "health".into()],
+                    timeout: "30s".into(),
+                },
+            },
+        }
+    }
+
+    fn owner() -> OwnerReference {
+        OwnerReference {
+            api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+            kind: "SandboxPool".into(),
+            name: "agents".into(),
+            uid: "pool-uid".into(),
+            controller: Some(true),
+            block_owner_deletion: Some(true),
+        }
+    }
+
+    fn reference(kind: &str, name: &str, uid: &str) -> SandboxObjectReference {
+        SandboxObjectReference {
+            api_version: AGENT_SANDBOX_API_VERSION.into(),
+            kind: kind.into(),
+            namespace: Some("targets".into()),
+            name: name.into(),
+            uid: uid.into(),
+            generation: Some(1),
+        }
+    }
+
+    fn cluster_pool_reference(namespace: &str) -> SandboxObjectReference {
+        SandboxObjectReference {
+            api_version: KOBE_API_VERSION.into(),
+            kind: "ClusterPool".into(),
+            namespace: Some(namespace.into()),
+            name: "ci".into(),
+            uid: "pool-uid".into(),
+            generation: Some(1),
+        }
+    }
+
+    fn provenance(claim: Option<SandboxObjectReference>) -> SandboxTargetProvenance {
+        SandboxTargetProvenance {
+            namespace: "targets".into(),
+            child_cluster_lease: None,
+            child_cluster_instance: None,
+            sandbox_template: Some(reference("SandboxTemplate", "agents", "template-uid")),
+            sandbox_warm_pool: None,
+            sandbox_claim: claim,
+            sandbox: None,
+            pod: None,
+        }
+    }
+
+    #[test]
+    fn template_projection_is_v1beta1_and_closed() {
+        let object = build_sandbox_template("agents", "targets", &pool(), Some(&owner())).unwrap();
+        let value = serde_json::to_value(object).unwrap();
+
+        assert_eq!(value["apiVersion"], AGENT_SANDBOX_API_VERSION);
+        assert_eq!(value["kind"], SANDBOX_TEMPLATE_KIND);
+        assert_eq!(value["metadata"]["ownerReferences"][0]["uid"], "pool-uid");
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["runtimeClassName"],
+            "runsc"
+        );
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["automountServiceAccountToken"],
+            false
+        );
+        assert_eq!(value["spec"]["envVarsInjectionPolicy"], "Disallowed");
+        assert_eq!(value["spec"]["volumeClaimTemplatesPolicy"], "Disallowed");
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["containers"][0]["resources"]["limits"]["ephemeral-storage"],
+            "2Gi"
+        );
+        assert!(value["spec"].get("volumeClaimTemplates").is_none());
+        assert!(
+            value["spec"]["podTemplate"]["spec"]["containers"][0]
+                .get("env")
+                .is_none()
+        );
+        assert!(
+            value["spec"]["podTemplate"]["spec"]
+                .get("volumes")
+                .is_none()
+        );
+    }
+
+    #[test]
+    fn warm_pool_projection_uses_exact_template_reference() {
+        let value = serde_json::to_value(
+            build_sandbox_warm_pool("agents", "targets", "agents-template", 3, None).unwrap(),
+        )
+        .unwrap();
+        assert_eq!(value["apiVersion"], AGENT_SANDBOX_API_VERSION);
+        assert_eq!(value["kind"], SANDBOX_WARM_POOL_KIND);
+        assert_eq!(value["spec"]["replicas"], 3);
+        assert_eq!(
+            value["spec"]["sandboxTemplateRef"]["name"],
+            "agents-template"
+        );
+    }
+
+    #[test]
+    fn claim_projection_starts_ttl_only_after_ready() {
+        let expires_at = DateTime::parse_from_rfc3339("2026-08-10T12:34:56Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let value = serde_json::to_value(build_sandbox_claim("lease-a", "targets", "agents", None))
+            .unwrap();
+
+        assert_eq!(value["apiVersion"], AGENT_SANDBOX_API_VERSION);
+        assert_eq!(value["kind"], SANDBOX_CLAIM_KIND);
+        assert_eq!(value["spec"]["warmPoolRef"]["name"], "agents");
+        assert!(value["spec"]["lifecycle"].get("shutdownTime").is_none());
+        assert_eq!(
+            value["spec"]["lifecycle"]["shutdownPolicy"],
+            "DeleteForeground"
+        );
+
+        let patch = build_sandbox_claim_lifecycle_patch("claim-rv", expires_at).unwrap();
+        assert_eq!(patch["metadata"]["resourceVersion"], "claim-rv");
+        assert_eq!(
+            patch["spec"]["lifecycle"]["shutdownTime"],
+            "2026-08-10T12:34:56Z"
+        );
+        assert_eq!(
+            patch["spec"]["lifecycle"]["shutdownPolicy"],
+            "DeleteForeground"
+        );
+        assert!(build_sandbox_claim_lifecycle_patch(" ", expires_at).is_err());
+        for forbidden in [
+            "env",
+            "volumeClaimTemplates",
+            "additionalPodMetadata",
+            "namespace",
+            "credentials",
+        ] {
+            assert!(value["spec"].get(forbidden).is_none(), "found {forbidden}");
+        }
+    }
+
+    #[test]
+    fn aggregate_resources_are_unit_independent_and_ceiling_bounded() {
+        let totals = aggregate_resource_limits(&pool().template).unwrap();
+        assert_eq!(totals.cpu_millicores, 1000);
+        assert_eq!(totals.memory_bytes, 1024 * 1024 * 1024);
+        assert!(
+            resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "1000m".into(),
+                    max_memory: "1024Mi".into(),
+                },
+                &totals,
+            )
+            .unwrap()
+        );
+        assert!(
+            !resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "999m".into(),
+                    max_memory: "2Gi".into(),
+                },
+                &totals,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn quantity_parser_rejects_sub_millicore_cpu_and_whitespace() {
+        assert_eq!(parse_quantity("100u", QuantityDimension::Cpu), None);
+        assert_eq!(parse_quantity("1m", QuantityDimension::Cpu), Some(1));
+        assert_eq!(
+            parse_quantity("1n", QuantityDimension::Bytes),
+            Some(1),
+            "positive sub-byte quantities round up to one byte"
+        );
+        assert_eq!(parse_quantity(" 1", QuantityDimension::Bytes), None);
+        assert_eq!(parse_quantity("1 ", QuantityDimension::Bytes), None);
+    }
+
+    #[test]
+    fn invalid_or_inverted_resource_quantities_fail_closed() {
+        let mut template = pool().template;
+        template.containers[0].resources.requests.cpu = "2".into();
+        assert!(matches!(
+            aggregate_resource_limits(&template),
+            Err(SandboxResourceError::RequestExceedsLimit {
+                resource: "cpu",
+                ..
+            })
+        ));
+
+        assert!(
+            parse_resource_ceiling(&SandboxResourceCeiling {
+                max_cpu: "NaN".into(),
+                max_memory: "4Gi".into(),
+            })
+            .is_err()
+        );
+
+        let mut inverted_memory = pool().template;
+        inverted_memory.containers[0].resources.requests.memory = "900m".into();
+        inverted_memory.containers[0].resources.limits.memory = "100m".into();
+        assert!(matches!(
+            aggregate_resource_limits(&inverted_memory),
+            Err(SandboxResourceError::RequestExceedsLimit {
+                resource: "memory",
+                ..
+            })
+        ));
+
+        let mut fine_cpu = pool().template;
+        fine_cpu.containers[0].resources.requests.cpu = "100u".into();
+        assert!(matches!(
+            aggregate_resource_limits(&fine_cpu),
+            Err(SandboxResourceError::InvalidQuantity {
+                field: "requests.cpu",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn fractional_memory_is_compared_exactly_across_containers_and_policy() {
+        let mut template = pool().template;
+        let mut first = template.containers[0].clone();
+        first.name = "first".into();
+        first.resources.requests.cpu = "1m".into();
+        first.resources.limits.cpu = "1m".into();
+        first.resources.requests.memory = "100m".into();
+        first.resources.limits.memory = "450m".into();
+        let mut second = first.clone();
+        second.name = "second".into();
+        template.containers = vec![first, second];
+
+        let totals = aggregate_resource_limits(&template).unwrap();
+        assert_eq!(
+            totals.memory_bytes, 1,
+            "reporting rounds only after summing"
+        );
+        assert!(
+            !resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "2m".into(),
+                    max_memory: "100m".into(),
+                },
+                &totals,
+            )
+            .unwrap(),
+            "900m bytes must not fit beneath a 100m-byte ceiling"
+        );
+        assert!(
+            resource_ceiling_allows(
+                &SandboxResourceCeiling {
+                    max_cpu: "2m".into(),
+                    max_memory: "900m".into(),
+                },
+                &totals,
+            )
+            .unwrap()
+        );
+    }
+
+    #[test]
+    fn placement_has_no_default_and_cannot_change() {
+        let status = SandboxLeaseStatus::default();
+        assert_eq!(
+            require_resolved_placement(&status, "kobe"),
+            Err(SandboxProvenanceError::UnresolvedPlacement)
+        );
+
+        let placement = ResolvedSandboxPlacement::Management {};
+        assert_eq!(
+            record_placement_once(None, placement.clone(), "kobe"),
+            Ok(placement.clone())
+        );
+        assert_eq!(
+            record_placement_once(Some(&placement), placement.clone(), "kobe"),
+            Ok(placement)
+        );
+        assert_eq!(
+            record_placement_once(
+                Some(&ResolvedSandboxPlacement::Management {}),
+                ResolvedSandboxPlacement::ChildCluster {
+                    cluster_pool: cluster_pool_reference("kobe"),
+                },
+                "kobe",
+            ),
+            Err(SandboxProvenanceError::PlacementChanged)
+        );
+
+        let wrong_namespace = ResolvedSandboxPlacement::ChildCluster {
+            cluster_pool: cluster_pool_reference("other"),
+        };
+        assert!(matches!(
+            record_placement_once(None, wrong_namespace, "kobe"),
+            Err(SandboxProvenanceError::InvalidReference {
+                field: "clusterPool",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn provenance_only_allows_monotonic_exact_enrichment() {
+        let existing = provenance(None);
+        let enriched = provenance(Some(reference("SandboxClaim", "lease-a", "claim-uid")));
+        let placement = ResolvedSandboxPlacement::Management {};
+        assert_eq!(
+            merge_target_provenance(Some(&existing), enriched.clone(), &placement, "kobe"),
+            Ok(enriched.clone())
+        );
+
+        let mut name_reused = enriched.clone();
+        name_reused.sandbox_claim.as_mut().unwrap().uid = "replacement-uid".into();
+        assert_eq!(
+            merge_target_provenance(Some(&enriched), name_reused, &placement, "kobe"),
+            Err(SandboxProvenanceError::ReferenceChanged("sandboxClaim"))
+        );
+
+        let mut cleared = enriched.clone();
+        cleared.sandbox_claim = None;
+        assert_eq!(
+            merge_target_provenance(Some(&enriched), cleared, &placement, "kobe"),
+            Err(SandboxProvenanceError::ReferenceCleared("sandboxClaim"))
+        );
+
+        let mut moved = enriched.clone();
+        moved.namespace = "other".into();
+        assert_eq!(
+            merge_target_provenance(Some(&enriched), moved, &placement, "kobe"),
+            Err(SandboxProvenanceError::InvalidReference {
+                field: "sandboxTemplate",
+                reason: "namespace does not match the target namespace",
+            })
+        );
+
+        let mut wrong_gvk = enriched.clone();
+        wrong_gvk.sandbox_claim.as_mut().unwrap().kind = "Secret".into();
+        assert!(matches!(
+            merge_target_provenance(None, wrong_gvk, &placement, "kobe"),
+            Err(SandboxProvenanceError::InvalidReference {
+                field: "sandboxClaim",
+                ..
+            })
+        ));
+    }
+
+    #[test]
+    fn lifecycle_starts_ttl_at_ready_and_requires_cleanup_proof() {
+        let accepted_at = DateTime::parse_from_rfc3339("2026-08-10T10:00:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let ready_at = DateTime::parse_from_rfc3339("2026-08-10T10:03:00Z")
+            .unwrap()
+            .with_timezone(&Utc);
+        let provisioning = begin_sandbox_provisioning(
+            &SandboxLeaseStatus::default(),
+            2,
+            accepted_at,
+            chrono::Duration::minutes(10),
+        )
+        .unwrap();
+        assert_eq!(
+            provisioning.provisioning_deadline.as_deref(),
+            Some("2026-08-10T10:10:00Z")
+        );
+        assert!(provisioning.ready_at.is_none());
+        assert!(provisioning.expires_at.is_none());
+
+        let ready =
+            mark_sandbox_ready(&provisioning, 2, ready_at, chrono::Duration::hours(1)).unwrap();
+        assert_eq!(ready.ready_at.as_deref(), Some("2026-08-10T10:03:00Z"));
+        assert_eq!(ready.expires_at.as_deref(), Some("2026-08-10T11:03:00Z"));
+        assert_eq!(
+            transition_sandbox_phase(
+                SandboxLeasePhase::Releasing,
+                SandboxLeasePhase::Released,
+                false,
+            ),
+            Err(SandboxLifecycleError::CleanupProofRequired)
+        );
+        assert_eq!(
+            transition_sandbox_phase(
+                SandboxLeasePhase::Quarantined,
+                SandboxLeasePhase::Released,
+                true,
+            ),
+            Ok(SandboxLeasePhase::Released)
+        );
+    }
+}


### PR DESCRIPTION
Foundation of #70 — the four already-reviewed PRs that accumulated on `epic/agent-sandbox`.

| | |
|---|---|
| #93 | `SandboxPool`/`SandboxLease` APIs and the atomic admission ledger |
| #96 | Verified-teardown vocabulary and the `Quarantined` phase |
| #115 | Verified teardown — contract, k3s provider, and the finalizer gate |
| #116 | Reservation shape validation and the abandoned-admission reaper |

## Why this lands first

Each was reviewed and merged into the epic branch on its own. They are the base every remaining Sandbox PR builds on — the CRDs, the admission ledger, and #80's teardown machinery — so nothing above them can compile against `main` until they are here.

The remaining sixteen PRs (#117 → #135) then land **individually**, each rebased onto `main` as its predecessor merges, so CI runs on every one.

## State

Merges cleanly with `main` as it stands, including #119 and #121.

`cargo fmt --all`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` are clean on the branch.