### PR TITLE
hardening(sandbox): rate-limit admission per principal, per attempt

### DIFF
--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -278,8 +278,16 @@ When a requested TTL is reduced, `effective_ttl` reports the accepted value.
 | `403` | Missing Sandbox `lease` permission or resource ceiling exceeded |
 | `404` | An allowed SandboxPool does not exist |
 | `409` | Alias is already active |
-| `429` | Sandbox concurrency limit reached |
+| `429` | Sandbox concurrency limit reached, or the per-principal admission rate limit was hit |
 | `503` | Pool configuration or Kubernetes admission cannot be verified |
+
+Admission is rate limited per principal, independently of the concurrency
+limit. The budget is charged per *attempt* — a refused attempt costs the same
+as an accepted one, because refusing one still costs the API server a lease
+create, a contested reservation, and the cleanup that undoes them. A caller
+that has run out of budget gets `429` with a `Retry-After` header, in seconds;
+the concurrency `429` carries no such header. The limit is per API replica, and
+`kobe_sandbox_admission_rate_limited_total` counts every refusal.
 
 ### `GET /v1/sandbox-leases`
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -6,6 +6,7 @@ pub mod sandbox;
 pub mod sandbox_access;
 pub mod sandbox_credentials;
 pub mod sandbox_executions;
+pub mod sandbox_rate_limit;
 pub mod sandbox_streams;
 pub mod sandbox_transport;
 pub mod upgrade;

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -58,6 +58,11 @@ pub struct AppState<B: ClusterBackend> {
     /// which fans out into dozens of API calls) skip the per-request token
     /// validate + lease GET + kubeconfig Secret read + reqwest client build.
     pub connect_cache: ConnectCache,
+    /// Per-principal admission budget for the Sandbox create path. Shared
+    /// across requests because a limiter rebuilt per request would bound
+    /// nothing; see [`crate::api::sandbox_rate_limit`] for why it is charged
+    /// per attempt rather than per admitted lease.
+    pub sandbox_admission_limiter: crate::api::sandbox_rate_limit::AdmissionRateLimiter,
 }
 
 /// Per-lease connect-proxy context cache. Newtype over a shared, mutex-guarded
@@ -3181,6 +3186,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         (build_router(state), server)
@@ -3205,6 +3211,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         use wiremock::matchers::{method, path};
@@ -3292,6 +3299,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         use wiremock::matchers::{method, path};
@@ -3698,6 +3706,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         use wiremock::matchers::{method, path_regex};
@@ -3776,6 +3785,7 @@ mod tests {
             factory: Some(factory),
             datastore,
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         use wiremock::matchers::{header, method, path, path_regex};
@@ -3868,6 +3878,7 @@ mod tests {
             factory: Some(factory),
             datastore,
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         use wiremock::matchers::{header, method, path, path_regex};
@@ -3971,6 +3982,7 @@ mod tests {
             factory: Some(factory),
             datastore,
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         use wiremock::matchers::{method, path_regex};
@@ -4049,6 +4061,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
 
         let response = connect_proxy::<crate::testutil::MockBackend>(
@@ -4494,6 +4507,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         };
         (state, server)
     }

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -24,6 +24,7 @@ use tracing::{error, info, warn};
 use super::auth::AuthIdentity;
 use super::policy::{clamp_sandbox_ttl, format_duration, is_sandbox_allowed, policy_for};
 use super::routes::AppState;
+use super::sandbox_rate_limit::RateLimitDecision;
 use crate::backend::ClusterBackend;
 use crate::crd::{
     ResolvedSandboxPlacement, SandboxCondition, SandboxLease, SandboxLeasePhase, SandboxLeaseSpec,
@@ -1062,12 +1063,57 @@ fn sandbox_infra_error(message: &'static str, err: impl std::fmt::Display) -> Re
     sandbox_error(StatusCode::SERVICE_UNAVAILABLE, message, None)
 }
 
+/// 429 that tells the caller when to come back.
+///
+/// Without `Retry-After` a throttled client has no signal but "no", and the
+/// only strategy left is to poll — which is the load the throttle was raised
+/// against. The value is rounded *up* and floored at one second: advertising a
+/// wait shorter than the real one converts one rejection into two.
+fn sandbox_throttled(error: String, retry_after: std::time::Duration) -> Response {
+    let seconds = retry_after.as_secs_f64().ceil().max(1.0) as u64;
+    let mut response = sandbox_error(
+        StatusCode::TOO_MANY_REQUESTS,
+        error,
+        Some(format!("Retry in {seconds}s")),
+    );
+    if let Ok(value) = axum::http::HeaderValue::from_str(&seconds.to_string()) {
+        response
+            .headers_mut()
+            .insert(axum::http::header::RETRY_AFTER, value);
+    }
+    response
+}
+
 #[tracing::instrument(skip_all)]
 async fn create_sandbox_lease<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
     Json(request): Json<CreateSandboxLeaseRequest>,
 ) -> Response {
+    // FIRST statement, deliberately. Everything below — the CRD probe, the pool
+    // GET, the lease CREATE, up to `max_concurrent_leases` reservation CREATEs,
+    // and the DELETE that undoes them — is apiserver work this handler performs
+    // *before* it can decide the answer, and it performs all of it just as
+    // eagerly for a request that is going to be refused. So the budget is spent
+    // by the attempt, not by its outcome: a caller looping on 429s pays exactly
+    // like one looping on 202s, and no exit below can skip the charge because
+    // none of them is reachable without passing through here.
+    let principal = principal_hash(&identity);
+    if let RateLimitDecision::Throttled { retry_after } =
+        state.sandbox_admission_limiter.charge(&principal)
+    {
+        crate::metrics::SANDBOX_ADMISSION_RATE_LIMITED_TOTAL.inc();
+        warn!(
+            identity = %identity.identity,
+            retry_after_secs = retry_after.as_secs_f64(),
+            "Sandbox admission throttled for this principal"
+        );
+        return sandbox_throttled(
+            "Sandbox admission rate limit reached for this principal".into(),
+            retry_after,
+        );
+    }
+
     if let Err(response) =
         require_sandbox_crds(&state.client, &[SANDBOX_POOL_CRD, SANDBOX_LEASE_CRD]).await
     {
@@ -2341,6 +2387,7 @@ mod tests {
             factory: None,
             datastore: Default::default(),
             connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
         }
     }
 
@@ -2905,6 +2952,145 @@ mod tests {
             principal_hash(&split_a),
             principal_hash(&split_b),
             "concatenation must be unambiguous across component boundaries"
+        );
+    }
+
+    /// A role change must not move a principal into a fresh quota namespace.
+    ///
+    /// `requester_type` is `"{provider}:{matched rule value}"` — it names the
+    /// AccessPolicy rule that happened to match *this* request, not the caller.
+    /// It moves when an admin reorders or edits rules, when the IdP changes a
+    /// claim, and — decisively — when the same subject presents a token whose
+    /// claims select a different rule. Feeding it into the digest would make
+    /// every one of those a rename of `sbx-quota-{hash}-{slot}` and
+    /// `sbx-alias-{hash}-{alias}`.
+    ///
+    /// A rename is a bypass, not a partition: the old reservations still exist
+    /// and still consume backend resources, but the new selector cannot see
+    /// them, so the caller immediately gets their full `max_concurrent_leases`
+    /// again and can re-take an alias someone is still holding. `principal_hash`
+    /// already documents that hazard for a *code* change, where it is a one-off
+    /// migration; including `requester_type` would make it reachable at runtime,
+    /// repeatedly, by a caller who can influence their own claims.
+    ///
+    /// The exclusion is therefore the safe direction, and this test is what
+    /// stops it being "corrected" later.
+    #[test]
+    fn a_changed_requester_type_keeps_a_principal_in_the_same_quota_namespace() {
+        let base = identity();
+        let mut promoted = base.clone();
+        promoted.requester_type = "oidc:admin".into();
+
+        assert_eq!(
+            principal_hash(&base),
+            principal_hash(&promoted),
+            "a role change must not renumber this principal's quota slots"
+        );
+
+        // The digest is only a prefilter; ownership is decided by
+        // `principal_matches`. The two must agree, or the label selector
+        // narrows a caller out of leases they still own — and then they cannot
+        // release the very lease holding their slot.
+        let lease = build_sandbox_lease(
+            "sandbox-abc",
+            "test-ns",
+            pool_reference(),
+            "1h",
+            None,
+            &base,
+        );
+        assert!(
+            principal_owns_lease(&lease, &promoted),
+            "a caller must keep ownership of their own lease across a role change"
+        );
+    }
+
+    /// A caller whose every attempt fails must still run out of budget.
+    ///
+    /// This is the loop the rate limit exists to close. A principal at their
+    /// concurrency limit is refused — but only after the handler has created a
+    /// `SandboxLease`, contested the reservation ledger, and deleted the lease
+    /// again. That work is done eagerly, before the answer is known, so an
+    /// outcome-sensitive budget (charged on success, or refunded on failure)
+    /// would leave the retry loop free and unbounded: the caller spends none of
+    /// their own quota and saturates the API server every other principal
+    /// shares.
+    ///
+    /// Asserting the limiter's arithmetic would prove nothing here — the
+    /// mistake lives in *where* the handler charges, so the test has to be the
+    /// endpoint. The request count is the assertion that matters: a throttled
+    /// attempt must cost the API server nothing at all.
+    #[tokio::test]
+    async fn a_caller_whose_creates_all_fail_still_runs_out_of_admission_budget() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        let principal = principal_hash(&identity());
+        // Both of this principal's slots are held by someone else's lease, so
+        // every attempt below reaches the ledger and is refused there.
+        mount_reservation_api(
+            &server,
+            &[
+                quota_reservation_name(&principal, 0),
+                quota_reservation_name(&principal, 1),
+            ],
+        )
+        .await;
+        mount_create_lease_objects(&server, false, false).await;
+
+        // One state for every attempt: the limiter is shared process state, and
+        // a fresh one per request would bound nothing.
+        let state = test_state(&server);
+        let attempt = || {
+            create_sandbox_lease::<crate::testutil::MockBackend>(
+                State(state.clone()),
+                identity(),
+                Json(CreateSandboxLeaseRequest {
+                    pool: "agent-small".into(),
+                    ttl: Some("1h".into()),
+                    alias: None,
+                }),
+            )
+        };
+
+        let burst = crate::api::sandbox_rate_limit::ADMISSION_BURST as u32;
+        for index in 0..burst {
+            let response = attempt().await;
+            assert_eq!(
+                response.status(),
+                StatusCode::TOO_MANY_REQUESTS,
+                "attempt {index} must be refused by the quota ledger"
+            );
+            assert!(
+                response
+                    .headers()
+                    .get(axum::http::header::RETRY_AFTER)
+                    .is_none(),
+                "attempt {index} is within the burst and must reach the ledger, not the throttle"
+            );
+        }
+
+        let throttled = attempt().await;
+        assert_eq!(throttled.status(), StatusCode::TOO_MANY_REQUESTS);
+        assert!(
+            throttled
+                .headers()
+                .get(axum::http::header::RETRY_AFTER)
+                .is_some(),
+            "the throttled attempt must tell the caller when to come back"
+        );
+
+        let creates = server
+            .received_requests()
+            .await
+            .unwrap()
+            .iter()
+            .filter(|request| {
+                request.method.as_str() == "POST" && request.url.path().ends_with("/sandboxleases")
+            })
+            .count();
+        assert_eq!(
+            creates as u32, burst,
+            "a throttled attempt must not reach the API server at all"
         );
     }
 

--- a/src/api/sandbox_rate_limit.rs
+++ b/src/api/sandbox_rate_limit.rs
@@ -1,0 +1,329 @@
+//! Per-principal rate limiting for the Sandbox admission path.
+//!
+//! ## Why this is not the concurrency limit
+//!
+//! `max_concurrent_leases` bounds how many sandboxes a principal may *hold*. It
+//! says nothing about how fast they may *ask*, and refusing an attempt is not
+//! free: by the time admission can answer "no", the request has already cost
+//! the API server a `SandboxLease` CREATE, up to `max_concurrent_leases`
+//! reservation CREATEs, and a fenced DELETE to undo them. A principal sitting
+//! at their limit can therefore retry forever, spend none of their own quota,
+//! and still saturate the API server that every unrelated principal shares.
+//!
+//! ## Why the budget is charged per attempt
+//!
+//! The budget is charged before that work is scheduled and is never refunded,
+//! so a caller whose requests all fail is charged exactly like one whose
+//! requests all succeed. Charging on success — or refunding on failure — would
+//! leave the loop above completely unbounded, which is the specific evasion
+//! this module exists to close. That is why the charge is the first statement
+//! of the handler and not a decision taken at one of its exits: every exit
+//! below it has already paid.
+//!
+//! A *throttled* attempt is different, and costs nothing: it is refused before
+//! any I/O, so there is nothing to bill. Charging it as well would turn a
+//! bounded delay into a permanent lockout for any client with a tight retry
+//! loop, which punishes bad retry code rather than bounding load.
+//!
+//! ## Scope, stated narrowly
+//!
+//! This is a per-process limiter, so with `N` API replicas a principal's
+//! effective ceiling is `N` times the numbers below. That is deliberate: a
+//! cluster-wide limiter would need a write per *rejected* attempt, spending the
+//! exact resource it is meant to protect. Bounding the blast radius by a
+//! constant factor is the honest claim; a global rate guarantee is not.
+
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+/// Attempts a principal may make back-to-back from an idle start.
+///
+/// Sized for the legitimate shape of the workload: an agent runner opening a
+/// handful of sandboxes at once must never see a 429, and no realistic caller
+/// bursts past this without something being wrong — `max_concurrent_leases`
+/// caps what they could usefully be holding anyway.
+///
+/// Crate-visible so the admission handler's own test can drive the boundary
+/// through the real endpoint. A test that hard-coded `10` would keep passing if
+/// this value moved, which is the one thing it must not do.
+pub(crate) const ADMISSION_BURST: f64 = 10.0;
+
+/// Sustained refill, in attempts per second, once the burst is spent.
+///
+/// One attempt every two seconds. Interactive use never notices; a retry loop
+/// is cut from "as fast as the network allows" to a rate whose worst case is a
+/// bounded, uninteresting trickle of apiserver writes.
+const ADMISSION_REFILL_PER_SEC: f64 = 0.5;
+
+/// Ceiling on distinct principals tracked at once.
+///
+/// The map only ever holds principals that attempted admission within the last
+/// [`ADMISSION_BURST`] / [`ADMISSION_REFILL_PER_SEC`] seconds (anything older
+/// has refilled and is pruned), so this bound is reached only under a genuine
+/// flood from thousands of distinct credentials.
+const MAX_TRACKED_PRINCIPALS: usize = 10_000;
+
+/// What the limiter decided about one attempt.
+#[derive(Debug, Clone, Copy, PartialEq)]
+pub(crate) enum RateLimitDecision {
+    /// Budget was available and has been spent. The attempt may proceed.
+    Allowed,
+    /// No budget. Nothing was spent, and the caller may retry after this long.
+    Throttled { retry_after: Duration },
+}
+
+/// One principal's budget.
+///
+/// A bucket that has refilled to [`ADMISSION_BURST`] is indistinguishable from
+/// a bucket that has never been used, which is what makes eviction safe: the
+/// limiter can forget an idle principal without ever giving them budget they
+/// had not already earned back.
+#[derive(Debug, Clone, Copy)]
+struct TokenBucket {
+    tokens: f64,
+    updated_at: Instant,
+}
+
+impl TokenBucket {
+    fn fresh(now: Instant) -> Self {
+        Self {
+            tokens: ADMISSION_BURST,
+            updated_at: now,
+        }
+    }
+
+    /// Tokens accrued since the last update, clamped to the burst ceiling.
+    ///
+    /// `saturating_duration_since` matters even though [`Instant`] is
+    /// monotonic: on a platform where two reads can tie, an unchecked
+    /// subtraction would panic in a release-critical path to save nothing.
+    fn refilled(self, now: Instant) -> f64 {
+        let elapsed = now.saturating_duration_since(self.updated_at).as_secs_f64();
+        (self.tokens + elapsed * ADMISSION_REFILL_PER_SEC).min(ADMISSION_BURST)
+    }
+
+    /// Spend one token if there is one. Pure: `now` is supplied, so every
+    /// boundary here is testable without sleeping or reaching a cluster.
+    fn take(&mut self, now: Instant) -> RateLimitDecision {
+        let tokens = self.refilled(now);
+        self.updated_at = now;
+        if tokens >= 1.0 {
+            self.tokens = tokens - 1.0;
+            return RateLimitDecision::Allowed;
+        }
+        self.tokens = tokens;
+        RateLimitDecision::Throttled {
+            retry_after: Duration::from_secs_f64((1.0 - tokens) / ADMISSION_REFILL_PER_SEC),
+        }
+    }
+
+    /// Whether this bucket now carries exactly what a new one would, and can
+    /// therefore be dropped without changing any future decision.
+    fn is_idle(&self, now: Instant) -> bool {
+        self.refilled(now) >= ADMISSION_BURST
+    }
+}
+
+/// Shared, per-process admission budget keyed by principal.
+///
+/// Mirrors the connect cache's shape — a `std::sync::Mutex` around a small map.
+/// Entries are two words and every operation is a hash lookup, so a coarse lock
+/// is cheaper here than anything asynchronous, and it is never held across an
+/// `.await`.
+#[derive(Clone, Default)]
+pub struct AdmissionRateLimiter(Arc<Mutex<HashMap<String, TokenBucket>>>);
+
+impl AdmissionRateLimiter {
+    /// Charge one admission attempt against `principal`.
+    ///
+    /// `principal` must be the same digest that names the quota and alias
+    /// reservations, so the limiter and the ledger cannot disagree about who a
+    /// caller is — a limiter keyed on anything narrower would be evadable by
+    /// whatever the two definitions disagreed on.
+    pub(crate) fn charge(&self, principal: &str) -> RateLimitDecision {
+        self.charge_at(principal, Instant::now())
+    }
+
+    fn charge_at(&self, principal: &str, now: Instant) -> RateLimitDecision {
+        let mut buckets = self
+            .0
+            .lock()
+            .unwrap_or_else(|poisoned| poisoned.into_inner());
+
+        if let Some(bucket) = buckets.get_mut(principal) {
+            return bucket.take(now);
+        }
+
+        if buckets.len() >= MAX_TRACKED_PRINCIPALS {
+            buckets.retain(|_, bucket| !bucket.is_idle(now));
+        }
+        if buckets.len() >= MAX_TRACKED_PRINCIPALS {
+            // Fail closed. Forgetting an active principal to make room is the
+            // evasion itself: a flood of distinct credentials would evict the
+            // very buckets holding it back, and the limiter would disable
+            // itself exactly when it is needed. Refusing instead keeps the
+            // apiserver-write bound intact, which is what this protects.
+            return RateLimitDecision::Throttled {
+                retry_after: Duration::from_secs_f64(1.0 / ADMISSION_REFILL_PER_SEC),
+            };
+        }
+
+        let mut bucket = TokenBucket::fresh(now);
+        let decision = bucket.take(now);
+        buckets.insert(principal.to_string(), bucket);
+        decision
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// A caller who is refused must still be charged.
+    ///
+    /// If budget were spent only by attempts that end in success, a principal
+    /// at their concurrency limit could retry forever: every attempt fails, so
+    /// every attempt is free, while each one still costs the apiserver a lease
+    /// CREATE plus reservation CREATEs plus a DELETE. The limiter has no view
+    /// of the outcome by construction — this pins that it never grows one.
+    #[test]
+    fn budget_is_spent_by_the_attempt_not_by_its_outcome() {
+        let limiter = AdmissionRateLimiter::default();
+        let now = Instant::now();
+        for attempt in 0..ADMISSION_BURST as u32 {
+            assert_eq!(
+                limiter.charge_at("principal", now),
+                RateLimitDecision::Allowed,
+                "attempt {attempt} is within the burst"
+            );
+        }
+        assert!(
+            matches!(
+                limiter.charge_at("principal", now),
+                RateLimitDecision::Throttled { .. }
+            ),
+            "the burst must run out even though no attempt reported success"
+        );
+    }
+
+    /// Throttling must expire on its own.
+    ///
+    /// A limiter that never refilled would turn one burst into a permanent
+    /// lockout — the same class of unrecoverable state the admission reaper
+    /// exists to prevent, reintroduced at the front door.
+    #[test]
+    fn a_throttled_principal_recovers_at_the_refill_rate() {
+        // Each probe gets its own limiter: a rejected charge still advances the
+        // bucket's clock, so reusing one would make the second assertion depend
+        // on the first rather than on the rule under test.
+        let exhausted = |start: Instant| {
+            let limiter = AdmissionRateLimiter::default();
+            for _ in 0..ADMISSION_BURST as u32 {
+                assert_eq!(
+                    limiter.charge_at("principal", start),
+                    RateLimitDecision::Allowed
+                );
+            }
+            limiter
+        };
+
+        let start = Instant::now();
+        let RateLimitDecision::Throttled { retry_after } =
+            exhausted(start).charge_at("principal", start)
+        else {
+            panic!("the burst is spent");
+        };
+
+        // Just short of the advertised wait must still be refused, or
+        // `Retry-After` is telling callers to come back too early and the
+        // limiter answers a thundering herd with a second thundering herd.
+        assert!(
+            matches!(
+                exhausted(start)
+                    .charge_at("principal", start + retry_after - Duration::from_millis(1)),
+                RateLimitDecision::Throttled { .. }
+            ),
+            "recovering early would make Retry-After a lie"
+        );
+        assert_eq!(
+            exhausted(start).charge_at("principal", start + retry_after),
+            RateLimitDecision::Allowed,
+            "the advertised wait must actually be enough"
+        );
+    }
+
+    /// One principal's flood must not touch anyone else's budget.
+    ///
+    /// A shared bucket would make the limiter a denial-of-service amplifier:
+    /// one noisy caller would lock out every tenant on the same API replica,
+    /// which is precisely the collateral damage the limit is meant to prevent.
+    #[test]
+    fn exhausting_one_principal_leaves_every_other_principal_untouched() {
+        let limiter = AdmissionRateLimiter::default();
+        let now = Instant::now();
+        for _ in 0..ADMISSION_BURST as u32 + 5 {
+            let _ = limiter.charge_at("noisy", now);
+        }
+        assert_eq!(
+            limiter.charge_at("quiet", now),
+            RateLimitDecision::Allowed,
+            "budgets are per principal, not global"
+        );
+    }
+
+    /// Idle principals may be forgotten; active ones may not.
+    ///
+    /// Eviction is only sound because a refilled bucket and a new bucket are
+    /// the same value. If a partly-spent bucket could be pruned, a caller could
+    /// mint fresh burst on demand by cycling the table — the limiter's own
+    /// bookkeeping becoming the bypass.
+    #[test]
+    fn eviction_can_only_drop_buckets_that_have_already_refilled() {
+        let now = Instant::now();
+        let mut spent = TokenBucket::fresh(now);
+        assert_eq!(spent.take(now), RateLimitDecision::Allowed);
+        assert!(
+            !spent.is_idle(now),
+            "a bucket with budget outstanding must not be evictable"
+        );
+
+        let full_again = now + Duration::from_secs_f64(ADMISSION_BURST / ADMISSION_REFILL_PER_SEC);
+        assert!(
+            spent.refilled(full_again) >= ADMISSION_BURST,
+            "a bucket left alone for a full refill window carries nothing to remember"
+        );
+    }
+
+    /// A flood of unknown principals must not disable the limiter.
+    ///
+    /// The table is bounded, so something has to give when it fills. Handing
+    /// out budget would let an attacker with many credentials switch the limit
+    /// off for everyone by filling it — the failure mode has to be refusal.
+    #[test]
+    fn a_full_principal_table_refuses_rather_than_forgets() {
+        let limiter = AdmissionRateLimiter::default();
+        let now = Instant::now();
+        for principal in 0..MAX_TRACKED_PRINCIPALS {
+            assert_eq!(
+                limiter.charge_at(&format!("principal-{principal}"), now),
+                RateLimitDecision::Allowed
+            );
+        }
+        assert!(
+            matches!(
+                limiter.charge_at("one-too-many", now),
+                RateLimitDecision::Throttled { .. }
+            ),
+            "a full table must refuse; evicting live buckets is the bypass"
+        );
+
+        // Once the flood has aged out, the table drains and normal service
+        // resumes — the refusal above is backpressure, not a permanent wall.
+        let drained = now + Duration::from_secs_f64(ADMISSION_BURST / ADMISSION_REFILL_PER_SEC);
+        assert_eq!(
+            limiter.charge_at("one-too-many", drained),
+            RateLimitDecision::Allowed
+        );
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -113,6 +113,7 @@ async fn main() -> anyhow::Result<()> {
         factory: Some(factory.clone()),
         datastore: datastore.clone(),
         connect_cache: Default::default(),
+        sandbox_admission_limiter: Default::default(),
     };
 
     let app = build_router(state);

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -34,8 +34,8 @@ use std::sync::LazyLock;
 use std::time::Instant;
 
 use prometheus::{
-    Encoder, HistogramVec, IntCounterVec, IntGaugeVec, TextEncoder, register_histogram_vec,
-    register_int_counter_vec, register_int_gauge_vec,
+    Encoder, HistogramVec, IntCounter, IntCounterVec, IntGaugeVec, TextEncoder,
+    register_histogram_vec, register_int_counter, register_int_counter_vec, register_int_gauge_vec,
 };
 
 /// Pool state gauges — set at scrape time from shared pool state.
@@ -1265,6 +1265,20 @@ pub static CONNECT_PROXY_CACHE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(||
     .unwrap()
 });
 
+/// Sandbox admission attempts refused by the per-principal rate limiter.
+///
+/// Unlabelled on purpose. The only dimension anyone would want here is *which*
+/// principal, and that is precisely the high-cardinality identifier this module
+/// forbids as a label; the throttle already logs the identity, so traces answer
+/// "who" and this series answers "how much, and is it growing".
+pub static SANDBOX_ADMISSION_RATE_LIMITED_TOTAL: LazyLock<IntCounter> = LazyLock::new(|| {
+    register_int_counter!(
+        "kobe_sandbox_admission_rate_limited_total",
+        "Sandbox lease admission attempts refused by the per-principal rate limit"
+    )
+    .unwrap()
+});
+
 // ─────────────────────────────────────────────────────────────────────
 // Helpers
 // ─────────────────────────────────────────────────────────────────────
@@ -1378,6 +1392,10 @@ pub fn init() {
     // Connect proxy
     LazyLock::force(&CONNECT_PROXY_REQUEST_DURATION);
     LazyLock::force(&CONNECT_PROXY_CACHE_TOTAL);
+    // Sandbox admission. Registered up front so an alert on
+    // `rate(kobe_sandbox_admission_rate_limited_total[5m])` reads zero rather
+    // than "no data" until the first throttle.
+    LazyLock::force(&SANDBOX_ADMISSION_RATE_LIMITED_TOTAL);
     // Lease timing
     LazyLock::force(&LEASE_QUEUE_WAIT_SECONDS);
     LazyLock::force(&LEASE_HOLD_SECONDS);


### PR DESCRIPTION
Closes the last two open boxes of #101. One is a change; the other is a deliberate non-change, argued and pinned by a test.

Stacked on #135 (`feat/sandbox-conformance`).

## The rate limit

`max_concurrent_leases` bounds what a principal may **hold**. It says nothing about how fast they may **ask**, and the two are not the same bound — because refusing an attempt is not free. By the time admission can answer "no", the handler has already spent a `SandboxLease` CREATE, up to `max_concurrent_leases` reservation CREATEs, and a fenced DELETE to undo them. A caller sitting at their limit can loop on 429s forever, spend none of their own quota, and still saturate the API server every other principal shares. That is the gap the issue names.

So the budget is charged per **attempt**, as the first statement of the handler, and never refunded. A caller whose requests all fail is charged exactly like one whose requests all succeed — which is the whole point, and why the charge is not a decision taken at one of the handler's exits: every exit below has already paid, and none is reachable without passing through it.

A *throttled* attempt is the one thing that costs nothing: it is refused before any I/O, so there is nothing to bill. Charging it too would turn a bounded delay into a permanent lockout for anything with a tight retry loop — punishing bad retry code rather than bounding load.

Token bucket: ten attempts back-to-back, then one every two seconds. Sized so an agent runner opening a handful of sandboxes at once never sees a 429, while a retry loop drops from "as fast as the network allows" to a trickle. The key is `principal_hash` — the same digest that names the quota and alias reservations, so the limiter and the ledger cannot disagree about who a caller is.

Refusals answer with `Retry-After`, rounded up. Without it a throttled client has no signal but "no", and the only strategy left is to poll — which is the load the throttle was raised against.

Two claims stated narrowly rather than implied:

- **Per-process.** With N replicas the effective ceiling is N times these numbers. A cluster-wide limiter would need a write per *rejected* attempt, spending the exact resource it protects; bounding the blast radius by a constant factor is the honest claim.
- **Bounded table.** At the cap it refuses rather than evicting live buckets — forgetting an active principal to make room *is* the evasion, since a flood of distinct credentials would evict the very buckets holding it back.

`kobe_sandbox_admission_rate_limited_total` counts refusals, registered at startup so an alert reads zero rather than "no data".

## `requester_type` stays out of the principal digest

The issue asks to confirm this is intended. It is — and including it would be a quota **bypass**, not a tightening.

`requester_type` is `"{provider}:{matched rule value}"`. It names the AccessPolicy rule that matched *this* request, not the caller. It moves when an admin reorders or edits rules, when the IdP changes a claim, and — decisively — when the same subject presents a token whose claims select a different rule. Feeding it into the digest would make each of those a rename of `sbx-quota-{hash}-{slot}` and `sbx-alias-{hash}-{alias}`.

A rename is not a partition. The old reservations still exist and still consume backend resources, but the new selector cannot see them — so the caller gets their full `max_concurrent_leases` again and can re-take an alias someone is still holding. `principal_hash` already documents that hazard for a *code* change, where it is a one-off migration; including `requester_type` makes it reachable at runtime, repeatedly, by a caller who can influence their own claims.

It would also split the digest from `principal_matches`, which decides ownership on provider/issuer/identity. The label selector would then narrow a caller out of leases they still own, and they could no longer release the very lease holding their slot — the lockout class this epic has spent several PRs removing.

Unchanged, with the reasoning moved into a test so it is a constraint rather than a comment.

## Mutation checks

Each mutation was applied, the named test confirmed to fail, and the tree restored:

| Mutation | Test that caught it |
|---|---|
| charge on success instead of at entry | `a_caller_whose_creates_all_fail_still_runs_out_of_admission_budget` |
| throttled attempt falls through to the handler | `a_caller_whose_creates_all_fail_still_runs_out_of_admission_budget` |
| bucket never refills | `a_throttled_principal_recovers_at_the_refill_rate` |
| one bucket shared by all principals | `exhausting_one_principal_leaves_every_other_principal_untouched` |
| full principal table fails open | `a_full_principal_table_refuses_rather_than_forgets` |
| `requester_type` folded into the digest | `a_changed_requester_type_keeps_a_principal_in_the_same_quota_namespace` |

The endpoint test is the create that gets refused, not the limiter's arithmetic: the defect it guards against lives in *where* the handler charges, and a unit test of the bucket would pass with the charge in the wrong place. It asserts the API-server request count, because the property is that a throttled attempt reaches the API server not at all.

`cargo fmt --check`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` are clean.