### PR TITLE
fix(auth): back off the AccessPolicy watch, and pin its fail-closed path

### DIFF
--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -1598,4 +1598,48 @@ mod tests {
             axum::http::StatusCode::INTERNAL_SERVER_ERROR
         );
     }
+
+    /// A token policy whose Secret could not be read must be skipped entirely,
+    /// not registered with an empty credential.
+    ///
+    /// `load_token_secrets` omits the entry on any Secret read failure — RBAC,
+    /// a missing `token` key, a transient API error — so the policy still
+    /// reaches `update_policies` without its token. The `continue` above is the
+    /// SOLE defence: kunobi-auth will happily register an empty static token,
+    /// compares it with a constant-time equality that returns true for
+    /// `("", "")`, and checks static tokens before anything else. An
+    /// `Authorization: Bearer ` header strips to `""`, so without that guard an
+    /// empty bearer authenticates as the provider.
+    #[tokio::test]
+    async fn a_token_policy_whose_secret_is_missing_authenticates_nobody() {
+        for secrets in [
+            HashMap::new(),
+            HashMap::from([("local-token-secret".to_string(), String::new())]),
+        ] {
+            let auth = JwtAuthenticator::new("test".to_string());
+            let policy: AccessPolicy = serde_json::from_value(serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "AccessPolicy",
+                "metadata": { "name": "local-token" },
+                "spec": {
+                    "auth": { "token": { "secretRef": "local-token-secret" } },
+                    "rules": [{
+                        "pools": ["*"],
+                        "maxTtl": "1h",
+                        "maxConcurrentLeases": 10
+                    }]
+                }
+            }))
+            .unwrap();
+
+            auth.update_policies(vec![policy], secrets).await;
+
+            for candidate in ["", "e2e-dev-token", "anything"] {
+                assert!(
+                    auth.validate(candidate).await.is_err(),
+                    "credential {candidate:?} authenticated against a policy with no token"
+                );
+            }
+        }
+    }
 }

--- a/src/controllers/auth_policy.rs
+++ b/src/controllers/auth_policy.rs
@@ -5,6 +5,7 @@ use k8s_openapi::api::core::v1::Secret;
 use kube::Client;
 use kube::ResourceExt;
 use kube::api::{Api, ListParams};
+use kube::runtime::WatchStreamExt;
 use kube::runtime::watcher::{self, Config, Event};
 use tokio_util::sync::CancellationToken;
 use tracing::{error, info};
@@ -29,7 +30,21 @@ pub async fn run_auth_policy_watcher(
 
     info!("Starting AccessPolicy watcher");
 
-    let watcher = watcher::watcher(policies_api.clone(), Config::default());
+    // `.default_backoff()` is the fix that matters here.
+    //
+    // kube's `watcher()` never terminates — it is a `stream::unfold` whose
+    // closure unconditionally yields `Some`, so the stream is statically
+    // infinite and errors arrive as `Some(Err(_))`. Its own documentation is
+    // explicit that "errors from the underlying watch are propagated, after
+    // which the stream will go into recovery mode on the next poll. You can
+    // apply your own backoff by not polling the stream for a duration after
+    // errors."
+    //
+    // Without that, the `Some(Err(_))` arm below logs and immediately
+    // re-polls, so a persistent failure — the apiserver unreachable, or RBAC
+    // revoked on AccessPolicy — becomes a tight loop hammering the API while
+    // the authenticator serves its last-loaded policies.
+    let watcher = watcher::watcher(policies_api.clone(), Config::default()).default_backoff();
     let mut stream = Box::pin(watcher);
 
     loop {
@@ -48,8 +63,12 @@ pub async fn run_auth_policy_watcher(
                     Some(Err(e)) => {
                         error!("AccessPolicy watcher error: {e}");
                     }
+                    // Unreachable with kube-runtime 3.x, whose watcher stream
+                    // never terminates (watcher.rs:762-768). Kept as a total
+                    // match; `main` also monitors this task's handle and
+                    // triggers a shutdown if it ever returns.
                     None => {
-                        info!("AccessPolicy watcher stream ended");
+                        error!("AccessPolicy watcher stream ended unexpectedly");
                         break;
                     }
                 }


### PR DESCRIPTION
**Rewritten.** A cross-family review refuted the original version of this PR, and the mistake is worth recording alongside the fix.

## What I claimed, and why it was wrong

I claimed `run_auth_policy_watcher` could exit permanently and silently when its watch stream ended, so AccessPolicy revocations would appear to succeed and never take effect. Both halves were false:

- **`None` is unreachable.** kube-runtime 3.1.0's `watcher()` is a `stream::unfold` whose closure unconditionally yields `Some` (`watcher.rs:762-768`). The stream is statically infinite; errors arrive as `Some(Err(_))`. My ~90 lines of restart machinery guarded dead code.
- **It was neither silent nor permanent.** `main.rs:262-317` monitors every controller handle, including this one. Had the task returned it would log `Auth policy watcher exited unexpectedly`, then `Controller died, initiating shutdown`, and cancel the shutdown token — the pod restarts with a fresh policy load. I read the spawn at `main.rs:101` and never looked further down the file.

## The bug that is actually there

The reachable failure is the arm I walked straight past:

```rust
Some(Err(e)) => { error!("AccessPolicy watcher error: {e}"); }   // then re-polls immediately
```

kube's own documentation is explicit:

> Errors from the underlying watch are propagated, after which the stream will go into recovery mode on the next poll. **You can apply your own backoff by not polling the stream for a duration after errors.**

So a persistent failure — apiserver unreachable, or RBAC revoked on AccessPolicy — is a tight loop hammering the API, while the authenticator quietly serves its last-loaded policies. That is the "spinning against the apiserver" my first version claimed to prevent and didn't, because the backoff sat behind the unreachable branch.

Fixed with `.default_backoff()`. The `None` arm now documents that it is unreachable rather than implying a failure history it never had.

## A fail-closed path nothing pinned

Kept from the original, and the review confirmed it is the real value here.

When a token Secret can't be read, `load_token_secrets` omits the entry on **any** failure — RBAC, a missing `token` key, a transient API error — so the policy still reaches `update_policies` without its token. A single `continue` is the sole defence.

That matters more than it looks. Verified through the pinned `kunobi-auth`: it registers an empty static token happily, its constant-time comparison returns true for `("", "")`, it checks static tokens **before** anything else, and `Authorization: Bearer ` strips to `""`. So without that guard, an empty bearer authenticates as the provider.

Mutation-verified — dropping the emptiness guard fails with:

```
credential "" authenticated against a policy with no token
```

## Negative results, confirmed by review

- **A failed initial load does not fail open.** `JwtAuthenticator::new` starts with an empty `by_provider` and `validate` denies when empty (`auth.rs:561`).
- **A failed list retains the previous policy set** rather than clearing it — the right trade-off for a transient blip.
- One pre-existing inaccuracy noted but not changed here: the comment at `auth_policy.rs:27` says the initial load happens "before the HTTP server starts accepting requests", but `main.rs` serves HTTP before spawning the watcher. The window is deny-all 401s, so it is fail-closed — the comment is simply wrong.

Workspace green, clippy `-D warnings` clean.