### PR TITLE
test(e2e): expose restart, failure-injection and pty control for Sandbox conformance

### DIFF
--- a/hack/e2e.test.ts
+++ b/hack/e2e.test.ts
@@ -1,6 +1,14 @@
 import { expect, test } from "bun:test";
 
-import { guestImagesForBackend, parseArgs } from "./e2e";
+import {
+  decodeKeystrokes,
+  guestImagesForBackend,
+  LEASE_STAGES,
+  leaseStageReached,
+  parseArgs,
+  ptyCommand,
+  revokeVerb,
+} from "./e2e";
 
 test("k3s only preloads the always-warm k3s guest image", () => {
   const args = parseArgs(["up", "--backend", "k3s"]);
@@ -15,4 +23,158 @@ test("k0s also preloads its on-demand guest image", () => {
     "rancher/k3s:v1.31.3-k3s1",
     "k0sproject/k0s:v1.35.1-k0s.0",
   ]);
+});
+
+// ---------------------------------------------------------------------------
+// Conformance harness (#138)
+// ---------------------------------------------------------------------------
+
+test("a bare `--` hands the rest to the attached session, not to the harness", () => {
+  // Without this the workload's own flags are parsed as the harness's, and
+  // `attach -- sh --norc` would silently become a harness it does not have.
+  const args = parseArgs(["attach-pty", "--lease", "abc", "--expect", "hi", "--", "/bin/sh", "--norc"]);
+
+  expect(args.lease).toBe("abc");
+  expect(args.attachArgv).toEqual(["/bin/sh", "--norc"]);
+});
+
+test("#138's --after-phase and the clearer --wait-for-phase name the same stage", () => {
+  // A recipe copied verbatim out of the issue has to run.
+  expect(parseArgs(["restart-operator", "--after-phase", "claim"]).waitForStage).toBe("claim");
+  expect(parseArgs(["restart-operator", "--wait-for-phase", "claim"]).waitForStage).toBe("claim");
+});
+
+test("the core API group survives argument parsing", () => {
+  // The core group IS the empty string. A parser that treated it as a missing
+  // value would make every core-resource revocation impossible to ask for.
+  const args = parseArgs(["inject-failure", "--kind", "rbac-revoke", "--api-group", "", "--resource", "pods", "--verb", "get"]);
+
+  expect(args.revocation).toEqual({ apiGroup: "", resource: "pods", verb: "get" });
+});
+
+test("an unknown failure kind is refused rather than defaulted", () => {
+  // Silently falling back to the default would break the target in a way the
+  // caller did not ask for, and the scenario would assert against it.
+  expect(() => parseArgs(["inject-failure", "--kind", "chaos"])).toThrow(/unknown failure kind/);
+});
+
+test("every stage is backed by a signal the operator actually writes", () => {
+  // Guards the mistake the stage list exists to avoid: a stage nobody reaches
+  // reads as covered while the restart it names never happens. `provisioning`
+  // is the concrete case — no production path writes that phase.
+  expect(Object.keys(LEASE_STAGES)).not.toContain("provisioning");
+  expect(Object.keys(LEASE_STAGES)).not.toContain("bootstrap");
+});
+
+test("a stage is reached by its own marker and by nothing else", () => {
+  const bound = { status: { target: { namespace: "kobe-system", childClusterLease: { uid: "u" } } } };
+
+  expect(leaseStageReached("provenance", bound)).toBe(true);
+  expect(leaseStageReached("bind", bound)).toBe(true);
+  expect(leaseStageReached("claim", bound)).toBe(false);
+  expect(leaseStageReached("ready", bound)).toBe(false);
+});
+
+test("an unknown stage fails loudly instead of never matching", () => {
+  // The alternative is a wait that runs to its timeout and reports the target
+  // as slow, when the harness was asked for something that does not exist.
+  expect(() => leaseStageReached("halfway", {})).toThrow(/unknown stage/);
+});
+
+test("revoking a verb leaves the resources sharing its rule untouched", () => {
+  // The rule kobe actually ships: three upstream resources, seven verbs. If
+  // the whole rule were narrowed, the scenario would be testing a far larger
+  // breakage than the one it names.
+  const { rules, revoked } = revokeVerb(
+    [
+      {
+        apiGroups: ["extensions.agents.x-k8s.io"],
+        resources: ["sandboxtemplates", "sandboxwarmpools", "sandboxclaims"],
+        verbs: ["get", "list", "watch", "create", "update", "patch", "delete"],
+      },
+    ],
+    { apiGroup: "extensions.agents.x-k8s.io", resource: "sandboxclaims", verb: "get" },
+  );
+
+  expect(revoked).toBe(1);
+  expect(rules).toEqual([
+    {
+      apiGroups: ["extensions.agents.x-k8s.io"],
+      resources: ["sandboxtemplates", "sandboxwarmpools"],
+      verbs: ["get", "list", "watch", "create", "update", "patch", "delete"],
+    },
+    {
+      apiGroups: ["extensions.agents.x-k8s.io"],
+      resources: ["sandboxclaims"],
+      verbs: ["list", "watch", "create", "update", "patch", "delete"],
+    },
+  ]);
+});
+
+test("a rule granting nothing relevant is passed through byte-for-byte", () => {
+  const untouched = [{ apiGroups: [""], resources: ["pods"], verbs: ["get"] }];
+
+  const { rules, revoked } = revokeVerb(untouched, { apiGroup: "policy", resource: "poddisruptionbudgets", verb: "delete" });
+
+  expect(revoked).toBe(0);
+  expect(rules).toEqual(untouched);
+});
+
+test("a wildcard grant is refused, not silently left in place", () => {
+  // Subtraction cannot narrow `*`. Editing around it would produce a role that
+  // still grants the verb, and the injection would prove nothing while
+  // reporting success.
+  expect(() =>
+    revokeVerb([{ apiGroups: ["*"], resources: ["*"], verbs: ["*"] }], {
+      apiGroup: "kobe.kunobi.ninja",
+      resource: "clusterleases",
+      verb: "get",
+    }),
+  ).toThrow(/wildcard/);
+});
+
+test("a verb held by several rules is revoked from all of them", () => {
+  // One rule left granting it means the operator never gets a 403, and the
+  // scenario waits for a quarantine that will not come.
+  const { revoked } = revokeVerb(
+    [
+      { apiGroups: ["kobe.kunobi.ninja"], resources: ["clusterleases"], verbs: ["get", "list"] },
+      { apiGroups: ["kobe.kunobi.ninja"], resources: ["clusterleases", "clusterpools"], verbs: ["get"] },
+    ],
+    { apiGroup: "kobe.kunobi.ninja", resource: "clusterleases", verb: "get" },
+  );
+
+  expect(revoked).toBe(2);
+});
+
+test("the control characters that cannot be typed into an argument decode", () => {
+  // \r ends the line and \x03 is the Ctrl-C whose arrival at the workload is
+  // the property under test. Neither can appear literally on a command line.
+  expect(Array.from(decodeKeystrokes("a\\r"))).toEqual([0x61, 0x0d]);
+  expect(Array.from(decodeKeystrokes("\\x03"))).toEqual([0x03]);
+  expect(Array.from(decodeKeystrokes("\\e[A"))).toEqual([0x1b, 0x5b, 0x41]);
+  expect(Array.from(decodeKeystrokes("back\\\\slash"))).toEqual(Array.from(new TextEncoder().encode("back\\slash")));
+});
+
+test("a malformed escape is refused rather than sent as literal text", () => {
+  // Sending `\q` verbatim would put two stray characters into the workload's
+  // stdin, and the resulting mismatch would be blamed on the transport.
+  expect(() => decodeKeystrokes("\\q")).toThrow(/unknown escape/);
+  expect(() => decodeKeystrokes("\\xZZ")).toThrow(/two hex digits/);
+});
+
+test("the pty wrapper passes argv through without a shell in between", () => {
+  // Every argument stays its own argv element. Building one shell string
+  // instead would make a lease alias containing a quote executable, and the
+  // aliases are caller-supplied.
+  const cmd = ptyCommand("python3", ["kobe", "sandbox", "attach", "it's mine"]);
+
+  expect(cmd.slice(0, 2)).toEqual(["python3", "-c"]);
+  expect(cmd.slice(3)).toEqual(["kobe", "sandbox", "attach", "it's mine"]);
+});
+
+test("the pty wrapper exits with the attached command's own status", () => {
+  // --expect-exit asserts kobe's 125-on-abnormal-end contract. A wrapper that
+  // reported its own success would make that assertion meaningless.
+  expect(ptyCommand("python3", ["kobe"])[2]).toContain("waitstatus_to_exitcode");
 });

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -59,6 +59,38 @@ const DEMO_VKOBE_VERSION = "1.35";
 const LOCAL_TARGET = "e2e";
 const LOCAL_ENDPOINT = "http://127.0.0.1:8080";
 const LOCAL_NODE_PORT = 30080;
+// Where an injected failure's ORIGINAL state is parked until `clear-failure`.
+// On disk rather than in memory because the two halves are separate process
+// invocations: a conformance scenario injects, asserts, and clears from three
+// different `bun run` calls, and an in-memory capture would be gone by the
+// second one.
+const FAILURE_DIR = `${process.cwd()}/.tmp/e2e-failures`;
+// Coordination Lease the operator's leader election holds (src/main.rs).
+// Restarting is only half of "restart": the HTTP server answers from any
+// replica, but the reconcilers run solely in whichever replica owns this.
+const OPERATOR_LEADER_LEASE = "kobe-operator";
+// Label the admission ledger stamps on a lease's quota/alias reservations
+// (SANDBOX_RESERVATION_LEASE_UID_LABEL in src/api/sandbox.rs). `reap-lease`
+// needs it because a quarantined lease's reservations outlive the lease.
+const SANDBOX_LEASE_UID_LABEL = "kobe.kunobi.ninja/sandbox-lease-uid";
+// Label every backend stamps on the resources of one child cluster
+// (`cluster_labels` in src/backend/k3s.rs and its k0s/vkobe siblings). It is
+// how `inject-failure --kind=child-api-unreachable` finds the Service in front
+// of a child API server without knowing which backend built it.
+const CHILD_CLUSTER_LABEL = "kobe.kunobi.ninja/cluster";
+// Sentinel selector a severed Service is given. Nothing carries this label, so
+// the Service resolves to zero endpoints and the child API stops answering —
+// while every object behind it stays exactly where it was.
+const UNREACHABLE_SELECTOR = { "kobe.kunobi.ninja/e2e-unreachable": "true" };
+// The two reads whose 403 the operator treats as DURABLE uncertainty rather
+// than a transient error: `claim_absence()` and the child-receipt lookup in
+// src/controllers/sandbox.rs. Revoking `get` on exactly these is what makes a
+// teardown unverifiable — and therefore what makes quarantine reachable —
+// without breaking anything else the operator does.
+const UNVERIFIABLE_TEARDOWN_REVOCATIONS: ReadonlyArray<RevocationTarget> = [
+  { apiGroup: "extensions.agents.x-k8s.io", resource: "sandboxclaims", verb: "get" },
+  { apiGroup: "kobe.kunobi.ninja", resource: "clusterleases", verb: "get" },
+];
 const REQUIRED_MISE_TOOLS = ["bun", "helm", "kind", "kubectl"];
 const FINGERPRINT_INPUTS = [
   "Cargo.toml",
@@ -72,8 +104,43 @@ const FINGERPRINT_INPUTS = [
   "src",
 ];
 
+/// Everything this script can be asked to do.
+///
+/// `up`/`down` own the environment. The rest exist because #76's matrix needs
+/// the target *disturbed* — restarted mid-phase, deliberately broken, driven
+/// through a real terminal — and the conformance suite deliberately cannot do
+/// any of that: a suite able to break its own target could also mask a break it
+/// did not intend.
+const COMMANDS = [
+  "up",
+  "down",
+  "restart-operator",
+  "inject-failure",
+  "clear-failure",
+  "reap-lease",
+  "attach-pty",
+] as const;
+
+type Command = (typeof COMMANDS)[number];
+
+/// Ways the target can be deliberately broken.
+///
+/// `teardown-unverifiable` is the one #76 turns on; the other two are the
+/// primitives it is built from, exposed separately because a scenario that
+/// needs a different verb should not have to add a new kind.
+const FAILURE_KINDS = ["teardown-unverifiable", "rbac-revoke", "child-api-unreachable"] as const;
+
+type FailureKind = (typeof FAILURE_KINDS)[number];
+
+/// One verb, on one resource, in one API group.
+type RevocationTarget = {
+  apiGroup: string;
+  resource: string;
+  verb: string;
+};
+
 type Args = {
-  command: "up" | "down";
+  command: Command;
   cluster: string;
   namespace: string;
   release: string;
@@ -82,6 +149,34 @@ type Args = {
   /// known. Only used to decide which guest images are worth pre-loading —
   /// every pool is still applied regardless.
   backend?: string;
+  /// kubectl context to drive. Defaults to the kind context for `--cluster`,
+  /// which is what `up` creates; overridable so the same subcommands work
+  /// against a CI cluster that kind did not build.
+  kubeContext?: string;
+  /// Kobe HTTP endpoint used to confirm the operator is serving again.
+  endpoint: string;
+  /// SandboxLease to observe, restart at, or reap.
+  lease?: string;
+  /// Stage that lease must reach before the disturbance is applied.
+  waitForStage?: string;
+  timeoutSeconds: number;
+  failure: FailureKind;
+  revocation: Partial<RevocationTarget>;
+  /// ClusterInstance whose child API is to be severed.
+  instance?: string;
+  /// The `kobe` binary the pty harness drives. A path, not a shell string:
+  /// it is passed to the pty as argv[0] and never re-parsed.
+  kobeBin: string;
+  /// Keystroke payloads, in order. Escapes are decoded by `decodeKeystrokes`.
+  send: string[];
+  sendDelayMs: number;
+  settleMs: number;
+  /// Substring the attached session must produce for the run to pass.
+  expect?: string;
+  /// Exit code `kobe sandbox attach` must terminate with.
+  expectExit?: number;
+  /// Argv handed to `kobe sandbox attach ... -- <argv>`, after a bare `--`.
+  attachArgv: string[];
 };
 
 type E2eState = {
@@ -243,6 +338,14 @@ function canReuseExistingEnvironment(args: Args, fingerprint: string): boolean {
   );
 }
 
+function isCommand(token: string | undefined): token is Command {
+  return COMMANDS.includes(token as Command);
+}
+
+function isFailureKind(token: string): token is FailureKind {
+  return FAILURE_KINDS.includes(token as FailureKind);
+}
+
 export function parseArgs(argv: string[]): Args {
   const args = {
     command: "up" as const,
@@ -250,18 +353,38 @@ export function parseArgs(argv: string[]): Args {
     namespace: DEFAULT_NAMESPACE,
     release: DEFAULT_RELEASE,
     imageTag: DEFAULT_IMAGE_TAG,
+    endpoint: LOCAL_ENDPOINT,
+    timeoutSeconds: 300,
+    failure: "teardown-unverifiable" as const,
+    revocation: {},
+    kobeBin: process.env.KOBE_BIN ?? "kobe",
+    send: [],
+    // Long enough for the attach WebSocket to be established and the CLI to
+    // have entered raw mode. Keystrokes written before that are typed into a
+    // pty nobody is reading yet and are simply lost — which reads exactly like
+    // "the keystroke never reached the workload", the failure this harness
+    // exists to detect. Better to spend two seconds than to report it falsely.
+    sendDelayMs: 300,
+    settleMs: 2000,
+    attachArgv: [],
   } as Args;
 
   const [maybeCommand, ...rest] = argv;
-  const tokens = maybeCommand === "up" || maybeCommand === "down" ? rest : argv;
-  if (maybeCommand === "down") {
-    args.command = "down";
+  const tokens = isCommand(maybeCommand) ? rest : argv;
+  if (isCommand(maybeCommand)) {
+    args.command = maybeCommand;
   }
 
   for (let i = 0; i < tokens.length; i += 1) {
     const token = tokens[i];
     const next = tokens[i + 1];
 
+    // Everything after a bare `--` belongs to the attached session, not to
+    // this script. Parsing it here would eat the workload's own flags.
+    if (token === "--") {
+      args.attachArgv = tokens.slice(i + 1);
+      break;
+    }
     if (token === "--cluster" && next) {
       args.cluster = next;
       i += 1;
@@ -287,6 +410,93 @@ export function parseArgs(argv: string[]): Args {
       i += 1;
       continue;
     }
+    if (token === "--kube-context" && next) {
+      args.kubeContext = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--endpoint" && next) {
+      args.endpoint = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--lease" && next) {
+      args.lease = next;
+      i += 1;
+      continue;
+    }
+    // `--after-phase` is what #138 wrote; `--wait-for-phase` is what it means.
+    // Both accepted so a recipe copied from the issue still runs.
+    if ((token === "--wait-for-phase" || token === "--after-phase") && next) {
+      args.waitForStage = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--timeout" && next) {
+      args.timeoutSeconds = parsePositiveInt(next, "--timeout");
+      i += 1;
+      continue;
+    }
+    if (token === "--kind" && next) {
+      if (!isFailureKind(next)) {
+        throw new Error(`unknown failure kind '${next}' (expected one of: ${FAILURE_KINDS.join(", ")})`);
+      }
+      args.failure = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--api-group" && next !== undefined) {
+      // Deliberately not `&& next`: the core API group is the empty string,
+      // and rejecting it would make every core-resource revocation impossible.
+      args.revocation.apiGroup = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--resource" && next) {
+      args.revocation.resource = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--verb" && next) {
+      args.revocation.verb = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--instance" && next) {
+      args.instance = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--kobe" && next) {
+      args.kobeBin = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--send" && next !== undefined) {
+      args.send.push(next);
+      i += 1;
+      continue;
+    }
+    if (token === "--send-delay" && next) {
+      args.sendDelayMs = parsePositiveInt(next, "--send-delay");
+      i += 1;
+      continue;
+    }
+    if (token === "--settle" && next) {
+      args.settleMs = parsePositiveInt(next, "--settle");
+      i += 1;
+      continue;
+    }
+    if (token === "--expect" && next !== undefined) {
+      args.expect = next;
+      i += 1;
+      continue;
+    }
+    if (token === "--expect-exit" && next) {
+      args.expectExit = parsePositiveInt(next, "--expect-exit", { allowZero: true });
+      i += 1;
+      continue;
+    }
     if (token === "--help" || token === "-h") {
       printHelpAndExit();
     }
@@ -295,12 +505,43 @@ export function parseArgs(argv: string[]): Args {
   return args;
 }
 
+function parsePositiveInt(value: string, name: string, options?: { allowZero?: boolean }): number {
+  const parsed = Number.parseInt(value, 10);
+  const floor = options?.allowZero ? 0 : 1;
+  if (!Number.isFinite(parsed) || parsed < floor) {
+    throw new Error(`${name} must be an integer >= ${floor}, got '${value}'`);
+  }
+  return parsed;
+}
+
 function printHelpAndExit(): never {
   info("Usage:");
   info(
     "  bun run ./hack/e2e.ts up [--cluster NAME] [--namespace NS] [--release NAME] [--image-tag TAG] [--backend NAME]",
   );
   info("  bun run ./hack/e2e.ts down [--cluster NAME]");
+  info("");
+  info("Conformance harness (#138) — disturbs the target so #76's matrix can be run.");
+  info("All of these accept [--cluster NAME] [--namespace NS] [--release NAME]");
+  info("[--kube-context CTX] [--timeout SECONDS].");
+  info("");
+  info("  bun run ./hack/e2e.ts restart-operator [--wait-for-phase STAGE] [--lease ID] [--endpoint URL]");
+  info("      Restart the operator and wait until it is BOTH serving and leading again.");
+  info(`      Stages: ${Object.keys(LEASE_STAGES).join(", ")}`);
+  info("");
+  info("  bun run ./hack/e2e.ts inject-failure [--kind KIND] [--api-group G --resource R --verb V] [--instance NAME|--lease ID]");
+  info("  bun run ./hack/e2e.ts clear-failure  [--kind KIND]");
+  info(`      Kinds: ${FAILURE_KINDS.join(", ")} (default: teardown-unverifiable)`);
+  info("      rbac-revoke needs --api-group/--resource/--verb;");
+  info("      child-api-unreachable needs --instance, or --lease to resolve one from the CR.");
+  info("");
+  info("  bun run ./hack/e2e.ts reap-lease --lease ID");
+  info("      Delete a SandboxLease and its admission reservations. Quarantine has no API exit;");
+  info("      without this a quarantine scenario withholds capacity from every scenario after it.");
+  info("");
+  info("  bun run ./hack/e2e.ts attach-pty --lease ID [--send KEYS]... [--expect TEXT] [--expect-exit N]");
+  info("                                   [--kobe PATH] [--settle MS] [--send-delay MS] [-- ARGV...]");
+  info("      Drive `kobe sandbox attach` through a real pty. --send accepts \\r \\n \\t \\e \\xNN.");
   process.exit(0);
 }
 
@@ -1226,16 +1467,909 @@ async function down(args: Args): Promise<void> {
   clearStateFiles();
 }
 
+// ---------------------------------------------------------------------------
+// Conformance harness (#138)
+//
+// Three capabilities the dual-placement suite (tests/sandbox_conformance.rs)
+// cannot have and must not have. The suite asserts only through the public
+// HTTP API, because a suite that could reach around the API could pass while
+// the API was broken — and one that could break its own target could mask a
+// break it did not intend. So the disturbance lives here, on the other side of
+// a process boundary, and the suite still asserts nothing but the contract.
+// ---------------------------------------------------------------------------
+
+/// The shape of a `SandboxLease` this harness reads. Deliberately partial:
+/// naming only the fields that are waited on means a CRD field added later
+/// cannot silently change what a stage means.
+type SandboxLeaseObject = {
+  metadata?: {
+    name?: string;
+    uid?: string;
+    annotations?: Record<string, string>;
+  };
+  status?: {
+    phase?: string;
+    readyAt?: string;
+    target?: {
+      namespace?: string;
+      childClusterLease?: { uid?: string };
+      childClusterInstance?: { name?: string; uid?: string };
+      sandboxClaim?: { uid?: string };
+      sandbox?: { uid?: string };
+      pod?: { uid?: string };
+    };
+    conditions?: Array<{ type?: string; status?: string; reason?: string }>;
+  };
+};
+
+type LeaseStage = {
+  /// What the operator has finished doing, in the words of #76's matrix.
+  readonly describe: string;
+  readonly reached: (lease: SandboxLeaseObject) => boolean;
+};
+
+function conditionIsTrue(lease: SandboxLeaseObject, type: string): boolean {
+  return (lease.status?.conditions ?? []).some(
+    (condition) => condition.type === type && condition.status === "True",
+  );
+}
+
+/// The points a restart can be aimed at.
+///
+/// Every one of these is a signal the operator ALREADY writes and never
+/// unwrites — `child_provenance` is explicit that provenance is monotonic, a
+/// reference only ever added. That matters more than it looks: a stage defined
+/// by something that can flip back would let `restart-operator` fire twice, or
+/// fire after the moment it was aiming at, and the scenario would be testing a
+/// different restart than the one it named.
+///
+/// Two stages #76 asks for are deliberately ABSENT:
+///
+/// - `provisioning`, because nothing in production writes that phase. The only
+///   caller of `begin_sandbox_provisioning` is a unit test, so a real lease
+///   never passes through it and a harness waiting for it would hang until the
+///   timeout and report a restart that never happened.
+/// - `bootstrap`, because the upstream `SandboxTemplate`/`SandboxWarmPool`
+///   references on `status.target` are only ever copied from themselves — no
+///   code path populates them. Offering a stage backed by a marker nobody
+///   writes is worse than not offering it: the scenario reads as covered.
+export const LEASE_STAGES: Record<string, LeaseStage> = {
+  admitted: {
+    describe: "the HTTP API has admitted the lease and the controller may act",
+    reached: (lease) =>
+      lease.metadata?.annotations?.["kobe.kunobi.ninja/sandbox-admission"] === "admitted",
+  },
+  provenance: {
+    describe: "the first provenance write has landed",
+    reached: (lease) => Boolean(lease.status?.target?.namespace),
+  },
+  bind: {
+    describe: "the internal ClusterLease for a child-placed Sandbox is bound and recorded",
+    reached: (lease) => Boolean(lease.status?.target?.childClusterLease?.uid),
+  },
+  instance: {
+    describe: "the child ClusterInstance is recorded by UID",
+    reached: (lease) => Boolean(lease.status?.target?.childClusterInstance?.uid),
+  },
+  claim: {
+    describe: "the upstream SandboxClaim exists and is recorded by UID",
+    reached: (lease) => Boolean(lease.status?.target?.sandboxClaim?.uid),
+  },
+  access: {
+    describe: "the Pod a per-lease scoped credential can name is recorded",
+    reached: (lease) => Boolean(lease.status?.target?.pod?.uid),
+  },
+  canary: {
+    describe: "the readiness canary has run inside the Sandbox and passed",
+    reached: (lease) => conditionIsTrue(lease, "ReadinessCanary"),
+  },
+  ready: {
+    describe: "the lease is Ready and its runtime TTL has started",
+    reached: (lease) => lease.status?.phase === "Ready",
+  },
+  teardown: {
+    describe: "release has begun",
+    reached: (lease) => lease.status?.phase === "Releasing",
+  },
+  quarantined: {
+    describe: "teardown could not be proven and capacity is withheld",
+    reached: (lease) => lease.status?.phase === "Quarantined",
+  },
+  settled: {
+    describe: "the lease reached a clean terminal state",
+    reached: (lease) => lease.status?.phase === "Released" || lease.status?.phase === "Expired",
+  },
+};
+
+export function leaseStageReached(stage: string, lease: SandboxLeaseObject): boolean {
+  const definition = LEASE_STAGES[stage];
+  if (!definition) {
+    throw new Error(`unknown stage '${stage}' (expected one of: ${Object.keys(LEASE_STAGES).join(", ")})`);
+  }
+  return definition.reached(lease);
+}
+
+function contextFor(args: Args): string {
+  return args.kubeContext ?? kubeContext(args.cluster);
+}
+
+async function kubectl(
+  args: Args,
+  argv: string[],
+  options?: { allowFailure?: boolean; step?: string; stream?: boolean },
+): Promise<{ stdout: string; stderr: string; exitCode: number }> {
+  const bin = await resolveTool("kubectl");
+  return runCommand([bin, "--context", contextFor(args), ...argv], options);
+}
+
+async function kubectlJson<T>(args: Args, argv: string[], options?: { step?: string }): Promise<T> {
+  const { stdout } = await kubectl(args, [...argv, "-o", "json"], options);
+  return JSON.parse(stdout) as T;
+}
+
+/// Read one SandboxLease, or `null` while it does not exist yet.
+///
+/// Absence is not an error here: `restart-operator --wait-for-phase` is
+/// routinely started in parallel with the lease's own creation, and treating
+/// the gap as a failure would make the harness lose a race it is meant to win.
+async function readSandboxLease(args: Args, lease: string): Promise<SandboxLeaseObject | null> {
+  const { stdout, exitCode } = await kubectl(
+    args,
+    ["get", "sandboxleases.kobe.kunobi.ninja", "-n", args.namespace, lease, "-o", "json"],
+    { allowFailure: true },
+  );
+  if (exitCode !== 0) return null;
+  return JSON.parse(stdout) as SandboxLeaseObject;
+}
+
+async function waitForLeaseStage(args: Args, lease: string, stage: string): Promise<void> {
+  const definition = LEASE_STAGES[stage];
+  if (!definition) {
+    throw new Error(`unknown stage '${stage}' (expected one of: ${Object.keys(LEASE_STAGES).join(", ")})`);
+  }
+
+  step(`Waiting for sandbox lease '${lease}' to reach '${stage}' (${definition.describe})`);
+  const deadline = Date.now() + args.timeoutSeconds * 1000;
+  let lastPhase = "<absent>";
+  for (;;) {
+    const observed = await readSandboxLease(args, lease);
+    if (observed && definition.reached(observed)) {
+      info(`  - reached '${stage}' (phase=${observed.status?.phase ?? "<none>"})`);
+      return;
+    }
+    lastPhase = observed?.status?.phase ?? "<absent>";
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `sandbox lease '${lease}' never reached '${stage}' within ${args.timeoutSeconds}s (last phase: ${lastPhase})`,
+      );
+    }
+    await Bun.sleep(1000);
+  }
+}
+
+/// Resolve the operator Deployment by selector rather than by name.
+///
+/// Its name is the Helm template `kobe.fullname`, which is `kobe` for a release
+/// called `kobe` and `<release>-kobe` for anything else. Hardcoding either
+/// would, against the other, restart nothing at all — and `kubectl rollout
+/// restart` on a name that does not exist is the kind of failure that reads as
+/// "the restart had no effect" rather than as a broken harness.
+async function operatorDeployment(args: Args): Promise<string> {
+  const { stdout } = await kubectl(args, [
+    "get",
+    "deployment",
+    "-n",
+    args.namespace,
+    "-l",
+    `app.kubernetes.io/name=kobe,app.kubernetes.io/instance=${args.release}`,
+    "-o",
+    "jsonpath={range .items[*]}{.metadata.name}{\"\\n\"}{end}",
+  ]);
+  const names = stdout.split("\n").map((line) => line.trim()).filter(Boolean);
+  if (names.length !== 1) {
+    throw new Error(
+      `expected exactly one operator Deployment in '${args.namespace}' for release '${args.release}', found: ${names.join(", ") || "none"}`,
+    );
+  }
+  return names[0];
+}
+
+type CoordinationLease = { spec?: { holderIdentity?: string; renewTime?: string } };
+
+async function leaderRenewTime(args: Args): Promise<string | undefined> {
+  const { stdout, exitCode } = await kubectl(
+    args,
+    ["get", "lease.coordination.k8s.io", "-n", args.namespace, OPERATOR_LEADER_LEASE, "-o", "json"],
+    { allowFailure: true },
+  );
+  if (exitCode !== 0) return undefined;
+  return (JSON.parse(stdout) as CoordinationLease).spec?.renewTime;
+}
+
+/// Wait until the operator answers `/readyz`.
+///
+/// Necessary but NOT sufficient — see `waitForFreshLeader`.
+async function waitForEndpointServing(args: Args): Promise<void> {
+  step(`Waiting for ${args.endpoint}/readyz`);
+  const deadline = Date.now() + args.timeoutSeconds * 1000;
+  let lastError = "no attempt made";
+  for (;;) {
+    try {
+      const response = await fetch(`${args.endpoint}/readyz`);
+      if (response.ok) {
+        info("  - serving");
+        return;
+      }
+      lastError = `HTTP ${response.status}: ${(await response.text()).trim()}`;
+    } catch (error) {
+      lastError = error instanceof Error ? error.message : String(error);
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(`operator did not serve /readyz within ${args.timeoutSeconds}s (${lastError})`);
+    }
+    await Bun.sleep(1000);
+  }
+}
+
+/// Wait until a NEW process is renewing the leader Lease.
+///
+/// `kubectl rollout status` returning and `/readyz` answering both only prove
+/// the HTTP server is up, and the HTTP server is up in every replica. The
+/// reconcilers — the thing a restart scenario is actually about — run solely in
+/// whichever replica holds this Lease, and it is acquired after the server
+/// starts. Acting on the sooner signal would drive a cluster whose controllers
+/// are not running yet, and the scenario would blame the operator for a race
+/// the harness created.
+///
+/// Freshness is judged by `renewTime` advancing rather than by matching
+/// `holderIdentity` against a pod name: the identity format belongs to the
+/// leader-election library, and a harness that asserted its shape would break
+/// on a dependency bump for no reason.
+async function waitForFreshLeader(args: Args, before: string | undefined): Promise<void> {
+  step("Waiting for a fresh leader to renew the operator Lease");
+  const deadline = Date.now() + args.timeoutSeconds * 1000;
+  for (;;) {
+    const now = await leaderRenewTime(args);
+    if (now && now !== before) {
+      info(`  - leading again (renewTime=${now})`);
+      return;
+    }
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `no replica took the '${OPERATOR_LEADER_LEASE}' Lease within ${args.timeoutSeconds}s (renewTime still ${before ?? "<absent>"})`,
+      );
+    }
+    await Bun.sleep(1000);
+  }
+}
+
+async function restartOperator(args: Args): Promise<void> {
+  if (args.waitForStage) {
+    if (!args.lease) {
+      throw new Error("--wait-for-phase needs --lease: a stage is a property of one lease, not of the cluster");
+    }
+    await waitForLeaseStage(args, args.lease, args.waitForStage);
+  }
+
+  const deployment = await operatorDeployment(args);
+  // Captured BEFORE the restart: the comparison in `waitForFreshLeader` is
+  // against this exact value, and reading it afterwards would compare the new
+  // leader with itself and return immediately.
+  const renewedBefore = await leaderRenewTime(args);
+
+  step(`Restarting deployment '${deployment}' in namespace '${args.namespace}'`);
+  await kubectl(args, ["rollout", "restart", `deployment/${deployment}`, "-n", args.namespace], {
+    step: `failed to restart deployment '${deployment}'`,
+  });
+  await kubectl(
+    args,
+    [
+      "rollout",
+      "status",
+      `deployment/${deployment}`,
+      "-n",
+      args.namespace,
+      `--timeout=${args.timeoutSeconds}s`,
+    ],
+    { step: `deployment '${deployment}' did not roll out`, stream: true },
+  );
+
+  await waitForEndpointServing(args);
+  await waitForFreshLeader(args, renewedBefore);
+  step("Operator is serving and leading again");
+}
+
+// ---------------------------------------------------------------------------
+// Failure injection
+// ---------------------------------------------------------------------------
+
+type PolicyRule = {
+  apiGroups?: string[];
+  resources?: string[];
+  verbs?: string[];
+  resourceNames?: string[];
+};
+
+type FailureState = {
+  kind: FailureKind;
+  capturedAt: string;
+  clusterRole?: { name: string; rules: PolicyRule[] };
+  services?: Array<{ namespace: string; name: string; selector: Record<string, string> | null }>;
+};
+
+function failureStatePath(kind: FailureKind): string {
+  return `${FAILURE_DIR}/${kind}.json`;
+}
+
+/// Remove one verb from one resource in one API group, leaving every other
+/// grant in the ClusterRole byte-identical.
+///
+/// RBAC has no deny, so the only way to take a permission away is to narrow the
+/// rule that grants it — and a rule usually grants several resources at once.
+/// Narrowing the whole rule would revoke the verb from its siblings too, and
+/// the scenario would then be testing a much larger breakage than it named. So
+/// a matching rule is SPLIT: the siblings keep everything they had, and the
+/// target resource gets its own rule minus the one verb.
+///
+/// A wildcard rule is refused rather than edited. `*` cannot be narrowed by
+/// subtraction — the split would leave the wildcard rule still granting the
+/// verb, and the injection would silently do nothing at all.
+export function revokeVerb(
+  rules: PolicyRule[],
+  target: RevocationTarget,
+): { rules: PolicyRule[]; revoked: number } {
+  let revoked = 0;
+  const next: PolicyRule[] = [];
+
+  for (const rule of rules) {
+    const groups = rule.apiGroups ?? [];
+    const resources = rule.resources ?? [];
+    const verbs = rule.verbs ?? [];
+
+    const grants =
+      (groups.includes("*") || groups.includes(target.apiGroup)) &&
+      (resources.includes("*") || resources.includes(target.resource)) &&
+      (verbs.includes("*") || verbs.includes(target.verb));
+    if (!grants) {
+      next.push(rule);
+      continue;
+    }
+
+    const named =
+      groups.includes(target.apiGroup) && resources.includes(target.resource) && verbs.includes(target.verb);
+    if (!named) {
+      throw new Error(
+        `cannot revoke ${target.apiGroup || "core"}/${target.resource}:${target.verb}: rule ${JSON.stringify(rule)} grants it through a wildcard, which subtraction cannot narrow`,
+      );
+    }
+
+    revoked += 1;
+    const otherGroups = groups.filter((group) => group !== target.apiGroup);
+    if (otherGroups.length > 0) {
+      next.push({ ...rule, apiGroups: otherGroups });
+    }
+    const otherResources = resources.filter((resource) => resource !== target.resource);
+    if (otherResources.length > 0) {
+      next.push({ ...rule, apiGroups: [target.apiGroup], resources: otherResources });
+    }
+    const remainingVerbs = verbs.filter((verb) => verb !== target.verb);
+    if (remainingVerbs.length > 0) {
+      next.push({
+        ...rule,
+        apiGroups: [target.apiGroup],
+        resources: [target.resource],
+        verbs: remainingVerbs,
+      });
+    }
+  }
+
+  return { rules: next, revoked };
+}
+
+function loadFailureState(kind: FailureKind): FailureState | null {
+  const path = failureStatePath(kind);
+  if (!existsSync(path)) return null;
+  return JSON.parse(readFileSync(path, "utf8")) as FailureState;
+}
+
+async function saveFailureState(state: FailureState): Promise<void> {
+  await runCommand(["mkdir", "-p", FAILURE_DIR], { step: "failed to create the failure state directory" });
+  await Bun.write(failureStatePath(state.kind), JSON.stringify(state, null, 2));
+}
+
+/// Refuse to inject a failure that is already injected.
+///
+/// The second capture would record the ALREADY BROKEN state as the original,
+/// and `clear-failure` would then faithfully restore the breakage — leaving a
+/// cluster that looks repaired and is not. Every scenario after it would fail
+/// for a reason that has nothing to do with what it asserts.
+function refuseDoubleInjection(kind: FailureKind): void {
+  const existing = loadFailureState(kind);
+  if (existing) {
+    throw new Error(
+      `failure '${kind}' is already injected (captured ${existing.capturedAt}); run 'clear-failure --kind ${kind}' first`,
+    );
+  }
+}
+
+function revocationsFor(args: Args): RevocationTarget[] {
+  if (args.failure === "teardown-unverifiable") {
+    return [...UNVERIFIABLE_TEARDOWN_REVOCATIONS];
+  }
+  const { apiGroup, resource, verb } = args.revocation;
+  if (apiGroup === undefined || !resource || !verb) {
+    throw new Error("--kind rbac-revoke needs --api-group, --resource and --verb");
+  }
+  return [{ apiGroup, resource, verb }];
+}
+
+async function injectRbacRevocation(args: Args): Promise<void> {
+  // Resolved before anything is read or written: an incomplete request should
+  // say so, not fail three calls later with a message about a Deployment.
+  const targets = revocationsFor(args);
+  refuseDoubleInjection(args.failure);
+  // Same name as the Deployment: both render from `kobe.fullname`. Resolving
+  // the Deployment first means a release named anything at all still finds its
+  // own ClusterRole rather than a same-labelled one from another release.
+  const name = await operatorDeployment(args);
+  const role = await kubectlJson<{ rules: PolicyRule[] }>(args, ["get", "clusterrole", name], {
+    step: `failed to read ClusterRole '${name}'`,
+  });
+  const original = role.rules;
+
+  let rules = original;
+  for (const target of targets) {
+    const result = revokeVerb(rules, target);
+    if (result.revoked === 0) {
+      throw new Error(
+        `ClusterRole '${name}' never granted ${target.apiGroup || "core"}/${target.resource}:${target.verb}, so revoking it would prove nothing`,
+      );
+    }
+    info(`  - revoking ${target.apiGroup || "core"}/${target.resource}:${target.verb} (${result.revoked} rule(s))`);
+    rules = result.rules;
+  }
+
+  await saveFailureState({
+    kind: args.failure,
+    capturedAt: new Date().toISOString(),
+    clusterRole: { name, rules: original },
+  });
+  await kubectl(args, ["patch", "clusterrole", name, "--type=merge", "-p", JSON.stringify({ rules })], {
+    step: `failed to narrow ClusterRole '${name}'`,
+  });
+  step(`Injected '${args.failure}' into ClusterRole '${name}'`);
+}
+
+type ServiceList = {
+  items: Array<{
+    metadata: { name: string; namespace: string };
+    spec?: { selector?: Record<string, string> };
+  }>;
+};
+
+/// Make a child cluster's API server unreachable without destroying it.
+///
+/// The Service in front of it keeps existing; only its selector is swapped for
+/// one nothing carries, so it resolves to zero endpoints. Deleting the
+/// StatefulSet instead would have made teardown succeed for the WRONG reason —
+/// the property under test is what the operator does when it cannot REACH a
+/// cluster that is still there, which is the case where releasing capacity
+/// would be a double-booking rather than a cleanup.
+async function injectChildApiUnreachable(args: Args): Promise<void> {
+  // `--lease` rather than `--instance` is the form a conformance scenario can
+  // actually use: the API strips `childClusterInstance` from what a caller may
+  // read, on purpose, so the suite never learns the name. The harness reads it
+  // from the CR instead — which is the whole reason the harness exists.
+  refuseDoubleInjection(args.failure);
+  const instance = args.instance ?? (await childInstanceOf(args));
+
+  const found = await kubectlJson<ServiceList>(args, [
+    "get",
+    "service",
+    "--all-namespaces",
+    "-l",
+    `${CHILD_CLUSTER_LABEL}=${instance}`,
+  ]);
+  if (found.items.length === 0) {
+    throw new Error(
+      `no Service carries ${CHILD_CLUSTER_LABEL}=${instance}; the instance may not exist, or its backend (vcluster installs an upstream Helm chart) may not stamp the label`,
+    );
+  }
+
+  const captured = found.items.map((service) => ({
+    namespace: service.metadata.namespace,
+    name: service.metadata.name,
+    selector: service.spec?.selector ?? null,
+  }));
+  await saveFailureState({
+    kind: args.failure,
+    capturedAt: new Date().toISOString(),
+    services: captured,
+  });
+
+  for (const service of captured) {
+    info(`  - severing ${service.namespace}/${service.name} (instance ${instance})`);
+    await kubectl(
+      args,
+      [
+        "patch",
+        "service",
+        service.name,
+        "-n",
+        service.namespace,
+        "--type=merge",
+        "-p",
+        JSON.stringify({ spec: { selector: UNREACHABLE_SELECTOR } }),
+      ],
+      { step: `failed to sever Service '${service.namespace}/${service.name}'` },
+    );
+  }
+  step(`Injected '${args.failure}' for ClusterInstance '${instance}'`);
+}
+
+/// Resolve the child cluster behind a lease, by reading the CR.
+async function childInstanceOf(args: Args): Promise<string> {
+  if (!args.lease) {
+    throw new Error("--kind child-api-unreachable needs --instance <ClusterInstance> or --lease <id>");
+  }
+  const lease = await readSandboxLease(args, args.lease);
+  if (!lease) {
+    throw new Error(`sandbox lease '${args.lease}' does not exist`);
+  }
+  const instance = lease.status?.target?.childClusterInstance?.name;
+  if (!instance) {
+    throw new Error(
+      `sandbox lease '${args.lease}' records no child ClusterInstance; a management-placed lease has no child API to sever`,
+    );
+  }
+  return instance;
+}
+
+async function injectFailure(args: Args): Promise<void> {
+  if (args.failure === "child-api-unreachable") {
+    await injectChildApiUnreachable(args);
+    return;
+  }
+  await injectRbacRevocation(args);
+}
+
+async function clearFailure(args: Args): Promise<void> {
+  const state = loadFailureState(args.failure);
+  if (!state) {
+    // Not an error. `clear-failure` is what a scenario runs on its way out,
+    // including on the path where the injection itself failed — making that
+    // path noisy would bury the real failure under a second one.
+    info(`no '${args.failure}' failure is injected`);
+    return;
+  }
+
+  if (state.clusterRole) {
+    step(`Restoring ClusterRole '${state.clusterRole.name}'`);
+    await kubectl(
+      args,
+      [
+        "patch",
+        "clusterrole",
+        state.clusterRole.name,
+        "--type=merge",
+        "-p",
+        JSON.stringify({ rules: state.clusterRole.rules }),
+      ],
+      { step: `failed to restore ClusterRole '${state.clusterRole.name}'` },
+    );
+  }
+
+  for (const service of state.services ?? []) {
+    step(`Restoring Service '${service.namespace}/${service.name}'`);
+    await kubectl(
+      args,
+      [
+        "patch",
+        "service",
+        service.name,
+        "-n",
+        service.namespace,
+        "--type=merge",
+        "-p",
+        JSON.stringify({ spec: { selector: service.selector } }),
+      ],
+      { step: `failed to restore Service '${service.namespace}/${service.name}'` },
+    );
+  }
+
+  // Removed LAST. A state file deleted before the restore landed would leave a
+  // broken cluster that no longer knows it is broken.
+  rmSync(failureStatePath(args.failure), { force: true });
+  step(`Cleared '${args.failure}'`);
+}
+
+/// Delete a SandboxLease and the admission reservations it still holds.
+///
+/// Quarantine is deliberately terminal and deliberately keeps consuming
+/// capacity: an operator can reconcile an under-counted pool, but nobody can
+/// see a Sandbox that was quietly double-booked. That is the right product
+/// behaviour and the wrong test behaviour — a scenario that proves quarantine
+/// happens would otherwise withhold a slot from every scenario after it, and
+/// they would fail by queueing, for a reason none of them assert.
+///
+/// So the exit exists here, in the harness, and nowhere in the API. That is the
+/// point: the "operator intervention" quarantine requires is exactly what this
+/// is, performed against the cluster rather than through the contract.
+async function reapLease(args: Args): Promise<void> {
+  if (!args.lease) {
+    throw new Error("reap-lease needs --lease <id>");
+  }
+  const lease = await readSandboxLease(args, args.lease);
+  if (!lease) {
+    info(`sandbox lease '${args.lease}' does not exist`);
+    return;
+  }
+
+  const uid = lease.metadata?.uid;
+  if (uid) {
+    step(`Deleting admission reservations for lease uid ${uid}`);
+    await kubectl(
+      args,
+      [
+        "delete",
+        "lease.coordination.k8s.io",
+        "-n",
+        args.namespace,
+        "-l",
+        `${SANDBOX_LEASE_UID_LABEL}=${uid}`,
+        "--ignore-not-found",
+      ],
+      { step: "failed to delete admission reservations" },
+    );
+  }
+
+  step(`Deleting sandbox lease '${args.lease}'`);
+  await kubectl(
+    args,
+    [
+      "delete",
+      "sandboxleases.kobe.kunobi.ninja",
+      "-n",
+      args.namespace,
+      args.lease,
+      "--ignore-not-found",
+      `--timeout=${args.timeoutSeconds}s`,
+    ],
+    { step: `failed to delete sandbox lease '${args.lease}'` },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// pty harness
+// ---------------------------------------------------------------------------
+
+/// Decode a `--send` payload into the bytes a keyboard would have produced.
+///
+/// Control characters have to be expressible on a command line, and the ones
+/// that matter most are precisely the ones that cannot be typed into an
+/// argument: `\r` ends a line and `\x03` is the Ctrl-C whose arrival at the
+/// workload is the property being tested.
+export function decodeKeystrokes(spec: string): Uint8Array {
+  const bytes: number[] = [];
+  for (let i = 0; i < spec.length; i += 1) {
+    if (spec[i] !== "\\") {
+      bytes.push(...new TextEncoder().encode(spec[i]));
+      continue;
+    }
+    const escape = spec[i + 1];
+    i += 1;
+    switch (escape) {
+      case "r":
+        bytes.push(0x0d);
+        break;
+      case "n":
+        bytes.push(0x0a);
+        break;
+      case "t":
+        bytes.push(0x09);
+        break;
+      case "e":
+        bytes.push(0x1b);
+        break;
+      case "0":
+        bytes.push(0x00);
+        break;
+      case "\\":
+        bytes.push(0x5c);
+        break;
+      case "x": {
+        const hex = spec.slice(i + 1, i + 3);
+        if (!/^[0-9a-fA-F]{2}$/.test(hex)) {
+          throw new Error(`\\x must be followed by two hex digits, got '${hex}'`);
+        }
+        bytes.push(Number.parseInt(hex, 16));
+        i += 2;
+        break;
+      }
+      default:
+        throw new Error(`unknown escape '\\${escape ?? ""}' in --send payload`);
+    }
+  }
+  return new Uint8Array(bytes);
+}
+
+/// Run argv on a pty, forward this process's stdin to it, and exit with its
+/// status. `sys.argv[1:]` because `-c` occupies `sys.argv[0]`.
+const PTY_SPAWN = "import os,pty,sys; sys.exit(os.waitstatus_to_exitcode(pty.spawn(sys.argv[1:])))";
+
+/// Wrap a command so it runs with a controlling terminal.
+///
+/// A pty is not a convenience here, it is the only option. `kobe sandbox attach`
+/// reads keys through crossterm's event stream, which uses stdin only when
+/// `isatty(0)` and otherwise opens `/dev/tty` — so a pipe on stdin is not read
+/// at all, and in CI, where there is no controlling terminal to fall back to,
+/// the stream errors out. Feeding keystrokes to attach therefore REQUIRES a
+/// real terminal on the other end, which is exactly why this could not be
+/// tested before.
+///
+/// `python3 -c 'pty.spawn(...)'` rather than `script(1)`, which is the obvious
+/// choice and does not work: BSD `script` calls `tcgetattr` on ITS stdin to
+/// clone the terminal settings, and a harness necessarily feeds keystrokes
+/// through a pipe, so it dies with `tcgetattr/ioctl: Operation not supported on
+/// socket` before the command starts. util-linux's `script` tolerates it, so
+/// the harness would work in CI and fail on every maintainer's laptop —
+/// and it would fail by producing no output, which is indistinguishable from
+/// the keystroke-delivery bug this exists to detect. `pty.spawn` handles a
+/// non-tty stdin explicitly and identically on both.
+///
+/// Python rather than a pty binding because this repo has no JavaScript
+/// dependencies at all, and adding one would put a node_modules tree in the
+/// path of every e2e run.
+export function ptyCommand(python: string, argv: string[]): string[] {
+  return [python, "-c", PTY_SPAWN, ...argv];
+}
+
+/// Locate a Python that can allocate the pty, or say so plainly.
+///
+/// Named explicitly rather than falling back to `script`: two allocators with
+/// different behaviour would make a failure mean two different things.
+async function resolvePython(): Promise<string> {
+  for (const candidate of [process.env.PYTHON ?? "python3", "python"]) {
+    const { exitCode } = await runCommand([candidate, "-c", "import pty"], { allowFailure: true });
+    if (exitCode === 0) return candidate;
+  }
+  throw new Error(
+    "attach-pty needs a python3 with the stdlib `pty` module to allocate a terminal; set PYTHON to one",
+  );
+}
+
+async function attachPty(args: Args): Promise<void> {
+  if (!args.lease) {
+    throw new Error("attach-pty needs --lease <id>");
+  }
+  if (!args.expect && args.expectExit === undefined) {
+    throw new Error("attach-pty needs --expect and/or --expect-exit: a session with no assertion proves nothing");
+  }
+
+  const attach = [
+    args.kobeBin,
+    "sandbox",
+    "attach",
+    args.lease,
+    ...(args.attachArgv.length > 0 ? ["--", ...args.attachArgv] : []),
+  ];
+  const cmd = ptyCommand(await resolvePython(), attach);
+  step(`Attaching through a pty: ${attach.join(" ")}`);
+
+  const proc = Bun.spawn({
+    cmd,
+    stdin: "pipe",
+    stdout: "pipe",
+    stderr: "pipe",
+    cwd: process.cwd(),
+    // A terminal type the remote shell can render into. Without one it falls
+    // back to `dumb`, where a prompt may never be drawn — and a harness waiting
+    // on output would then time out with nothing to show for it.
+    env: { ...process.env, TERM: process.env.TERM ?? "xterm-256color" },
+  });
+
+  let transcript = "";
+  const decoder = new TextDecoder();
+  const drain = async (stream: ReadableStream<Uint8Array>): Promise<void> => {
+    const reader = stream.getReader();
+    for (;;) {
+      const { done, value } = await reader.read();
+      if (done) return;
+      transcript += decoder.decode(value, { stream: true });
+    }
+  };
+  const pumped = Promise.all([drain(proc.stdout), drain(proc.stderr)]);
+
+  const writer = proc.stdin;
+  await Bun.sleep(args.settleMs);
+  for (const payload of args.send) {
+    writer.write(decodeKeystrokes(payload));
+    await writer.flush();
+    await Bun.sleep(args.sendDelayMs);
+  }
+
+  let matched = args.expect === undefined;
+  if (args.expect !== undefined) {
+    const deadline = Date.now() + args.timeoutSeconds * 1000;
+    while (Date.now() < deadline) {
+      if (transcript.includes(args.expect)) {
+        matched = true;
+        break;
+      }
+      await Bun.sleep(200);
+    }
+  }
+
+  if (args.expectExit === undefined) {
+    // Nothing asserts how the session ends, so end it. Leaving it attached
+    // would hold one of the lease's eight concurrent streams until the idle
+    // timeout, and the next scenario would be refused with a 429 it never asked
+    // about.
+    //
+    // stdin is closed first: that collapses the pty, which hangs up `kobe` the
+    // way a closed terminal window would. `kill` alone reaches `script`, and a
+    // `kobe` reparented away from it would keep the stream open exactly as if
+    // nothing had been cleaned up.
+    writer.end();
+  }
+  // Bounded either way. An attach that never exits would otherwise hang here
+  // long past the timeout the caller asked for, and CI would kill the run with
+  // no transcript at all — the one artefact that says what went wrong.
+  //
+  // A cleared timer rather than a bare sleep: an un-cleared one keeps the event
+  // loop alive, and every successful run would then take the full timeout.
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const expired = new Promise<"timeout">((resolve) => {
+    timer = setTimeout(() => resolve("timeout"), args.timeoutSeconds * 1000);
+  });
+  const outcome = await Promise.race([proc.exited, expired]);
+  clearTimeout(timer);
+  if (outcome === "timeout") {
+    proc.kill();
+  }
+  const exitCode = outcome === "timeout" ? await proc.exited : outcome;
+  await pumped;
+
+  info("--- session transcript ---");
+  info(transcript.trimEnd());
+  info("--- end transcript ---");
+
+  if (!matched) {
+    throw new Error(`the attached session never produced ${JSON.stringify(args.expect)} within ${args.timeoutSeconds}s`);
+  }
+  if (args.expectExit !== undefined && exitCode !== args.expectExit) {
+    throw new Error(`kobe sandbox attach exited ${exitCode}, expected ${args.expectExit}`);
+  }
+  step("Attached session satisfied every assertion");
+}
+
 async function main() {
   try {
     const args = parseArgs(Bun.argv.slice(2));
 
-    if (args.command === "up") {
-      await up(args);
-      return;
+    switch (args.command) {
+      case "up":
+        await up(args);
+        return;
+      case "down":
+        await down(args);
+        return;
+      case "restart-operator":
+        await restartOperator(args);
+        return;
+      case "inject-failure":
+        await injectFailure(args);
+        return;
+      case "clear-failure":
+        await clearFailure(args);
+        return;
+      case "reap-lease":
+        await reapLease(args);
+        return;
+      case "attach-pty":
+        await attachPty(args);
+        return;
     }
-
-    await down(args);
   } catch (error) {
     const message = error instanceof Error ? error.message : String(error);
     fail(message);

--- a/justfile
+++ b/justfile
@@ -115,9 +115,16 @@ test-smoke-k3s cluster='e2e-kobe' *args:
 # KOBE_TOKEN_OTHER is REQUIRED. The cross-tenant scenarios are not optional,
 # and a suite that skipped them would report success while proving nothing
 # about the property they exist for.
+#
+# KOBE_SANDBOX_HARNESS names the command that restarts, breaks and attaches to
+# the target (#138). It defaults to this repo's own harness because that is
+# right whenever the suite runs against the environment `just e2e-up` built;
+# override it when the endpoint lives somewhere else, and remember that the
+# harness needs kubectl access to the cluster serving it — the restart,
+# failure-injection and pty scenarios FAIL rather than skip without one.
 [group('test')]
 test-sandbox-conformance:
-    @KOBE_SANDBOX_E2E=1 cargo test --test sandbox_conformance -- --ignored --test-threads=1
+    @KOBE_SANDBOX_E2E=1 KOBE_SANDBOX_HARNESS="${KOBE_SANDBOX_HARNESS:-bun run ./hack/e2e.ts}" cargo test --test sandbox_conformance -- --ignored --test-threads=1
 
 # Local e2e environment entrypoint
 [group('dev')]

--- a/tests/sandbox_conformance.rs
+++ b/tests/sandbox_conformance.rs
@@ -23,6 +23,27 @@
 //! cannot: that a caller is **unable** to reach the cluster underneath. A test
 //! holding a kubeconfig cannot prove the absence of one.
 //!
+//! # The harness is not the target
+//!
+//! Some properties cannot be provoked through the contract at all. A crash
+//! never causing a duplicate spawn needs a crash; uncertain teardown withholding
+//! capacity needs teardown made uncertain; Ctrl-C reaching the workload needs a
+//! terminal. #138 supplies all three through `hack/e2e.ts`, and this suite
+//! *invokes* them — but it still does not perform them, and it still asserts
+//! only through HTTP.
+//!
+//! That boundary is the point rather than an inconvenience. A suite that could
+//! break its own target could also mask a break it did not intend, and a suite
+//! reaching into the cluster to check its work could pass while the API was
+//! broken. So the disturbance happens in another process, and every assertion
+//! about the result comes back through the same public surface every other
+//! scenario uses.
+//!
+//! `KOBE_SANDBOX_HARNESS` names that command — `bun run ./hack/e2e.ts`. Absent,
+//! the scenarios that need it **fail**, exactly like a missing
+//! `KOBE_TOKEN_OTHER`. #138 says why in one line: a scenario that cannot run
+//! reads as a scenario that passed.
+//!
 //! # Running it
 //!
 //! ```text
@@ -79,8 +100,14 @@ impl Placement {
 /// A failure names the placement, because "the exec scenario failed" is not
 /// actionable when the whole point is that one placement behaves differently
 /// from the other.
+///
+/// Leading attributes are forwarded, so a scenario can carry the doc comment
+/// that says what breaks when it does not hold. Without the passthrough that
+/// reasoning would have to live in an ordinary comment, where `cargo doc` and
+/// a reader jumping to the definition both miss it.
 macro_rules! both_placements {
-    ($name:ident, $body:expr) => {
+    ($(#[$attribute:meta])* $name:ident, $body:expr) => {
+        $(#[$attribute])*
         #[tokio::test]
         #[ignore = "requires a live Kobe endpoint; see the module docs"]
         async fn $name() {
@@ -126,6 +153,79 @@ fn other_token() -> String {
 fn pool_for(placement: Placement) -> String {
     std::env::var(placement.pool_env())
         .unwrap_or_else(|_| panic!("{} is required", placement.pool_env()))
+}
+
+/// The command that disturbs the target.
+///
+/// Absent means **fail**, never skip — the same rule as [`other_token`], for
+/// the same reason. The three properties this unlocks are asserted by
+/// construction today and proven nowhere; a scenario that quietly declined to
+/// run would leave them looking covered.
+fn harness_command() -> Vec<String> {
+    let configured = std::env::var("KOBE_SANDBOX_HARNESS").expect(
+        "KOBE_SANDBOX_HARNESS is required: it names the command that restarts, breaks and \
+         attaches to the target (e.g. `bun run ./hack/e2e.ts`). The restart, failure-injection \
+         and pty scenarios cannot run without it, and a skipped scenario reads as a passing one",
+    );
+    configured
+        .split_whitespace()
+        .map(str::to_string)
+        .collect::<Vec<_>>()
+}
+
+/// Invoke the harness, failing with everything it printed.
+///
+/// The whole output rather than a status: these subcommands fail for reasons
+/// the suite cannot see — a lease that never reached the stage a restart was
+/// aimed at, a ClusterRole that never granted the verb being revoked — and a
+/// bare exit code would send the reader to the wrong side of the boundary.
+async fn harness(argv: &[&str]) -> anyhow::Result<String> {
+    let command = harness_command();
+    let (program, prefix) = command
+        .split_first()
+        .ok_or_else(|| anyhow::anyhow!("KOBE_SANDBOX_HARNESS is set but empty"))?;
+
+    let output = tokio::process::Command::new(program)
+        .args(prefix)
+        .args(argv)
+        .output()
+        .await?;
+
+    let stdout = String::from_utf8_lossy(&output.stdout).into_owned();
+    anyhow::ensure!(
+        output.status.success(),
+        "harness `{} {}` failed ({}):\n{stdout}\n{}",
+        command.join(" "),
+        argv.join(" "),
+        output.status,
+        String::from_utf8_lossy(&output.stderr)
+    );
+    Ok(stdout)
+}
+
+/// A value no other run of this suite can produce.
+///
+/// A restart scenario outlives reconciles and retries, so a fixed marker from
+/// an earlier run could still be sitting in the sandbox — and matching it would
+/// pass without anything having happened this time.
+fn nonce(placement: Placement) -> String {
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|elapsed| elapsed.as_nanos())
+        .unwrap_or_default();
+    format!("{}-{now}", placement.label())
+}
+
+/// The UID a lease recorded for one composed object.
+///
+/// UIDs rather than names throughout, because a same-named replacement is
+/// fresh capacity rather than evidence of continuity — the exact distinction
+/// the operator's own teardown receipts are built on.
+fn provenance_uid(lease: &Value, field: &str) -> anyhow::Result<String> {
+    lease["target"][field]["uid"]
+        .as_str()
+        .map(str::to_string)
+        .ok_or_else(|| anyhow::anyhow!("no target.{field}.uid in {lease}"))
 }
 
 struct Api {
@@ -208,6 +308,17 @@ impl LeasedSandbox {
             id,
             released: false,
         })
+    }
+
+    /// The lease as its own holder sees it, right now.
+    async fn status(&self) -> anyhow::Result<(reqwest::StatusCode, Value)> {
+        self.api
+            .json(
+                reqwest::Method::GET,
+                &format!("/v1/sandbox-leases/{}", self.id),
+                None,
+            )
+            .await
     }
 
     async fn wait_ready(&self, within: Duration) -> anyhow::Result<Value> {
@@ -733,6 +844,386 @@ both_placements!(
     }
 );
 
+// ---------------------------------------------------------------------------
+// Harness-driven scenarios (#138)
+//
+// The three rows of #76's matrix that needed the target disturbed rather than
+// merely queried. Each covers a property the design leans on and that nothing
+// proves end to end: a crash never causes a duplicate spawn; uncertain teardown
+// withholds capacity rather than releasing it; Ctrl-C reaches the workload.
+//
+// A restart takes longer than an untouched lease does, so these use wider
+// budgets than the scenarios above. That is not slack — a restart scenario that
+// timed out during the restart would report the operator as broken for having
+// been asked to reboot.
+// ---------------------------------------------------------------------------
+
+both_placements!(
+    /// A restart before readiness resumes the same composition rather than
+    /// starting a second one.
+    ///
+    /// If this does not hold, a crash mid-provision leaves a Sandbox nobody
+    /// owns while the lease builds another — and for child placement the
+    /// orphan is an entire cluster, charged to a pool that has stopped
+    /// counting it.
+    a_restart_before_readiness_resumes_the_same_composition,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+
+        // Aimed at the claim, not at a wall-clock delay. A restart timed by
+        // sleeping lands somewhere different on every run, and a scenario that
+        // sometimes restarts after readiness is not running the same test
+        // twice — which is precisely the class of flake that gets an
+        // idempotency suite switched off.
+        harness(&[
+            "restart-operator",
+            "--wait-for-phase",
+            "claim",
+            "--lease",
+            &sandbox.id,
+            "--timeout",
+            "600",
+        ])
+        .await?;
+
+        let ready = sandbox.wait_ready(Duration::from_secs(600)).await?;
+        let claim = provenance_uid(&ready, "sandboxClaim")?;
+        let pod = provenance_uid(&ready, "pod")?;
+
+        // A second restart, now past readiness. Same objects, and the same
+        // readiness instant: a moved `readyAt` would mean the runtime TTL
+        // restarted along with the operator, quietly handing the caller time
+        // they did not buy — or taking time they did.
+        harness(&[
+            "restart-operator",
+            "--wait-for-phase",
+            "ready",
+            "--lease",
+            &sandbox.id,
+            "--timeout",
+            "600",
+        ])
+        .await?;
+
+        let (_, after) = sandbox.status().await?;
+        anyhow::ensure!(
+            after["phase"] == "Ready",
+            "a restart moved a Ready lease to {}: {after}",
+            after["phase"]
+        );
+        anyhow::ensure!(
+            provenance_uid(&after, "sandboxClaim")? == claim,
+            "the resumed operator composed a second claim: {claim} then {after}"
+        );
+        anyhow::ensure!(
+            provenance_uid(&after, "pod")? == pod,
+            "the resumed operator landed on a different Pod: {pod} then {after}"
+        );
+        anyhow::ensure!(
+            after["readyAt"] == ready["readyAt"],
+            "readyAt moved across a restart ({} then {}); the runtime TTL restarted with the operator",
+            ready["readyAt"],
+            after["readyAt"]
+        );
+
+        sandbox.release().await
+    }
+);
+
+both_placements!(
+    /// A restart between a retry and its original still runs the command once.
+    ///
+    /// The reservation that makes two concurrent retries race for one object
+    /// lives in the cluster, so it must survive the process that wrote it. If
+    /// it does not, a client that retried across a Kobe restart runs its
+    /// command twice — and the commands people least want run twice are exactly
+    /// the ones they wrap in an idempotency key.
+    a_restart_between_a_retry_and_its_original_still_runs_it_once,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+        sandbox.wait_ready(Duration::from_secs(600)).await?;
+
+        let marker = format!("/tmp/kobe-restart-{}", nonce(placement));
+        let script = format!("echo x >> {marker}");
+        let argv = ["/bin/sh", "-c", script.as_str()];
+        let key = "conformance-restart-idempotent";
+
+        let (_, first) = sandbox.exec(&argv, key).await?;
+        harness(&[
+            "restart-operator",
+            "--wait-for-phase",
+            "ready",
+            "--lease",
+            &sandbox.id,
+            "--timeout",
+            "600",
+        ])
+        .await?;
+        let (_, second) = sandbox.exec(&argv, key).await?;
+
+        anyhow::ensure!(
+            first["id"] == second["id"],
+            "a retry across a restart produced a second execution: {first} vs {second}"
+        );
+
+        // The side effect settles it. Two executions sharing an id would still
+        // be one spawn; two spawns sharing an id would not show up in the ids
+        // at all, and this is where they would.
+        let count_script = format!("wc -l < {marker}");
+        let (_, count) = sandbox
+            .exec(
+                &["/bin/sh", "-c", count_script.as_str()],
+                "conformance-restart-count",
+            )
+            .await?;
+        let lines: i64 = count["stdout"]
+            .as_str()
+            .unwrap_or_default()
+            .trim()
+            .parse()
+            .unwrap_or(-1);
+        anyhow::ensure!(
+            lines == 1,
+            "the command ran {lines} times across a restart, expected exactly 1"
+        );
+
+        sandbox.release().await
+    }
+);
+
+both_placements!(
+    /// A restart during teardown still settles the lease exactly once.
+    ///
+    /// Teardown is where a restart is most expensive to get wrong: a resumed
+    /// operator that forgets it was mid-release either strands the capacity or
+    /// declares it clean without proof. Neither is visible until somebody
+    /// counts a pool that no longer adds up.
+    a_restart_during_teardown_still_settles_the_lease_once,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+        sandbox.wait_ready(Duration::from_secs(600)).await?;
+
+        // Started BEFORE the release, not after. `Releasing` is a state the
+        // management path can pass through in well under a second, and a
+        // harness asked to wait for it afterwards would be waiting for
+        // something already gone.
+        let id = sandbox.id.clone();
+        let argv = [
+            "restart-operator",
+            "--wait-for-phase",
+            "teardown",
+            "--lease",
+            id.as_str(),
+            "--timeout",
+            "600",
+        ];
+        let (restarted, released) = tokio::join!(harness(&argv), sandbox.release());
+        released?;
+        restarted?;
+
+        let deadline = Instant::now() + Duration::from_secs(600);
+        loop {
+            let (status, body) = sandbox.status().await?;
+            if status.as_u16() == 404 {
+                return Ok(());
+            }
+            match body["phase"].as_str() {
+                Some("Released" | "Expired") => return Ok(()),
+                // A lease that was already mid-teardown when the operator
+                // restarted has proof available; withholding capacity here
+                // would mean the restart itself destroyed the evidence.
+                Some("Quarantined") => anyhow::bail!(
+                    "a restart during teardown quarantined a lease that had proof: {body}"
+                ),
+                _ => {}
+            }
+            anyhow::ensure!(
+                Instant::now() < deadline,
+                "a lease restarted mid-teardown never settled: {body}"
+            );
+            tokio::time::sleep(Duration::from_secs(5)).await;
+        }
+    }
+);
+
+both_placements!(
+    /// An unverifiable teardown withholds capacity instead of releasing it.
+    ///
+    /// The safe direction is the counter-intuitive one. An under-counted pool
+    /// is visible and an administrator can reconcile it; a Sandbox that was
+    /// quietly double-booked is visible to nobody, and the second tenant finds
+    /// out by sharing a workload with the first.
+    ///
+    /// Asserted by construction today: the code path is unit-tested with a
+    /// faked 403. What is not tested is that a real revocation produces one.
+    an_unverifiable_teardown_withholds_capacity_instead_of_releasing_it,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+        sandbox.wait_ready(Duration::from_secs(600)).await?;
+
+        // Revokes `get` — not `delete`. A revoked delete stalls in `Releasing`
+        // and retries forever, which is a clean failure; only a read the
+        // operator is not permitted to make is DURABLE uncertainty, and
+        // durable uncertainty is what quarantine exists for.
+        harness(&["inject-failure", "--kind", "teardown-unverifiable"]).await?;
+
+        let observed = quarantine_after_release(&mut sandbox).await;
+
+        // Both cleanups run whatever the assertion did. An injection left
+        // behind breaks every scenario after this one, and a quarantined lease
+        // holds a pool slot on purpose and has no exit through the API — the
+        // next scenario would queue behind capacity it cannot see and fail for
+        // a reason it does not assert.
+        let cleared = harness(&["clear-failure", "--kind", "teardown-unverifiable"]).await;
+        let reaped = harness(&["reap-lease", "--lease", &sandbox.id]).await;
+
+        observed?;
+        cleared?;
+        reaped?;
+        anyhow::Ok(())
+    }
+);
+
+both_placements!(
+    /// A keystroke typed on a real terminal reaches the workload.
+    ///
+    /// Framing, key encoding and URL derivation are unit-tested on both sides.
+    /// The round trip is not, and it is the only part a user experiences: an
+    /// attach that connects, renders output and swallows every keystroke
+    /// passes every existing test.
+    a_keystroke_typed_on_a_real_terminal_reaches_the_workload,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+        sandbox.wait_ready(Duration::from_secs(600)).await?;
+
+        let token = nonce(placement);
+        // What is typed and what is expected are deliberately different
+        // strings. A pty echoes input, so an expectation matching the
+        // keystrokes would be satisfied by the terminal alone, without the
+        // workload ever seeing them. Only the shell's own concatenation
+        // produces the joined form.
+        let typed = format!("echo ko\"\"be-typed-{token}\\r");
+        let expected = format!("kobe-typed-{token}");
+
+        // A shell is started rather than attaching to whatever the pool
+        // declared: the pool's process is an administrator's choice and nothing
+        // promises it reads stdin, so attaching to it would make this scenario
+        // a test of that pool's configuration.
+        harness(&[
+            "attach-pty",
+            "--lease",
+            &sandbox.id,
+            "--send",
+            &typed,
+            "--expect",
+            &expected,
+            "--timeout",
+            "120",
+            "--",
+            "/bin/sh",
+        ])
+        .await?;
+
+        sandbox.release().await
+    }
+);
+
+both_placements!(
+    /// Ctrl-C reaches the workload rather than the client.
+    ///
+    /// Raw mode exists for this one keystroke. If it regressed, `kobe` would
+    /// die and the caller's process would keep running inside a sandbox they
+    /// can no longer see — the failure that costs the most and announces
+    /// itself the least.
+    ctrl_c_reaches_the_workload_rather_than_the_client,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+        sandbox.wait_ready(Duration::from_secs(600)).await?;
+
+        let token = nonce(placement);
+        let marker = format!("echo ko\"\"be-interrupted-{token}\\r");
+        let expected = format!("kobe-interrupted-{token}");
+
+        // Three keystrokes, and only one outcome produces the marker. If
+        // Ctrl-C killed the client, the session is gone and nothing more is
+        // typed. If it never arrived, the shell is still sleeping and the
+        // marker waits behind it. It appears only when the interrupt was
+        // delivered to the process on the other end.
+        harness(&[
+            "attach-pty",
+            "--lease",
+            &sandbox.id,
+            "--send",
+            "sleep 300\\r",
+            "--send",
+            "\\x03",
+            "--send",
+            &marker,
+            "--expect",
+            &expected,
+            // Wider than the default gap between keystrokes, because the
+            // interrupt has to arrive while `sleep` is the foreground process.
+            // Sent too early it lands on the prompt, the shell shrugs, and the
+            // sleep then runs for its full five minutes — a pass turned into a
+            // timeout by a race the assertion never mentions.
+            "--send-delay",
+            "1000",
+            "--timeout",
+            "120",
+            "--",
+            "/bin/sh",
+        ])
+        .await?;
+
+        sandbox.release().await
+    }
+);
+
+/// Release a lease whose teardown cannot be proven, and hold it to quarantine.
+///
+/// Split out because the assertion has to run between the injection and its
+/// cleanup, and inlining it would put the `?` that skips the cleanup in the
+/// middle of the scenario.
+async fn quarantine_after_release(sandbox: &mut LeasedSandbox) -> anyhow::Result<()> {
+    sandbox.release().await?;
+
+    let deadline = Instant::now() + Duration::from_secs(300);
+    loop {
+        let (status, body) = sandbox.status().await?;
+        anyhow::ensure!(
+            status.as_u16() != 404,
+            "a lease whose teardown could not be proven was retired anyway"
+        );
+        match body["phase"].as_str() {
+            Some("Quarantined") => break,
+            // The failure this scenario exists to catch: capacity handed back
+            // on the strength of a teardown nothing confirmed.
+            Some(clean @ ("Released" | "Expired")) => anyhow::bail!(
+                "an unverifiable teardown reported {clean}, releasing capacity it could not prove free: {body}"
+            ),
+            _ => {}
+        }
+        anyhow::ensure!(
+            Instant::now() < deadline,
+            "an unverifiable teardown never settled either way: {body}"
+        );
+        tokio::time::sleep(Duration::from_secs(5)).await;
+    }
+
+    // Withheld, not merely marked. A quarantined lease that had dropped out of
+    // the caller's own listing would be holding a slot nobody can account for,
+    // which is the under-counting this phase exists to make visible.
+    let api = Api::as_caller(token());
+    let (_, listed) = api
+        .json(reqwest::Method::GET, "/v1/sandbox-leases", None)
+        .await?;
+    anyhow::ensure!(
+        listed.to_string().contains(&sandbox.id),
+        "a quarantined lease vanished from its holder's listing: {listed}"
+    );
+    Ok(())
+}
+
 #[cfg(test)]
 mod suite_shape {
     use super::*;
@@ -767,8 +1258,13 @@ mod suite_shape {
     #[test]
     fn no_scenario_is_declared_outside_the_dual_placement_macro() {
         let source = include_str!("sandbox_conformance.rs");
+        // Anchored to the start of a line. `"// Scenarios"` alone is also a
+        // substring of any doc comment beginning `/// Scenarios`, and writing
+        // one silently moved this marker forward — the guard then examined an
+        // empty span and reported an under-populated suite. A guard that can be
+        // relocated by prose is not a guard.
         let body = source
-            .split("// Scenarios")
+            .split("\n// Scenarios\n")
             .nth(1)
             .expect("the scenario section is marked");
         let scenarios = body.split("mod suite_shape").next().unwrap_or(body);
@@ -779,8 +1275,10 @@ mod suite_shape {
              which would run it against one placement only"
         );
         assert!(
-            scenarios.matches("both_placements!").count() >= 10,
-            "the #76 matrix expects at least ten dual-placement scenarios"
+            scenarios.matches("both_placements!").count() >= 17,
+            "the #76 matrix expects at least eleven dual-placement scenarios, plus the six \
+             #138 unlocked; a floor rather than an exact count, because the failure being \
+             guarded is deletion, not addition"
         );
     }
 }


### PR DESCRIPTION
Closes #138.

Three rows of #76's matrix needed the target **disturbed** rather than merely queried, and `hack/e2e.ts` could not do it. Writing those scenarios without the harness would have produced tests that cannot run — worse than not having them, because a skipped scenario reads as a passing one.

The suite still asserts nothing but the public HTTP contract. The disturbance lives on the other side of a process boundary, invoked through `KOBE_SANDBOX_HARNESS`. A suite able to break its own target could also mask a break it did not intend; one reaching into the cluster to check its work could pass while the API was broken.

## The three capabilities

**`restart-operator --wait-for-phase=<stage> --lease=<id>`** waits for one lease to reach a named point, restarts the operator Deployment, and returns only once it is *both serving and leading* again. `rollout status` and `/readyz` only prove the HTTP server is up, and it is up in every replica — the reconcilers run solely in whichever replica holds the `kobe-operator` Lease, acquired afterwards. Acting on the sooner signal drives a cluster whose controllers are not running yet.

Two stages #76 asks for are deliberately **absent**, with the reason in the code: `provisioning`, because nothing in production writes that phase, and `bootstrap`, because the template/warm-pool references on `status.target` are only ever copied from themselves. A stage backed by a marker nobody writes hangs to the timeout and reports a restart that never happened.

**`inject-failure` / `clear-failure`**. `--kind=teardown-unverifiable` revokes `get` on `sandboxclaims` and `clusterleases` — not `delete`. That distinction is the point: a revoked delete stalls in `Releasing` and retries forever, a clean failure; only a read the operator is not permitted to make is the durable uncertainty quarantine exists for. Because RBAC has no deny, a matching rule is **split** so its sibling resources keep every verb they had; a wildcard rule is refused rather than edited, since subtraction cannot narrow `*` and the injection would silently do nothing while reporting success. `--kind=child-api-unreachable` swaps a child API Service's selector for one nothing carries — deleting the StatefulSet would make teardown succeed for the wrong reason.

**`attach-pty`** drives `kobe sandbox attach` through a real terminal. The allocator is `python3 -c 'pty.spawn(...)'` and not the obvious `script(1)`: BSD `script` calls `tcgetattr` on its own stdin, and a harness necessarily feeds keystrokes through a pipe, so it dies with `tcgetattr/ioctl: Operation not supported on socket` before the command starts — observed, not assumed. util-linux tolerates it, so `script` would work in CI and fail on every maintainer's laptop, by producing no output, which is indistinguishable from the keystroke-delivery bug this exists to detect.

Plus **`reap-lease`**: quarantine is terminal, keeps consuming capacity on purpose, and has no exit through the API. Right product behaviour, wrong test behaviour — a scenario proving quarantine happens would starve every scenario after it.

## Six new dual-placement scenarios (twelve runs)

- a restart before readiness resumes the same composition — same claim UID, same Pod UID, same `readyAt`;
- a restart between a retry and its original still runs the command once, asserted through a side effect;
- a restart during teardown still settles the lease once, never quarantining one that had proof;
- an unverifiable teardown withholds capacity instead of releasing it;
- a keystroke typed on a real terminal reaches the workload — typed and expected text differ on purpose, because a pty echoes input;
- Ctrl-C reaches the workload rather than the client.

`both_placements!` now forwards leading attributes, so each carries a doc comment saying what breaks when it does not hold.

## Guard fixes

The suite-shape guard split on `"// Scenarios"`, which is also a substring of any doc comment starting `/// Scenarios`. Writing one silently moved the marker and the guard examined an empty span — it failed safe, but a guard relocatable by prose is not a guard. Now anchored to a line start, and mutation-checked. The scenario floor moved 10 → 17.

## Deliberately not written

No scenario uses `child-api-unreachable`. Severing a child API means nothing under management placement, so the scenario would be single-placement — the exact thing the guard prevents. The capability ships; a scenario for it needs a way to say "this placement only" that does not weaken the matrix.

## Verified / not verified

**Verified locally:** `bun test hack/e2e.test.ts` (17 pass), `--help`, every new subcommand's argument validation, and the pty machinery end to end against a stand-in for `kobe` — keystrokes delivered, Ctrl-C interrupting a running `sleep`, and the assertion failing when the marker never appears. `cargo fmt`, `cargo clippy --workspace --all-targets -- -D warnings`, and `cargo test --workspace` are clean; the suite-shape guards pass.

**Not verified:** every new scenario, and the harness's cluster-facing paths (rollout, leader wait, ClusterRole patch, Service severing, lease reaping). They need a live Kobe endpoint with both a management and a child pool, and none was available. They are `#[ignore]`d and will run for the first time on a real cluster.

## One thing found, and not fixed here

On this branch nothing in production writes `SandboxLeasePhase::Provisioning` or `status.provisioningDeadline` — the only caller of `begin_sandbox_provisioning` is a unit test. `mark_sandbox_ready` requires the deadline, and `transition_sandbox_phase` disallows `Pending → Ready`. A lease created through the HTTP API therefore appears unable to reach `Ready` at all, which would stall *every* scenario in this file at `wait_ready`, old and new. That is a controller change rather than a harness one, and worth its own issue.
