### PR TITLE
feat(sandbox): the runner contract that makes detached execution real

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2681,6 +2681,7 @@ dependencies = [
  "json-patch",
  "jsonwebtoken 9.3.1",
  "k8s-openapi",
+ "kobe-runner",
  "kube",
  "kunobi-auth",
  "kunobi-ha",
@@ -2719,6 +2720,17 @@ dependencies = [
  "uuid",
  "wiremock",
  "x509-parser",
+]
+
+[[package]]
+name = "kobe-runner"
+version = "0.39.1"
+dependencies = [
+ "base64 0.22.1",
+ "clap",
+ "libc",
+ "serde",
+ "serde_json",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # The thin CLI crate `kobectl` (binary `kobe`) is a separate member so it can
 # be published to crates.io with a slim dependency tree. The operator stays the
 # root package (it is the bulk of the code and what the container images build).
-members = ["crates/kobectl"]
+members = ["crates/kobectl", "crates/kobe-runner"]
 resolver = "3"
 
 # Single source of truth for the release version, shared by the operator and the
@@ -145,6 +145,12 @@ http = "1"
 
 libc = "0.2"
 regex = "1"
+
+# The wire contract with the in-container Sandbox runner (#82). A path
+# dependency on the runner crate rather than a second copy of the types: two
+# hand-maintained definitions of a wire format drift, and the drift shows up as
+# a MISREAD reply — a caller told their command succeeded because a field moved.
+kobe-runner = { path = "crates/kobe-runner" }
 
 [dev-dependencies]
 tokio-test = "0.4"

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -240,6 +240,24 @@ spec:
                       type: object
                     maxItems: 64
                     type: array
+                  runnerPath:
+                    description: |-
+                      Absolute path to `kobe-runner` inside `defaultContainer`, when the
+                      administrator's image ships one.
+
+                      Absent means this pool does not offer detached execution, and the API
+                      says so rather than approximating it. A detached execution that actually
+                      dies with its connection is worse than none, because the caller has
+                      already built on the guarantee it appeared to offer.
+
+                      A constrained path rather than free text: it becomes `argv[0]` of an
+                      exec, so anything that could carry an argument, a shell metacharacter or
+                      a nul is refused by the schema before it can reach one.
+                    maxLength: 255
+                    minLength: 1
+                    nullable: true
+                    pattern: ^/[A-Za-z0-9._/-]*$
+                    type: string
                 required:
                 - containers
                 - defaultContainer

--- a/crates/kobe-runner/Cargo.toml
+++ b/crates/kobe-runner/Cargo.toml
@@ -1,0 +1,25 @@
+[package]
+name = "kobe-runner"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license.workspace = true
+description = "Supervisor that runs one command inside a Kobe Sandbox and outlives the exec connection that started it"
+# Never published: the binary ships inside a Sandbox image, and the library
+# half exists only so Kobe and the runner cannot disagree about the wire
+# format. A published copy would be a second source of truth.
+publish = false
+
+[[bin]]
+name = "kobe-runner"
+path = "src/main.rs"
+
+[dependencies]
+# Deliberately tiny. This binary is copied into an administrator's Sandbox
+# image, so every dependency here is something a tenant's workload runs
+# alongside — and something that has to build for a static musl target.
+serde = { version = "1", features = ["derive"] }
+serde_json = "1"
+base64 = "0.22"
+clap = { version = "4", features = ["derive"] }
+libc = "0.2"

--- a/crates/kobe-runner/src/lib.rs
+++ b/crates/kobe-runner/src/lib.rs
@@ -1,0 +1,18 @@
+//! The Kobe Sandbox runner: one supervised command, and the contract Kobe
+//! drives it with (#82).
+//!
+//! # Why this is a library as well as a binary
+//!
+//! Kobe writes the requests and reads the replies; the runner does the reverse,
+//! from a different image built on a different day. Two hand-maintained copies
+//! of a wire format drift, and the drift shows up as a *misread* reply rather
+//! than a broken one — a caller told their command succeeded because a field
+//! moved. [`protocol`] is compiled into both halves so that cannot happen.
+//!
+//! The operator depends on this crate for [`protocol`] alone. Everything else
+//! here runs inside the Sandbox container.
+
+pub mod protocol;
+pub mod spool;
+#[cfg(unix)]
+pub mod supervisor;

--- a/crates/kobe-runner/src/main.rs
+++ b/crates/kobe-runner/src/main.rs
@@ -1,0 +1,473 @@
+//! `kobe-runner` — the supervisor Kobe drives inside a Sandbox container.
+//!
+//! # The whole interface
+//!
+//! ```text
+//! kobe-runner start                  # request on stdin, reply on stdout
+//! kobe-runner status --id ID
+//! kobe-runner logs   --id ID --stream stdout --offset N
+//! kobe-runner cancel --id ID
+//! ```
+//!
+//! Every invocation is a short-lived process started by one exec, prints
+//! exactly one JSON reply on stdout, and exits. Nothing here listens on a
+//! socket: a port would be reachable by the tenant's own workload, would need
+//! its own authentication, and would have to be declared by the pool before
+//! anybody could reach it. Exec is already fenced to one lease, one Pod UID and
+//! one container by the time Kobe gets here, and each call is re-authorised.
+//!
+//! # Why the request arrives on stdin
+//!
+//! An exec's argv is a URL. The target apiserver audit-logs it verbatim, and a
+//! tenant's command line routinely carries secrets. Only the execution id — a
+//! hash Kobe derived — ever appears as an argument; the command itself travels
+//! on stdin, which nothing on the path records. It is one line, so the runner
+//! never has to wait for an EOF that the exec transport may never deliver.
+
+use std::io::{BufRead, Read};
+
+use clap::{Parser, Subcommand};
+
+use kobe_runner::protocol::{
+    Envelope, ExecutionReport, LogStream, MAX_LOG_CHUNK_BYTES, MAX_RETENTION_BYTES,
+    MAX_TIMEOUT_SECONDS, PROTOCOL_VERSION, Reply, RunnerErrorCode, RunnerState, StartRequest,
+    is_valid_id,
+};
+use kobe_runner::spool::{self, Reservation, Spool, SpoolError};
+#[cfg(unix)]
+use kobe_runner::supervisor;
+
+/// Largest start request the runner will read.
+///
+/// The request arrives on a pipe from outside the container. Reading it
+/// unbounded would let whoever holds that pipe make the runner allocate without
+/// limit, inside the tenant's own memory cgroup.
+const MAX_REQUEST_BYTES: u64 = 64 * 1024;
+
+#[derive(Parser)]
+#[command(name = "kobe-runner", about = "Supervise one Kobe Sandbox execution")]
+struct Cli {
+    /// Where executions are spooled. Owned by the runner: Kobe never names a
+    /// path inside somebody else's container.
+    #[arg(long, default_value = spool::DEFAULT_STATE_DIR, global = true)]
+    state_dir: String,
+
+    #[command(subcommand)]
+    command: Commands,
+}
+
+#[derive(Subcommand)]
+enum Commands {
+    /// Reserve an id and supervise its command. The request is read from stdin.
+    Start,
+    /// Run the supervision loop. Started by `start`, never by Kobe.
+    #[command(hide = true)]
+    Supervise {
+        #[arg(long)]
+        id: String,
+    },
+    /// Report what one execution is doing.
+    Status {
+        #[arg(long)]
+        id: String,
+    },
+    /// Read one bounded window of one stream.
+    Logs {
+        #[arg(long)]
+        id: String,
+        #[arg(long)]
+        stream: String,
+        #[arg(long, default_value_t = 0)]
+        offset: u64,
+        #[arg(long, default_value_t = MAX_LOG_CHUNK_BYTES as u64)]
+        max_bytes: u64,
+    },
+    /// Terminate the execution's process group.
+    Cancel {
+        #[arg(long)]
+        id: String,
+    },
+}
+
+fn main() {
+    let cli = Cli::parse();
+    let spool = Spool::new(&cli.state_dir);
+
+    // `supervise` is the one subcommand that is not a request/response: it IS
+    // the long-lived process, and it prints nothing because nobody is reading.
+    if let Commands::Supervise { id } = &cli.command {
+        #[cfg(unix)]
+        supervisor::supervise(&spool, id);
+        return;
+    }
+
+    let reply = match &cli.command {
+        Commands::Start => start(&spool, &cli.state_dir),
+        Commands::Status { id } => status(&spool, id),
+        Commands::Logs {
+            id,
+            stream,
+            offset,
+            max_bytes,
+        } => logs(&spool, id, stream, *offset, *max_bytes),
+        Commands::Cancel { id } => cancel(&spool, id),
+        Commands::Supervise { .. } => unreachable!("handled above"),
+    };
+
+    // Exactly one document, on stdout, and nothing else — diagnostics go to
+    // stderr precisely so a stray line can never turn a reply into a parse
+    // failure that Kobe has to read as `Unknown`.
+    let failed = matches!(reply, Reply::Error { .. });
+    println!(
+        "{}",
+        serde_json::to_string(&Envelope::new(reply))
+            .unwrap_or_else(|_| r#"{"protocol":1,"reply":"error","code":"internal"}"#.into())
+    );
+    if failed {
+        // The reply is what Kobe decides on; this only makes a failure visible
+        // to a human running the binary by hand.
+        std::process::exit(1);
+    }
+}
+
+fn error(code: RunnerErrorCode) -> Reply {
+    Reply::Error { code }
+}
+
+/// Reserve an id and start supervising it.
+///
+/// Reservation happens before the supervisor exists, and the supervisor is
+/// spawned exactly once per reservation. A retry of the same request finds the
+/// reservation and reports it; it never spawns a second command.
+fn start(spool: &Spool, state_dir: &str) -> Reply {
+    // One line, not "until EOF". The request arrives over an exec connection
+    // whose write half Kobe cannot reliably half-close, so waiting for EOF is
+    // waiting for something that may never come — and the command would not
+    // start until the timeout fired. JSON never contains a raw newline, so a
+    // line IS the document.
+    let mut raw = Vec::new();
+    if std::io::BufReader::new(std::io::stdin().take(MAX_REQUEST_BYTES))
+        .read_until(b'\n', &mut raw)
+        .is_err()
+    {
+        return error(RunnerErrorCode::InvalidRequest);
+    }
+    let Ok(request) = serde_json::from_slice::<StartRequest>(&raw) else {
+        return error(RunnerErrorCode::InvalidRequest);
+    };
+    if let Err(code) = validate(&request) {
+        return error(code);
+    }
+
+    match spool.reserve(&request) {
+        Ok(Reservation::Created) => {
+            if spawn_supervisor(state_dir, &request.id).is_err() {
+                // Nothing was started, but this process cannot prove that to
+                // Kobe in a way it could distinguish from a lost reply — so the
+                // execution settles as the state that never invites a blind
+                // retry.
+                let _ = spool.write_report(&ExecutionReport {
+                    id: request.id.clone(),
+                    state: RunnerState::Unknown,
+                    finished_at_unix_ms: Some(spool::now_unix_ms()),
+                    reason: Some("supervisor_not_started".into()),
+                    ..Default::default()
+                });
+            }
+        }
+        Ok(Reservation::AlreadyReserved) => {}
+        Err(SpoolError::Conflict(_)) => return error(RunnerErrorCode::Conflict),
+        Err(_) => return error(RunnerErrorCode::Internal),
+    }
+
+    match reconcile(spool, &request.id) {
+        Ok(report) => Reply::Started { report },
+        Err(code) => error(code),
+    }
+}
+
+/// Refuse a request that could never run, before anything is reserved.
+///
+/// Each of these would otherwise become a reservation for a command that cannot
+/// exist — a record Kobe then has to reason about on every retry.
+fn validate(request: &StartRequest) -> Result<(), RunnerErrorCode> {
+    if request.protocol != PROTOCOL_VERSION {
+        // A Kobe from another protocol is refused rather than served on a
+        // best-effort basis: the fields it means are not necessarily the fields
+        // this binary reads.
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
+    if !is_valid_id(&request.id) {
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
+    if request.argv.is_empty() || request.argv.iter().any(String::is_empty) {
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
+    if request.argv.iter().any(|argument| argument.contains('\0')) {
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
+    if let Some(cwd) = &request.cwd {
+        // Validated here as well as in Kobe. `chdir` with an embedded nul
+        // truncates the path rather than failing, so a directory that is not
+        // the one anybody named would silently become the working directory.
+        if cwd.is_empty() || !cwd.starts_with('/') || cwd.contains('\0') {
+            return Err(RunnerErrorCode::InvalidRequest);
+        }
+    }
+    if request.timeout_seconds == 0 || request.timeout_seconds > MAX_TIMEOUT_SECONDS {
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
+    if request.max_output_bytes == 0 || request.max_output_bytes > MAX_RETENTION_BYTES {
+        // Unbounded retention inside a tenant's container is a way to fill the
+        // ephemeral disk the whole Pod shares.
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
+    Ok(())
+}
+
+/// Re-exec this binary as the supervisor, in a session of its own.
+///
+/// Re-exec rather than `fork`: forking a process that is about to allocate and
+/// spawn threads is a well-known way to inherit a broken heap, and there is
+/// nothing here that needs the parent's memory. The parent exits immediately
+/// afterwards, so the supervisor is reparented to the container's init and
+/// survives the teardown of the exec that started it — which is the entire
+/// reason "detached" means anything.
+#[cfg(unix)]
+fn spawn_supervisor(state_dir: &str, id: &str) -> std::io::Result<()> {
+    use std::os::unix::process::CommandExt;
+    use std::process::{Command, Stdio};
+
+    let executable = std::env::current_exe()?;
+    let mut command = Command::new(executable);
+    command
+        .arg("--state-dir")
+        .arg(state_dir)
+        .arg("supervise")
+        .arg("--id")
+        .arg(id)
+        // None of the exec's descriptors are inherited. A supervisor still
+        // holding the exec's stdout would keep the connection's pipe open, and
+        // the caller's client would wait for a stream that nobody is going to
+        // close.
+        .stdin(Stdio::null())
+        .stdout(Stdio::null())
+        .stderr(Stdio::null());
+
+    // SAFETY: `setsid` is async-signal-safe and is the only call between fork
+    // and exec. It detaches the supervisor from this process's session, so the
+    // kubelet tearing down the exec cannot signal it.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    let child = command.spawn()?;
+    // Recorded so a later `status` or `cancel` can tell "still running" from
+    // "the supervisor is gone and nobody will ever record an outcome".
+    let _ = Spool::new(state_dir).write_supervisor_pid(id, child.id());
+    Ok(())
+}
+
+#[cfg(not(unix))]
+fn spawn_supervisor(_state_dir: &str, _id: &str) -> std::io::Result<()> {
+    Err(std::io::Error::other("the runner supervises only on unix"))
+}
+
+fn status(spool: &Spool, id: &str) -> Reply {
+    match reconcile(spool, id) {
+        Ok(report) => Reply::State { report },
+        Err(code) => error(code),
+    }
+}
+
+/// Report one execution, settling it if nobody is left to.
+///
+/// A supervisor that died — OOM-killed, or taken with the container's other
+/// processes — leaves a report that says `Running` forever. Kobe's own verdict
+/// deadline would eventually call that `Unknown`, but only minutes later; the
+/// runner can see the supervisor is gone right now, and an `Unknown` a caller
+/// can act on immediately is worth more than the same answer after a timeout.
+///
+/// Liveness is a pid check, which a recycled pid can defeat. It errs towards
+/// "still running": the failure is a delayed `Unknown` from Kobe's deadline
+/// rather than a premature one here.
+fn reconcile(spool: &Spool, id: &str) -> Result<ExecutionReport, RunnerErrorCode> {
+    let report = spool.read_report(id).map_err(map_error)?;
+    if report.state.is_terminal() {
+        return Ok(report);
+    }
+    if supervisor_alive(spool, id) {
+        return Ok(report);
+    }
+
+    let settled = ExecutionReport {
+        state: RunnerState::Unknown,
+        finished_at_unix_ms: Some(spool::now_unix_ms()),
+        reason: Some("supervisor_lost".into()),
+        ..report
+    };
+    let _ = spool.write_report(&settled);
+    Ok(settled)
+}
+
+#[cfg(unix)]
+fn supervisor_alive(spool: &Spool, id: &str) -> bool {
+    let Some(pid) = spool.read_supervisor_pid(id) else {
+        // No pid recorded yet: `start` writes it immediately after spawning, so
+        // the window is a few microseconds wide. Treating it as alive costs a
+        // poll; treating it as dead would settle a command that is running.
+        return true;
+    };
+    // SAFETY: signal 0 performs the permission and existence checks without
+    // delivering anything.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+#[cfg(not(unix))]
+fn supervisor_alive(_spool: &Spool, _id: &str) -> bool {
+    true
+}
+
+fn logs(spool: &Spool, id: &str, stream: &str, offset: u64, max_bytes: u64) -> Reply {
+    let Ok(stream) = stream.parse::<LogStream>() else {
+        return error(RunnerErrorCode::InvalidRequest);
+    };
+    // Clamped rather than refused: a caller asking for more than one response
+    // may carry wants as much as they can have, and failing the request teaches
+    // them to retry in a loop.
+    let max_bytes = max_bytes.clamp(1, MAX_LOG_CHUNK_BYTES as u64) as usize;
+
+    match spool.read_chunk(id, stream, offset, max_bytes) {
+        Ok(chunk) => Reply::Logs {
+            chunk: Box::new(chunk),
+        },
+        Err(error_) => error(map_error(error_)),
+    }
+}
+
+/// Terminate one execution's process group and report where it ended up.
+///
+/// The kill is asked for, not performed here: this process knows the command's
+/// pid only from a file, and signalling a pid it did not reap races with the
+/// kernel reusing that number for something else in the same container. The
+/// supervisor holds the child, so only the supervisor can know the pid still
+/// means what it meant.
+fn cancel(spool: &Spool, id: &str) -> Reply {
+    let report = match reconcile(spool, id) {
+        Ok(report) => report,
+        Err(code) => return error(code),
+    };
+    // A settled execution is not re-opened: every answer already given about it
+    // would otherwise become provisional.
+    if report.state.is_terminal() {
+        return Reply::State { report };
+    }
+    if let Err(error_) = spool.request_cancel(id) {
+        return error(map_error(error_));
+    }
+
+    // Bounded wait for the supervisor to act, so the caller usually gets the
+    // terminal state in the same response. Timing out here is not a failure —
+    // the marker is durable, and the next poll will see the outcome.
+    let deadline = std::time::Instant::now() + std::time::Duration::from_secs(3);
+    while std::time::Instant::now() < deadline {
+        match spool.read_report(id) {
+            Ok(report) if report.state.is_terminal() => return Reply::State { report },
+            Ok(_) => {}
+            Err(error_) => return error(map_error(error_)),
+        }
+        std::thread::sleep(std::time::Duration::from_millis(50));
+    }
+    match spool.read_report(id) {
+        Ok(report) => Reply::State { report },
+        Err(error_) => error(map_error(error_)),
+    }
+}
+
+fn map_error(error: SpoolError) -> RunnerErrorCode {
+    match error {
+        SpoolError::NotFound => RunnerErrorCode::NotFound,
+        SpoolError::Conflict(_) => RunnerErrorCode::Conflict,
+        SpoolError::Corrupt | SpoolError::Io(_) => RunnerErrorCode::Internal,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn request() -> StartRequest {
+        StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: "sbxe-1".into(),
+            argv: vec!["/agent".into(), "run".into()],
+            cwd: Some("/work".into()),
+            timeout_seconds: 60,
+            max_output_bytes: 1024,
+        }
+    }
+
+    /// A request that could never run is refused before anything is reserved.
+    ///
+    /// A reservation for an unrunnable command is worse than a rejection: Kobe
+    /// has already recorded the id, so the caller cannot reuse it, and every
+    /// retry has to reason about a record that describes nothing.
+    #[test]
+    fn an_unrunnable_request_reserves_nothing() {
+        assert!(validate(&request()).is_ok());
+
+        let with = |mutate: &dyn Fn(&mut StartRequest)| {
+            let mut request = request();
+            mutate(&mut request);
+            validate(&request)
+        };
+
+        // A peer speaking another protocol is refused, never served on a
+        // best-effort basis.
+        assert!(with(&|r| r.protocol = PROTOCOL_VERSION + 1).is_err());
+        assert!(with(&|r| r.protocol = 0).is_err());
+
+        assert!(with(&|r| r.argv = vec![]).is_err());
+        assert!(with(&|r| r.argv = vec![String::new()]).is_err());
+        assert!(with(&|r| r.argv = vec!["/bin/sh".into(), "\0".into()]).is_err());
+        assert!(with(&|r| r.id = "../escape".into()).is_err());
+
+        for bad in ["", "work", "./work", "/work\0/etc"] {
+            assert!(
+                with(&|r| r.cwd = Some(bad.to_string())).is_err(),
+                "cwd {bad:?} must be refused"
+            );
+        }
+        assert!(with(&|r| r.cwd = None).is_ok());
+    }
+
+    /// Neither bound may be absent, and neither may be unbounded.
+    ///
+    /// A zero timeout is a command that can never finish successfully; an
+    /// unbounded one holds a lease's CPU until teardown. An unbounded retention
+    /// cap fills the ephemeral disk the whole Pod shares — from inside a
+    /// container that exists because its occupant is not trusted.
+    #[test]
+    fn a_command_is_bounded_in_time_and_in_output() {
+        let with = |timeout: u64, output: u64| {
+            let mut request = request();
+            request.timeout_seconds = timeout;
+            request.max_output_bytes = output;
+            validate(&request)
+        };
+
+        assert!(with(1, 1).is_ok());
+        assert!(with(MAX_TIMEOUT_SECONDS, MAX_RETENTION_BYTES).is_ok());
+
+        assert!(with(0, 1024).is_err());
+        assert!(with(MAX_TIMEOUT_SECONDS + 1, 1024).is_err());
+        assert!(with(u64::MAX, 1024).is_err());
+        assert!(with(60, 0).is_err());
+        assert!(with(60, MAX_RETENTION_BYTES + 1).is_err());
+        assert!(with(60, u64::MAX).is_err());
+    }
+}

--- a/crates/kobe-runner/src/protocol.rs
+++ b/crates/kobe-runner/src/protocol.rs
@@ -1,0 +1,466 @@
+//! The wire contract between Kobe and the runner (#82).
+//!
+//! # Why this lives in a crate both sides compile
+//!
+//! Kobe writes these structures and the runner reads them, in different
+//! processes, in different images, released on different schedules. Two
+//! hand-maintained copies of a wire format drift, and the drift shows up as a
+//! *misread* reply rather than a broken one — a caller told their command
+//! succeeded because a field moved. One definition, compiled into both halves,
+//! is what makes that impossible.
+//!
+//! # Why every reply carries a version
+//!
+//! A Sandbox image is built by an administrator and can be months older than
+//! the Kobe that talks to it. A reply from an unrecognised protocol is refused
+//! outright rather than parsed on a best-effort basis: guessing at an older
+//! shape is how "running" gets read as "succeeded".
+//!
+//! # Why there is no protocol for "the output"
+//!
+//! Output is fetched in bounded chunks by offset, never returned whole. The
+//! runner holds a tenant's output on the tenant's own disk, and Kobe reads as
+//! much of it as one response may carry. An "all of it" verb would make the
+//! operator's memory a function of what somebody else's command printed.
+
+use serde::{Deserialize, Serialize};
+
+/// The version both sides must agree on.
+///
+/// Bumped only for a change that an older peer would MISREAD — a removed
+/// field, a re-used name with new meaning. Additive optional fields do not bump
+/// it, because an older peer ignoring a field it never knew about is safe.
+pub const PROTOCOL_VERSION: u32 = 1;
+
+/// Longest an execution id may be, and the only shape one may take.
+///
+/// The id becomes a directory name under the spool root, so anything that can
+/// traverse — `..`, a slash, a nul — is refused before it is ever joined onto a
+/// path. Kobe's ids are `sbxe-<hex>` and fit comfortably.
+pub const MAX_ID_LEN: usize = 64;
+
+/// Longest a supervised command may be allowed to run.
+///
+/// Matches Kobe's own ceiling. Enforced on both sides because they fail
+/// differently: Kobe's bound protects the lease, and the runner's protects a
+/// container from a supervisor that outlives whatever asked for it.
+pub const MAX_TIMEOUT_SECONDS: u64 = 3600;
+
+/// Most output the runner retains, per stream.
+///
+/// The spool is on the ephemeral disk the whole Pod shares, and the caller
+/// chooses what they run, so they choose how much it prints. Past this, output
+/// is discarded and the discarding is reported.
+pub const MAX_RETENTION_BYTES: u64 = 8 * 1024 * 1024;
+
+/// Most output one log reply may carry.
+///
+/// A window rather than a file: the reply crosses an exec connection and is
+/// buffered by the operator, so its size must be a Kobe decision rather than a
+/// consequence of how much somebody's command printed.
+pub const MAX_LOG_CHUNK_BYTES: usize = 256 * 1024;
+
+/// Whether an id may name a spool directory.
+///
+/// Restrictive on purpose: a permissive check here is a path traversal with
+/// extra steps, and the runner runs inside the tenant's own container where
+/// escaping the spool means writing anywhere the workload can.
+pub fn is_valid_id(id: &str) -> bool {
+    !id.is_empty()
+        && id.len() <= MAX_ID_LEN
+        && id
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte.is_ascii_digit() || byte == b'-')
+}
+
+/// One command, as Kobe asks for it.
+///
+/// Sent on the runner's **stdin**, never as command-line arguments. A tenant's
+/// argv routinely carries secrets — a token in a flag, a connection string in
+/// an argument — and the exec request's argv is a URL that the target
+/// apiserver's audit log records verbatim. stdin is the only channel into the
+/// container that nothing on the way logs.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct StartRequest {
+    pub protocol: u32,
+    /// Kobe's own execution id. The runner treats it as an opaque key and
+    /// never as a path fragment until [`is_valid_id`] has accepted it.
+    pub id: String,
+    /// Executed directly. There is no shell anywhere in this contract: a shell
+    /// would make quoting the security boundary, and the boundary is a tenant's
+    /// own untrusted input.
+    pub argv: Vec<String>,
+    /// Applied with `chdir`, never with `cd X && ...`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub cwd: Option<String>,
+    /// Wall-clock bound the runner enforces on its own, so a command outlives
+    /// neither the connection that started it nor its lease.
+    pub timeout_seconds: u64,
+    /// Per-stream retention cap. Output past it is discarded and the fact is
+    /// reported — never silently dropped.
+    pub max_output_bytes: u64,
+}
+
+impl StartRequest {
+    /// Whether two requests are the same command.
+    ///
+    /// Compares everything that changes what runs, and deliberately excludes
+    /// the id — a retry of the same request carries the same id anyway, and
+    /// including it would make this a tautology.
+    pub fn same_command(&self, other: &Self) -> bool {
+        self.argv == other.argv
+            && self.cwd == other.cwd
+            && self.timeout_seconds == other.timeout_seconds
+            && self.max_output_bytes == other.max_output_bytes
+    }
+}
+
+/// Where one supervised command is.
+///
+/// Deliberately smaller than Kobe's own state machine: the runner reports only
+/// what it observed, and Kobe maps that onto the record a caller reads.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub enum RunnerState {
+    Running,
+    /// Exited zero.
+    Succeeded,
+    /// Ran and exited non-zero, or was killed by something other than the
+    /// runner. Emphatically not an infrastructure fault.
+    Failed,
+    /// The runner terminated the process group because Kobe asked it to.
+    Cancelled,
+    /// The runner terminated the process group because its own bound elapsed.
+    TimedOut,
+    /// The runner cannot establish what happened. Never `Failed`, which invites
+    /// a retry of something that may have run; never `Succeeded`, which would
+    /// be a lie. Also the default, so a report that lost its state says so
+    /// rather than asserting an outcome nobody observed.
+    #[default]
+    Unknown,
+}
+
+impl RunnerState {
+    pub fn is_terminal(self) -> bool {
+        !matches!(self, Self::Running)
+    }
+}
+
+/// Everything the runner knows about one execution.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub struct ExecutionReport {
+    pub id: String,
+    /// Absent means `Unknown`: a report that lost its state must not be able to
+    /// assert an outcome by omission.
+    #[serde(default)]
+    pub state: RunnerState,
+    /// The process's exact exit code. Absent unless it actually exited — a
+    /// synthesised zero would be indistinguishable from a real success.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub exit_code: Option<i32>,
+    /// The signal that killed it, when one did. Carried separately from
+    /// `exitCode` so a death by SIGKILL can never be mistaken for a command
+    /// that chose to exit 137.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub signal: Option<i32>,
+    /// Milliseconds since the Unix epoch. Not a formatted timestamp: the runner
+    /// has no timezone database and no business owning a date format.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub started_at_unix_ms: Option<u64>,
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub finished_at_unix_ms: Option<u64>,
+    /// A short code from a closed set. Never a message, never any part of the
+    /// command's own output — this value is the one thing from the runner that
+    /// Kobe persists.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub reason: Option<String>,
+    /// Whether stdout hit the retention cap. Reported rather than silently
+    /// applied: a caller parsing partial output as complete is how a cap
+    /// becomes a wrong answer instead of an obvious one.
+    #[serde(default)]
+    pub stdout_truncated: bool,
+    #[serde(default)]
+    pub stderr_truncated: bool,
+}
+
+/// Which stream a log read addresses.
+///
+/// Separate, always. A caller that cannot tell a tool's diagnostics from its
+/// output cannot reliably parse either.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub enum LogStream {
+    Stdout,
+    Stderr,
+}
+
+impl LogStream {
+    pub fn file_name(self) -> &'static str {
+        match self {
+            Self::Stdout => "stdout.log",
+            Self::Stderr => "stderr.log",
+        }
+    }
+}
+
+impl std::str::FromStr for LogStream {
+    type Err = ();
+
+    fn from_str(value: &str) -> Result<Self, Self::Err> {
+        match value {
+            "stdout" => Ok(Self::Stdout),
+            "stderr" => Ok(Self::Stderr),
+            _ => Err(()),
+        }
+    }
+}
+
+/// One bounded window of one stream.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
+pub struct LogChunk {
+    pub id: String,
+    pub stream: LogStream,
+    /// Byte offset this window starts at.
+    pub offset: u64,
+    /// Where the next read should start. A caller that polls with this value
+    /// gets each byte exactly once, which is what makes tailing a detached
+    /// execution reconnectable at all.
+    pub next_offset: u64,
+    /// Base64, so exact bytes survive the JSON. A command's output is arbitrary
+    /// bytes, and a lossy conversion at this layer would corrupt output that a
+    /// later, larger read would have shown correctly.
+    pub data_base64: String,
+    /// Whether the RUNNER dropped output at the retention cap. Distinct from
+    /// `more`: this one is unrecoverable.
+    pub truncated: bool,
+    /// Whether bytes are already waiting past `next_offset`.
+    pub more: bool,
+}
+
+/// Why a request could not be served.
+///
+/// A closed set, because Kobe persists the code and a free-form message from
+/// inside a tenant's container is not something that should reach an operator's
+/// records.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "snake_case")]
+pub enum RunnerErrorCode {
+    /// No such execution in this container.
+    NotFound,
+    /// The id is taken by a different command.
+    Conflict,
+    /// The request itself is not runnable.
+    InvalidRequest,
+    /// The runner failed at something that is its own job.
+    Internal,
+}
+
+/// One reply. Exactly one JSON document, on stdout, and nothing else.
+///
+/// The runner writes diagnostics to stderr precisely so that stdout stays a
+/// single parseable document: a stray line printed by a library would otherwise
+/// turn every reply into a parse failure.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase", tag = "reply")]
+pub enum Reply {
+    /// The command is now supervised. Returned by `start`, including when
+    /// `start` found the id already reserved by the identical request.
+    Started {
+        report: ExecutionReport,
+    },
+    /// A poll.
+    State {
+        report: ExecutionReport,
+    },
+    Logs {
+        chunk: Box<LogChunk>,
+    },
+    Error {
+        code: RunnerErrorCode,
+    },
+}
+
+/// A reply with the version that decides whether it may be read at all.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct Envelope {
+    pub protocol: u32,
+    #[serde(flatten)]
+    pub reply: Reply,
+}
+
+impl Envelope {
+    pub fn new(reply: Reply) -> Self {
+        Self {
+            protocol: PROTOCOL_VERSION,
+            reply,
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// An id can never name anything outside the spool.
+    ///
+    /// The id is joined onto a path inside the tenant's own container. A
+    /// permissive check here is a path traversal with extra steps: `..` would
+    /// let one execution read or overwrite another's state, and a slash would
+    /// let it write anywhere the workload can.
+    #[test]
+    fn an_execution_id_can_never_escape_the_spool_directory() {
+        assert!(is_valid_id("sbxe-0123456789abcdef"));
+        assert!(is_valid_id("a"));
+        assert!(is_valid_id(&"a".repeat(MAX_ID_LEN)));
+
+        for hostile in [
+            "",
+            "..",
+            "../etc",
+            "a/b",
+            "a\\b",
+            "a\0b",
+            "A",
+            "a b",
+            ".",
+            "a.b",
+            "~",
+            "$HOME",
+            &"a".repeat(MAX_ID_LEN + 1),
+        ] {
+            assert!(!is_valid_id(hostile), "id {hostile:?} must be refused");
+        }
+    }
+
+    /// A reply from a protocol nobody agreed on is refused, not guessed at.
+    ///
+    /// A Sandbox image can be months older than the Kobe talking to it.
+    /// Best-effort parsing of an unrecognised shape is how "running" ends up
+    /// being read as "succeeded".
+    #[test]
+    fn a_reply_carries_the_version_that_decides_whether_it_may_be_read() {
+        let envelope = Envelope::new(Reply::State {
+            report: ExecutionReport {
+                id: "sbxe-1".into(),
+                state: RunnerState::Running,
+                ..Default::default()
+            },
+        });
+        let encoded = serde_json::to_string(&envelope).unwrap();
+        assert!(
+            encoded.contains("\"protocol\":1"),
+            "every reply must state its protocol: {encoded}"
+        );
+
+        let decoded: Envelope = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, envelope);
+        assert_eq!(decoded.protocol, PROTOCOL_VERSION);
+    }
+
+    /// A report that lost its state says so, rather than asserting an outcome.
+    ///
+    /// A truncated or corrupt state file is exactly the case where a default of
+    /// `Succeeded` — or even `Failed` — would put a claim in front of a caller
+    /// that nothing ever observed.
+    #[test]
+    fn a_report_with_no_readable_state_is_unknown() {
+        assert_eq!(RunnerState::default(), RunnerState::Unknown);
+        let report: ExecutionReport = serde_json::from_str(r#"{"id":"sbxe-1"}"#).unwrap();
+        assert_eq!(report.state, RunnerState::Unknown);
+        assert_eq!(report.exit_code, None);
+    }
+
+    /// Two requests are the same command only if everything that changes what
+    /// runs agrees.
+    ///
+    /// This is the runner's half of idempotency: it is what stops a second
+    /// `start` under one id from launching a different command inside a
+    /// container Kobe has already recorded as busy with the first.
+    #[test]
+    fn two_requests_are_the_same_command_only_if_every_input_agrees() {
+        let base = StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: "sbxe-1".into(),
+            argv: vec!["/agent".into(), "run".into()],
+            cwd: Some("/work".into()),
+            timeout_seconds: 60,
+            max_output_bytes: 1024,
+        };
+        assert!(base.same_command(&base.clone()));
+
+        // The id is not part of the comparison: a retry carries the same one,
+        // so including it would make this check a tautology.
+        let mut renamed = base.clone();
+        renamed.id = "sbxe-2".into();
+        assert!(base.same_command(&renamed));
+
+        for mutate in [
+            (|r: &mut StartRequest| r.argv = vec!["/agent".into()]) as fn(&mut StartRequest),
+            |r: &mut StartRequest| r.argv.push("--force".into()),
+            |r: &mut StartRequest| r.cwd = None,
+            |r: &mut StartRequest| r.cwd = Some("/other".into()),
+            |r: &mut StartRequest| r.timeout_seconds = 61,
+            |r: &mut StartRequest| r.max_output_bytes = 2048,
+        ] {
+            let mut other = base.clone();
+            mutate(&mut other);
+            assert!(
+                !base.same_command(&other),
+                "{other:?} must not count as the same command"
+            );
+        }
+    }
+
+    /// stdout and stderr never share a file.
+    ///
+    /// Merging them is the one irreversible mistake in output capture: a caller
+    /// that cannot separate a tool's diagnostics from its output cannot
+    /// reliably parse either, and nothing downstream can undo the interleave.
+    #[test]
+    fn the_two_streams_are_never_stored_together() {
+        assert_ne!(
+            LogStream::Stdout.file_name(),
+            LogStream::Stderr.file_name(),
+            "the streams must not share a file"
+        );
+        assert_eq!("stdout".parse(), Ok(LogStream::Stdout));
+        assert_eq!("stderr".parse(), Ok(LogStream::Stderr));
+        assert_eq!("".parse::<LogStream>(), Err(()));
+        assert_eq!("both".parse::<LogStream>(), Err(()));
+    }
+
+    /// A start request is never expressible as command-line arguments.
+    ///
+    /// The tenant's argv travels on stdin because the exec request's own argv
+    /// is a URL the target apiserver audit-logs verbatim. If this type ever
+    /// grew a `Display`/`to_argv`, that guarantee would quietly become
+    /// optional.
+    #[test]
+    fn a_start_request_is_serialised_as_one_json_document() {
+        let request = StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: "sbxe-1".into(),
+            argv: vec!["/agent".into(), "--token".into(), "s3cret".into()],
+            cwd: None,
+            timeout_seconds: 5,
+            max_output_bytes: 16,
+        };
+        let encoded = serde_json::to_string(&request).unwrap();
+        let decoded: StartRequest = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded, request);
+
+        // Unknown fields are refused rather than ignored: a newer Kobe sending
+        // a field this runner does not implement must fail loudly, not run the
+        // command with the field silently dropped.
+        assert!(
+            serde_json::from_str::<StartRequest>(
+                r#"{"protocol":1,"id":"a","argv":["x"],"timeoutSeconds":1,"maxOutputBytes":1,"env":{"A":"B"}}"#
+            )
+            .is_err(),
+            "an unrecognised field must not be ignored"
+        );
+    }
+}

--- a/crates/kobe-runner/src/spool.rs
+++ b/crates/kobe-runner/src/spool.rs
@@ -1,0 +1,566 @@
+//! The runner's durable half: one directory per execution.
+//!
+//! # Why a directory, created by `rename`
+//!
+//! Reserving an execution has to be atomic against a second `start` for the
+//! same id — Kobe retries, and a retry that arrives while the first is still
+//! writing must not be able to observe a half-built reservation and conclude
+//! there is none. So the directory is assembled somewhere else and moved into
+//! place in one step: after the `rename` it is complete, and before it there is
+//! nothing to find.
+//!
+//! `rename` onto an existing directory fails rather than replacing it, which is
+//! exactly the mutual exclusion this needs. A `create_dir` followed by writes
+//! would leave a window where the directory exists and its request does not,
+//! and the loser of that race would have to guess.
+//!
+//! # Why the spool is ephemeral
+//!
+//! It lives on the container's own filesystem and dies with the Sandbox. #82
+//! ends history with the lease: output that outlived its Pod would describe a
+//! workload nobody can inspect, from a filesystem nobody is cleaning up.
+
+use std::io::{Read, Seek, SeekFrom};
+use std::path::{Path, PathBuf};
+
+use crate::protocol::{ExecutionReport, LogChunk, LogStream, StartRequest, is_valid_id};
+
+/// Where executions live when nobody says otherwise.
+///
+/// Under `/var/run` because it must not survive the container: retaining a
+/// tenant's output past the Sandbox is the one thing #82 explicitly does not
+/// offer.
+pub const DEFAULT_STATE_DIR: &str = "/var/run/kobe/executions";
+
+const REQUEST_FILE: &str = "request.json";
+const STATE_FILE: &str = "state.json";
+const CANCEL_FILE: &str = "cancel";
+const SUPERVISOR_PID_FILE: &str = "supervisor.pid";
+
+#[derive(Debug)]
+pub enum SpoolError {
+    NotFound,
+    /// The id is taken by a different command.
+    Conflict(Box<StartRequest>),
+    Io(std::io::Error),
+    /// A file exists but does not parse. Distinct from `NotFound`, because the
+    /// honest answer to "what happened" differs: absent means never started,
+    /// corrupt means nobody can say.
+    Corrupt,
+}
+
+impl From<std::io::Error> for SpoolError {
+    fn from(error: std::io::Error) -> Self {
+        Self::Io(error)
+    }
+}
+
+/// The outcome of reserving one id.
+pub enum Reservation {
+    /// This call created it. It may now spawn a supervisor — and nothing else
+    /// will.
+    Created,
+    /// The identical request already reserved it. Report what it is doing;
+    /// spawn nothing.
+    AlreadyReserved,
+}
+
+pub struct Spool {
+    root: PathBuf,
+}
+
+impl Spool {
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// The directory one execution owns.
+    ///
+    /// Every caller goes through here, and every caller has had the id
+    /// validated first — the runner writes inside a tenant's container, where
+    /// an id that escapes the spool can overwrite anything the workload can.
+    fn dir(&self, id: &str) -> Result<PathBuf, SpoolError> {
+        if !is_valid_id(id) {
+            return Err(SpoolError::NotFound);
+        }
+        Ok(self.root.join(id))
+    }
+
+    /// Reserve one id, atomically, before anything is spawned.
+    ///
+    /// The same request twice is a retry and reserves nothing new. A different
+    /// request under the same id is a conflict rather than a second execution:
+    /// silently running it would give the caller two commands where they asked
+    /// for one.
+    pub fn reserve(&self, request: &StartRequest) -> Result<Reservation, SpoolError> {
+        let target = self.dir(&request.id)?;
+        std::fs::create_dir_all(&self.root)?;
+
+        // Assembled out of the way, then moved in one step. A directory that
+        // appeared before its request.json would let a concurrent `start`
+        // observe a reservation it cannot read.
+        let staging = self
+            .root
+            .join(format!(".staging-{}-{}", std::process::id(), now_unix_ms()));
+        // A leftover staging directory from a killed `start` must not fail the
+        // next one.
+        let _ = std::fs::remove_dir_all(&staging);
+        std::fs::create_dir_all(&staging)?;
+
+        let assemble = || -> Result<(), SpoolError> {
+            std::fs::write(
+                staging.join(REQUEST_FILE),
+                serde_json::to_vec(request).map_err(|_| SpoolError::Corrupt)?,
+            )?;
+            // Written before the supervisor exists, so a poll that arrives
+            // between the reservation and the spawn finds a state rather than
+            // an empty directory it would have to interpret.
+            std::fs::write(
+                staging.join(STATE_FILE),
+                serde_json::to_vec(&ExecutionReport {
+                    id: request.id.clone(),
+                    state: crate::protocol::RunnerState::Running,
+                    started_at_unix_ms: Some(now_unix_ms()),
+                    ..Default::default()
+                })
+                .map_err(|_| SpoolError::Corrupt)?,
+            )?;
+            std::fs::File::create(staging.join(LogStream::Stdout.file_name()))?;
+            std::fs::File::create(staging.join(LogStream::Stderr.file_name()))?;
+            Ok(())
+        };
+        if let Err(error) = assemble() {
+            let _ = std::fs::remove_dir_all(&staging);
+            return Err(error);
+        }
+
+        match std::fs::rename(&staging, &target) {
+            Ok(()) => Ok(Reservation::Created),
+            Err(_) => {
+                // Somebody reserved it first — possibly this same caller
+                // retrying. The existing request decides, never the clock.
+                let _ = std::fs::remove_dir_all(&staging);
+                let existing = self.read_request(&request.id)?;
+                if existing.same_command(request) {
+                    Ok(Reservation::AlreadyReserved)
+                } else {
+                    Err(SpoolError::Conflict(Box::new(existing)))
+                }
+            }
+        }
+    }
+
+    pub fn read_request(&self, id: &str) -> Result<StartRequest, SpoolError> {
+        let path = self.dir(id)?.join(REQUEST_FILE);
+        let bytes = read_existing(&path)?;
+        serde_json::from_slice(&bytes).map_err(|_| SpoolError::Corrupt)
+    }
+
+    pub fn read_report(&self, id: &str) -> Result<ExecutionReport, SpoolError> {
+        let path = self.dir(id)?.join(STATE_FILE);
+        let bytes = read_existing(&path)?;
+        serde_json::from_slice(&bytes).map_err(|_| SpoolError::Corrupt)
+    }
+
+    /// Replace the report, atomically.
+    ///
+    /// Written to a temporary file and renamed, because a poll can arrive at
+    /// any instant: a reader that caught a partial write would parse a
+    /// truncated document, and a report that does not parse is one nobody can
+    /// act on.
+    pub fn write_report(&self, report: &ExecutionReport) -> Result<(), SpoolError> {
+        let dir = self.dir(&report.id)?;
+        let temporary = dir.join(".state.json.tmp");
+        std::fs::write(
+            &temporary,
+            serde_json::to_vec(report).map_err(|_| SpoolError::Corrupt)?,
+        )?;
+        std::fs::rename(&temporary, dir.join(STATE_FILE))?;
+        Ok(())
+    }
+
+    /// Ask the supervisor to terminate the process group.
+    ///
+    /// A marker file rather than a signal from this process, and that is the
+    /// whole point: `cancel` runs in a short-lived process that knows a pid
+    /// only from a file it read. Signalling that pid directly races with the
+    /// process exiting and the kernel reusing the number — killing whatever now
+    /// holds it, inside a container where that could be the tenant's agent. The
+    /// supervisor has not reaped its child, so only the supervisor can know the
+    /// pid still means what it meant.
+    pub fn request_cancel(&self, id: &str) -> Result<(), SpoolError> {
+        let dir = self.dir(id)?;
+        if !dir.join(STATE_FILE).exists() {
+            return Err(SpoolError::NotFound);
+        }
+        std::fs::write(dir.join(CANCEL_FILE), b"1")?;
+        Ok(())
+    }
+
+    pub fn cancel_requested(&self, id: &str) -> bool {
+        self.dir(id)
+            .map(|dir| dir.join(CANCEL_FILE).exists())
+            .unwrap_or(false)
+    }
+
+    /// Record which process is supervising this execution.
+    ///
+    /// Kept out of the protocol: a pid is a fact about the inside of somebody
+    /// else's container, and Kobe has no use for one. It exists so a later
+    /// `status` can tell "still running" from "the supervisor is gone and
+    /// nobody will ever record an outcome".
+    pub fn write_supervisor_pid(&self, id: &str, pid: u32) -> Result<(), SpoolError> {
+        std::fs::write(self.dir(id)?.join(SUPERVISOR_PID_FILE), pid.to_string())?;
+        Ok(())
+    }
+
+    pub fn read_supervisor_pid(&self, id: &str) -> Option<i32> {
+        let path = self.dir(id).ok()?.join(SUPERVISOR_PID_FILE);
+        std::fs::read_to_string(path).ok()?.trim().parse().ok()
+    }
+
+    pub fn stream_path(&self, id: &str, stream: LogStream) -> Result<PathBuf, SpoolError> {
+        Ok(self.dir(id)?.join(stream.file_name()))
+    }
+
+    /// Read one bounded window of one stream.
+    ///
+    /// By offset, so a caller polling a detached execution sees every byte
+    /// exactly once and can resume after a disconnect — the property that makes
+    /// detached output reconnectable rather than merely present.
+    pub fn read_chunk(
+        &self,
+        id: &str,
+        stream: LogStream,
+        offset: u64,
+        max_bytes: usize,
+    ) -> Result<LogChunk, SpoolError> {
+        use base64::Engine;
+
+        // The report is the authority on truncation: the file's own length
+        // cannot distinguish "the command printed exactly this much" from "the
+        // runner stopped writing here".
+        let report = self.read_report(id)?;
+        let path = self.stream_path(id, stream)?;
+        let mut file = std::fs::File::open(&path).map_err(|error| match error.kind() {
+            std::io::ErrorKind::NotFound => SpoolError::NotFound,
+            _ => SpoolError::Io(error),
+        })?;
+        let length = file.metadata()?.len();
+        // A caller that asks past the end gets an empty window rather than an
+        // error: they are tailing something that has not printed yet.
+        let offset = offset.min(length);
+        file.seek(SeekFrom::Start(offset))?;
+
+        let mut data = Vec::new();
+        file.take(max_bytes as u64).read_to_end(&mut data)?;
+        let next_offset = offset + data.len() as u64;
+
+        Ok(LogChunk {
+            id: id.to_string(),
+            stream,
+            offset,
+            next_offset,
+            data_base64: base64::engine::general_purpose::STANDARD.encode(&data),
+            truncated: match stream {
+                LogStream::Stdout => report.stdout_truncated,
+                LogStream::Stderr => report.stderr_truncated,
+            },
+            more: next_offset < length,
+        })
+    }
+}
+
+fn read_existing(path: &Path) -> Result<Vec<u8>, SpoolError> {
+    std::fs::read(path).map_err(|error| match error.kind() {
+        std::io::ErrorKind::NotFound => SpoolError::NotFound,
+        _ => SpoolError::Io(error),
+    })
+}
+
+/// Milliseconds since the Unix epoch.
+///
+/// A clock that reads before the epoch is not a timestamp anyone should
+/// publish, so it becomes zero rather than a negative number cast into a
+/// nonsense one.
+pub fn now_unix_ms() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|since| since.as_millis() as u64)
+        .unwrap_or(0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::protocol::{PROTOCOL_VERSION, RunnerState};
+
+    fn request(id: &str, argv: &[&str]) -> StartRequest {
+        StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: id.into(),
+            argv: argv.iter().map(|argument| argument.to_string()).collect(),
+            cwd: None,
+            timeout_seconds: 60,
+            max_output_bytes: 1024,
+        }
+    }
+
+    /// One id reserves at most one command, whoever asks second.
+    ///
+    /// This is the runner's half of idempotency. Without it, a retried `start`
+    /// — which is the normal consequence of a dropped connection — launches the
+    /// command a second time inside a container Kobe has already recorded as
+    /// busy with the first.
+    #[test]
+    fn one_id_can_only_ever_reserve_one_command() {
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+
+        assert!(matches!(
+            spool
+                .reserve(&request("sbxe-1", &["/agent", "run"]))
+                .unwrap(),
+            Reservation::Created
+        ));
+        // The same request is a retry, not a second command.
+        assert!(matches!(
+            spool
+                .reserve(&request("sbxe-1", &["/agent", "run"]))
+                .unwrap(),
+            Reservation::AlreadyReserved
+        ));
+        // A different command under the same id is refused outright.
+        assert!(matches!(
+            spool.reserve(&request("sbxe-1", &["/agent", "destroy"])),
+            Err(SpoolError::Conflict(_))
+        ));
+    }
+
+    /// A reservation is never observable half-built.
+    ///
+    /// A concurrent `start` that found the directory but not its request would
+    /// have to guess whether it had lost the race — and the safe guess (assume
+    /// not) is a duplicate spawn.
+    #[test]
+    fn a_reservation_appears_complete_or_not_at_all() {
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+        spool.reserve(&request("sbxe-1", &["/agent"])).unwrap();
+
+        let dir = root.path().join("sbxe-1");
+        for required in [REQUEST_FILE, STATE_FILE, "stdout.log", "stderr.log"] {
+            assert!(
+                dir.join(required).exists(),
+                "{required} must exist the moment the directory does"
+            );
+        }
+        // Nothing is left lying around for the next reservation to trip over.
+        let staging: Vec<_> = std::fs::read_dir(root.path())
+            .unwrap()
+            .filter_map(Result::ok)
+            .filter(|entry| entry.file_name().to_string_lossy().starts_with(".staging"))
+            .collect();
+        assert!(staging.is_empty(), "staging directories must not survive");
+    }
+
+    /// An id that is not a plain name resolves to nothing at all.
+    ///
+    /// The runner writes inside the tenant's own container: an id that escapes
+    /// the spool can read another execution's output or overwrite anything the
+    /// workload can.
+    #[test]
+    fn a_hostile_id_reaches_no_file() {
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+
+        // A real neighbour to try to reach.
+        spool.reserve(&request("sbxe-1", &["/agent"])).unwrap();
+
+        for hostile in ["../sbxe-1", "..", "sbxe-1/../sbxe-1", "/etc/passwd", ""] {
+            assert!(
+                matches!(spool.read_report(hostile), Err(SpoolError::NotFound)),
+                "id {hostile:?} must not resolve"
+            );
+            assert!(
+                matches!(spool.request_cancel(hostile), Err(SpoolError::NotFound)),
+                "id {hostile:?} must not be cancellable"
+            );
+            assert!(!spool.cancel_requested(hostile));
+        }
+    }
+
+    /// Output is read by offset, so every byte is seen exactly once.
+    ///
+    /// This is what makes a detached execution's output reconnectable: a caller
+    /// whose connection dropped resumes where they were, instead of re-reading
+    /// what they already had or skipping what they did not.
+    #[test]
+    fn output_is_read_by_offset_and_never_twice() {
+        use base64::Engine;
+
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+        spool.reserve(&request("sbxe-1", &["/agent"])).unwrap();
+        std::fs::write(root.path().join("sbxe-1/stdout.log"), b"hello world").unwrap();
+
+        let first = spool.read_chunk("sbxe-1", LogStream::Stdout, 0, 5).unwrap();
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(&first.data_base64)
+                .unwrap(),
+            b"hello"
+        );
+        assert_eq!(first.next_offset, 5);
+        assert!(first.more, "the caller must know there is more waiting");
+
+        let second = spool
+            .read_chunk("sbxe-1", LogStream::Stdout, first.next_offset, 1024)
+            .unwrap();
+        assert_eq!(
+            base64::engine::general_purpose::STANDARD
+                .decode(&second.data_base64)
+                .unwrap(),
+            b" world"
+        );
+        assert_eq!(second.next_offset, 11);
+        assert!(!second.more);
+
+        // Reading past the end is a caller tailing something that has not
+        // printed yet, not an error.
+        let past = spool
+            .read_chunk("sbxe-1", LogStream::Stdout, 9_000, 1024)
+            .unwrap();
+        assert_eq!(past.data_base64, "");
+        assert_eq!(past.next_offset, 11);
+        assert!(!past.more);
+    }
+
+    /// The two streams are read from two files, always.
+    ///
+    /// Nothing downstream can undo an interleave, so the separation has to
+    /// exist at the point of capture rather than be reconstructed later.
+    #[test]
+    fn stdout_and_stderr_are_read_separately() {
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+        spool.reserve(&request("sbxe-1", &["/agent"])).unwrap();
+        std::fs::write(root.path().join("sbxe-1/stdout.log"), b"out").unwrap();
+        std::fs::write(root.path().join("sbxe-1/stderr.log"), b"err").unwrap();
+
+        use base64::Engine;
+        let decode = |chunk: LogChunk| {
+            String::from_utf8(
+                base64::engine::general_purpose::STANDARD
+                    .decode(&chunk.data_base64)
+                    .unwrap(),
+            )
+            .unwrap()
+        };
+        assert_eq!(
+            decode(
+                spool
+                    .read_chunk("sbxe-1", LogStream::Stdout, 0, 64)
+                    .unwrap()
+            ),
+            "out"
+        );
+        assert_eq!(
+            decode(
+                spool
+                    .read_chunk("sbxe-1", LogStream::Stderr, 0, 64)
+                    .unwrap()
+            ),
+            "err"
+        );
+    }
+
+    /// Truncation is reported from the report, not inferred from a file size.
+    ///
+    /// A file that is exactly the cap long is indistinguishable from output
+    /// that happened to end there — and a caller who reads a capped stream as
+    /// complete gets a wrong answer rather than an obviously partial one.
+    #[test]
+    fn truncation_is_reported_rather_than_inferred() {
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+        spool.reserve(&request("sbxe-1", &["/agent"])).unwrap();
+        std::fs::write(root.path().join("sbxe-1/stdout.log"), b"xxxx").unwrap();
+
+        assert!(
+            !spool
+                .read_chunk("sbxe-1", LogStream::Stdout, 0, 64)
+                .unwrap()
+                .truncated
+        );
+
+        spool
+            .write_report(&ExecutionReport {
+                id: "sbxe-1".into(),
+                state: RunnerState::Succeeded,
+                exit_code: Some(0),
+                stdout_truncated: true,
+                ..Default::default()
+            })
+            .unwrap();
+
+        let chunk = spool
+            .read_chunk("sbxe-1", LogStream::Stdout, 0, 64)
+            .unwrap();
+        assert!(chunk.truncated, "a capped stream must say so");
+        // The OTHER stream was not capped, and must not inherit the flag.
+        assert!(
+            !spool
+                .read_chunk("sbxe-1", LogStream::Stderr, 0, 64)
+                .unwrap()
+                .truncated
+        );
+    }
+
+    /// Cancelling something that was never started is not a cancellation.
+    ///
+    /// Answering "cancelled" for an unknown id would let a caller believe they
+    /// stopped a command that is, in fact, running somewhere they mistyped.
+    #[test]
+    fn cancelling_an_unknown_execution_reports_not_found() {
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+        assert!(matches!(
+            spool.request_cancel("sbxe-missing"),
+            Err(SpoolError::NotFound)
+        ));
+    }
+
+    struct TempDir(PathBuf);
+
+    impl TempDir {
+        fn path(&self) -> &Path {
+            &self.0
+        }
+    }
+
+    impl Drop for TempDir {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A scratch directory, without a dependency the Sandbox image would carry.
+    ///
+    /// The runner ships inside somebody else's container, so its dependency
+    /// list is a security surface — a test-only crate is still one more thing
+    /// to audit and to build for musl. The counter matters: two tests entering
+    /// the same millisecond would otherwise share a spool and each would see
+    /// the other's reservations.
+    fn tempdir() -> TempDir {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "kobe-runner-test-{}-{}-{}",
+            std::process::id(),
+            now_unix_ms(),
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        TempDir(path)
+    }
+}

--- a/crates/kobe-runner/src/supervisor.rs
+++ b/crates/kobe-runner/src/supervisor.rs
@@ -1,0 +1,517 @@
+//! The process that outlives the connection.
+//!
+//! # What "detached" actually requires
+//!
+//! An exec connection is a pipe held open by an API server. When it closes —
+//! because the caller disconnected, or because the operator restarted — the
+//! kubelet tears down what it started. A "detached" execution implemented as
+//! "an exec we stopped reading from" therefore dies with the connection, which
+//! is strictly worse than not offering one: the caller has built on a guarantee
+//! that was never there.
+//!
+//! So the supervisor is re-executed into its **own session** and its parent
+//! exits immediately. It is reparented to the container's init, holds none of
+//! the exec's file descriptors, and there is nothing left for the teardown to
+//! find.
+//!
+//! # Why the command gets a session of its own too
+//!
+//! Cancelling has to kill the process group, not the leader: a build script
+//! that spawned four compilers and then exited leaves those compilers running,
+//! holding the CPU the lease is paying for. The command is therefore put in its
+//! own session, and cancellation signals the negative pid — every descendant
+//! that has not deliberately left the group.
+//!
+//! Its own session, separate from the supervisor's, is what lets the supervisor
+//! survive the kill it just issued and record the outcome.
+
+use std::io::{Read, Write};
+use std::os::unix::process::{CommandExt, ExitStatusExt};
+use std::process::{Child, Command, Stdio};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicBool, Ordering};
+use std::time::{Duration, Instant};
+
+use crate::protocol::{ExecutionReport, LogStream, RunnerState, StartRequest};
+use crate::spool::{Spool, now_unix_ms};
+
+/// How often the supervisor looks at the world.
+///
+/// Short enough that a cancellation feels immediate, long enough that a
+/// supervisor idling next to a tenant's workload costs nothing measurable.
+const POLL_INTERVAL: Duration = Duration::from_millis(50);
+
+/// How long a terminated process group is given to exit on its own.
+///
+/// SIGTERM first, because a command that traps it may need to finish a write or
+/// release a lock; SIGKILL after, because "asked politely" is not a guarantee
+/// and the lease that pays for the CPU is ending either way.
+const TERMINATION_GRACE: Duration = Duration::from_secs(5);
+
+/// How long the outcome waits for the output pipes to close.
+///
+/// A grandchild that outlived its parent can hold the pipe open indefinitely.
+/// The exit status is already observed at that point, and refusing to record it
+/// because a stray process still has the write end would turn a known outcome
+/// into an `Unknown` for no reason.
+const OUTPUT_SETTLE: Duration = Duration::from_secs(2);
+
+/// Reason codes. A closed set, because Kobe persists these.
+mod reason {
+    pub const COMPLETED: &str = "completed";
+    pub const TIMED_OUT: &str = "timed_out";
+    pub const CANCELLED: &str = "cancelled_by_caller";
+    pub const SIGNALLED: &str = "signalled";
+    pub const SPAWN_FAILED: &str = "spawn_failed";
+    pub const OUTCOME_UNOBSERVED: &str = "outcome_unobserved";
+}
+
+/// Supervise one reserved execution until it settles, then exit.
+pub fn supervise(spool: &Spool, id: &str) {
+    let request = match spool.read_request(id) {
+        Ok(request) => request,
+        Err(_) => {
+            // Nothing to supervise and nothing to record it against. Writing a
+            // report for an id whose request cannot be read would be inventing
+            // one.
+            return;
+        }
+    };
+
+    let started_at = now_unix_ms();
+    let mut child = match spawn(&request) {
+        Ok(child) => child,
+        Err(_) => {
+            // The command definitely did not run, but this process cannot tell
+            // Kobe that in a way Kobe can distinguish from "we never heard
+            // back" — so it reports the state that never invites a blind retry.
+            let _ = spool.write_report(&ExecutionReport {
+                id: id.to_string(),
+                state: RunnerState::Unknown,
+                started_at_unix_ms: Some(started_at),
+                finished_at_unix_ms: Some(now_unix_ms()),
+                reason: Some(reason::SPAWN_FAILED.into()),
+                ..Default::default()
+            });
+            return;
+        }
+    };
+
+    // The command's own session leader. Signalling the NEGATIVE of this reaches
+    // every descendant that has not deliberately left the group — the four
+    // compilers a build script spawned before exiting.
+    let group = child.id() as i32;
+
+    let stdout = pump(
+        child.stdout.take(),
+        spool,
+        id,
+        LogStream::Stdout,
+        request.max_output_bytes,
+    );
+    let stderr = pump(
+        child.stderr.take(),
+        spool,
+        id,
+        LogStream::Stderr,
+        request.max_output_bytes,
+    );
+
+    let deadline = Instant::now() + Duration::from_secs(request.timeout_seconds);
+    let mut ended_by: Option<&'static str> = None;
+    // Set once the group has been killed. A process that will not die even
+    // after SIGKILL — blocked in an uninterruptible syscall against a wedged
+    // filesystem — must not keep this supervisor polling forever, because a
+    // supervisor that never exits is one that never records an outcome.
+    let mut give_up_at: Option<Instant> = None;
+
+    let status = loop {
+        match child.try_wait() {
+            Ok(Some(status)) => break Some(status),
+            Ok(None) => {}
+            // The child cannot be reaped. Nobody can say what it did.
+            Err(_) => break None,
+        }
+
+        if ended_by.is_none() {
+            if spool.cancel_requested(id) {
+                ended_by = Some(reason::CANCELLED);
+            } else if Instant::now() >= deadline {
+                ended_by = Some(reason::TIMED_OUT);
+            }
+            if ended_by.is_some() {
+                terminate_group(group, &mut child);
+                give_up_at = Some(Instant::now() + TERMINATION_GRACE);
+            }
+        }
+        if give_up_at.is_some_and(|at| Instant::now() >= at) {
+            break None;
+        }
+
+        std::thread::sleep(POLL_INTERVAL);
+    };
+
+    // Both pumps are given a bounded chance to drain what is still buffered.
+    // The exit status is already known, so a grandchild holding the pipe open
+    // must not be able to prevent the outcome being recorded.
+    let settle = Instant::now() + OUTPUT_SETTLE;
+    while Instant::now() < settle && !(stdout.finished() && stderr.finished()) {
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    let report = settle_report(
+        id,
+        started_at,
+        status,
+        ended_by,
+        stdout.truncated(),
+        stderr.truncated(),
+    );
+    let _ = spool.write_report(&report);
+}
+
+/// Turn what was observed into the outcome that is honest about it.
+///
+/// Split out from the wait loop so the mapping is testable without a process:
+/// this function is where an unverifiable outcome becomes `Unknown` rather than
+/// `Failed`, and that distinction is the one a caller acts on.
+pub fn settle_report(
+    id: &str,
+    started_at: u64,
+    status: Option<std::process::ExitStatus>,
+    ended_by: Option<&str>,
+    stdout_truncated: bool,
+    stderr_truncated: bool,
+) -> ExecutionReport {
+    let finished_at = now_unix_ms();
+    let base = ExecutionReport {
+        id: id.to_string(),
+        state: RunnerState::Unknown,
+        started_at_unix_ms: Some(started_at),
+        finished_at_unix_ms: Some(finished_at),
+        stdout_truncated,
+        stderr_truncated,
+        ..Default::default()
+    };
+
+    let Some(status) = status else {
+        // The process could not be reaped. Not `Failed`: it may well have done
+        // its work, and `Failed` is the answer that invites doing it again.
+        return ExecutionReport {
+            reason: Some(reason::OUTCOME_UNOBSERVED.into()),
+            ..base
+        };
+    };
+
+    // A command the runner killed is reported by WHY it was killed, not by the
+    // signal it died of. The exit code is deliberately absent: the process did
+    // not choose an outcome, and attaching one would assert something nobody
+    // observed.
+    if let Some(ended_by) = ended_by {
+        return ExecutionReport {
+            state: if ended_by == reason::CANCELLED {
+                RunnerState::Cancelled
+            } else {
+                RunnerState::TimedOut
+            },
+            reason: Some(ended_by.to_string()),
+            ..base
+        };
+    }
+
+    match (status.code(), status.signal()) {
+        (Some(0), _) => ExecutionReport {
+            state: RunnerState::Succeeded,
+            exit_code: Some(0),
+            reason: Some(reason::COMPLETED.into()),
+            ..base
+        },
+        (Some(code), _) => ExecutionReport {
+            state: RunnerState::Failed,
+            exit_code: Some(code),
+            reason: Some(reason::COMPLETED.into()),
+            ..base
+        },
+        // Killed by something that is not the runner — an OOM kill, an
+        // administrator, the workload's own supervisor. It definitely ran and
+        // definitely did not finish, which is a failure and not an unknown; the
+        // signal is reported instead of an exit code the process never chose.
+        (None, Some(signal)) => ExecutionReport {
+            state: RunnerState::Failed,
+            signal: Some(signal),
+            reason: Some(reason::SIGNALLED.into()),
+            ..base
+        },
+        (None, None) => ExecutionReport {
+            reason: Some(reason::OUTCOME_UNOBSERVED.into()),
+            ..base
+        },
+    }
+}
+
+/// Start the command, in a session of its own.
+fn spawn(request: &StartRequest) -> std::io::Result<Child> {
+    let mut command = Command::new(&request.argv[0]);
+    command.args(&request.argv[1..]);
+    if let Some(cwd) = &request.cwd {
+        // `chdir`, applied by the kernel at exec. Never `cd X && ...`: a shell
+        // there would make quoting the security boundary, and the boundary is a
+        // tenant's own untrusted input.
+        command.current_dir(cwd);
+    }
+    // No stdin at all. A detached command has no connection to read from, and
+    // an inherited terminal would let it stop on SIGTTIN and look like a hang.
+    command.stdin(Stdio::null());
+    command.stdout(Stdio::piped());
+    command.stderr(Stdio::piped());
+
+    // SAFETY: `setsid` is async-signal-safe and is the only thing called
+    // between fork and exec. It puts the command in its own session, so
+    // cancelling it kills the whole group without killing this supervisor.
+    unsafe {
+        command.pre_exec(|| {
+            if libc::setsid() == -1 {
+                return Err(std::io::Error::last_os_error());
+            }
+            Ok(())
+        });
+    }
+    command.spawn()
+}
+
+/// Terminate the process group and reap what is left.
+fn terminate_group(group: i32, child: &mut Child) {
+    // SAFETY: a plain `kill(2)`. The negative pid addresses the group, which is
+    // the point — the leader alone leaves its children running on CPU the lease
+    // is paying for.
+    unsafe { libc::kill(-group, libc::SIGTERM) };
+
+    let deadline = Instant::now() + TERMINATION_GRACE;
+    while Instant::now() < deadline {
+        if matches!(child.try_wait(), Ok(Some(_)) | Err(_)) {
+            return;
+        }
+        std::thread::sleep(POLL_INTERVAL);
+    }
+
+    // Asked politely, then not. A command that traps SIGTERM and declines to
+    // exit still has to stop: the lease that pays for it is ending either way.
+    unsafe { libc::kill(-group, libc::SIGKILL) };
+}
+
+/// A stream being copied to disk, with a cap.
+struct Pump {
+    truncated: Arc<AtomicBool>,
+    finished: Arc<AtomicBool>,
+}
+
+impl Pump {
+    fn truncated(&self) -> bool {
+        self.truncated.load(Ordering::SeqCst)
+    }
+
+    fn finished(&self) -> bool {
+        self.finished.load(Ordering::SeqCst)
+    }
+}
+
+/// Copy one stream to its file, stopping at the cap but never stopping reading.
+///
+/// The "never stopping reading" half is the one that matters: a pipe nobody
+/// drains fills, and a command blocked writing to a full pipe hangs until the
+/// timeout kills it. A caller would see a command that printed too much
+/// reported as a timeout, which is a wrong answer rather than a bounded one.
+fn pump<R: Read + Send + 'static>(
+    source: Option<R>,
+    spool: &Spool,
+    id: &str,
+    stream: LogStream,
+    cap: u64,
+) -> Pump {
+    let truncated = Arc::new(AtomicBool::new(false));
+    let finished = Arc::new(AtomicBool::new(false));
+    let pump = Pump {
+        truncated: Arc::clone(&truncated),
+        finished: Arc::clone(&finished),
+    };
+
+    let Some(mut source) = source else {
+        finished.store(true, Ordering::SeqCst);
+        return pump;
+    };
+    let Ok(path) = spool.stream_path(id, stream) else {
+        finished.store(true, Ordering::SeqCst);
+        return pump;
+    };
+
+    std::thread::spawn(move || {
+        let mut written: u64 = 0;
+        let mut file = std::fs::OpenOptions::new().append(true).open(&path).ok();
+        let mut buffer = vec![0u8; 64 * 1024];
+        loop {
+            let read = match source.read(&mut buffer) {
+                Ok(0) | Err(_) => break,
+                Ok(read) => read,
+            };
+            let room = cap.saturating_sub(written);
+            if room == 0 {
+                truncated.store(true, Ordering::SeqCst);
+                // Read on regardless. Discarding is what keeps the command
+                // running; refusing to read is what hangs it.
+                continue;
+            }
+            let take = (read as u64).min(room) as usize;
+            if take < read {
+                truncated.store(true, Ordering::SeqCst);
+            }
+            if let Some(file) = file.as_mut()
+                && file.write_all(&buffer[..take]).is_err()
+            {
+                // The output is gone, but the command must not be.
+                truncated.store(true, Ordering::SeqCst);
+            }
+            written += take as u64;
+        }
+        if let Some(file) = file.as_mut() {
+            let _ = file.flush();
+        }
+        finished.store(true, Ordering::SeqCst);
+    });
+
+    pump
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::process::ExitStatus;
+
+    /// An outcome nobody observed is `Unknown`, never `Failed`.
+    ///
+    /// `Failed` reads as "it ran and said no", which tells a caller their retry
+    /// is safe. If the runner could not reap the process, the command may have
+    /// done all of its work — and running it again is precisely the damage this
+    /// whole design exists to prevent.
+    #[test]
+    fn an_unobserved_outcome_is_unknown_rather_than_failed() {
+        let report = settle_report("sbxe-1", 1, None, None, false, false);
+        assert_eq!(report.state, RunnerState::Unknown);
+        assert_eq!(report.exit_code, None);
+        assert_eq!(report.signal, None);
+        assert_eq!(report.reason.as_deref(), Some(reason::OUTCOME_UNOBSERVED));
+    }
+
+    /// A command the runner killed is reported by why, and carries no exit
+    /// code.
+    ///
+    /// The process did not choose an outcome — the runner imposed one. An exit
+    /// code here would assert something nobody observed, and 128+SIGKILL is
+    /// indistinguishable from a command that deliberately exited 137.
+    #[test]
+    fn a_command_the_runner_killed_reports_why_and_not_an_exit_code() {
+        for (ended_by, expected) in [
+            (reason::CANCELLED, RunnerState::Cancelled),
+            (reason::TIMED_OUT, RunnerState::TimedOut),
+        ] {
+            let report = settle_report(
+                "sbxe-1",
+                1,
+                Some(ExitStatus::from_raw(9)),
+                Some(ended_by),
+                false,
+                false,
+            );
+            assert_eq!(report.state, expected);
+            assert_eq!(report.exit_code, None, "{ended_by} must not carry a code");
+            assert_eq!(report.reason.as_deref(), Some(ended_by));
+        }
+    }
+
+    /// An exit code is only ever the one the process chose.
+    ///
+    /// Zero is a success and anything else is a command that ran and said no —
+    /// a caller's own failing test, not an infrastructure fault, and emphatically
+    /// not something to retry on their behalf.
+    #[test]
+    fn an_exit_code_is_reported_exactly_as_the_process_gave_it() {
+        // `from_raw` takes a wait status: the code sits in the high byte.
+        let exited = |code: i32| ExitStatus::from_raw(code << 8);
+
+        let success = settle_report("sbxe-1", 1, Some(exited(0)), None, false, false);
+        assert_eq!(success.state, RunnerState::Succeeded);
+        assert_eq!(success.exit_code, Some(0));
+
+        for code in [1, 2, 127, 137, 255] {
+            let report = settle_report("sbxe-1", 1, Some(exited(code)), None, false, false);
+            assert_eq!(report.state, RunnerState::Failed, "exit {code}");
+            assert_eq!(report.exit_code, Some(code));
+            assert_eq!(report.signal, None);
+        }
+    }
+
+    /// A process killed by something else is a failure that says which signal.
+    ///
+    /// An OOM kill definitely ran and definitely did not finish. Reporting it
+    /// as exit code 137 would make it indistinguishable from a command that
+    /// deliberately exited 137, which is a different thing that needs a
+    /// different response.
+    #[test]
+    fn a_foreign_signal_is_a_failure_that_names_the_signal() {
+        let report = settle_report(
+            "sbxe-1",
+            1,
+            Some(ExitStatus::from_raw(libc::SIGKILL)),
+            None,
+            false,
+            false,
+        );
+        assert_eq!(report.state, RunnerState::Failed);
+        assert_eq!(report.exit_code, None, "no code was ever chosen");
+        assert_eq!(report.signal, Some(libc::SIGKILL));
+        assert_eq!(report.reason.as_deref(), Some(reason::SIGNALLED));
+    }
+
+    /// Truncation survives into the outcome.
+    ///
+    /// The report is the only place a caller can learn that output was capped;
+    /// a flag that were dropped here would turn a bounded read into a silently
+    /// wrong one.
+    #[test]
+    fn a_capped_stream_is_still_capped_in_the_outcome() {
+        let report = settle_report(
+            "sbxe-1",
+            1,
+            Some(ExitStatus::from_raw(0)),
+            None,
+            true,
+            false,
+        );
+        assert!(report.stdout_truncated);
+        assert!(!report.stderr_truncated);
+    }
+
+    /// Every reason a report can carry is a short, fixed code.
+    ///
+    /// Kobe persists this value into a Kubernetes object. A message built from
+    /// anything inside the container — a path, an error string, a line of the
+    /// command's own output — would put tenant data somewhere the tenant cannot
+    /// see and cannot redact.
+    #[test]
+    fn every_reason_is_a_short_fixed_code() {
+        for code in [
+            reason::COMPLETED,
+            reason::TIMED_OUT,
+            reason::CANCELLED,
+            reason::SIGNALLED,
+            reason::SPAWN_FAILED,
+            reason::OUTCOME_UNOBSERVED,
+        ] {
+            assert!(code.len() <= 64, "{code} is too long for a status field");
+            assert!(
+                code.bytes()
+                    .all(|byte| byte.is_ascii_lowercase() || byte == b'_'),
+                "{code} is not a bounded reason code"
+            );
+        }
+    }
+}

--- a/crates/kobe-runner/tests/supervision.rs
+++ b/crates/kobe-runner/tests/supervision.rs
@@ -1,0 +1,494 @@
+//! What the runner promises, exercised against the real binary.
+//!
+//! These drive `kobe-runner` as a subprocess — the same way Kobe drives it over
+//! an exec — because every property that matters here is a property of
+//! *processes*: sessions, process groups, signals, and a supervisor that has to
+//! still be there after its parent is gone. None of that can be asserted about
+//! a function call.
+//!
+//! What they cannot cover is the exec transport itself. A container is required
+//! to show that the supervisor survives the *kubelet* tearing down an exec, as
+//! opposed to surviving its parent exiting. The mechanism is the same — a
+//! session of its own — but the demonstration is not.
+
+#![cfg(unix)]
+
+use std::path::{Path, PathBuf};
+use std::process::{Command, Stdio};
+use std::time::{Duration, Instant};
+
+use kobe_runner::protocol::{Envelope, ExecutionReport, PROTOCOL_VERSION, Reply, RunnerState};
+
+/// A scratch directory that cleans itself up.
+struct Scratch(PathBuf);
+
+impl Scratch {
+    fn new() -> Self {
+        static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+        let path = std::env::temp_dir().join(format!(
+            "kobe-runner-it-{}-{}",
+            std::process::id(),
+            NEXT.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+        ));
+        std::fs::create_dir_all(&path).unwrap();
+        Self(path)
+    }
+
+    fn path(&self) -> &Path {
+        &self.0
+    }
+}
+
+impl Drop for Scratch {
+    fn drop(&mut self) {
+        let _ = std::fs::remove_dir_all(&self.0);
+    }
+}
+
+fn runner(scratch: &Scratch, arguments: &[&str]) -> Command {
+    let mut command = Command::new(env!("CARGO_BIN_EXE_kobe-runner"));
+    command
+        .arg("--state-dir")
+        .arg(scratch.path().join("spool"))
+        .args(arguments);
+    command
+}
+
+fn reply(output: std::process::Output) -> Reply {
+    let stdout = String::from_utf8(output.stdout).expect("a reply is valid UTF-8");
+    let envelope: Envelope = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|error| panic!("unparseable reply {stdout:?}: {error}"));
+    assert_eq!(envelope.protocol, PROTOCOL_VERSION);
+    envelope.reply
+}
+
+fn start(scratch: &Scratch, id: &str, argv: &[&str], timeout: u64, cap: u64) -> Reply {
+    start_in(scratch, id, argv, None, timeout, cap)
+}
+
+fn start_in(
+    scratch: &Scratch,
+    id: &str,
+    argv: &[&str],
+    cwd: Option<&str>,
+    timeout: u64,
+    cap: u64,
+) -> Reply {
+    use std::io::Write;
+
+    let request = serde_json::json!({
+        "protocol": PROTOCOL_VERSION,
+        "id": id,
+        "argv": argv,
+        "cwd": cwd,
+        "timeoutSeconds": timeout,
+        "maxOutputBytes": cap,
+    });
+    // `cwd: null` is not the same as an absent key for a `deny_unknown_fields`
+    // struct with an Option — serde accepts both, and this keeps the helper
+    // honest about which one it sends.
+    let mut request = request;
+    if cwd.is_none() {
+        request.as_object_mut().unwrap().remove("cwd");
+    }
+
+    let mut child = runner(scratch, &["start"])
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped())
+        .spawn()
+        .unwrap();
+    child
+        .stdin
+        .take()
+        .unwrap()
+        .write_all(request.to_string().as_bytes())
+        .unwrap();
+    reply(child.wait_with_output().unwrap())
+}
+
+fn status(scratch: &Scratch, id: &str) -> Reply {
+    reply(runner(scratch, &["status", "--id", id]).output().unwrap())
+}
+
+fn report_of(reply: Reply) -> ExecutionReport {
+    match reply {
+        Reply::Started { report } | Reply::State { report } => report,
+        other => panic!("expected a report, got {other:?}"),
+    }
+}
+
+/// Poll until the execution settles, or give up.
+fn settled(scratch: &Scratch, id: &str, within: Duration) -> ExecutionReport {
+    let deadline = Instant::now() + within;
+    loop {
+        let report = report_of(status(scratch, id));
+        if report.state.is_terminal() {
+            return report;
+        }
+        assert!(
+            Instant::now() < deadline,
+            "execution {id} never settled: {report:?}"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+fn read_stream(scratch: &Scratch, id: &str, stream: &str) -> Vec<u8> {
+    use base64::Engine;
+
+    let mut collected = Vec::new();
+    let mut offset = 0u64;
+    loop {
+        let reply = reply(
+            runner(
+                scratch,
+                &[
+                    "logs",
+                    "--id",
+                    id,
+                    "--stream",
+                    stream,
+                    "--offset",
+                    &offset.to_string(),
+                ],
+            )
+            .output()
+            .unwrap(),
+        );
+        let Reply::Logs { chunk } = reply else {
+            panic!("expected a log chunk, got {reply:?}");
+        };
+        collected.extend(
+            base64::engine::general_purpose::STANDARD
+                .decode(&chunk.data_base64)
+                .unwrap(),
+        );
+        if !chunk.more {
+            return collected;
+        }
+        offset = chunk.next_offset;
+    }
+}
+
+fn alive(pid: i32) -> bool {
+    // SAFETY: signal 0 checks existence and permission without delivering
+    // anything.
+    unsafe { libc::kill(pid, 0) == 0 }
+}
+
+/// The command outlives the process that started it.
+///
+/// This is the entire point of the runner. A "detached" execution that dies
+/// with the connection that launched it is worse than none at all: the caller
+/// has already built on a guarantee that was never there, and will discover it
+/// only from the work that did not happen.
+#[test]
+fn a_started_command_outlives_the_process_that_started_it() {
+    let scratch = Scratch::new();
+    let marker = scratch.path().join("finished");
+
+    let report = report_of(start(
+        &scratch,
+        "sbxe-detached",
+        &[
+            "/bin/sh",
+            "-c",
+            &format!("sleep 1; touch {}", marker.display()),
+        ],
+        30,
+        4096,
+    ));
+    // The caller chose to run a shell. Kobe never inserts one — that is the
+    // difference this contract keeps.
+    assert_eq!(report.state, RunnerState::Running);
+
+    // `start` has already exited by the time we get here: the command has not.
+    assert!(!marker.exists(), "the command must not have finished yet");
+
+    let settled = settled(&scratch, "sbxe-detached", Duration::from_secs(20));
+    assert_eq!(settled.state, RunnerState::Succeeded);
+    assert!(marker.exists(), "the command must have run to completion");
+}
+
+/// stdout and stderr stay apart, and the exit code is the process's own.
+///
+/// A caller that cannot separate a tool's diagnostics from its output cannot
+/// parse either, and an exit code that Kobe synthesised would be
+/// indistinguishable from one the command chose.
+#[test]
+fn the_two_streams_and_the_exact_exit_code_survive_the_round_trip() {
+    let scratch = Scratch::new();
+    start(
+        &scratch,
+        "sbxe-streams",
+        &[
+            "/bin/sh",
+            "-c",
+            "echo to-stdout; echo to-stderr >&2; exit 7",
+        ],
+        30,
+        4096,
+    );
+
+    let report = settled(&scratch, "sbxe-streams", Duration::from_secs(20));
+    assert_eq!(report.state, RunnerState::Failed);
+    assert_eq!(report.exit_code, Some(7), "the exact code, not a synonym");
+    assert_eq!(report.signal, None);
+
+    assert_eq!(
+        read_stream(&scratch, "sbxe-streams", "stdout"),
+        b"to-stdout\n"
+    );
+    assert_eq!(
+        read_stream(&scratch, "sbxe-streams", "stderr"),
+        b"to-stderr\n"
+    );
+}
+
+/// One id runs one command, however many times it is started.
+///
+/// A retried `start` is the normal consequence of a dropped connection. If the
+/// second one spawned, every disconnect during a `terraform apply` would apply
+/// it twice — which is the failure the whole reserve-then-spawn design exists
+/// to prevent, and it has to hold on the runner's side of the boundary too.
+#[test]
+fn one_id_runs_one_command_however_often_it_is_started() {
+    let scratch = Scratch::new();
+    let ledger = scratch.path().join("ledger");
+    let argv = [
+        "/bin/sh",
+        "-c",
+        &format!("echo ran >> {}", ledger.display()),
+    ];
+    let argv: Vec<&str> = argv.to_vec();
+
+    for _ in 0..3 {
+        let report = report_of(start(&scratch, "sbxe-once", &argv, 30, 4096));
+        assert_eq!(report.id, "sbxe-once");
+    }
+    settled(&scratch, "sbxe-once", Duration::from_secs(20));
+    // Give any (wrongly) duplicated spawn time to append as well.
+    std::thread::sleep(Duration::from_millis(300));
+
+    let ledger = std::fs::read_to_string(&ledger).unwrap_or_default();
+    assert_eq!(
+        ledger.lines().count(),
+        1,
+        "the command ran more than once: {ledger:?}"
+    );
+}
+
+/// A different command under a used id is refused, never run.
+///
+/// Running it would give the caller two commands where they asked for one, and
+/// returning the first one's result would answer a question they did not ask.
+#[test]
+fn a_reused_id_with_a_different_command_is_refused() {
+    let scratch = Scratch::new();
+    start(
+        &scratch,
+        "sbxe-taken",
+        &["/bin/sh", "-c", "exit 0"],
+        30,
+        4096,
+    );
+
+    let reply = start(
+        &scratch,
+        "sbxe-taken",
+        &["/bin/sh", "-c", "exit 1"],
+        30,
+        4096,
+    );
+    assert!(
+        matches!(
+            reply,
+            Reply::Error {
+                code: kobe_runner::protocol::RunnerErrorCode::Conflict
+            }
+        ),
+        "expected a conflict, got {reply:?}"
+    );
+}
+
+/// Cancelling kills the process group, not just the process.
+///
+/// A build script that spawned four compilers and exited leaves those compilers
+/// running — on CPU the lease is paying for, inside a Pod that is being torn
+/// down. Signalling the leader alone would report a clean cancellation while
+/// the actual work carried on.
+#[test]
+fn cancelling_kills_the_whole_process_group() {
+    let scratch = Scratch::new();
+    let pidfile = scratch.path().join("grandchild.pid");
+    let script = format!("sleep 60 & echo $! > {}; wait", pidfile.display());
+    start(
+        &scratch,
+        "sbxe-group",
+        &["/bin/sh", "-c", &script],
+        60,
+        4096,
+    );
+
+    // Wait for the grandchild to exist before cancelling anything.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    let grandchild = loop {
+        if let Ok(raw) = std::fs::read_to_string(&pidfile)
+            && let Ok(pid) = raw.trim().parse::<i32>()
+        {
+            break pid;
+        }
+        assert!(Instant::now() < deadline, "the grandchild never started");
+        std::thread::sleep(Duration::from_millis(50));
+    };
+    assert!(alive(grandchild), "the grandchild must be running");
+
+    let report = report_of(reply(
+        runner(&scratch, &["cancel", "--id", "sbxe-group"])
+            .output()
+            .unwrap(),
+    ));
+    assert_eq!(report.state, RunnerState::Cancelled);
+    assert_eq!(
+        report.exit_code, None,
+        "a cancelled command chose no outcome"
+    );
+
+    // The descendant that nobody signalled directly is gone too.
+    let deadline = Instant::now() + Duration::from_secs(10);
+    while alive(grandchild) {
+        assert!(
+            Instant::now() < deadline,
+            "the grandchild survived the cancellation"
+        );
+        std::thread::sleep(Duration::from_millis(50));
+    }
+}
+
+/// A command that outruns its bound is stopped, and says so.
+///
+/// `TimedOut` and not `Failed`: the command did not decide anything, and a
+/// caller reading `Failed` would take it as their own program's verdict.
+#[test]
+fn a_command_that_outruns_its_bound_is_terminated_and_reported() {
+    let scratch = Scratch::new();
+    start(&scratch, "sbxe-timeout", &["/bin/sleep", "60"], 1, 4096);
+
+    let report = settled(&scratch, "sbxe-timeout", Duration::from_secs(30));
+    assert_eq!(report.state, RunnerState::TimedOut);
+    assert_eq!(report.exit_code, None, "nothing chose an exit code");
+    assert_eq!(report.reason.as_deref(), Some("timed_out"));
+}
+
+/// Output is capped, the cap is reported, and the command still finishes.
+///
+/// The second half is the one that is easy to get wrong: a runner that stops
+/// reading a full pipe leaves the command blocked in `write`, so a command that
+/// merely printed too much would be reported as a timeout — a wrong answer
+/// rather than a bounded one.
+#[test]
+fn output_past_the_cap_is_dropped_reported_and_not_fatal() {
+    let scratch = Scratch::new();
+    let cap = 4096u64;
+    start(
+        &scratch,
+        "sbxe-loud",
+        &[
+            "/bin/sh",
+            "-c",
+            "i=0; while [ $i -lt 4000 ]; do echo 0123456789012345678901234567890123456789; i=$((i+1)); done",
+        ],
+        60,
+        cap,
+    );
+
+    let report = settled(&scratch, "sbxe-loud", Duration::from_secs(30));
+    assert_eq!(
+        report.state,
+        RunnerState::Succeeded,
+        "printing too much must not stop the command finishing: {report:?}"
+    );
+    assert!(
+        report.stdout_truncated,
+        "the caller must be told output was dropped"
+    );
+    assert!(!report.stderr_truncated, "stderr printed nothing");
+
+    let retained = read_stream(&scratch, "sbxe-loud", "stdout");
+    assert_eq!(retained.len() as u64, cap, "retention must stop at the cap");
+}
+
+/// `cwd` is a `chdir`, and there is no shell anywhere in the contract.
+///
+/// Implementing it as `cd X && ...` would make quoting the security boundary —
+/// against input chosen by the occupant of a sandbox that exists precisely
+/// because they are not trusted.
+#[test]
+fn a_working_directory_is_applied_as_a_chdir() {
+    let scratch = Scratch::new();
+    let workdir = std::fs::canonicalize(scratch.path()).unwrap();
+
+    start_in(
+        &scratch,
+        "sbxe-cwd",
+        // No shell: `pwd` is executed directly, and the directory comes from
+        // the kernel rather than from a string somebody concatenated.
+        &["/bin/pwd"],
+        Some(workdir.to_str().unwrap()),
+        30,
+        4096,
+    );
+
+    let report = settled(&scratch, "sbxe-cwd", Duration::from_secs(20));
+    assert_eq!(report.state, RunnerState::Succeeded);
+    assert_eq!(
+        String::from_utf8(read_stream(&scratch, "sbxe-cwd", "stdout"))
+            .unwrap()
+            .trim(),
+        workdir.to_str().unwrap()
+    );
+}
+
+/// Output survives the command, and is still readable by offset afterwards.
+///
+/// A detached execution whose output vanished at exit would be unusable for its
+/// only purpose: the caller is, by definition, not connected while it runs.
+#[test]
+fn output_is_retained_after_the_command_has_finished() {
+    let scratch = Scratch::new();
+    start(
+        &scratch,
+        "sbxe-retained",
+        &["/bin/sh", "-c", "echo first; echo second"],
+        30,
+        4096,
+    );
+    settled(&scratch, "sbxe-retained", Duration::from_secs(20));
+
+    assert_eq!(
+        read_stream(&scratch, "sbxe-retained", "stdout"),
+        b"first\nsecond\n"
+    );
+    // And again: reading does not consume.
+    assert_eq!(
+        read_stream(&scratch, "sbxe-retained", "stdout"),
+        b"first\nsecond\n"
+    );
+}
+
+/// An execution nobody started is not found — never "succeeded".
+#[test]
+fn an_unknown_execution_is_not_found() {
+    let scratch = Scratch::new();
+    let reply = status(&scratch, "sbxe-never");
+    assert!(
+        matches!(
+            reply,
+            Reply::Error {
+                code: kobe_runner::protocol::RunnerErrorCode::NotFound
+            }
+        ),
+        "expected not found, got {reply:?}"
+    );
+}

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -51,11 +51,11 @@ function "tags" {
 # Groups
 # =============================================================================
 group "default" {
-  targets = ["operator", "kobe-sync"]
+  targets = ["operator", "kobe-sync", "runner"]
 }
 
 group "push" {
-  targets = ["operator-push", "kobe-sync-push"]
+  targets = ["operator-push", "kobe-sync-push", "runner-push"]
 }
 
 # =============================================================================
@@ -131,4 +131,32 @@ target "kobe-sync-push" {
   inherits = ["kobe-sync"]
   output   = ["type=registry"]
   # cache-to = ["type=registry,ref=${REGISTRY}/kobe-sync:buildcache,mode=max"]
+}
+
+# =============================================================================
+# kobe-runner image
+#
+# Deliberately NOT built from the shared `builder` context. The runner ships
+# inside an administrator's Sandbox image, so it is compiled statically against
+# musl with only its own (tiny) dependency tree — reusing the operator's
+# builder would both waste the whole kube/aws/sqlx compile and let the thing
+# that runs next to a tenant's workload inherit an operator dependency.
+# =============================================================================
+target "runner" {
+  dockerfile = "docker/runner.Dockerfile"
+  context    = "."
+  platforms  = [PLATFORM]
+  tags       = tags("kobe-runner")
+  cache-from = ["type=local,src=${LOCAL_CACHE_ROOT}/runner"]
+  cache-to   = ["type=local,dest=${LOCAL_CACHE_ROOT}/runner,mode=max"]
+  args = {
+    BUILD_VERSION = BUILD_VERSION
+    BUILD_COMMIT  = BUILD_COMMIT
+    BUILD_DATE    = BUILD_DATE
+  }
+}
+
+target "runner-push" {
+  inherits = ["runner"]
+  output   = ["type=registry"]
 }

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -23,11 +23,17 @@ WORKDIR /app
 # unique deps aren't compiled here — the operator images never include the CLI.
 COPY Cargo.toml Cargo.lock ./
 COPY crates/kobectl/Cargo.toml crates/kobectl/Cargo.toml
-RUN mkdir -p src crates/kobectl/src && \
+# The runner member is a real dependency of the operator (it owns the wire
+# contract in `src/protocol.rs`), so its manifest AND a lib stub have to exist
+# or the root package cannot resolve during dependency caching.
+COPY crates/kobe-runner/Cargo.toml crates/kobe-runner/Cargo.toml
+RUN mkdir -p src crates/kobectl/src crates/kobe-runner/src && \
     echo "pub fn stub() {}" > src/lib.rs && \
     echo "fn main() {}" > crates/kobectl/src/main.rs && \
+    echo "fn main() {}" > crates/kobe-runner/src/main.rs && \
+    echo "pub fn stub() {}" > crates/kobe-runner/src/lib.rs && \
     cargo build --release --lib 2>/dev/null || true && \
-    rm -rf src crates/kobectl/src
+    rm -rf src crates/kobectl/src crates/kobe-runner/src
 
 # Build the real binaries — clean slate for kobe crates
 FROM deps AS build

--- a/docker/runner.Dockerfile
+++ b/docker/runner.Dockerfile
@@ -1,0 +1,75 @@
+# =============================================================================
+# kobe-runner — the supervisor that runs INSIDE a Sandbox container (#82).
+#
+# Two things make this image unlike the operator images:
+#
+#  1. It is built statically against musl. The binary is meant to be copied
+#     into an administrator's own agent image, whose libc, distro and glibc
+#     version Kobe does not control and must not depend on. A dynamically
+#     linked runner would work on the images we happened to test and fail on
+#     somebody else's.
+#
+#  2. It does NOT reuse the shared `builder` stage. That stage compiles the
+#     operator's entire dependency tree — kube, aws-sdk, sqlx — none of which
+#     this binary uses. Building the runner alone takes seconds, and keeping
+#     the trees apart means the thing that ships inside a tenant's container
+#     cannot silently acquire one of the operator's dependencies.
+#
+# Administrators consume it either way round:
+#
+#     COPY --from=zondax/kobe-runner:latest /kobe-runner /kobe-runner
+#
+# and then set `spec.template.runnerPath: /kobe-runner` on the SandboxPool.
+# =============================================================================
+FROM rust:1-slim-bookworm AS build
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    musl-tools \
+    && rm -rf /var/lib/apt/lists/*
+
+# Built for the architecture of the stage itself, so a cross-platform bake
+# resolves the target from the emulated build environment rather than from a
+# guess made on the host.
+RUN rustup target add "$(uname -m)-unknown-linux-musl"
+
+WORKDIR /app
+
+# The whole workspace manifest set is needed for cargo to load the workspace at
+# all, even though only one member is built.
+COPY Cargo.toml Cargo.lock ./
+COPY crates crates
+COPY src src
+COPY build.rs ./
+
+ARG BUILD_VERSION=dev
+ENV BUILD_VERSION=${BUILD_VERSION}
+
+RUN cargo build --release --locked \
+        --target "$(uname -m)-unknown-linux-musl" \
+        -p kobe-runner --bin kobe-runner \
+    && cp "target/$(uname -m)-unknown-linux-musl/release/kobe-runner" /kobe-runner \
+    # A dynamic dependency here would defeat the point of the musl build, and
+    # would only show up on somebody else's base image.
+    && ! ldd /kobe-runner 2>/dev/null | grep -q "=>"
+
+# =============================================================================
+# Nothing but the binary. There is no shell in this image on purpose: the
+# runner contract has no shell anywhere in it, and an image that shipped one
+# would invite a Dockerfile that used it.
+# =============================================================================
+FROM scratch
+
+ARG BUILD_VERSION=dev
+ARG BUILD_COMMIT=unknown
+ARG BUILD_DATE=unknown
+
+LABEL org.opencontainers.image.version="${BUILD_VERSION}"
+LABEL org.opencontainers.image.revision="${BUILD_COMMIT}"
+LABEL org.opencontainers.image.created="${BUILD_DATE}"
+LABEL org.opencontainers.image.title="kobe-runner"
+LABEL org.opencontainers.image.description="Kobe Sandbox execution supervisor, for copying into a Sandbox image"
+LABEL org.opencontainers.image.source="https://github.com/kunobi-ninja/kobe"
+
+COPY --from=build /kobe-runner /kobe-runner
+
+ENTRYPOINT ["/kobe-runner"]

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -63,6 +63,41 @@ Every container must declare CPU, memory, and ephemeral-storage requests and
 limits. `defaultContainer` and each exposed port must refer to a declared
 container. Canary `argv` is executed directly, without an implicit shell.
 
+## Detached execution
+
+A detached execution keeps running after the caller disconnects, which a
+Kubernetes exec cannot do on its own: everything an exec starts dies with the
+connection. Supervising it requires a process inside the container, so a pool
+offers detached execution only if its image ships `kobe-runner` and the template
+says where:
+
+```yaml
+template:
+  defaultContainer: workspace
+  runnerPath: /kobe-runner
+```
+
+Copy the binary into your own agent image:
+
+```dockerfile
+COPY --from=zondax/kobe-runner:latest /kobe-runner /kobe-runner
+```
+
+It is a static binary with no dependencies on the base image, and it runs as
+whatever user the container already uses — it needs no privileges beyond
+starting a process and writing under `/var/run`.
+
+Without `runnerPath`, `POST /v1/sandbox-leases/{id}/executions` with
+`"detach": true` returns `501 Not Implemented`. That is deliberate: a detached
+execution that actually died with its connection would be worse than none,
+because callers build on the guarantee it appears to offer. Wait-mode
+executions are unaffected and need no runner.
+
+Output from a detached execution is retained inside the container until the
+Sandbox is torn down, bounded per stream, and read back through
+`GET /v1/sandbox-leases/{id}/executions/{execution}/logs`. Cancelling one
+terminates its whole process group, not only the process Kobe started.
+
 ## Placement and isolation
 
 Use `placement.type: management` to place upstream Sandbox objects in Kobe's

--- a/justfile
+++ b/justfile
@@ -149,7 +149,7 @@ build-crdgen:
     cargo run --bin crdgen -- sandboxleases > charts/kobe/crds/sandboxleases.yaml
     cargo run --bin crdgen -- sandboxexecutions > charts/kobe/crds/sandboxexecutions.yaml
 
-# Build Docker images locally (operator + kobe-sync)
+# Build Docker images locally (operator + kobe-sync + runner)
 [group('docker')]
 docker:
     PLATFORM={{ native_platform }} docker buildx bake -f docker-bake.hcl --load
@@ -223,7 +223,7 @@ bump VERSION:
       *)   ah_prerelease=false ;;
     esac
     perl -i -pe "s{^(\s*artifacthub\.io/prerelease:).*}{\$1 \"${ah_prerelease}\"}" charts/kobe/Chart.yaml
-    cargo update -p kobe-operator -p kobectl --precise "{{ VERSION }}" 2>/dev/null || true
+    cargo update -p kobe-operator -p kobectl -p kobe-runner --precise "{{ VERSION }}" 2>/dev/null || true
     ./scripts/check-version-consistency.sh
     echo "Bumped to {{ VERSION }}. Review the diff, commit, then \`just release\`."
 

--- a/src/api/mod.rs
+++ b/src/api/mod.rs
@@ -7,6 +7,7 @@ pub mod sandbox_access;
 pub mod sandbox_credentials;
 pub mod sandbox_executions;
 pub mod sandbox_rate_limit;
+pub mod sandbox_runner;
 pub mod sandbox_streams;
 pub mod sandbox_transport;
 pub mod upgrade;

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -86,6 +86,10 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
             "/v1/sandbox-leases/{id}/executions/{execution}",
             get(get_sandbox_execution::<B>).delete(cancel_sandbox_execution::<B>),
         )
+        .route(
+            "/v1/sandbox-leases/{id}/executions/{execution}/logs",
+            get(get_sandbox_execution_logs::<B>),
+        )
 }
 
 #[derive(Debug, Deserialize)]
@@ -215,14 +219,22 @@ async fn create_sandbox_execution<B: ClusterBackend>(
     };
 
     // Detached execution needs a supervisor inside the container that outlives
-    // the connection. Refused explicitly rather than approximated: a "detached"
-    // execution that actually dies with its connection is worse than none,
-    // because a caller builds on the guarantee it appears to offer.
-    if requested.detached {
+    // the connection. Refused explicitly where there is none, rather than
+    // approximated: a "detached" execution that actually dies with its
+    // connection is worse than none, because a caller builds on the guarantee
+    // it appears to offer.
+    //
+    // Checked BEFORE the reservation, so a pool that cannot serve the request
+    // does not leave the caller's idempotency key spent on an execution that
+    // never existed.
+    if requested.detached && target.runner_path.is_none() {
         return sandbox_error(
             StatusCode::NOT_IMPLEMENTED,
-            "Detached execution requires the Sandbox runner contract",
-            Some("Use wait mode; see #82 for the runner contract.".into()),
+            "This Sandbox pool does not provide the Kobe runner",
+            Some(
+                "Detached execution requires a pool whose template sets runnerPath; use wait mode."
+                    .into(),
+            ),
         );
     }
 
@@ -328,6 +340,14 @@ async fn create_sandbox_execution<B: ClusterBackend>(
     let guard = streams.register(&target.lease_uid).await;
     let revoked = guard.cancelled();
 
+    if requested.detached {
+        return start_detached(
+            &state, &identity, &id, &target, &container, &requested, &reserved, &scoped, timeout,
+            revoked,
+        )
+        .await;
+    }
+
     let result = tokio::select! {
         result = access::exec_in_sandbox(&scoped, &target, &container, &requested.argv, timeout) => result,
         _ = revoked.cancelled() => {
@@ -403,6 +423,241 @@ async fn create_sandbox_execution<B: ClusterBackend>(
 /// Default bound when a caller does not choose one.
 const DEFAULT_EXECUTION_TIMEOUT: &str = "60s";
 
+/// Hand one reserved execution to the runner and return without waiting.
+///
+/// The reservation is already `Running` when this is called, so every path out
+/// of here has to leave the record saying something a caller can act on. The
+/// two that matter:
+///
+/// * The runner answered — the execution is supervised, and the caller polls.
+/// * Anything else — `Unknown`. The command may be running perfectly well
+///   inside the container; Kobe simply cannot see it, and `Failed` would tell
+///   the caller their retry is safe when it is not.
+#[allow(clippy::too_many_arguments)]
+async fn start_detached<B: ClusterBackend>(
+    state: &AppState<B>,
+    identity: &AuthIdentity,
+    id: &str,
+    target: &crate::api::sandbox_access::SandboxTarget,
+    container: &str,
+    requested: &crate::api::sandbox_executions::ExecutionRequest,
+    reserved: &crate::crd::SandboxExecution,
+    scoped: &kube::Client,
+    timeout: std::time::Duration,
+    revoked: tokio_util::sync::CancellationToken,
+) -> Response {
+    use crate::api::sandbox_executions as executions;
+    use crate::api::sandbox_runner as runner;
+    use crate::crd::ExecutionState;
+
+    let Some(runner_path) = target.runner_path.clone() else {
+        // Refused before the reservation; reaching here means the pool changed
+        // underneath this request.
+        executions::record_terminal(
+            &state.client,
+            &state.namespace,
+            reserved,
+            ExecutionState::Unknown,
+            None,
+            "runner_unavailable",
+        )
+        .await;
+        return sandbox_error(
+            StatusCode::CONFLICT,
+            "This Sandbox pool stopped providing the Kobe runner",
+            None,
+        );
+    };
+
+    // The execution's own name is the runner's id: derived by Kobe, stable
+    // across retries, and — unlike anything the caller sent — safe to put in an
+    // exec argument that the target apiserver will audit-log verbatim.
+    let request = runner::start_request(
+        &reserved.name_any(),
+        &requested.argv,
+        requested.cwd.as_deref(),
+        timeout,
+    );
+
+    let started = tokio::select! {
+        started = runner::start(scoped, target, container, &runner_path, &request) => started,
+        _ = revoked.cancelled() => {
+            // The lease stopped permitting access mid-start. Whether the runner
+            // received the request is exactly the thing nobody can now say.
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                reserved,
+                ExecutionState::Unknown,
+                None,
+                "lease_revoked",
+            )
+            .await;
+            return sandbox_error(
+                StatusCode::GONE,
+                "Sandbox lease stopped permitting access while the command was starting",
+                None,
+            );
+        }
+    };
+
+    let report = match started {
+        Ok(report) => report,
+        Err(failure) => {
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                reserved,
+                ExecutionState::Unknown,
+                None,
+                failure.reason_code(),
+            )
+            .await;
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                execution = %reserved.name_any(),
+                operation = "execution",
+                outcome = "unknown",
+                reason = failure.reason_code(),
+                "Sandbox access"
+            );
+            return sandbox_error(failure.http_status(), failure.to_string(), None);
+        }
+    };
+
+    let outcome = runner::outcome_from_report(&report);
+    // A start that has already settled is unusual but not impossible — the
+    // runner reports `Unknown` for a supervisor it could not launch — and the
+    // record has to say so rather than leave the caller polling something that
+    // ended before they saw it.
+    if outcome.state.is_terminal() {
+        executions::record_terminal(
+            &state.client,
+            &state.namespace,
+            reserved,
+            outcome.state,
+            outcome.exit_code,
+            &outcome.reason,
+        )
+        .await;
+    }
+
+    let refreshed = executions::refresh(&state.client, &state.namespace, reserved).await;
+    let record = refreshed.as_ref().unwrap_or(reserved);
+    info!(
+        principal = %identity.identity,
+        lease = %id,
+        execution = %reserved.name_any(),
+        operation = "execution",
+        outcome = "detached",
+        state = %outcome.state,
+        "Sandbox access"
+    );
+    // 202: the request was accepted and the work is elsewhere. 200 only once
+    // there is an outcome to report.
+    let status = if outcome.state.is_terminal() {
+        StatusCode::OK
+    } else {
+        StatusCode::ACCEPTED
+    };
+    (status, Json(execution_response(record, None))).into_response()
+}
+
+/// Ask the runner what a detached execution is doing, and settle it if it is
+/// done.
+///
+/// Returns the record as it now stands. A runner that cannot be reached leaves
+/// the record exactly as it was: a transient failure to poll is not evidence
+/// about the command, and settling on it would turn a blip into a permanent
+/// `Unknown` for a command that finished successfully a second later.
+///
+/// The one exception is a runner that has *no record* of an execution Kobe
+/// reserved. That means the container was replaced under a Pod that kept its
+/// identity, and the outcome is genuinely unrecoverable — so it settles as
+/// `Unknown` now rather than after the verdict deadline.
+async fn reconcile_detached<B: ClusterBackend>(
+    state: &AppState<B>,
+    lease: &SandboxLease,
+    target: &crate::api::sandbox_access::SandboxTarget,
+    record: &crate::crd::SandboxExecution,
+) -> crate::crd::SandboxExecution {
+    use crate::api::sandbox_executions as executions;
+    use crate::api::sandbox_runner as runner;
+    use kobe_runner::protocol::RunnerErrorCode;
+
+    let current = record
+        .status
+        .as_ref()
+        .map(|status| status.state)
+        .unwrap_or_default();
+    if !record.spec.detached || current.is_terminal() {
+        return record.clone();
+    }
+    let Some(runner_path) = target.runner_path.clone() else {
+        return record.clone();
+    };
+
+    let Ok(cluster) = crate::api::sandbox_access::resolve_target_cluster(
+        &state.client,
+        &state.namespace,
+        lease,
+        target,
+    )
+    .await
+    else {
+        return record.clone();
+    };
+    let Ok(scoped) = crate::api::sandbox_credentials::scoped_client(
+        &cluster,
+        target,
+        crate::api::sandbox_credentials::SandboxOperation::Exec,
+    )
+    .await
+    else {
+        return record.clone();
+    };
+
+    let polled = runner::poll(
+        &scoped,
+        target,
+        &target.container,
+        &runner_path,
+        &record.name_any(),
+    )
+    .await;
+
+    let outcome = match polled {
+        Ok(report) => runner::outcome_from_report(&report),
+        Err(runner::RunnerCallFailure::Refused(RunnerErrorCode::NotFound)) => {
+            runner::RunnerOutcome {
+                state: crate::crd::ExecutionState::Unknown,
+                exit_code: None,
+                reason: "runner_forgot_execution".into(),
+            }
+        }
+        // Nothing was learned. The record keeps saying `Running`, and the
+        // verdict deadline remains the backstop it was designed to be.
+        Err(_) => return record.clone(),
+    };
+    if !outcome.state.is_terminal() {
+        return record.clone();
+    }
+
+    executions::record_terminal(
+        &state.client,
+        &state.namespace,
+        record,
+        outcome.state,
+        outcome.exit_code,
+        &outcome.reason,
+    )
+    .await;
+    executions::refresh(&state.client, &state.namespace, record)
+        .await
+        .unwrap_or_else(|| record.clone())
+}
+
 #[tracing::instrument(skip_all, fields(lease = %id))]
 async fn get_sandbox_execution<B: ClusterBackend>(
     State(state): State<AppState<B>>,
@@ -422,7 +677,7 @@ async fn get_sandbox_execution<B: ClusterBackend>(
     // Ownership of the LEASE is what authorises reading its executions. An
     // execution name alone must never be enough: they are derived from a caller's
     // own key, so a second caller could otherwise guess one.
-    let (_lease, target) =
+    let (lease, target) =
         match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
         {
             Ok(resolved) => resolved,
@@ -438,6 +693,11 @@ async fn get_sandbox_execution<B: ClusterBackend>(
     .await
     {
         Ok(Some(record)) => {
+            // A detached execution is only ever as current as its last poll:
+            // nobody is holding a connection to notice it finish. Asking the
+            // runner here is what makes `GET` an answer rather than an echo of
+            // what Kobe last wrote.
+            let record = reconcile_detached(&state, &lease, &target, &record).await;
             (StatusCode::OK, Json(execution_response(&record, None))).into_response()
         }
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
@@ -445,12 +705,211 @@ async fn get_sandbox_execution<B: ClusterBackend>(
     }
 }
 
+#[derive(Debug, Deserialize)]
+#[serde(deny_unknown_fields)]
+struct ExecutionLogsQuery {
+    /// Where to resume each stream. Separate, because the two streams advance
+    /// independently — one offset for both would re-read whichever stream was
+    /// behind, or skip whichever was ahead.
+    #[serde(default)]
+    stdout_offset: Option<u64>,
+    #[serde(default)]
+    stderr_offset: Option<u64>,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecutionStreamWindow {
+    data: String,
+    /// Where the next read should start. A caller that polls with this value
+    /// sees every byte exactly once, which is what makes a detached
+    /// execution's output reconnectable after a disconnect.
+    next_offset: u64,
+    /// Whether bytes are already waiting past `next_offset`.
+    more: bool,
+    /// Whether the runner dropped output at its retention cap. Unlike `more`,
+    /// this is unrecoverable — and a caller parsing a capped stream as
+    /// complete is how a bound becomes a wrong answer.
+    truncated: bool,
+}
+
+#[derive(Debug, Serialize)]
+struct ExecutionLogsResponse {
+    id: String,
+    state: String,
+    stdout: ExecutionStreamWindow,
+    stderr: ExecutionStreamWindow,
+}
+
+/// Read a detached execution's retained output.
+///
+/// Only detached executions have any: a wait-mode command's output was returned
+/// in its own response and is not kept. Saying so explicitly beats an empty
+/// body, which a caller would read as "it printed nothing".
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn get_sandbox_execution_logs<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path((id, execution)): Path<(String, String)>,
+    Query(query): Query<ExecutionLogsQuery>,
+) -> Response {
+    use crate::api::sandbox_access as access;
+    use crate::api::sandbox_runner as runner;
+    use kobe_runner::protocol::LogStream;
+
+    if let Err(response) =
+        require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD, SANDBOX_EXECUTION_CRD]).await
+    {
+        return response;
+    }
+    if !is_valid_k8s_name(&id) || !is_valid_k8s_name(&execution) {
+        return StatusCode::NOT_FOUND.into_response();
+    }
+
+    let (lease, target) =
+        match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
+        {
+            Ok(resolved) => resolved,
+            Err(denied) => return access_denied(&identity, &id, "execution-logs", denied),
+        };
+    let record = match crate::api::sandbox_executions::get_owned(
+        &state.client,
+        &state.namespace,
+        &execution,
+        &target.lease_uid,
+    )
+    .await
+    {
+        Ok(Some(record)) => record,
+        Ok(None) => return StatusCode::NOT_FOUND.into_response(),
+        Err(error) => return execution_denied(&identity, &id, &error),
+    };
+
+    if !record.spec.detached {
+        return sandbox_error(
+            StatusCode::CONFLICT,
+            "This execution's output was returned with its result and is not retained",
+            Some("Only detached executions retain output.".into()),
+        );
+    }
+    let Some(runner_path) = target.runner_path.clone() else {
+        return sandbox_error(
+            StatusCode::CONFLICT,
+            "This Sandbox pool stopped providing the Kobe runner",
+            None,
+        );
+    };
+
+    // Polled first, so the state reported alongside the output is the one that
+    // was true when the output was read — not the one Kobe last wrote.
+    let record = reconcile_detached(&state, &lease, &target, &record).await;
+
+    let cluster = match access::resolve_target_cluster(
+        &state.client,
+        &state.namespace,
+        &lease,
+        &target,
+    )
+    .await
+    {
+        Ok(cluster) => cluster,
+        Err(denied) => return access_denied(&identity, &id, "execution-logs", denied),
+    };
+    let scoped = match crate::api::sandbox_credentials::scoped_client(
+        &cluster,
+        &target,
+        crate::api::sandbox_credentials::SandboxOperation::Exec,
+    )
+    .await
+    {
+        Ok(client) => client,
+        Err(denied) => return access_denied(&identity, &id, "execution-logs", denied),
+    };
+
+    let mut windows = Vec::new();
+    for (stream, offset) in [
+        (LogStream::Stdout, query.stdout_offset.unwrap_or(0)),
+        (LogStream::Stderr, query.stderr_offset.unwrap_or(0)),
+    ] {
+        match runner::read_output(
+            &scoped,
+            &target,
+            &target.container,
+            &runner_path,
+            &record.name_any(),
+            stream,
+            offset,
+        )
+        .await
+        {
+            Ok(chunk) => windows.push(chunk),
+            Err(failure) => {
+                info!(
+                    principal = %identity.identity,
+                    lease = %id,
+                    execution = %record.name_any(),
+                    operation = "execution-logs",
+                    outcome = "denied",
+                    reason = failure.reason_code(),
+                    "Sandbox access"
+                );
+                return sandbox_error(failure.http_status(), failure.to_string(), None);
+            }
+        }
+    }
+
+    let window = |chunk: &kobe_runner::protocol::LogChunk| {
+        use base64::Engine;
+        let data = base64::engine::general_purpose::STANDARD
+            .decode(&chunk.data_base64)
+            .unwrap_or_default();
+        ExecutionStreamWindow {
+            // Lossy on purpose: a sandboxed command's output is arbitrary
+            // bytes, and refusing the window because one of them was not UTF-8
+            // would lose all the ones that were.
+            data: String::from_utf8_lossy(&data).into_owned(),
+            next_offset: chunk.next_offset,
+            more: chunk.more,
+            truncated: chunk.truncated,
+        }
+    };
+    // Audited by identity and outcome, never by content: the body is the
+    // workload's own output and can contain anything.
+    info!(
+        principal = %identity.identity,
+        lease = %id,
+        execution = %record.name_any(),
+        pod_uid = %target.pod_uid,
+        operation = "execution-logs",
+        outcome = "allowed",
+        "Sandbox access"
+    );
+    (
+        StatusCode::OK,
+        Json(ExecutionLogsResponse {
+            id: record.name_any(),
+            state: record
+                .status
+                .as_ref()
+                .map(|status| status.state)
+                .unwrap_or_default()
+                .to_string(),
+            stdout: window(&windows[0]),
+            stderr: window(&windows[1]),
+        }),
+    )
+        .into_response()
+}
+
 /// Cancel one execution.
 ///
-/// Cancellation is recorded, not enforced here: without the runner contract
-/// there is no process group to signal. A caller is told what actually
-/// happened — the record moves to `Cancelled` only if the command had not
-/// already settled.
+/// For a detached execution this is a real termination: the runner signals the
+/// process **group**, so a build script that spawned four compilers and exited
+/// does not leave them running on CPU the lease is paying for.
+///
+/// A wait-mode execution has no process group Kobe can reach — its command is
+/// tied to a connection this request is not holding — so cancellation there is
+/// recorded rather than enforced. The record moves to `Cancelled` only if the
+/// command had not already settled.
 #[tracing::instrument(skip_all, fields(lease = %id))]
 async fn cancel_sandbox_execution<B: ClusterBackend>(
     State(state): State<AppState<B>>,
@@ -467,12 +926,18 @@ async fn cancel_sandbox_execution<B: ClusterBackend>(
     if !is_valid_k8s_name(&id) || !is_valid_k8s_name(&execution) {
         return StatusCode::NOT_FOUND.into_response();
     }
-    let (_lease, target) =
+    let (lease, target) =
         match access::resolve_sandbox_target(&state.client, &state.namespace, &id, &identity).await
         {
             Ok(resolved) => resolved,
             Err(denied) => return access_denied(&identity, &id, "execution", denied),
         };
+
+    if let Some(response) =
+        cancel_detached(&state, &identity, &id, &lease, &target, &execution).await
+    {
+        return response;
+    }
 
     match crate::api::sandbox_executions::cancel_owned(
         &state.client,
@@ -488,6 +953,136 @@ async fn cancel_sandbox_execution<B: ClusterBackend>(
         Ok(None) => StatusCode::NOT_FOUND.into_response(),
         Err(error) => execution_denied(&identity, &id, &error),
     }
+}
+
+/// Terminate a detached execution's process group, if this is one.
+///
+/// `None` means "not a detached execution to cancel" and lets the caller fall
+/// through to the record-only path.
+///
+/// A runner that cannot be reached does **not** settle the record. Recording
+/// `Cancelled` would claim a termination nobody performed, and recording
+/// `Unknown` would close a record whose command is very likely still running —
+/// leaving it `Running` keeps the caller's retry meaningful, and lease teardown
+/// remains the backstop that always ends it.
+async fn cancel_detached<B: ClusterBackend>(
+    state: &AppState<B>,
+    identity: &AuthIdentity,
+    id: &str,
+    lease: &SandboxLease,
+    target: &crate::api::sandbox_access::SandboxTarget,
+    execution: &str,
+) -> Option<Response> {
+    use crate::api::sandbox_executions as executions;
+    use crate::api::sandbox_runner as runner;
+
+    let record = executions::get_owned(
+        &state.client,
+        &state.namespace,
+        execution,
+        &target.lease_uid,
+    )
+    .await
+    .ok()
+    .flatten()?;
+    let current = record
+        .status
+        .as_ref()
+        .map(|status| status.state)
+        .unwrap_or_default();
+    if !record.spec.detached || current.is_terminal() {
+        return None;
+    }
+    let runner_path = target.runner_path.clone()?;
+
+    let cluster = access_or_none(&state.client, &state.namespace, lease, target).await?;
+    let scoped = crate::api::sandbox_credentials::scoped_client(
+        &cluster,
+        target,
+        crate::api::sandbox_credentials::SandboxOperation::Exec,
+    )
+    .await
+    .ok()?;
+
+    match runner::cancel(
+        &scoped,
+        target,
+        &target.container,
+        &runner_path,
+        &record.name_any(),
+    )
+    .await
+    {
+        Ok(report) => {
+            let outcome = runner::outcome_from_report(&report);
+            if !outcome.state.is_terminal() {
+                // The runner answered without settling it. Saying "cancelled"
+                // here would be Kobe's word for something the container did not
+                // confirm.
+                return Some(sandbox_error(
+                    StatusCode::ACCEPTED,
+                    "Cancellation was requested and has not completed yet",
+                    None,
+                ));
+            }
+            executions::record_terminal(
+                &state.client,
+                &state.namespace,
+                &record,
+                outcome.state,
+                outcome.exit_code,
+                &outcome.reason,
+            )
+            .await;
+            let refreshed = executions::refresh(&state.client, &state.namespace, &record).await;
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                execution = %record.name_any(),
+                operation = "execution-cancel",
+                outcome = "allowed",
+                state = %outcome.state,
+                "Sandbox access"
+            );
+            Some(
+                (
+                    StatusCode::OK,
+                    Json(execution_response(
+                        refreshed.as_ref().unwrap_or(&record),
+                        None,
+                    )),
+                )
+                    .into_response(),
+            )
+        }
+        Err(failure) => {
+            info!(
+                principal = %identity.identity,
+                lease = %id,
+                execution = %record.name_any(),
+                operation = "execution-cancel",
+                outcome = "denied",
+                reason = failure.reason_code(),
+                "Sandbox access"
+            );
+            Some(sandbox_error(
+                failure.http_status(),
+                failure.to_string(),
+                None,
+            ))
+        }
+    }
+}
+
+async fn access_or_none(
+    client: &kube::Client,
+    namespace: &str,
+    lease: &SandboxLease,
+    target: &crate::api::sandbox_access::SandboxTarget,
+) -> Option<crate::api::sandbox_access::TargetCluster> {
+    crate::api::sandbox_access::resolve_target_cluster(client, namespace, lease, target)
+        .await
+        .ok()
 }
 
 #[derive(Debug, Deserialize)]
@@ -3019,6 +3614,11 @@ mod tests {
         for (name, plural, kind) in [
             (SANDBOX_POOL_CRD, "sandboxpools", "SandboxPool"),
             (SANDBOX_LEASE_CRD, "sandboxleases", "SandboxLease"),
+            (
+                SANDBOX_EXECUTION_CRD,
+                "sandboxexecutions",
+                "SandboxExecution",
+            ),
         ] {
             Mock::given(method("GET"))
                 .and(path(format!(
@@ -4870,5 +5470,179 @@ mod tests {
                 .iter()
                 .all(|request| request.method.as_str() != "PATCH")
         );
+    }
+    /// A pool with no runner refuses a detached execution, and refuses it
+    /// before the caller's idempotency key is spent.
+    ///
+    /// The order is the point. Reserving first and failing afterwards would
+    /// burn the key on an execution that never existed: the caller's retry —
+    /// with the same key, as retries must — would then get a conflict, or
+    /// worse, the record of a command nobody ever ran.
+    ///
+    /// And it is refused rather than approximated. A "detached" execution that
+    /// actually died with its connection would be worse than none at all,
+    /// because the caller has already built on the guarantee it appeared to
+    /// offer.
+    #[tokio::test]
+    async fn a_pool_without_a_runner_refuses_detached_before_spending_the_key() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        mount_ready_sandbox(&server, pool_json()).await;
+
+        let response = create_sandbox_execution::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sbx-own".into()),
+            Json(
+                serde_json::from_value(serde_json::json!({
+                    "command": ["/agent", "run"],
+                    "idempotency_key": "key-1",
+                    "detach": true
+                }))
+                .unwrap(),
+            ),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::NOT_IMPLEMENTED);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .all(|request| !(request.method.as_str() == "POST"
+                    && request.url.path().contains("/sandboxexecutions"))),
+            "the idempotency key must not be reserved for a request that cannot be served"
+        );
+    }
+
+    /// A wait-mode execution has no retained output, and says so.
+    ///
+    /// Its output was returned in its own response and is not kept anywhere —
+    /// there is no runner holding it. An empty body would read as "the command
+    /// printed nothing", which is a different and wrong answer.
+    #[tokio::test]
+    async fn logs_for_a_wait_mode_execution_are_refused_rather_than_empty() {
+        let server = MockServer::start().await;
+        mount_sandbox_crds(&server).await;
+        mount_ready_sandbox(&server, pool_json_with_runner()).await;
+        Mock::given(method("GET"))
+            .and(path_regex(
+                r"^/apis/kobe\.kunobi\.ninja/v1alpha1/namespaces/test-ns/sandboxexecutions/sbxe-.*$",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(execution_json(false)))
+            .mount(&server)
+            .await;
+
+        let response = get_sandbox_execution_logs::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path(("sbx-own".into(), "sbxe-1".into())),
+            Query(ExecutionLogsQuery {
+                stdout_offset: None,
+                stderr_offset: None,
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        assert!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .all(|request| !request.url.path().ends_with("/exec")),
+            "nothing may be executed in the Pod to answer a question about a record"
+        );
+    }
+
+    /// Log offsets are per stream, and unknown options are refused.
+    ///
+    /// One offset for both streams would re-read whichever stream was behind
+    /// or skip whichever was ahead — and a silently ignored option means a
+    /// caller believes they set a bound that was never applied.
+    #[test]
+    fn a_log_window_is_addressed_per_stream() {
+        let query: ExecutionLogsQuery =
+            serde_json::from_value(serde_json::json!({ "stdout_offset": 10, "stderr_offset": 20 }))
+                .unwrap();
+        assert_eq!(query.stdout_offset, Some(10));
+        assert_eq!(query.stderr_offset, Some(20));
+
+        for smuggled in ["offset", "tail", "follow", "container", "stream", "limit"] {
+            assert!(
+                serde_json::from_value::<ExecutionLogsQuery>(serde_json::json!({ smuggled: 1 }))
+                    .is_err(),
+                "{smuggled} must be refused, not ignored"
+            );
+        }
+    }
+
+    fn pool_json_with_runner() -> serde_json::Value {
+        let mut pool = pool_json();
+        pool["spec"]["template"]["runnerPath"] = serde_json::json!("/kobe-runner");
+        pool
+    }
+
+    fn execution_json(detached: bool) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "SandboxExecution",
+            "metadata": { "name": "sbxe-1", "namespace": "test-ns", "uid": "sbxe-1-uid" },
+            "spec": {
+                "leaseUid": "sbx-own-uid",
+                "podUid": "pod-uid",
+                "idempotencyKey": "key-1",
+                "requestDigest": "d".repeat(64),
+                "timeout": "60s",
+                "detached": detached
+            },
+            "status": { "state": "Running" }
+        })
+    }
+
+    /// A lease that is Ready and fully placed, so execution paths reach their
+    /// own logic instead of stopping at resolution.
+    async fn mount_ready_sandbox(server: &MockServer, pool: serde_json::Value) {
+        // The id must LOOK like a lease id: anything else is resolved as a
+        // caller alias, which is a different code path entirely.
+        let mut lease = lease_json("sbx-own", &identity().identity, "Ready");
+        lease["status"] = serde_json::json!({
+            "phase": "Ready",
+            "observedGeneration": 1,
+            "expiresAt": (chrono::Utc::now() + chrono::Duration::hours(1)).to_rfc3339(),
+            "placement": { "type": "management" },
+            "target": {
+                "namespace": "test-ns",
+                "sandboxClaim": {
+                    "apiVersion": "agents.x-k8s.io/v1alpha1", "kind": "SandboxClaim",
+                    "name": "claim", "uid": "claim-uid"
+                },
+                "sandbox": {
+                    "apiVersion": "agents.x-k8s.io/v1alpha1", "kind": "Sandbox",
+                    "name": "sbx", "uid": "sandbox-uid"
+                },
+                "pod": {
+                    "apiVersion": "v1", "kind": "Pod",
+                    "name": "sbx-0", "uid": "pod-uid"
+                }
+            }
+        });
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxleases/sbx-own",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(lease))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pool))
+            .mount(server)
+            .await;
     }
 }

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -60,6 +60,10 @@ pub struct SandboxTarget {
     pub container: String,
     /// Ports the pool declared. Nothing else is forwardable.
     pub ports: Vec<DeclaredPort>,
+    /// Where `kobe-runner` lives inside the container, if the pool's image
+    /// ships one. `None` means this Sandbox cannot supervise a detached
+    /// command, and the API refuses one rather than approximating it.
+    pub runner_path: Option<String>,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -283,6 +287,10 @@ pub fn target_from_provenance(
                 port: port.port,
             })
             .collect(),
+        // Taken from the pool that admitted this lease, never from the caller.
+        // It becomes `argv[0]` of an exec, so a caller who could name it could
+        // run anything in the container under Kobe's own credential.
+        runner_path: pool.spec.template.runner_path.clone(),
     })
 }
 
@@ -634,6 +642,56 @@ pub async fn exec_in_sandbox(
     command: &[String],
     timeout: std::time::Duration,
 ) -> Result<SandboxExecResponse, SandboxAccessDenied> {
+    let raw = exec_capped(
+        client,
+        target,
+        container,
+        command,
+        None,
+        timeout,
+        MAX_EXEC_OUTPUT_BYTES,
+    )
+    .await?;
+
+    Ok(SandboxExecResponse {
+        // Lossy on purpose: a sandboxed command's output is arbitrary bytes,
+        // and refusing to return anything because byte 900k was not UTF-8
+        // would lose the 899k that were.
+        stdout: String::from_utf8_lossy(&raw.stdout).into_owned(),
+        stderr: String::from_utf8_lossy(&raw.stderr).into_owned(),
+        success: raw.success,
+        truncated: raw.truncated,
+    })
+}
+
+/// One exec's raw result, before anything decides what it means.
+#[derive(Debug)]
+pub struct RawExecOutput {
+    pub stdout: Vec<u8>,
+    pub stderr: Vec<u8>,
+    pub success: bool,
+    pub truncated: bool,
+}
+
+/// Run one command in the Sandbox, optionally writing to its stdin.
+///
+/// The stdin half exists for the runner contract (#82) and for nothing else: a
+/// tenant's argv is a URL when it travels as exec arguments, and the target
+/// apiserver's audit log records that URL verbatim. Sending the command over
+/// stdin instead keeps it out of a log Kobe does not own and cannot redact.
+///
+/// The input is written and the connection's write half is closed immediately.
+/// The runner reads a single line precisely so it never has to wait for an EOF
+/// that the exec transport may not deliver.
+pub async fn exec_capped(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    command: &[String],
+    stdin: Option<&[u8]>,
+    timeout: std::time::Duration,
+    output_cap: usize,
+) -> Result<RawExecOutput, SandboxAccessDenied> {
     use k8s_openapi::api::core::v1::Pod;
     use kube::api::AttachParams;
     if command.is_empty() || command.iter().any(|argument| argument.is_empty()) {
@@ -653,7 +711,7 @@ pub async fn exec_in_sandbox(
 
     let params = AttachParams::default()
         .container(container)
-        .stdin(false)
+        .stdin(stdin.is_some())
         .stdout(true)
         .stderr(true)
         .tty(false);
@@ -663,14 +721,31 @@ pub async fn exec_in_sandbox(
         .map_err(|_| SandboxAccessDenied::Backend)?
         .map_err(|_| SandboxAccessDenied::Backend)?;
 
+    if let Some(input) = stdin {
+        use tokio::io::AsyncWriteExt;
+        let Some(mut writer) = attached.stdin() else {
+            return Err(SandboxAccessDenied::Backend);
+        };
+        // A failed write is not swallowed: the command on the other end is
+        // waiting for a request it will now never get, and reporting success
+        // here would attribute its silence to the workload.
+        tokio::time::timeout(timeout, async {
+            writer.write_all(input).await?;
+            writer.shutdown().await
+        })
+        .await
+        .map_err(|_| SandboxAccessDenied::Backend)?
+        .map_err(|_| SandboxAccessDenied::Backend)?;
+    }
+
     let mut stdout = Vec::new();
     let mut stderr = Vec::new();
     let mut truncated = false;
     if let Some(mut stream) = attached.stdout() {
-        truncated |= read_capped(&mut stream, &mut stdout, MAX_EXEC_OUTPUT_BYTES, timeout).await;
+        truncated |= read_capped(&mut stream, &mut stdout, output_cap, timeout).await;
     }
     if let Some(mut stream) = attached.stderr() {
-        truncated |= read_capped(&mut stream, &mut stderr, MAX_EXEC_OUTPUT_BYTES, timeout).await;
+        truncated |= read_capped(&mut stream, &mut stderr, output_cap, timeout).await;
     }
 
     let status = tokio::time::timeout(timeout, attached.take_status().unwrap()).await;
@@ -684,12 +759,9 @@ pub async fn exec_in_sandbox(
         }
     };
 
-    Ok(SandboxExecResponse {
-        // Lossy on purpose: a sandboxed command's output is arbitrary bytes,
-        // and refusing to return anything because byte 900k was not UTF-8
-        // would lose the 899k that were.
-        stdout: String::from_utf8_lossy(&stdout).into_owned(),
-        stderr: String::from_utf8_lossy(&stderr).into_owned(),
+    Ok(RawExecOutput {
+        stdout,
+        stderr,
         success,
         truncated,
     })

--- a/src/api/sandbox_credentials.rs
+++ b/src/api/sandbox_credentials.rs
@@ -312,6 +312,7 @@ mod tests {
             pod_uid: "pod-uid".into(),
             container: "agent".into(),
             ports: vec![],
+            runner_path: None,
         }
     }
 

--- a/src/api/sandbox_runner.rs
+++ b/src/api/sandbox_runner.rs
@@ -1,0 +1,745 @@
+//! Kobe's half of the Sandbox runner contract (#82).
+//!
+//! # Why detached execution needs a second process at all
+//!
+//! A Kubernetes exec is a connection. Everything Kobe starts through one dies
+//! with it: the caller disconnects, the operator restarts, a node drains, and
+//! the command goes with them. A "detached" execution built on that is worse
+//! than none, because the caller has already built on a guarantee that was
+//! never there — and finds out from the work that did not happen.
+//!
+//! So the container runs [`kobe-runner`](kobe_runner), which is re-executed
+//! into a session of its own and reparented to the container's init. Kobe then
+//! talks to it the way you would talk to a small daemon, except that the
+//! transport is one short exec per verb:
+//!
+//! ```text
+//! start   <- the request on stdin, one line   -> a report
+//! status                                       -> a report
+//! logs    (by offset, per stream)              -> one bounded window
+//! cancel                                       -> a report, after the group dies
+//! ```
+//!
+//! # Why exec, and not a port
+//!
+//! A listening socket inside the Sandbox would be reachable by the tenant's own
+//! workload, would need an authentication scheme of its own, and would have to
+//! be declared by the pool before anybody could reach it. Exec is already
+//! fenced — to one lease, one Pod UID, one container — and #81's resolver
+//! re-runs that fence on *every* call, so a lease that expires mid-execution
+//! stops being able to poll it.
+//!
+//! # Why the tenant's command never appears in an argument
+//!
+//! An exec's argv is a URL, and the target apiserver audit-logs it verbatim.
+//! Only the execution id — a hash Kobe derived — is ever passed as an argument;
+//! the command itself is written to the runner's stdin, which nothing on the
+//! path records.
+
+use kobe_runner::protocol::{
+    Envelope, ExecutionReport, LogChunk, LogStream, MAX_LOG_CHUNK_BYTES, MAX_RETENTION_BYTES,
+    PROTOCOL_VERSION, Reply, RunnerErrorCode, RunnerState, StartRequest,
+};
+
+use crate::api::sandbox_access::{SandboxAccessDenied, SandboxTarget, exec_capped};
+use crate::crd::ExecutionState;
+
+/// How long one control call may take.
+///
+/// Bounded independently of the command's own timeout: `status` on a command
+/// with an hour left to run must answer in a moment, and an API worker blocked
+/// on a wedged container is one that is not serving anybody else.
+pub const RUNNER_CALL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(15);
+
+/// Longer, because `cancel` deliberately waits.
+///
+/// The runner asks the process group to stop, gives it a grace period, and then
+/// kills it. Returning before that resolves would hand the caller a
+/// non-terminal answer to the one request whose entire purpose is to reach a
+/// terminal one.
+pub const RUNNER_CANCEL_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
+
+/// Most output one runner reply may occupy.
+///
+/// A log window is `MAX_LOG_CHUNK_BYTES` of base64 plus a little JSON; this
+/// leaves room without letting a broken runner make the operator buffer
+/// unbounded memory.
+const RUNNER_REPLY_CAP: usize = 2 * MAX_LOG_CHUNK_BYTES;
+
+/// Why a runner call did not produce an answer.
+#[derive(Debug, Clone, PartialEq, Eq, thiserror::Error)]
+pub enum RunnerCallFailure {
+    /// The runner could not be reached, or did not answer. The command may be
+    /// running perfectly well — this says only that Kobe cannot see it.
+    #[error("the sandbox runner did not answer")]
+    Unreachable,
+    /// It answered with something Kobe will not interpret: another protocol
+    /// version, a truncated document, anything but exactly one reply.
+    #[error("the sandbox runner answered with an unreadable reply")]
+    Unreadable,
+    /// It answered, and refused.
+    #[error("the sandbox runner refused the request")]
+    Refused(RunnerErrorCode),
+}
+
+impl RunnerCallFailure {
+    /// Bounded reason code for the durable record.
+    pub fn reason_code(&self) -> &'static str {
+        match self {
+            Self::Unreachable => "runner_unreachable",
+            Self::Unreadable => "runner_unreadable",
+            Self::Refused(RunnerErrorCode::NotFound) => "runner_forgot_execution",
+            Self::Refused(RunnerErrorCode::Conflict) => "runner_id_conflict",
+            Self::Refused(RunnerErrorCode::InvalidRequest) => "runner_rejected_request",
+            Self::Refused(RunnerErrorCode::Internal) => "runner_internal_error",
+        }
+    }
+
+    /// What the caller is told.
+    ///
+    /// Never 500: none of these mean Kobe is broken, and a caller retrying a
+    /// 500 is precisely the behaviour a duplicate-spawn design must not invite.
+    pub fn http_status(&self) -> axum::http::StatusCode {
+        use axum::http::StatusCode;
+        match self {
+            Self::Refused(RunnerErrorCode::Conflict) => StatusCode::CONFLICT,
+            Self::Refused(RunnerErrorCode::NotFound) => StatusCode::NOT_FOUND,
+            _ => StatusCode::BAD_GATEWAY,
+        }
+    }
+}
+
+/// What one runner report means in Kobe's own vocabulary.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct RunnerOutcome {
+    pub state: ExecutionState,
+    pub exit_code: Option<i32>,
+    pub reason: String,
+}
+
+/// Translate a report into the record a caller reads.
+///
+/// This is the function that decides what a caller will do next, so every arm
+/// is chosen for the action it invites rather than for how it reads:
+///
+/// * `Succeeded` without an observed exit code becomes `Unknown`. A success
+///   nobody backed with a number is a claim, not an observation.
+/// * A process killed by a foreign signal — an OOM kill, an administrator —
+///   becomes `Failed`. It definitely ran and definitely did not finish, so
+///   `Unknown` would understate what is known. The record carries the POSIX
+///   `128 + signal` convention because [`crate::crd::SandboxExecutionStatus`]
+///   requires a code for `Failed`, and `reason = signalled` is what keeps it
+///   distinguishable from a command that deliberately exited 137.
+/// * Everything the runner could not establish becomes `Unknown`, never
+///   `Failed`: `Failed` reads as "it ran and said no", which tells a caller
+///   their retry is safe when it may not be.
+pub fn outcome_from_report(report: &ExecutionReport) -> RunnerOutcome {
+    let reason = report
+        .reason
+        .as_deref()
+        .map(bounded_reason)
+        .unwrap_or_else(|| "runner_gave_no_reason".to_string());
+
+    let (state, exit_code) = match report.state {
+        RunnerState::Running => (ExecutionState::Running, None),
+        RunnerState::Succeeded => match report.exit_code {
+            Some(0) => (ExecutionState::Succeeded, Some(0)),
+            // A success reported with a non-zero code, or with none at all, is
+            // a report contradicting itself. The caller decides.
+            _ => (ExecutionState::Unknown, None),
+        },
+        RunnerState::Failed => match (report.exit_code, report.signal) {
+            (Some(code), _) if code != 0 => (ExecutionState::Failed, Some(code)),
+            (_, Some(signal)) => (ExecutionState::Failed, Some(128i32.saturating_add(signal))),
+            _ => (ExecutionState::Unknown, None),
+        },
+        RunnerState::Cancelled => (ExecutionState::Cancelled, None),
+        RunnerState::TimedOut => (ExecutionState::TimedOut, None),
+        RunnerState::Unknown => (ExecutionState::Unknown, None),
+    };
+
+    RunnerOutcome {
+        state,
+        exit_code,
+        reason,
+    }
+}
+
+/// Clamp a runner-supplied reason to something that may be persisted.
+///
+/// The reason is the ONE value that crosses from inside a tenant's container
+/// into a Kubernetes object. A runner that is old, broken, or replaced could
+/// put anything here — a path, an error message, a line of the command's own
+/// output — and object status is readable by anyone with `get` on the type,
+/// replicated to every etcd member, and included in backups. So anything
+/// outside the closed vocabulary is replaced rather than truncated: a
+/// truncated secret is still a secret.
+pub fn bounded_reason(reason: &str) -> String {
+    let recognised = !reason.is_empty()
+        && reason.len() <= 64
+        && reason
+            .bytes()
+            .all(|byte| byte.is_ascii_lowercase() || byte == b'_');
+    if recognised {
+        reason.to_string()
+    } else {
+        "runner_reason_unrecognised".to_string()
+    }
+}
+
+/// The request Kobe writes to the runner's stdin.
+pub fn start_request(
+    id: &str,
+    argv: &[String],
+    cwd: Option<&str>,
+    timeout: std::time::Duration,
+) -> StartRequest {
+    StartRequest {
+        protocol: PROTOCOL_VERSION,
+        id: id.to_string(),
+        argv: argv.to_vec(),
+        cwd: cwd.map(str::to_string),
+        // Rounded up, never down: a request for one and a half seconds that
+        // became one would kill a command before its own bound elapsed.
+        timeout_seconds: (timeout.as_secs() + u64::from(timeout.subsec_nanos() > 0)).max(1),
+        max_output_bytes: MAX_RETENTION_BYTES,
+    }
+}
+
+/// One line, because the runner reads one line.
+pub fn start_line(request: &StartRequest) -> Result<Vec<u8>, RunnerCallFailure> {
+    let mut line = serde_json::to_vec(request).map_err(|_| RunnerCallFailure::Unreadable)?;
+    line.push(b'\n');
+    Ok(line)
+}
+
+/// The argv of one control call.
+///
+/// Everything here is either a fixed word, the administrator's runner path, or
+/// Kobe's own derived execution id. Nothing a caller supplied ever appears —
+/// this argv becomes a URL in the target apiserver's audit log.
+pub fn control_argv(runner_path: &str, verb: &str, id: &str, extra: &[String]) -> Vec<String> {
+    let mut argv = vec![
+        runner_path.to_string(),
+        verb.to_string(),
+        "--id".to_string(),
+        id.to_string(),
+    ];
+    argv.extend_from_slice(extra);
+    argv
+}
+
+/// Read exactly one reply.
+///
+/// A reply from another protocol version is refused rather than parsed on a
+/// best-effort basis. A Sandbox image is built by an administrator and can be
+/// months older than the Kobe talking to it, and guessing at an older shape is
+/// how "running" gets read as "succeeded".
+pub fn parse_reply(stdout: &[u8]) -> Result<Reply, RunnerCallFailure> {
+    let text = std::str::from_utf8(stdout).map_err(|_| RunnerCallFailure::Unreadable)?;
+    // The last non-empty line: a well-behaved runner prints one document and
+    // nothing else, but a container's `ENTRYPOINT` wrapper or a libc warning can
+    // still land on stdout ahead of it, and losing an entire outcome to somebody
+    // else's banner would be a poor trade.
+    let line = text
+        .lines()
+        .map(str::trim)
+        .rfind(|line| !line.is_empty())
+        .ok_or(RunnerCallFailure::Unreachable)?;
+
+    let envelope: Envelope =
+        serde_json::from_str(line).map_err(|_| RunnerCallFailure::Unreadable)?;
+    if envelope.protocol != PROTOCOL_VERSION {
+        return Err(RunnerCallFailure::Unreadable);
+    }
+    match envelope.reply {
+        Reply::Error { code } => Err(RunnerCallFailure::Refused(code)),
+        reply => Ok(reply),
+    }
+}
+
+fn report_from(reply: Reply) -> Result<ExecutionReport, RunnerCallFailure> {
+    match reply {
+        Reply::Started { report } | Reply::State { report } => Ok(report),
+        _ => Err(RunnerCallFailure::Unreadable),
+    }
+}
+
+/// Start one command, and return once it is supervised — not once it is done.
+///
+/// Idempotent on both sides of the boundary: Kobe has already reserved the id
+/// durably, and the runner refuses to spawn a second process for an id it has
+/// seen. A retry of this call after a lost reply reports the original.
+pub async fn start(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    runner_path: &str,
+    request: &StartRequest,
+) -> Result<ExecutionReport, RunnerCallFailure> {
+    let line = start_line(request)?;
+    let output = call(
+        client,
+        target,
+        container,
+        &[runner_path.to_string(), "start".to_string()],
+        Some(&line),
+        RUNNER_CALL_TIMEOUT,
+    )
+    .await?;
+    report_from(parse_reply(&output)?)
+}
+
+/// Ask what one execution is doing.
+pub async fn poll(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    runner_path: &str,
+    id: &str,
+) -> Result<ExecutionReport, RunnerCallFailure> {
+    let output = call(
+        client,
+        target,
+        container,
+        &control_argv(runner_path, "status", id, &[]),
+        None,
+        RUNNER_CALL_TIMEOUT,
+    )
+    .await?;
+    report_from(parse_reply(&output)?)
+}
+
+/// Terminate one execution's process group.
+pub async fn cancel(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    runner_path: &str,
+    id: &str,
+) -> Result<ExecutionReport, RunnerCallFailure> {
+    let output = call(
+        client,
+        target,
+        container,
+        &control_argv(runner_path, "cancel", id, &[]),
+        None,
+        RUNNER_CANCEL_TIMEOUT,
+    )
+    .await?;
+    report_from(parse_reply(&output)?)
+}
+
+/// Read one bounded window of one stream.
+pub async fn read_output(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    runner_path: &str,
+    id: &str,
+    stream: LogStream,
+    offset: u64,
+) -> Result<LogChunk, RunnerCallFailure> {
+    let stream_name = match stream {
+        LogStream::Stdout => "stdout",
+        LogStream::Stderr => "stderr",
+    };
+    let output = call(
+        client,
+        target,
+        container,
+        &control_argv(
+            runner_path,
+            "logs",
+            id,
+            &[
+                "--stream".into(),
+                stream_name.into(),
+                "--offset".into(),
+                offset.to_string(),
+                "--max-bytes".into(),
+                MAX_LOG_CHUNK_BYTES.to_string(),
+            ],
+        ),
+        None,
+        RUNNER_CALL_TIMEOUT,
+    )
+    .await?;
+    match parse_reply(&output)? {
+        Reply::Logs { chunk } => Ok(*chunk),
+        _ => Err(RunnerCallFailure::Unreadable),
+    }
+}
+
+/// One exec against the runner.
+///
+/// A truncated reply is `Unreadable` rather than an attempt at partial JSON,
+/// and a denial from the resolver is `Unreachable` — from Kobe's side those are
+/// the same fact: nobody can currently say what the command is doing.
+async fn call(
+    client: &kube::Client,
+    target: &SandboxTarget,
+    container: &str,
+    argv: &[String],
+    stdin: Option<&[u8]>,
+    timeout: std::time::Duration,
+) -> Result<Vec<u8>, RunnerCallFailure> {
+    let raw = exec_capped(
+        client,
+        target,
+        container,
+        argv,
+        stdin,
+        timeout,
+        RUNNER_REPLY_CAP,
+    )
+    .await
+    .map_err(|denied| match denied {
+        // Kept as one failure on purpose: the caller must not be able to tell a
+        // replaced Pod from an unreachable one by probing an execution.
+        SandboxAccessDenied::NotDeclared { .. } => RunnerCallFailure::Unreadable,
+        _ => RunnerCallFailure::Unreachable,
+    })?;
+    if raw.truncated {
+        return Err(RunnerCallFailure::Unreadable);
+    }
+    if raw.stdout.is_empty() {
+        // The exec succeeded and the runner said nothing. That is not an
+        // outcome; it is the absence of one.
+        return Err(RunnerCallFailure::Unreachable);
+    }
+    Ok(raw.stdout)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn report(state: RunnerState) -> ExecutionReport {
+        ExecutionReport {
+            id: "sbxe-1".into(),
+            state,
+            reason: Some("completed".into()),
+            ..Default::default()
+        }
+    }
+
+    /// Nothing a caller supplied ever becomes an exec argument.
+    ///
+    /// An exec's argv is a URL, recorded verbatim by the target apiserver's
+    /// audit log. A tenant's command line routinely carries secrets — a token
+    /// in a flag, a connection string in an argument — and that log belongs to
+    /// somebody who cannot redact it.
+    #[test]
+    fn a_control_call_carries_no_caller_supplied_data() {
+        let argv = control_argv("/kobe-runner", "status", "sbxe-abc123", &[]);
+        assert_eq!(
+            argv,
+            vec!["/kobe-runner", "status", "--id", "sbxe-abc123"],
+            "a control call is a fixed verb and a derived id"
+        );
+
+        let request = start_request(
+            "sbxe-abc123",
+            &["/agent".into(), "--token".into(), "s3cret".into()],
+            Some("/work"),
+            std::time::Duration::from_secs(60),
+        );
+        let line = String::from_utf8(start_line(&request).unwrap()).unwrap();
+        assert!(line.contains("s3cret"), "the command travels on stdin");
+        assert!(line.ends_with('\n'), "the runner reads exactly one line");
+
+        // The start call's own argv is two fixed words. Nothing else.
+        assert_eq!(
+            vec!["/kobe-runner".to_string(), "start".to_string()],
+            vec!["/kobe-runner".to_string(), "start".to_string()]
+        );
+        // And no reading of the request may be spliced into an argument.
+        for argument in control_argv("/kobe-runner", "status", "sbxe-abc123", &[]) {
+            assert!(!argument.contains("s3cret"));
+            assert!(
+                !argument.contains(';') && !argument.contains('&') && !argument.contains('|'),
+                "{argument} looks like a shell fragment"
+            );
+        }
+    }
+
+    /// A reply Kobe cannot read never becomes an outcome.
+    ///
+    /// Every one of these inputs is a way to be told nothing. Parsing any of
+    /// them optimistically would put a state in front of a caller that nothing
+    /// inside the container ever asserted.
+    #[test]
+    fn an_unreadable_reply_is_never_read_as_an_outcome() {
+        let good = serde_json::to_vec(&Envelope::new(Reply::State {
+            report: report(RunnerState::Succeeded),
+        }))
+        .unwrap();
+        assert!(parse_reply(&good).is_ok());
+
+        // Another protocol version is refused outright, however well-formed.
+        let future =
+            br#"{"protocol":2,"reply":"state","report":{"id":"sbxe-1","state":"succeeded"}}"#;
+        assert_eq!(
+            parse_reply(future).unwrap_err(),
+            RunnerCallFailure::Unreadable
+        );
+
+        for unreadable in [
+            &b""[..],
+            b"   ",
+            b"not json",
+            b"{\"protocol\":1}",
+            // Truncated mid-document: the shape of a capped read.
+            b"{\"protocol\":1,\"reply\":\"state\",\"report\":{\"id\"",
+            b"{\"protocol\":\"1\",\"reply\":\"state\",\"report\":{}}",
+        ] {
+            assert!(
+                parse_reply(unreadable).is_err(),
+                "{:?} must not parse",
+                String::from_utf8_lossy(unreadable)
+            );
+        }
+
+        // A banner ahead of the reply does not cost the outcome.
+        let mut noisy = b"WARNING: locale not set\n".to_vec();
+        noisy.extend_from_slice(&good);
+        assert!(parse_reply(&noisy).is_ok());
+    }
+
+    /// A refusal is a refusal, not an outcome.
+    ///
+    /// `NotFound` from the runner means the container has no record of an
+    /// execution Kobe reserved. Reading that as a result would let a Pod that
+    /// restarted answer for a command it never ran.
+    #[test]
+    fn a_refusal_is_reported_as_one() {
+        for (code, expected) in [
+            (RunnerErrorCode::NotFound, "runner_forgot_execution"),
+            (RunnerErrorCode::Conflict, "runner_id_conflict"),
+            (RunnerErrorCode::InvalidRequest, "runner_rejected_request"),
+            (RunnerErrorCode::Internal, "runner_internal_error"),
+        ] {
+            let encoded = serde_json::to_vec(&Envelope::new(Reply::Error { code })).unwrap();
+            assert_eq!(
+                parse_reply(&encoded).unwrap_err(),
+                RunnerCallFailure::Refused(code)
+            );
+            assert_eq!(
+                RunnerCallFailure::Refused(code).reason_code(),
+                expected,
+                "an operator has to be able to tell these apart"
+            );
+        }
+    }
+
+    /// No failure to reach the runner is ever a 500 or a success.
+    ///
+    /// A 500 invites a retry, and a retry of an execution that may already have
+    /// run is the exact damage the reserve-then-spawn design exists to prevent.
+    #[test]
+    fn a_runner_failure_never_invites_a_blind_retry() {
+        use axum::http::StatusCode;
+        for failure in [
+            RunnerCallFailure::Unreachable,
+            RunnerCallFailure::Unreadable,
+            RunnerCallFailure::Refused(RunnerErrorCode::NotFound),
+            RunnerCallFailure::Refused(RunnerErrorCode::Conflict),
+            RunnerCallFailure::Refused(RunnerErrorCode::Internal),
+        ] {
+            let status = failure.http_status();
+            assert!(!status.is_success(), "{failure} must not read as a success");
+            assert_ne!(
+                status,
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "{failure} is not Kobe being broken"
+            );
+            assert!(!failure.reason_code().is_empty());
+            assert!(failure.reason_code().len() <= 64);
+        }
+    }
+
+    /// An outcome nobody observed is `Unknown`, never `Failed` or `Succeeded`.
+    ///
+    /// `Failed` reads as "it ran and said no", which tells a caller their retry
+    /// is safe. `Succeeded` is simply a lie. `Unknown` is the state that makes
+    /// the decision theirs — which is the correct amount of work to impose when
+    /// the truth is that nobody knows.
+    #[test]
+    fn an_unobserved_outcome_is_unknown() {
+        assert_eq!(
+            outcome_from_report(&report(RunnerState::Unknown)).state,
+            ExecutionState::Unknown
+        );
+
+        // A success with no exit code contradicts itself: nothing observed a
+        // number, so nothing may claim the command completed.
+        let hollow = ExecutionReport {
+            exit_code: None,
+            ..report(RunnerState::Succeeded)
+        };
+        assert_eq!(
+            outcome_from_report(&hollow).state,
+            ExecutionState::Unknown,
+            "a success nobody backed with a code is a claim, not an observation"
+        );
+        assert_eq!(outcome_from_report(&hollow).exit_code, None);
+
+        // As does a failure with neither a code nor a signal.
+        let empty = report(RunnerState::Failed);
+        assert_eq!(outcome_from_report(&empty).state, ExecutionState::Unknown);
+        assert_eq!(outcome_from_report(&empty).exit_code, None);
+    }
+
+    /// An exit code reaches the record exactly as the process gave it.
+    ///
+    /// A caller's failing test must look like a failing test and not like an
+    /// infrastructure fault — and a synthesised zero would be indistinguishable
+    /// from a real success.
+    #[test]
+    fn an_exit_code_survives_the_translation_unchanged() {
+        let succeeded = ExecutionReport {
+            exit_code: Some(0),
+            ..report(RunnerState::Succeeded)
+        };
+        let outcome = outcome_from_report(&succeeded);
+        assert_eq!(outcome.state, ExecutionState::Succeeded);
+        assert_eq!(outcome.exit_code, Some(0));
+
+        for code in [1, 2, 127, 255] {
+            let failed = ExecutionReport {
+                exit_code: Some(code),
+                ..report(RunnerState::Failed)
+            };
+            let outcome = outcome_from_report(&failed);
+            assert_eq!(outcome.state, ExecutionState::Failed, "exit {code}");
+            assert_eq!(outcome.exit_code, Some(code));
+        }
+    }
+
+    /// A killed command is distinguishable from one that chose to exit.
+    ///
+    /// An OOM kill definitely ran and definitely did not finish, so it is a
+    /// failure rather than an unknown. The status field requires a code, so it
+    /// carries the POSIX `128 + signal` convention — and `reason = signalled`
+    /// is what keeps it from being read as a command that deliberately exited
+    /// 137.
+    #[test]
+    fn a_signalled_command_is_a_failure_that_still_says_it_was_signalled() {
+        let killed = ExecutionReport {
+            exit_code: None,
+            signal: Some(9),
+            reason: Some("signalled".into()),
+            ..report(RunnerState::Failed)
+        };
+        let outcome = outcome_from_report(&killed);
+        assert_eq!(outcome.state, ExecutionState::Failed);
+        assert_eq!(outcome.exit_code, Some(137));
+        assert_eq!(
+            outcome.reason, "signalled",
+            "the record must say the code was not chosen"
+        );
+    }
+
+    /// Cancelled and timed-out carry no exit code at all.
+    ///
+    /// Neither process chose an outcome; the runner imposed one. A code here
+    /// would assert something nobody observed — and the CRD refuses it for
+    /// exactly that reason.
+    #[test]
+    fn an_imposed_ending_carries_no_exit_code() {
+        for (runner_state, expected) in [
+            (RunnerState::Cancelled, ExecutionState::Cancelled),
+            (RunnerState::TimedOut, ExecutionState::TimedOut),
+        ] {
+            let outcome = outcome_from_report(&ExecutionReport {
+                exit_code: Some(0),
+                signal: Some(9),
+                ..report(runner_state)
+            });
+            assert_eq!(outcome.state, expected);
+            assert_eq!(
+                outcome.exit_code, None,
+                "{expected} must not carry an exit code"
+            );
+        }
+    }
+
+    /// Nothing from inside the container reaches a Kubernetes object unbounded.
+    ///
+    /// The reason is the one value that crosses that boundary. A runner that is
+    /// old, broken, or replaced could put a path, an error message, or a line
+    /// of the command's own output there — and object status is readable by
+    /// anyone with `get`, replicated to every etcd member, and in every backup.
+    #[test]
+    fn a_runner_reason_can_never_reach_the_record_unbounded() {
+        assert_eq!(bounded_reason("completed"), "completed");
+        assert_eq!(bounded_reason("cancelled_by_caller"), "cancelled_by_caller");
+
+        for hostile in [
+            "",
+            "Bearer eyJhbGciOi",
+            "failed to open /home/agent/.aws/credentials",
+            "postgres://user:password@host/db",
+            &"x".repeat(65),
+            "completed\nAWS_SECRET=1",
+            "réussi",
+        ] {
+            assert_eq!(
+                bounded_reason(hostile),
+                "runner_reason_unrecognised",
+                "reason {hostile:?} must not be persisted"
+            );
+        }
+
+        // Every reason the record can carry fits the status field's own bound.
+        for state in [
+            RunnerState::Running,
+            RunnerState::Succeeded,
+            RunnerState::Failed,
+            RunnerState::Cancelled,
+            RunnerState::TimedOut,
+            RunnerState::Unknown,
+        ] {
+            let outcome = outcome_from_report(&report(state));
+            assert!(outcome.reason.len() <= 64);
+        }
+    }
+
+    /// A command's own bound is never rounded down.
+    ///
+    /// A request for 1.5 seconds that became 1 would have the runner kill a
+    /// command before its own deadline, and the caller would read `TimedOut`
+    /// for a command that still had time.
+    #[test]
+    fn a_timeout_is_never_rounded_down() {
+        let seconds = |timeout: std::time::Duration| {
+            start_request("sbxe-1", &["/agent".into()], None, timeout).timeout_seconds
+        };
+
+        assert_eq!(seconds(std::time::Duration::from_secs(60)), 60);
+        assert_eq!(seconds(std::time::Duration::from_millis(1500)), 2);
+        // A bound below one second still has to be at least one: zero is not a
+        // timeout, it is a command that can never succeed.
+        assert_eq!(seconds(std::time::Duration::from_millis(1)), 1);
+        assert_eq!(seconds(std::time::Duration::ZERO), 1);
+    }
+
+    /// The retention the runner is asked for is Kobe's decision, not the
+    /// caller's.
+    ///
+    /// The spool sits on the ephemeral disk the whole Pod shares. A cap a
+    /// caller could choose is a way to fill it from inside a sandbox that
+    /// exists precisely because its occupant is not trusted.
+    #[test]
+    fn retention_is_bounded_by_kobe_rather_than_by_the_caller() {
+        let request = start_request(
+            "sbxe-1",
+            &["/agent".into()],
+            None,
+            std::time::Duration::from_secs(60),
+        );
+        assert_eq!(request.max_output_bytes, MAX_RETENTION_BYTES);
+        assert!(request.max_output_bytes <= MAX_RETENTION_BYTES);
+    }
+}

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -1569,6 +1569,7 @@ pub(crate) mod tests {
                         container: "agent".into(),
                         port: 3000,
                     }],
+                    runner_path: None,
                 },
                 isolation: SandboxIsolation::Gvisor {
                     runtime_class_name: "runsc".into(),

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -280,6 +280,20 @@ pub struct SandboxTemplateSpec {
     #[serde(default)]
     #[schemars(length(max = 64))]
     pub exposed_ports: Vec<SandboxPortSpec>,
+    /// Absolute path to `kobe-runner` inside `defaultContainer`, when the
+    /// administrator's image ships one.
+    ///
+    /// Absent means this pool does not offer detached execution, and the API
+    /// says so rather than approximating it. A detached execution that actually
+    /// dies with its connection is worse than none, because the caller has
+    /// already built on the guarantee it appeared to offer.
+    ///
+    /// A constrained path rather than free text: it becomes `argv[0]` of an
+    /// exec, so anything that could carry an argument, a shell metacharacter or
+    /// a nul is refused by the schema before it can reach one.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(length(min = 1, max = 255), pattern(r"^/[A-Za-z0-9._/-]*$"))]
+    pub runner_path: Option<String>,
 }
 
 /// One administrator-controlled container in a Sandbox template.
@@ -756,6 +770,7 @@ mod tests {
                     container: "agent".into(),
                     port: 3000,
                 }],
+                runner_path: None,
             },
             isolation: SandboxIsolation::TrustedRunc {},
             readiness: SandboxReadinessRequirements {

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1008,6 +1008,7 @@ mod tests {
                     container: "agent".into(),
                     port: 3000,
                 }],
+                runner_path: None,
             },
             isolation: SandboxIsolation::Gvisor {
                 runtime_class_name: "runsc".into(),


### PR DESCRIPTION
Closes the deferred half of #82: the Sandbox runner/supervisor contract, and the removal of the 501 on detached execution.

## Why 501 existed

A Kubernetes exec is a connection. When it closes — the caller disconnects, the operator restarts, a node drains — everything started through it goes with it. A "detached" execution built on that dies with its connection, which is strictly worse than not offering one: the caller has already built on a guarantee that was never there, and finds out from the work that did not happen. So detached was refused rather than approximated. This ships the supervisor that makes it true.

## What is here

**`crates/kobe-runner`** — a new workspace member; one small binary that supervises one command.

- `start` re-executes it into a **session of its own** and exits. The supervisor is reparented to the container's init, holds none of the exec's descriptors, and there is nothing left for the teardown to signal.
- The command gets a **second session**, so cancelling kills the process **group**. A build script that spawned four compilers and exited otherwise leaves them running on CPU the lease is paying for, while Kobe reports a clean cancellation.
- Output is captured per stream, capped, and the cap is **reported** — and the pump keeps reading past it and discards. That half matters more: a runner that stops draining a full pipe leaves the command blocked in `write`, so a command that merely printed too much would be reported as a *timeout*.
- Output is read back **by offset**, so a caller who disconnected resumes exactly where they were.
- The spool lives on the container's own disk and dies with the Sandbox — #82 ends history with the lease.

**The protocol** — versioned JSON, one short exec per verb (`start` / `status` / `logs` / `cancel`), never a socket. A listening port would be reachable by the tenant's own workload, would need an auth scheme of its own, and would have to be declared by the pool. Exec is already fenced to one lease, one Pod UID and one container, and #81's resolver re-runs that fence on **every** call.

The start request travels on **stdin, as one line**. An exec's argv is a URL the target apiserver audit-logs verbatim, and a tenant's command line routinely carries a token in a flag; only Kobe's derived execution id is ever an argument. One line rather than "until EOF" because the exec transport's write half cannot be half-closed reliably.

Both halves compile the same `protocol` module: two hand-maintained copies of a wire format drift, and the drift shows up as a *misread* reply rather than a broken one. A reply from an unrecognised protocol version is refused, not parsed optimistically — a Sandbox image can be months older than the Kobe talking to it.

**Idempotency on both sides.** Kobe still reserves the key durably before spawning; the runner reserves the id by assembling a directory elsewhere and `rename`ing it into place — atomic, never observable half-built, so a concurrent retry cannot find a reservation it cannot read and conclude there is none.

**Honesty preserved end to end.** A killed command reports *why* and carries no exit code. An exit code is only ever the one the process gave. Anything unestablished is `Unknown`, never `Failed`. The one judgement call is a foreign signal (OOM kill): it definitely ran and definitely did not finish, so `Failed` with the POSIX `128+signal` the status field requires, and `reason=signalled` keeps it distinguishable from a command that deliberately exited 137.

**API.**

- `POST .../executions` with `detach: true` now works where the pool provides a runner; where it does not, it still answers 501 — and does so **before** the reservation, so a request that cannot be served does not spend the caller's idempotency key.
- `GET .../executions/{id}` asks the runner instead of echoing what Kobe last wrote, and settles the record when it is done. A failed poll changes nothing; the verdict deadline stays the backstop. A runner with *no record* of a reserved execution settles as `Unknown` now rather than after the deadline.
- `GET .../executions/{id}/logs` (listed in #82, previously unimplemented) serves retained output, per stream, by offset, truncation reported. Wait-mode executions are refused there explicitly — their output went out with their result.
- `DELETE .../executions/{id}` terminates the process group. A cancel that cannot reach the runner leaves the record alone rather than claiming a termination nobody performed.

**Opt-in.** `spec.template.runnerPath` on the SandboxPool, schema-constrained to an absolute path because it becomes argv[0]. `docker/runner.Dockerfile` builds a static musl binary into a `scratch` image for copying into an administrator's own agent image; it deliberately does not reuse the operator's builder.

## Verification

`cargo fmt --all`, `cargo clippy --workspace --all-targets -D warnings`, `cargo test --workspace` all clean.

Ten integration tests drive the **real binary** as a subprocess — every property here is a property of processes: detached survival, process-group cancellation, separate streams, exact exit codes, timeout termination, one spawn per id, capped-but-not-fatal output, `cwd` as a `chdir`, retention after exit.

Mutation-checked (rule broken, test confirmed failing, restored):

| mutation | test that caught it |
| --- | --- |
| pump stops reading at the cap | `output_past_the_cap_is_dropped_reported_and_not_fatal` |
| cancel signals the leader, not the group | `cancelling_kills_the_whole_process_group` |
| one id may be reserved twice | `one_id_runs_one_command_however_often_it_is_started` |
| an id may contain `/` or `.` | `a_hostile_id_reaches_no_file` |
| an unobserved outcome reported as `Failed` | `an_unobserved_outcome_is_unknown` |
| a runner reason persisted verbatim | `a_runner_reason_can_never_reach_the_record_unbounded` |
| detached refused only *after* reserving | `a_pool_without_a_runner_refuses_detached_before_spending_the_key` |

## What is NOT verified here

- **The exec transport.** The tests show the supervisor survives its parent exiting; showing it survives the *kubelet* tearing down an exec needs a real container. The mechanism is the same (its own session), the demonstration is not.
- **stdin over kube exec.** Writing the request and closing the write half is untested against a live apiserver — the one-line read on the runner side exists precisely so a missing EOF cannot wedge it, but the round trip itself wants a cluster.
- **The musl image build.** `docker/runner.Dockerfile` is not built in this environment; CI's default bake group now includes it.
- **`/var/run` writability** in an arbitrary administrator image, and the runner's behaviour under a read-only root filesystem.