### PR TITLE
fix(k3s): pin the node password so one restart cannot brick a cluster

### DIFF
--- a/hack/test-e2e-k3s.ts
+++ b/hack/test-e2e-k3s.ts
@@ -1,4 +1,5 @@
-// Provision→Ready→recycle CI smoke gate for the kobe operator's k3s backend.
+// Provision→Ready→restart→recycle CI smoke gate for the kobe operator's k3s
+// backend.
 //
 // Unlike test-smoke.ts (which leases through the kobe HTTP proxy and short-
 // circuits kubectl verification for local NodePort endpoints), this gate
@@ -6,7 +7,7 @@
 // and asserts guest readiness from the host's ClusterInstance/StatefulSet
 // status. There is intentionally no `shouldSkipKubectlVerification` path here.
 //
-// It exists because two regressions reached prod that unit tests cannot see:
+// It exists because three regressions reached prod that unit tests cannot see:
 //
 //   (A) the k3s readiness probe was changed to an HTTPS GET on /readyz, which
 //       k3s answers with 401 to an unauthenticated kubelet probe → the server
@@ -16,12 +17,31 @@
 //       fails if it does not reach `status.phase == Ready` with the server
 //       StatefulSet reporting `readyReplicas >= 1` inside the budget.
 //
-//   (B) the k3s backend deleted a PodDisruptionBudget on every recycle, but
+//   (B) the k3s server kept its node password at /etc/rancher/node/password —
+//       the container's overlay rw layer, which the kubelet discards whenever
+//       it rebuilds a container — while the datastore holding that password's
+//       hash lived on the `data` volume, which survives a container restart.
+//       So the FIRST transient restart left the hash intact but rolled a fresh
+//       password, k3s rejected its own node with
+//       `NodePasswordValidationFailed: hash does not match`, and because the
+//       file is regenerated on every attempt the retry never converged: one
+//       restart bricked the control plane permanently (#145). Assertion (B)
+//       below restarts the server container and fails unless the cluster comes
+//       back and STAYS back.
+//
+//       Note the shape of this one, because it generalizes: nothing was
+//       mis-written, something was merely absent from the pod spec, so no
+//       assertion about what the spec CONTAINS could have failed. Only
+//       crossing the restart boundary exposes it. Treat (B) as the guard for
+//       that whole class — any guest state that must outlive a container
+//       restart but sits on the overlay — not just for node passwords.
+//
+//   (C) the k3s backend deleted a PodDisruptionBudget on every recycle, but
 //       the Helm chart's ClusterRole lacked the `policy/poddisruptionbudgets`
 //       grant. RBAC is checked before existence, so even single-server
 //       instances (which never had a PDB) got 403 Forbidden on delete; the
 //       instance-cleanup finalizer was never released and the pool wedged in
-//       Recycling forever. Assertion (B) below deletes the ClusterInstance and
+//       Recycling forever. Assertion (C) below deletes the ClusterInstance and
 //       fails unless it is ACTUALLY GONE inside the budget (not merely that the
 //       delete call returned), AND that no orphaned `data-<name>-server-*` PVC
 //       is left behind (the #154 PVC-reaping path).
@@ -42,6 +62,19 @@ const readyTimeoutSeconds = parsePositiveInt(
 const recycleTimeoutSeconds = parsePositiveInt(
   Bun.env.K3S_RECYCLE_TIMEOUT_SECONDS ?? "90",
   "K3S_RECYCLE_TIMEOUT_SECONDS",
+);
+// A restart reuses the `data` volume (certs, DB and images are all still
+// there), so recovery is far cheaper than the cold provision budget above.
+const restartTimeoutSeconds = parsePositiveInt(
+  Bun.env.K3S_RESTART_TIMEOUT_SECONDS ?? "300",
+  "K3S_RESTART_TIMEOUT_SECONDS",
+);
+// How long the server must hold Ready after recovering. Without it the gate
+// would pass on a cluster that merely oscillates: #145's signature was a
+// restart count climbing 1→2→3→4, and the very first recovery looks healthy.
+const restartSettleSeconds = parsePositiveInt(
+  Bun.env.K3S_RESTART_SETTLE_SECONDS ?? "45",
+  "K3S_RESTART_SETTLE_SECONDS",
 );
 const pollRetrySeconds = parsePositiveInt(
   Bun.env.K3S_POLL_RETRY_SECONDS ?? "5",
@@ -297,7 +330,152 @@ async function waitForReadyInstance(): Promise<string> {
   process.exit(1);
 }
 
-// ── (B) recycle → clean teardown ─────────────────────────────────────────────
+// ── (B) restart → recovers, and STAYS recovered ──────────────────────────────
+// The server pod's status, as far as this gate cares: does it exist, is it
+// Ready, and how many times has the k3s-server container been rebuilt.
+type ServerPodStatus = {
+  exists: boolean;
+  ready: boolean;
+  restartCount: number;
+};
+
+async function serverPodStatus(instanceName: string): Promise<ServerPodStatus> {
+  const absent: ServerPodStatus = { exists: false, ready: false, restartCount: 0 };
+  const { stdout, exitCode } = await kubectl(
+    ["get", "pod", "-n", namespace, `${instanceName}-server-0`, "-o", "json"],
+    { allowFailure: true },
+  );
+  if (exitCode !== 0) return absent;
+
+  let pod: {
+    status?: {
+      conditions?: Array<{ type?: string; status?: string }>;
+      containerStatuses?: Array<{ name?: string; restartCount?: number }>;
+    };
+  };
+  try {
+    pod = JSON.parse(stdout);
+  } catch {
+    return absent;
+  }
+
+  const ready = (pod.status?.conditions ?? []).some(
+    (condition) => condition.type === "Ready" && condition.status === "True",
+  );
+  const server = (pod.status?.containerStatuses ?? []).find(
+    (container) => container.name === "k3s-server",
+  );
+  return { exists: true, ready, restartCount: server?.restartCount ?? 0 };
+}
+
+// Restart the k3s-server CONTAINER (not the pod) and assert the cluster comes
+// back and holds. Container-scoped is the whole point: the kubelet rebuilds the
+// container filesystem from the image while the pod's `data` volume survives
+// untouched — precisely the asymmetry that #145 turned into a permanent
+// outage. Deleting the pod instead would discard the emptyDir too and hide it.
+async function restartAndAssertRecovers(instanceName: string): Promise<void> {
+  const pod = `${instanceName}-server-0`;
+  info("");
+  info(`(B) Restarting the k3s-server container in '${pod}' and asserting it recovers...`);
+
+  const before = await serverPodStatus(instanceName);
+  if (!before.exists) {
+    errorLine(`(B) FAIL: server pod '${pod}' not found; cannot exercise the restart path.`);
+    await printDiagnostics("server pod missing before restart", instanceName);
+    process.exit(1);
+  }
+  info(`(B) Baseline: ready=${before.ready} restartCount=${before.restartCount}.`);
+
+  // SIGTERM to PID 1 (the k3s server process). NOT SIGKILL: PID 1 inside a
+  // namespace only receives signals it has installed a handler for, and the
+  // kernel drops an uncaught SIGKILL aimed at it — k3s handles SIGTERM, so
+  // this is both deliverable and a realistic restart. The exec itself is
+  // EXPECTED to fail (the connection dies with the process), so its exit code
+  // proves nothing; the restart count below is the real evidence.
+  await kubectl(
+    ["exec", "-n", namespace, pod, "-c", "k3s-server", "--", "sh", "-c", "kill 1"],
+    { allowFailure: true },
+  );
+
+  // 1. The container must actually have been rebuilt, or the rest of this
+  //    assertion would pass vacuously against a server that never restarted.
+  const restartDeadline = Date.now() + restartTimeoutSeconds * 1000;
+  let observed = before;
+  while (Date.now() < restartDeadline) {
+    observed = await serverPodStatus(instanceName);
+    if (observed.exists && observed.restartCount > before.restartCount) break;
+    await Bun.sleep(pollRetrySeconds * 1000);
+  }
+  if (observed.restartCount <= before.restartCount) {
+    errorLine(
+      `(B) FAIL: k3s-server in '${pod}' never restarted within ${restartTimeoutSeconds}s ` +
+        `(restartCount stuck at ${observed.restartCount}); the gate could not exercise the restart path.`,
+    );
+    await printDiagnostics("server container did not restart", instanceName);
+    process.exit(1);
+  }
+  const induced = observed.restartCount;
+  info(`(B) Container rebuilt (restartCount ${before.restartCount} → ${induced}); waiting for Ready...`);
+
+  // 2. It must come back: pod Ready AND the StatefulSet counting it ready.
+  while (Date.now() < restartDeadline) {
+    const status = await serverPodStatus(instanceName);
+    if (status.ready && (await serverReadyReplicas(instanceName)) >= 1) {
+      info(`(B) Server recovered after the restart.`);
+      break;
+    }
+    const remaining = Math.max(0, Math.ceil((restartDeadline - Date.now()) / 1000));
+    info(`  ${remaining}s left - ready=${status.ready} restartCount=${status.restartCount}`);
+    await Bun.sleep(pollRetrySeconds * 1000);
+  }
+  const recovered = await serverPodStatus(instanceName);
+  if (!recovered.ready || (await serverReadyReplicas(instanceName)) < 1) {
+    errorLine(
+      `(B) FAIL: '${pod}' did not return to Ready within ${restartTimeoutSeconds}s of a single ` +
+        `container restart (restartCount=${recovered.restartCount}).`,
+    );
+    errorLine(
+      "     This is the #145 node-identity class: state the guest must not lose across a container",
+    );
+    errorLine(
+      "     restart (there, /etc/rancher/node/password) is sitting on the container's overlay rw layer",
+    );
+    errorLine(
+      "     while the datastore that must agree with it sits on the `data` volume. The rebuilt container",
+    );
+    errorLine(
+      "     re-registers with fresh state, the server rejects it, and no retry can ever converge.",
+    );
+    errorLine("     Check the guest's own logs for NodePasswordValidationFailed.");
+    await printDiagnostics("server did not recover from a container restart", instanceName);
+    process.exit(1);
+  }
+
+  // 3. It must STAY back. #145 recovered on the first restart too — it was the
+  //    restart AFTER that which never converged, so a gate that stops at the
+  //    first Ready would have shipped the bug green.
+  info(`(B) Holding for ${restartSettleSeconds}s to prove the recovery is stable...`);
+  const settleDeadline = Date.now() + restartSettleSeconds * 1000;
+  while (Date.now() < settleDeadline) {
+    await Bun.sleep(pollRetrySeconds * 1000);
+    const status = await serverPodStatus(instanceName);
+    if (status.restartCount > induced) {
+      errorLine(
+        `(B) FAIL: '${pod}' restarted again after recovering (restartCount ${induced} → ` +
+          `${status.restartCount}) — the server is crashlooping, not healthy.`,
+      );
+      errorLine(
+        "     A cluster that oscillates is exactly the #145 signature (restart count climbing 1→2→3→4).",
+      );
+      await printDiagnostics("server crashlooped after restarting", instanceName);
+      process.exit(1);
+    }
+  }
+
+  info(`(B) PASS: server survived a container restart and held Ready for ${restartSettleSeconds}s.`);
+}
+
+// ── (C) recycle → clean teardown ─────────────────────────────────────────────
 // Delete the ClusterInstance, then assert it is ACTUALLY GONE within
 // recycleTimeoutSeconds (the delete call returning is NOT enough — the
 // instance-cleanup finalizer must be released), and that no orphaned
@@ -327,7 +505,7 @@ async function recycleAndAssertGone(instanceName: string): Promise<void> {
   );
   const doomedUid = uidExit === 0 ? uidOut.trim() : "";
 
-  info(`(B) Recycling instance '${instanceName}' (uid=${doomedUid || "?"}) via kubectl delete...`);
+  info(`(C) Recycling instance '${instanceName}' (uid=${doomedUid || "?"}) via kubectl delete...`);
   // --wait=false: do NOT block on the finalizer here; the assertion below is
   // exactly that the finalizer is eventually released and the object vanishes.
   await kubectl(
@@ -343,7 +521,7 @@ async function recycleAndAssertGone(instanceName: string): Promise<void> {
     { allowFailure: true },
   );
 
-  info(`(B) Waiting up to ${recycleTimeoutSeconds}s for instance '${instanceName}' to be fully gone...`);
+  info(`(C) Waiting up to ${recycleTimeoutSeconds}s for instance '${instanceName}' to be fully gone...`);
   const deadline = Date.now() + recycleTimeoutSeconds * 1000;
   let attempt = 0;
   let lastPhase = "(unknown)";
@@ -352,7 +530,7 @@ async function recycleAndAssertGone(instanceName: string): Promise<void> {
     const orphans = await orphanedServerPvcs(instanceName);
     if (orphans.length > 0) {
       errorLine(
-        `(B) FAIL: instance '${instanceName}' was deleted but orphaned PVC(s) remain: ${orphans.join(", ")}`,
+        `(C) FAIL: instance '${instanceName}' was deleted but orphaned PVC(s) remain: ${orphans.join(", ")}`,
       );
       errorLine("     This is the #154 PVC-reaping regression class.");
       await printDiagnostics("recycle left orphaned server data PVCs", instanceName);
@@ -360,7 +538,7 @@ async function recycleAndAssertGone(instanceName: string): Promise<void> {
     }
     const elapsed = Math.floor((Date.now() - (deadline - recycleTimeoutSeconds * 1000)) / 1000);
     info(
-      `(B) PASS: instance '${instanceName}' is fully gone (${goneHow}) after ~${elapsed}s and no data-${instanceName}-server-* PVC was orphaned.`,
+      `(C) PASS: instance '${instanceName}' is fully gone (${goneHow}) after ~${elapsed}s and no data-${instanceName}-server-* PVC was orphaned.`,
     );
   };
 
@@ -400,7 +578,7 @@ async function recycleAndAssertGone(instanceName: string): Promise<void> {
   }
 
   errorLine(
-    `(B) FAIL: instance '${instanceName}' was not fully removed within ${recycleTimeoutSeconds}s (last phase=${lastPhase}).`,
+    `(C) FAIL: instance '${instanceName}' was not fully removed within ${recycleTimeoutSeconds}s (last phase=${lastPhase}).`,
   );
   errorLine(
     "     This is the RBAC-403 recycle-wedge class: a missing policy/poddisruptionbudgets grant makes the",
@@ -428,10 +606,11 @@ async function main(): Promise<void> {
   }
 
   const instanceName = await waitForReadyInstance();
+  await restartAndAssertRecovers(instanceName);
   await recycleAndAssertGone(instanceName);
 
   info("");
-  info("k3s smoke gate PASSED (provision → Ready → clean recycle).");
+  info("k3s smoke gate PASSED (provision → Ready → survives restart → clean recycle).");
 }
 
 try {

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -146,6 +146,65 @@ sleep infinity
 /// (https://docs.k3s.io/installation/private-registry)
 const REGISTRIES_YAML_PATH: &str = "/etc/rancher/k3s/registries.yaml";
 
+/// Path every k3s node keeps its cleartext node password at.
+///
+/// k3s hashes this value into a `<nodename>.node-password.k3s` Secret in the
+/// guest's `kube-system` on first registration and re-checks it on every
+/// subsequent one. The path is fixed in k3s (`nodePasswordRoot = "/"` for
+/// non-rootless nodes; see `pkg/agent/config/config.go`) and is NOT under the
+/// data dir — which is exactly what makes #145 possible.
+const NODE_PASSWORD_PATH: &str = "/etc/rancher/node/password";
+
+/// Key under which the per-cluster node password lives in `{cluster}-token`.
+const NODE_PASSWORD_KEY: &str = "node-password";
+
+/// Volume carrying the pinned node password into a k3s pod.
+///
+/// Reuses the cluster's `{name}-token` Secret (already create-once and
+/// preserved across recreation) but projects ONLY the node-password key, so
+/// the token mount at `/var/lib/k3s/token` stays single-purpose.
+fn node_password_volume(name: &str) -> Volume {
+    Volume {
+        name: NODE_PASSWORD_KEY.to_string(),
+        secret: Some(SecretVolumeSource {
+            secret_name: Some(format!("{name}-token")),
+            items: Some(vec![KeyToPath {
+                key: NODE_PASSWORD_KEY.to_string(),
+                path: NODE_PASSWORD_KEY.to_string(),
+                // k3s writes it 0600; match that rather than the 0644 default.
+                mode: Some(0o400),
+            }]),
+            ..Default::default()
+        }),
+        ..Default::default()
+    }
+}
+
+/// Mount that pins `/etc/rancher/node/password` to the cluster's Secret.
+///
+/// LOAD-BEARING (#145). k3s generates this password on first boot and writes it
+/// to a path in the container's overlay rw layer, while the datastore holding
+/// its hash lives on the `data` volume (emptyDir → survives container restarts;
+/// PVC → survives reschedules). A container restart therefore discards the
+/// password but NOT the hash, so the restarted server re-registers its own node
+/// with a fresh random password, k3s reports
+/// `NodePasswordValidationFailed: hash does not match`, and the node never
+/// registers again — one transient restart permanently bricks the cluster.
+/// Sourcing the password from the Secret makes its lifetime that of the
+/// ClusterInstance, so it can never be younger than the datastore.
+///
+/// `read_only` is safe: k3s reads this file when it exists and only writes when
+/// it does not (`ensureNodePassword`).
+fn node_password_mount() -> VolumeMount {
+    VolumeMount {
+        name: NODE_PASSWORD_KEY.to_string(),
+        mount_path: NODE_PASSWORD_PATH.to_string(),
+        sub_path: Some(NODE_PASSWORD_KEY.to_string()),
+        read_only: Some(true),
+        ..Default::default()
+    }
+}
+
 /// True iff the ClusterConfig declares a non-empty registry_mirrors map.
 fn has_registry_mirrors(config: &ClusterConfig) -> bool {
     config
@@ -540,6 +599,18 @@ impl K3sBackend {
         hex::encode(bytes)
     }
 
+    /// Generate a node password in k3s's own format: 16 random bytes, hex.
+    ///
+    /// Matches `ensureNodePassword` in k3s (`pkg/agent/config/config.go`) so a
+    /// pinned password is indistinguishable from one k3s would have rolled
+    /// itself.
+    fn generate_node_password() -> String {
+        use rand::Rng;
+        let mut rng = rand::rng();
+        let bytes: Vec<u8> = (0..16).map(|_| rng.random()).collect();
+        hex::encode(bytes)
+    }
+
     /// Validate that a persisted node-token Secret is usable.
     fn validate_token_secret(secret: &Secret, secret_name: &str) -> Result<()> {
         secret
@@ -551,6 +622,20 @@ impl K3sBackend {
                 format!("Token secret {secret_name} is missing non-empty data.token")
             })?;
         Ok(())
+    }
+
+    /// True iff the Secret already carries a non-empty node password.
+    ///
+    /// Unlike `token`, a missing node password is repairable in place (see
+    /// `ensure_node_password`) — pods mount it via `subPath`, and a subPath
+    /// naming an absent key strands the pod in `ContainerCreating` forever, so
+    /// the key MUST exist before any workload is applied.
+    fn secret_has_node_password(secret: &Secret) -> bool {
+        secret
+            .data
+            .as_ref()
+            .and_then(|data| data.get(NODE_PASSWORD_KEY))
+            .is_some_and(|value| !value.0.is_empty())
     }
 
     /// Standard labels for resources belonging to a cluster.
@@ -589,10 +674,18 @@ impl K3sBackend {
 
     /// Ensure the token Secret for k3s node authentication exists.
     ///
-    /// The Secret is create-once: an existing non-empty `data.token` is never
-    /// patched or replaced because a running server may have persisted its
-    /// original token. Creation uses POST, and a concurrent creator winning the
-    /// race is read back and validated.
+    /// The Secret carries two create-once values:
+    ///   - `token`: the cluster join token. An existing non-empty `data.token`
+    ///     is never patched or replaced because a running server may have
+    ///     persisted its original token.
+    ///   - `node-password`: the per-cluster node password mounted at
+    ///     [`NODE_PASSWORD_PATH`] (see [`node_password_mount`] for why).
+    ///
+    /// Creation uses POST, and a concurrent creator winning the race is read
+    /// back and validated. A Secret predating the node-password key (created by
+    /// an operator older than #145) is repaired in place rather than left
+    /// keyless — pods mount that key via `subPath`, and a subPath naming an
+    /// absent key wedges the pod in `ContainerCreating`.
     async fn create_token_secret(&self, name: &str, namespace: &str) -> Result<()> {
         let secrets: Api<Secret> = Api::namespaced(self.client.clone(), namespace);
         let secret_name = format!("{name}-token");
@@ -601,7 +694,9 @@ impl K3sBackend {
             Ok(existing) => {
                 Self::validate_token_secret(&existing, &secret_name)?;
                 debug!(cluster = name, "Token secret already exists; preserving it");
-                return Ok(());
+                return self
+                    .ensure_node_password(&secrets, &existing, name, &secret_name)
+                    .await;
             }
             Err(kube::Error::Api(ae)) if ae.code == 404 => {}
             Err(e) => {
@@ -611,6 +706,7 @@ impl K3sBackend {
         }
 
         let token = Self::generate_token();
+        let node_password = Self::generate_node_password();
         let secret = Secret {
             metadata: ObjectMeta {
                 name: Some(secret_name.clone()),
@@ -621,6 +717,7 @@ impl K3sBackend {
             string_data: Some({
                 let mut data = BTreeMap::new();
                 data.insert("token".to_string(), token);
+                data.insert(NODE_PASSWORD_KEY.to_string(), node_password);
                 data
             }),
             ..Default::default()
@@ -637,6 +734,9 @@ impl K3sBackend {
                     cluster = name,
                     "Concurrent token secret creator won; preserving it"
                 );
+                return self
+                    .ensure_node_password(&secrets, &winner, name, &secret_name)
+                    .await;
             }
             Err(e) => {
                 return Err(e)
@@ -645,6 +745,66 @@ impl K3sBackend {
         }
 
         Ok(())
+    }
+
+    /// Backfill `node-password` into a token Secret that predates it.
+    ///
+    /// No-op when the key is already present — the password must be create-once
+    /// for the same reason the token is: rewriting it would invalidate the hash
+    /// the guest datastore already holds, reproducing #145 by hand.
+    ///
+    /// The merge patch pins `metadata.resourceVersion`, so two operators racing
+    /// to backfill cannot both win and leave a node holding the loser's value:
+    /// the loser gets a 409 and re-reads. A conflict is NOT fatal here — the
+    /// winner's key is equally valid, so we only verify one landed.
+    async fn ensure_node_password(
+        &self,
+        secrets: &Api<Secret>,
+        existing: &Secret,
+        name: &str,
+        secret_name: &str,
+    ) -> Result<()> {
+        if Self::secret_has_node_password(existing) {
+            return Ok(());
+        }
+
+        let resource_version = existing.metadata.resource_version.as_deref();
+        let patch = serde_json::json!({
+            "metadata": { "resourceVersion": resource_version },
+            "stringData": { NODE_PASSWORD_KEY: Self::generate_node_password() },
+        });
+
+        match secrets
+            .patch(secret_name, &PatchParams::default(), &Patch::Merge(&patch))
+            .await
+        {
+            Ok(_) => {
+                info!(
+                    cluster = name,
+                    "Backfilled node password into pre-existing token secret"
+                );
+                Ok(())
+            }
+            Err(kube::Error::Api(ae)) if ae.code == 409 => {
+                let winner = secrets.get(secret_name).await.with_context(|| {
+                    format!("Failed to re-read token secret {secret_name} after backfill conflict")
+                })?;
+                if Self::secret_has_node_password(&winner) {
+                    debug!(
+                        cluster = name,
+                        "Concurrent node-password backfill won; preserving it"
+                    );
+                    Ok(())
+                } else {
+                    Err(anyhow::anyhow!(
+                        "Token secret {secret_name} still has no {NODE_PASSWORD_KEY} after backfill conflict"
+                    ))
+                }
+            }
+            Err(e) => Err(e).with_context(|| {
+                format!("Failed to backfill {NODE_PASSWORD_KEY} into token secret {secret_name}")
+            }),
+        }
     }
 
     /// Create the ConfigMap containing the kubeconfig publisher script.
@@ -804,6 +964,9 @@ impl K3sBackend {
                 read_only: Some(true),
                 ..Default::default()
             },
+            // Pinned node password (#145) — without it a single container
+            // restart permanently breaks node registration.
+            node_password_mount(),
             VolumeMount {
                 name: "output".to_string(),
                 mount_path: "/output".to_string(),
@@ -998,6 +1161,8 @@ impl K3sBackend {
                 }),
                 ..Default::default()
             },
+            // Pinned node password, projected from the same Secret (#145).
+            node_password_volume(name),
             // Shared output volume (kubeconfig exchange between server and sidecar)
             Volume {
                 name: "output".to_string(),
@@ -1328,6 +1493,10 @@ impl K3sBackend {
                 read_only: Some(true),
                 ..Default::default()
             },
+            // Pinned node password, same rationale as the server (#145). An
+            // agent pod keeps its node name for its whole life, so a restarted
+            // agent container hits the identical hash mismatch.
+            node_password_mount(),
             // k3s data dir on an emptyDir, same rationale as the server (see
             // `build_server_container`): the agent's nested containerd needs a
             // real node filesystem, and its state must survive container
@@ -1409,6 +1578,7 @@ impl K3sBackend {
                 }),
                 ..Default::default()
             },
+            node_password_volume(name),
             // Agents are stateless across pod replacement — emptyDir is
             // always the right backing here (no PVC variant like the server).
             Volume {
@@ -2871,6 +3041,110 @@ mod tests {
         );
     }
 
+    /// Assert a pod spec pins `/etc/rancher/node/password` to the cluster's
+    /// token Secret. Shared by the server and agent cases (#145) — both run a
+    /// kubelet that registers a node, so both brick identically without it.
+    fn assert_node_password_pinned(pod_spec: &PodSpec, container: &Container, cluster: &str) {
+        let mount = container
+            .volume_mounts
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|m| m.mount_path == NODE_PASSWORD_PATH)
+            .unwrap_or_else(|| panic!("{} must mount the node password", container.name));
+        assert_eq!(mount.name, NODE_PASSWORD_KEY);
+        assert_eq!(mount.sub_path.as_deref(), Some(NODE_PASSWORD_KEY));
+        assert_eq!(
+            mount.read_only,
+            Some(true),
+            "k3s only reads an existing password file; nothing may rewrite it"
+        );
+
+        let volume = pod_spec
+            .volumes
+            .as_ref()
+            .unwrap()
+            .iter()
+            .find(|v| v.name == NODE_PASSWORD_KEY)
+            .expect("pod must carry the node-password volume");
+        let secret = volume.secret.as_ref().unwrap();
+        assert_eq!(
+            secret.secret_name.as_deref(),
+            Some(format!("{cluster}-token").as_str()),
+            "the password rides the create-once token Secret, so it outlives every pod"
+        );
+        let items = secret.items.as_ref().expect("must project a single key");
+        assert_eq!(items.len(), 1, "the token itself must not leak into /etc");
+        assert_eq!(items[0].key, NODE_PASSWORD_KEY);
+        assert_eq!(items[0].path, NODE_PASSWORD_KEY);
+    }
+
+    #[test]
+    fn test_server_pins_node_password_to_token_secret() {
+        let config = base_config();
+        let sts = K3sBackend::build_server_statefulset("my-cluster", "ns", &config, None, 1);
+        let pod_spec = sts.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        let server = &pod_spec.containers[0];
+        assert_eq!(server.name, "k3s-server");
+        assert_node_password_pinned(pod_spec, server, "my-cluster");
+    }
+
+    #[test]
+    fn test_agent_pins_node_password_to_token_secret() {
+        let config = base_config();
+        let deploy = K3sBackend::build_agent_deployment("my-cluster", "ns", &config, 2);
+        let pod_spec = deploy
+            .spec
+            .as_ref()
+            .unwrap()
+            .template
+            .spec
+            .as_ref()
+            .unwrap();
+        assert_node_password_pinned(pod_spec, &pod_spec.containers[0], "my-cluster");
+    }
+
+    /// The password must NOT ride the data volume: with persistence the data
+    /// volume comes from a claim template, and with an external datastore it is
+    /// an emptyDir the datastore outlives. Only the Secret has a lifetime that
+    /// is never shorter than the datastore's under every combination.
+    #[test]
+    fn test_node_password_survives_persistence_modes() {
+        for persistence in [
+            None,
+            Some(PersistenceConfig {
+                storage_type: Some("dynamic".to_string()),
+                storage_class_name: Some("local-path".to_string()),
+                storage_request_size: Some("20Gi".to_string()),
+            }),
+        ] {
+            let mut config = base_config();
+            config.persistence = persistence;
+            let sts = K3sBackend::build_server_statefulset("c", "ns", &config, None, 1);
+            let pod_spec = sts.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+            assert_node_password_pinned(pod_spec, &pod_spec.containers[0], "c");
+        }
+    }
+
+    /// The publisher sidecar runs no kubelet and registers no node — it has no
+    /// business holding the node password.
+    #[test]
+    fn test_publisher_sidecar_has_no_node_password() {
+        let config = base_config();
+        let sts = K3sBackend::build_server_statefulset("my-cluster", "ns", &config, None, 1);
+        let pod_spec = sts.spec.as_ref().unwrap().template.spec.as_ref().unwrap();
+        let sidecar = &pod_spec.containers[1];
+        assert_eq!(sidecar.name, PUBLISHER_CONTAINER);
+        assert!(
+            sidecar
+                .volume_mounts
+                .as_ref()
+                .unwrap()
+                .iter()
+                .all(|m| m.mount_path != NODE_PASSWORD_PATH)
+        );
+    }
+
     #[test]
     fn test_build_service_clusterip() {
         let config = base_config();
@@ -3538,11 +3812,38 @@ mod tests {
         assert!(backend.supports_verified_destroy());
     }
 
+    /// A fully-formed token Secret: join token AND node password, as every
+    /// Secret written since #145 carries.
     fn token_secret_response(name: &str, namespace: &str, token: &[u8]) -> serde_json::Value {
         serde_json::json!({
             "apiVersion": "v1",
             "kind": "Secret",
-            "metadata": { "name": name, "namespace": namespace },
+            "metadata": { "name": name, "namespace": namespace, "resourceVersion": "1" },
+            "data": {
+                "token": base64::engine::general_purpose::STANDARD.encode(token),
+                NODE_PASSWORD_KEY: base64::engine::general_purpose::STANDARD
+                    .encode(b"0123456789abcdef0123456789abcdef"),
+            }
+        })
+    }
+
+    /// A token Secret as an operator OLDER than #145 wrote it: join token only,
+    /// no node password. Mounting `NODE_PASSWORD_KEY` via subPath against this
+    /// would wedge the pod, so `create_token_secret` must backfill it.
+    fn legacy_token_secret_response(
+        name: &str,
+        namespace: &str,
+        token: &[u8],
+        resource_version: &str,
+    ) -> serde_json::Value {
+        serde_json::json!({
+            "apiVersion": "v1",
+            "kind": "Secret",
+            "metadata": {
+                "name": name,
+                "namespace": namespace,
+                "resourceVersion": resource_version,
+            },
             "data": {
                 "token": base64::engine::general_purpose::STANDARD.encode(token)
             }
@@ -3703,6 +4004,185 @@ mod tests {
             .create_token_secret("test-cluster", "test-ns")
             .await
             .unwrap();
+    }
+
+    /// The node password must be minted alongside the token, in k3s's own
+    /// format (16 random bytes, hex) — see `ensureNodePassword` upstream.
+    #[tokio::test]
+    async fn create_token_secret_mints_a_node_password() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let seen = Arc::new(Mutex::new(None::<String>));
+        let recorder = Arc::clone(&seen);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(404).set_body_json(crate::testutil::k8s_not_found(
+                    "secrets",
+                    "test-cluster-token",
+                )),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path("/api/v1/namespaces/test-ns/secrets"))
+            .respond_with(move |request: &wiremock::Request| {
+                let body: serde_json::Value =
+                    serde_json::from_slice(&request.body).expect("Secret request must be JSON");
+                *recorder.lock().unwrap() = body["stringData"][NODE_PASSWORD_KEY]
+                    .as_str()
+                    .map(str::to_string);
+                ResponseTemplate::new(201)
+                    .set_body_json(secret_response("test-cluster-token", "test-ns"))
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+
+        let password = seen
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("created Secret must carry a node password");
+        assert_eq!(
+            password.len(),
+            32,
+            "k3s mints 16 random bytes hex-encoded: {password}"
+        );
+        assert!(
+            password.chars().all(|c| c.is_ascii_hexdigit()),
+            "node password must be hex: {password}"
+        );
+    }
+
+    /// A Secret written before #145 has no node password. Leaving it that way
+    /// would strand every pod in ContainerCreating (subPath on an absent key),
+    /// so it is repaired in place — under a resourceVersion precondition, so a
+    /// racing operator cannot overwrite a value a node may already hold.
+    #[tokio::test]
+    async fn create_token_secret_backfills_node_password_into_legacy_secret() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+        let patch_body = Arc::new(Mutex::new(None::<serde_json::Value>));
+        let recorder = Arc::clone(&patch_body);
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(legacy_token_secret_response(
+                    "test-cluster-token",
+                    "test-ns",
+                    b"legacy-token",
+                    "4242",
+                )),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(move |request: &wiremock::Request| {
+                *recorder.lock().unwrap() =
+                    Some(serde_json::from_slice(&request.body).expect("patch body must be JSON"));
+                ResponseTemplate::new(200).set_body_json(token_secret_response(
+                    "test-cluster-token",
+                    "test-ns",
+                    b"legacy-token",
+                ))
+            })
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+
+        let body = patch_body
+            .lock()
+            .unwrap()
+            .clone()
+            .expect("a keyless Secret must be patched");
+        assert_eq!(
+            body["metadata"]["resourceVersion"].as_str(),
+            Some("4242"),
+            "backfill must be guarded by the observed resourceVersion: {body}"
+        );
+        assert_eq!(
+            body["stringData"][NODE_PASSWORD_KEY].as_str().map(str::len),
+            Some(32),
+            "backfill must write a k3s-format node password: {body}"
+        );
+        assert!(
+            body["stringData"]["token"].is_null(),
+            "backfill must never rewrite the join token: {body}"
+        );
+    }
+
+    /// A Secret that already has the key is left strictly alone: rewriting the
+    /// password would invalidate the hash the guest datastore already holds —
+    /// which is precisely the #145 failure, self-inflicted.
+    #[tokio::test]
+    async fn create_token_secret_never_rotates_an_existing_node_password() {
+        let server = MockServer::start().await;
+        let backend = K3sBackend::new(mock_client(&server), Default::default());
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/api/v1/namespaces/test-ns/secrets/test-cluster-token",
+            ))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(token_secret_response(
+                    "test-cluster-token",
+                    "test-ns",
+                    b"existing-token",
+                )),
+            )
+            .expect(1)
+            .mount(&server)
+            .await;
+        // No PATCH mock is mounted: any write at all fails the test.
+
+        backend
+            .create_token_secret("test-cluster", "test-ns")
+            .await
+            .unwrap();
+    }
+
+    #[test]
+    fn secret_has_node_password_rejects_missing_and_empty() {
+        let empty = Secret {
+            data: Some(BTreeMap::from([(
+                NODE_PASSWORD_KEY.to_string(),
+                k8s_openapi::ByteString(Vec::new()),
+            )])),
+            ..Default::default()
+        };
+        assert!(!K3sBackend::secret_has_node_password(&empty));
+        assert!(!K3sBackend::secret_has_node_password(&Secret::default()));
+
+        let present = Secret {
+            data: Some(BTreeMap::from([(
+                NODE_PASSWORD_KEY.to_string(),
+                k8s_openapi::ByteString(b"deadbeef".to_vec()),
+            )])),
+            ..Default::default()
+        };
+        assert!(K3sBackend::secret_has_node_password(&present));
     }
 
     #[test]


### PR DESCRIPTION
Fixes #145.

## What actually breaks

k3s binds a node's *identity* on top of the shared join token with a per-node password. On first boot a node writes 16 random bytes to `/etc/rancher/node/password`; the server hashes them into a `<nodename>.node-password.k3s` Secret in the guest's `kube-system` and re-checks the value on every later registration. That stops a node holding the join token from claiming another node's name.

The two halves had mismatched lifetimes here:

| | lives on | survives a container restart |
|---|---|---|
| the **hash** | the datastore, in the `data` volume (emptyDir, or a PVC with persistence) | yes |
| the **password** | `/etc/rancher/node/password`, container overlay rw layer | **no** |

The kubelet builds a fresh container filesystem on every container restart, so the first transient restart of a `-server-0` pod discarded the password while leaving the hash intact. k3s then re-registered its own node with a newly rolled random password and got `NodePasswordValidationFailed: hash does not match`. Because the file is regenerated on each attempt, the retry never converges: **one restart bricks the control plane permanently.** That matches the evidence in #145 exactly — escalating restart counts (1→2→3→4) rather than a single transient failure, and every victim a `-server-0`.

Two notes on the issue's framing, offered as corrections to the mental model rather than to the report:

- **"Recycled" is a misnomer.** Recycling mints a fresh monotonic index (`pool-{profile}-{index}`, hence 7266…7363), and with it a fresh node name and a fresh per-cluster database. Stale state cannot cross a recycle. The failure is entirely *within* one instance's life.
- **The verified-teardown work (#80/#96/#115) would not have reached this**, and not only for the reason given in the issue: the carrier isn't leaked volume state between leases, it's the container filesystem inside a single live pod.

## The fix

Mint the node password alongside the join token in the create-once `{cluster}-token` Secret, and project it read-only at `/etc/rancher/node/password`. Its lifetime becomes the ClusterInstance's, so it can never be younger than the datastore under *any* persistence mode — emptyDir, PVC, or external datastore.

- **Read-only is exactly right.** k3s's `ensureNodePassword` reads the file when it exists and writes only when absent. The one other write path, `upgradeOldNodePasswordPath`, early-returns unless the pre-2019 `<data-dir>/agent/node-password.txt` exists, and is non-fatal even then.
- **Agents get the same mount.** An agent pod keeps its node name for its whole life, so a restarted agent container hits the identical mismatch.
- **The publisher sidecar does not** — it runs no kubelet and registers no node.
- **Only the one key is projected**, so the join token does not leak into `/etc`.

Secrets written by an older operator carry no such key, and a `subPath` naming an absent key wedges a pod in `ContainerCreating` — so those are backfilled in place, guarded by a `resourceVersion` precondition so two operators racing cannot leave a node holding the loser's value. An existing password is **never** rotated: rewriting it would invalidate the hash the datastore already holds, which is this bug, self-inflicted.

Scope is k3s-only; k0s has no node-password mechanism. No CRD change, no new knob, no change to the recycle path.

## Rollout

`create()` runs once per instance (`Creating if !status.provisioned`), so deploying this **does not** re-apply StatefulSets for live pool members — no pod churn, no leased cluster reset at deploy time. The fix reaches instances created after the upgrade; existing members carry the old spec until they recycle, which for these pools is roughly a hundred times a day.

One residual, called out rather than fixed: a PVC- or external-datastore-backed cluster whose datastore *already* holds a pre-fix random hash stays broken until it recycles. That is pre-existing breakage — such a cluster bricks on any restart today — not a regression.

## Verification

1381 tests pass; clippy clean. New coverage pins each invariant:

- server and agent pods mount the password read-only at the k3s path via `subPath`, projecting only that key
- the mount holds across both persistence modes, and the sidecar stays clear of it
- creation mints a k3s-format password (16 bytes, hex)
- a legacy keyless Secret is backfilled under its observed `resourceVersion`, without touching the token
- an existing password is never rewritten (the test mounts no PATCH responder, so any write fails it)

Post-deploy, the issue's own query should trend to zero:

```
signoz logs | k8s.namespace.name = 'kobe-system' AND body CONTAINS 'NodePasswordValidationFailed'
```

Keep the issue's trap in mind — `kobe-system` logs carry no `severity_text`, so any `severity = ERROR` filter returns zero rows and looks falsely healthy.

## The regression guard (second commit)

This bug was invisible to unit tests *by construction*: nothing was written wrong, something was merely absent from the pod spec, so no assertion about what the spec **contains** could have failed. And the conformance smoke provisions a cluster and never perturbs it, so it passed at a 100% rate throughout. Only crossing the restart boundary exposes the class.

So `hack/test-e2e-k3s.ts` gains assertion **(B)**, between provision and recycle: SIGTERM PID 1 in the `k3s-server` container, confirm the kubelet actually rebuilt the container, then require the server back to Ready.

Two design points that carry the weight:

- **Container-scoped, not pod-scoped.** The kubelet rebuilds the container filesystem from the image while the pod's `data` volume survives untouched — exactly the asymmetry that turned a transient restart into a permanent outage. Deleting the pod would discard the emptyDir too and hide the bug entirely.
- **A settle window after recovery.** #145 recovered from its *first* restart too; it was the restart after that which never converged (counts climbing 1→2→3→4). A gate that stopped at the first Ready would have shipped this green, so the server must additionally hold Ready with no further restarts.

Read (B) as the guard for the whole class — any guest state that must outlive a container restart but sits on the overlay — not only for node passwords. That framing is not hypothetical: the join token is the *same* class, already fixed by making `{cluster}-token` create-once, and this is the second instance in the same file.

Worth knowing about the guard's own coverage: `conformance` does not run on `pull_request` (only dispatch / schedule / push to main and tags), so (B) guards at the merge boundary rather than blocking a PR. It has been dispatched against this branch, which validates on a real nested cluster the one thing unit tests cannot — that the read-only mount does not disturb k3s startup and that a restarted server genuinely recovers.

An honest caveat: (B) has been shown to pass with the fix, not yet shown to fail without it. Proving that needs a deliberate run with the mount removed.
