### PR TITLE
ci: give each image tag one meaning, and stop branch dispatches publishing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -183,6 +183,14 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v4
 
+      # Asserts what each tag MEANS (latest = newest release, dev = head of
+      # main, sha-<7> = that commit) by resolving `bake --print` under all three
+      # publish shapes. Resolution only — no build, no push — so it is seconds,
+      # and it runs on PRs where `publish` never does: the one place a tagging
+      # regression can still be caught before it reaches the registry.
+      - name: Verify image tag semantics
+        run: ./scripts/test-tag-semantics.sh
+
       - name: Build all images (dry-run, no cache)
         run: docker buildx bake -f docker-bake.hcl --set '*.cache-from='
 
@@ -319,9 +327,20 @@ jobs:
     # push on version-consistency too, so a tag that disagrees with the manifest
     # can't ship images while release-cli + crates are blocked. On push-to-main
     # (where version-consistency is skipped) keep publishing as before.
+    #
+    # The REF gate is load-bearing: this job used to key only off
+    # `event_name != 'pull_request'`, so `workflow_dispatch` on ANY branch
+    # published from that branch. Dispatch is the documented way to exercise
+    # conformance (which never runs on pull_request) before merging a backend
+    # change — so validating a branch silently republished the shared tags from
+    # unmerged code. Validation and publication are now separate concerns:
+    # dispatch a branch to test it, and only main / a release tag ships.
+    # Dispatch on main still publishes, which is the remedy for tags left
+    # pointing somewhere wrong.
     needs: [checks, version-consistency]
     if: >-
       ${{ always() && github.event_name != 'pull_request'
+          && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
           && needs.checks.result == 'success'
           && (!startsWith(github.ref, 'refs/tags/v') || needs['version-consistency'].result == 'success') }}
     runs-on: kunobi-runners
@@ -347,6 +366,11 @@ jobs:
       - name: Build and push
         env:
           VERSION: ${{ steps.version.outputs.version || '0.0.0' }}
+          # `dev` means head of main, so only a main build claims it. A release
+          # run sends IMAGE_TAG empty and publishes latest + the semver tags
+          # alone (see the `tags` function in docker-bake.hcl), leaving `dev`
+          # where it was until main next moves.
+          IMAGE_TAG: ${{ startsWith(github.ref, 'refs/tags/v') && '' || 'dev' }}
           BUILD_VERSION: ${{ github.ref_name || 'dev' }}
           BUILD_COMMIT: ${{ github.sha }}
         run: docker buildx bake -f docker-bake.hcl push

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -35,12 +35,31 @@ variable "LOCAL_CACHE_ROOT" {
   default = ".tmp/buildx-cache"
 }
 
-# Generate tag array: latest, IMAGE_TAG, and rolling semver tags (v0.1.0, v0.1, v0)
+# Generate the tag array. Each tag means exactly ONE thing:
+#
+#   dev        moving; head of main (the `IMAGE_TAG` slot — also how a local
+#              `docker buildx bake` and the e2e harness name their builds)
+#   sha-<7>    immutable; the exact commit that produced the image
+#   latest     newest RELEASE
+#   vX.Y.Z     that release, immutable
+#   vX.Y / vX  newest release in that series
+#
+# `latest` is release-gated on purpose. It used to be emitted unconditionally,
+# which made it a second name for `dev`: every publish moved it, so it tracked
+# whatever last ran (main push, nightly, or a branch dispatch) rather than the
+# newest release. Anyone pulling `latest` expecting a released build silently
+# got main — or worse, an unmerged branch.
+#
+# `IMAGE_TAG` is dropped when empty so a release run publishes ONLY the release
+# tags and leaves `dev` pointing where it was; `dev` advances on the next push
+# to main. Empty is checked rather than assumed because `"${REGISTRY}/${name}:"`
+# is a malformed tag, not an empty string, so `compact` would not remove it.
 function "tags" {
   params = [name]
   result = compact([
-    "${REGISTRY}/${name}:latest",
-    "${REGISTRY}/${name}:${IMAGE_TAG}",
+    notequal(IMAGE_TAG, "") ? "${REGISTRY}/${name}:${IMAGE_TAG}" : "",
+    notequal(BUILD_COMMIT, "unknown") ? "${REGISTRY}/${name}:sha-${substr(BUILD_COMMIT, 0, 7)}" : "",
+    notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:latest" : "",
     notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${VERSION}" : "",
     notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}.${split(".", VERSION)[1]}" : "",
     notequal(VERSION, "0.0.0") ? "${REGISTRY}/${name}:v${split(".", VERSION)[0]}" : "",

--- a/scripts/test-tag-semantics.sh
+++ b/scripts/test-tag-semantics.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Pin what each published image tag MEANS.
+#
+# `latest` was once emitted unconditionally, which quietly made it a second
+# name for `dev`: every publish moved it, so it tracked whichever run went
+# last — a main push, the nightly, or a `workflow_dispatch` on an unmerged
+# branch — rather than the newest release. The comment in docker-bake.hcl now
+# says otherwise; this asserts it, because a comment cannot fail CI.
+#
+# Resolves tags via `docker buildx bake --print` (no build, no push) under the
+# three ways this repo publishes, and compares against the exact expected set.
+set -euo pipefail
+
+cd "$(dirname "$0")/.."
+
+failures=0
+SHA=59af83006568890a6417fd3b0a4ab83823e94c0e
+
+# Resolve the tag list for one target under the given environment.
+resolve() {
+  docker buildx bake -f docker-bake.hcl operator --print 2>/dev/null \
+    | jq -r '.target.operator.tags[]' | sort
+}
+
+expect() {
+  local scenario="$1" expected="$2" actual="$3"
+  if [[ "$expected" == "$actual" ]]; then
+    echo "PASS: $scenario"
+  else
+    echo "FAIL: $scenario"
+    echo "  expected:"; echo "$expected" | sed 's/^/    /'
+    echo "  actual:"; echo "$actual" | sed 's/^/    /'
+    failures=$((failures + 1))
+  fi
+}
+
+# 1. A local build (and the e2e harness, which sets IMAGE_TAG itself) names
+#    only its own tag. It must NOT claim `latest`.
+actual="$(IMAGE_TAG=dev VERSION=0.0.0 BUILD_COMMIT=unknown resolve)"
+expect "local build tags only IMAGE_TAG" \
+  "zondax/kobe-operator:dev" "$actual"
+
+# 2. A push to main moves `dev` and stamps the immutable commit tag. `latest`
+#    must stay where the last RELEASE left it.
+actual="$(IMAGE_TAG=dev VERSION=0.0.0 BUILD_COMMIT=$SHA resolve)"
+expect "main push moves dev + sha, never latest" \
+  "$(printf 'zondax/kobe-operator:dev\nzondax/kobe-operator:sha-59af830' | sort)" "$actual"
+
+# 3. A release tag claims `latest` and the rolling semver tags — and leaves
+#    `dev` alone, since a release does not advance the head of main.
+actual="$(IMAGE_TAG= VERSION=0.40.0 BUILD_COMMIT=$SHA resolve)"
+expect "release tags latest + semver, never dev" \
+  "$(printf 'zondax/kobe-operator:latest\nzondax/kobe-operator:sha-59af830\nzondax/kobe-operator:v0\nzondax/kobe-operator:v0.40\nzondax/kobe-operator:v0.40.0' | sort)" "$actual"
+
+if [[ $failures -gt 0 ]]; then
+  echo ""
+  echo "$failures tag-semantics assertion(s) failed."
+  exit 1
+fi
+
+echo ""
+echo "All tag-semantics assertions passed."


### PR DESCRIPTION
Found while dispatching conformance to validate #146 on a real cluster — which silently republished `latest` and `dev` from that unmerged branch. Two separate defects made that possible.

## 1. Any branch dispatch published

`publish` was gated only on `github.event_name != 'pull_request'`, so a `workflow_dispatch` on **any** ref built and pushed from it.

That is not an exotic path. `conformance` never runs on `pull_request` (only dispatch / schedule / push to main and tags), so dispatching a branch is the documented way to exercise a backend change before merging — it is what the team's own notes recommend. Testing a branch and shipping it were the same button.

Now gated on `refs/heads/main` or `refs/tags/v*`. Dispatch on main still publishes, so the remedy for tags left pointing somewhere wrong is unchanged.

## 2. `latest` did not mean "latest release"

The bake `tags` function emitted `latest` unconditionally, which made it a second name for `dev` — same digest, moved by every publish. Observed live:

| tag | last updated | digest |
|---|---|---|
| `latest` | Aug 14 16:21 (a **branch dispatch**) | `d8f4f124…` |
| `dev` | Aug 14 16:21 | `d8f4f124…` |
| `v0.39.1` | Aug 12 (the release) | `bcf71096…` |

So `latest` tracked whichever run went last — a main push, the nightly, or an unmerged branch — and anyone pulling it for a released build got main instead. It equals the newest release only in the window between a release run and the next push to main, which is probably why the intended convention felt true.

`latest` now sits behind the same `VERSION != 0.0.0` guard the semver tags already use, and a release run sends `IMAGE_TAG` empty so it publishes only its own tags and leaves `dev` at the head of main.

## Resulting meanings

| tag | tracks | mutable |
|---|---|---|
| `dev` | head of main | yes |
| `sha-<7>` | that exact commit | no |
| `latest` | newest release | yes |
| `vX.Y.Z` | that release | no |
| `vX.Y`, `vX` | newest release in series | yes |

| event | publishes |
|---|---|
| PR | nothing |
| branch dispatch | **nothing** (was: `latest` + `dev`) |
| push to main | `dev`, `sha-<7>` |
| release tag | `latest`, `vX.Y.Z`, `vX.Y`, `vX`, `sha-<7>` |

`sha-<7>` is new — the only immutable tag a main build gets. "Which exact image was running when X broke?" had no answer before, which is the sort of question #145 turned out to need.

## Compatibility

Nothing in-repo pulls kobe `:latest`: `Chart.yaml` pins `v0.39.1`, `values.yaml` leaves `image.tag` empty and falls back to `appVersion`, and the e2e harness builds and loads its own `IMAGE_TAG`. Local `docker buildx bake` still produces `:dev` and no longer pollutes the daemon with a `latest` it never meant. Worth a second opinion on anything **outside** this repo that pulls `latest` expecting main — that is the one behavior change here.

## Verification

`scripts/test-tag-semantics.sh` resolves `bake --print` under all three publish shapes and compares exact tag sets. It runs in `docker-dry-run`, which is PR-only — the one place a tagging regression can still be caught before it reaches the registry — and costs seconds, since it resolves rather than builds.

It was verified to actually **fail**, not merely pass: reintroducing the bug (making `latest` unconditional again) fails 2 of its 3 assertions and exits 1, and restoring the fix returns it to green.

```
FAIL: local build tags only IMAGE_TAG
  expected: zondax/kobe-operator:dev
  actual:   zondax/kobe-operator:dev
            zondax/kobe-operator:latest
FAIL: main push moves dev + sha, never latest
PASS: release tags latest + semver, never dev
2 tag-semantics assertion(s) failed.
```

Full `cargo test` (1381) still green.

## One transitional detail before merging

`latest` currently points at a **main build** (`81a5d528…`, published 16:43Z from `59af8300`), not at a release. After this merges, main pushes stop moving `latest` — so it freezes on that main build until the next `v*` tag is cut and claims it.

That is no *less* truthful than today (it is a main build either way), but it does mean the tag stays wrong-and-now-static rather than wrong-and-moving, which is arguably easier to be misled by.

If you want it truthful the moment this lands, retag it to the current release without rebuilding:

```
docker buildx imagetools create -t zondax/kobe-operator:latest zondax/kobe-operator:v0.39.1
docker buildx imagetools create -t zondax/kobe-sync:latest     zondax/kobe-sync:v0.39.1
```

Needs Docker Hub push credentials, so it is a maintainer action rather than something CI does here. Otherwise the next release fixes it on its own.
