### PR TITLE
chore: release v0.39.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.39.1"
+version = "0.39.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.39.1"
+version = "0.39.2"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.39.1
-appVersion: "0.39.1"
+version: 0.39.2
+appVersion: "0.39.2"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.39.1
+      image: docker.io/zondax/kobe-operator:v0.39.2
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.39.1
+      image: docker.io/zondax/kobe-sync:v0.39.2
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Version bump only — no behaviour change in this PR.

Cuts a patch release so the two fixes that landed after `v0.39.1` become
reachable. Both are release-gated: shin pins int-pro to released semver tags
only, so operator code merged to main never ships on its own.

- #146 — pin the k3s node password, so one restart cannot brick a cluster.
- #147 — give each image tag one meaning, and stop branch dispatches publishing.

Moves the workspace version, the chart `version`/`appVersion`, and the Artifact
Hub image pins together, which is what `version-consistency` gates at tag time.

Note: main also carries the new SandboxPool/SandboxLease APIs (#93, #115, #116),
which a strict semver read would make `0.40.0`. Going out as a patch as
requested — say the word and I'll redo it as `0.40.0` instead.

After merge: `just release` pushes the signed `v0.39.2` tag, which is the entire
trigger for the publish chain.