### PR TITLE
chore: release v0.40.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.39.2"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.39.2"
+version = "0.40.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.39.2"
+version = "0.40.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.39.2
-appVersion: "0.39.2"
+version: 0.40.0
+appVersion: "0.40.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.39.2
+      image: docker.io/zondax/kobe-operator:v0.40.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.39.2
+      image: docker.io/zondax/kobe-sync:v0.40.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Version bump only — no behaviour change in this PR.

**Minor, not patch.** Main has been carrying new API surface for several releases:
SandboxPool/SandboxLease (#93), the verified-teardown vocabulary and Quarantined
phase (#96, #115), and admission-ledger hardening (#116). All landed after v0.39.0
and shipped under patch versions. Pre-1.0 that is still a feature addition, and
continuing to ship CRDs in patch releases makes the version number say less each
time. This corrects that.

Ships one behavioural change since v0.39.2:

- #151 — retire terminal leases that never bound, instead of retrying forever.

That fix drains the 75 leases which have re-reconciled every 30s on int-pro since
2026-08-12 (#150). The retirement happens in the operator's own reconcile loop, not
in pool member pod specs, so it takes effect as soon as this release is deployed —
no member recycling needed and no dependency on #149.

Moves the workspace version, chart `version`/`appVersion`, and the Artifact Hub
image pins together, which is what `version-consistency` gates at tag time.

After merge: `just release` pushes the signed `v0.40.0` tag, which is the entire
trigger for the publish chain.

Expected post-deploy signal: `kobe_leases_retired_unbound_total` jumps by ~75 on
int-pro, the `Lease binding is unavailable` WARN rate drops from a flat 4,500/30min
to ~0, and `kubectl -n kobe-system get clusterlease` returns close to empty.