### PR TITLE
feat(observability): let the operator state which build it is

### DIFF
--- a/build.rs
+++ b/build.rs
@@ -1,5 +1,6 @@
 fn main() {
     println!("cargo:rerun-if-env-changed=BUILD_VERSION");
+    println!("cargo:rerun-if-env-changed=BUILD_COMMIT");
 
     let version = std::env::var("BUILD_VERSION")
         .ok()
@@ -7,4 +8,21 @@ fn main() {
         .unwrap_or_else(|| std::env::var("CARGO_PKG_VERSION").unwrap_or_else(|_| "dev".into()));
 
     println!("cargo:rustc-env=BUILD_VERSION={version}");
+
+    // The commit is what makes a build identifiable when the version can't:
+    // every image built from main carries the same `BUILD_VERSION`, so "which
+    // main build is this?" has no answer without it. CI already computes it for
+    // the `sha-<7>` image tag; this carries the same value into the binary so
+    // the running process can state its own identity.
+    //
+    // `unknown` for local builds, matching the Dockerfile ARG default rather
+    // than inventing a second sentinel. Deliberately NOT shelling out to git:
+    // the value must describe the source that was compiled, and the container
+    // build has no git tree.
+    let commit = std::env::var("BUILD_COMMIT")
+        .ok()
+        .filter(|c| !c.is_empty())
+        .unwrap_or_else(|| "unknown".into());
+
+    println!("cargo:rustc-env=BUILD_COMMIT={commit}");
 }

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -88,6 +88,7 @@ target "builder" {
   cache-to   = ["type=local,dest=${LOCAL_CACHE_ROOT}/builder,mode=max"]
   args = {
     BUILD_VERSION = BUILD_VERSION
+    BUILD_COMMIT  = BUILD_COMMIT
   }
 }
 

--- a/docker/builder.Dockerfile
+++ b/docker/builder.Dockerfile
@@ -34,6 +34,13 @@ FROM deps AS build
 
 ARG BUILD_VERSION=dev
 ENV BUILD_VERSION=${BUILD_VERSION}
+# Read by build.rs and baked into the binaries, so a running process can state
+# which commit it was built from. Set here in the `build` stage rather than in
+# `deps`: the layer below is invalidated by `COPY . .` on every commit anyway,
+# so a per-commit ENV costs no extra cache — while putting it in `deps` would
+# rebuild every dependency on each commit.
+ARG BUILD_COMMIT=unknown
+ENV BUILD_COMMIT=${BUILD_COMMIT}
 
 COPY . .
 # Operator-side binaries only (the `kobe` CLI lives in the kobectl member and is

--- a/src/main.rs
+++ b/src/main.rs
@@ -44,7 +44,24 @@ async fn main() -> anyhow::Result<()> {
         .with_label_values::<&str>(&[])
         .set(pool::cidr_alloc::ipam_plan().capacity() as i64);
 
-    info!("Starting kobe-operator");
+    // Build identity, stated once per process and exported as a gauge.
+    //
+    // "Starting kobe-operator" already marked a restart, but carried no fields,
+    // so which build produced a given log line could only be inferred by
+    // correlating the ReplicaSet hash in the pod name against rollout history.
+    // Both values are baked by build.rs and already used elsewhere
+    // (`api::routes` serves the version; the profile controller stamps it into
+    // `provenance.operatorVersion`) — they were simply never announced.
+    let build_version = env!("BUILD_VERSION");
+    let build_commit = env!("BUILD_COMMIT");
+    metrics::BUILD_INFO
+        .with_label_values(&[build_version, build_commit])
+        .set(1);
+    info!(
+        version = build_version,
+        commit = build_commit,
+        "Starting kobe-operator"
+    );
 
     let client = Client::try_default().await?;
     let namespace = std::env::var("OPERATOR_NAMESPACE").unwrap_or_else(|_| "kunobi-pool".into());
@@ -468,6 +485,53 @@ mod controllers_test_anchor {
 mod diagnostics_test_anchor {
     #[allow(unused_imports)]
     use crate::diagnostics::bundle;
+}
+
+#[cfg(test)]
+mod build_identity_tests {
+    /// The startup path must not be able to panic the operator.
+    ///
+    /// `with_label_values` panics when the slice arity disagrees with the
+    /// metric's label set, and this call runs in the first few lines of `main`
+    /// — before the controllers start and before anything is serving. A
+    /// mismatch introduced by later editing the metric's labels without the
+    /// call site would crash-loop the operator on rollout, which is a far worse
+    /// failure than the missing observability this whole change adds. So
+    /// exercise the exact call, not a paraphrase of it.
+    #[test]
+    fn build_info_gauge_matches_its_call_site() {
+        let version = env!("BUILD_VERSION");
+        let commit = env!("BUILD_COMMIT");
+
+        crate::metrics::BUILD_INFO
+            .with_label_values(&[version, commit])
+            .set(1);
+
+        assert_eq!(
+            crate::metrics::BUILD_INFO
+                .with_label_values(&[version, commit])
+                .get(),
+            1,
+            "build_info must read 1 for the running build's labels"
+        );
+    }
+
+    /// build.rs must always define both values, so `env!` resolves and the
+    /// binary can state its identity. `env!` already fails the compile when a
+    /// variable is absent; this catches the subtler case of build.rs emitting
+    /// an EMPTY value, which compiles fine and yields a metric labelled with
+    /// the empty string.
+    #[test]
+    fn build_identity_is_never_empty() {
+        assert!(
+            !env!("BUILD_VERSION").is_empty(),
+            "build.rs must fall back to CARGO_PKG_VERSION, never an empty version"
+        );
+        assert!(
+            !env!("BUILD_COMMIT").is_empty(),
+            "build.rs must fall back to `unknown`, never an empty commit"
+        );
+    }
 }
 
 #[cfg(test)]

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -38,6 +38,24 @@ use prometheus::{
     register_int_counter_vec, register_int_gauge_vec,
 };
 
+/// Build identity of the running process, as the conventional info-gauge: the
+/// value is always 1 and the labels carry the payload.
+///
+/// Answers "what is actually running right now" without hunting for a startup
+/// log line, which is the question that matters during an incident and the one
+/// that was awkward to answer before: every build from main carries the same
+/// version, and log retention eventually drops the banner. A gauge is always
+/// current, and joins onto other metrics by `version`/`commit` so a behaviour
+/// change can be attributed to a specific build.
+pub static BUILD_INFO: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "kobe_build_info",
+        "Build identity of the running operator; value is always 1",
+        &["version", "commit"]
+    )
+    .unwrap()
+});
+
 /// Pool state gauges — set at scrape time from shared pool state.
 ///
 /// Labels: `profile` (e.g. "e2e-basic"), `state` (creating/ready/leased/unhealthy/recycling).


### PR DESCRIPTION
Follows from reading int-pro logs after v0.40.0. Restarts were already detectable;
the build behind them was not.

## Before

```json
{"timestamp":"2026-08-15T14:41:29Z","level":"INFO",
 "fields":{"message":"Starting kobe-operator"},"target":"kobe_operator"}
```

No version, no commit, and no `build_info` metric. The only way to tell which build
produced a log line was to correlate the ReplicaSet hash in `k8s.pod.name`
(`kobe-5f98b64bf-*` = v0.39.2, `kobe-b484d9d99-*` = v0.40.0) against rollout history —
the detour actually taken while investigating #150, where "is this before or after the
fix?" needed its own query.

The version was already available the whole time: `build.rs` bakes it, `api::routes:2441`
serves it, and `controllers/profile.rs:1735` stamps it into `provenance.operatorVersion`.
It was just never announced.

## After

```json
{"timestamp":"...","level":"INFO",
 "fields":{"message":"Starting kobe-operator","version":"0.40.0","commit":"e162f05..."},
 "target":"kobe_operator"}
```

plus `kobe_build_info{version,commit} 1`.

The gauge is the more useful half. Every build from main carries the same version, log
retention eventually drops the banner, and a gauge is always current — and joins onto
other metrics by `version`/`commit`, so a behaviour change can be attributed to a build.

## The commit needed plumbing, not a log field

`docker/operator.Dockerfile:37` declared `ARG BUILD_COMMIT` but never promoted it to
`ENV`, and the Rust compile happens in `builder.Dockerfile`, which only received
`BUILD_VERSION`. This carries it through `docker-bake.hcl` → `builder.Dockerfile` →
`build.rs`.

**No cache cost.** The `ENV` sits in the `build` stage, after `deps`. The layer below it
is invalidated by `COPY . .` on every commit anyway, so a per-commit `ENV` changes
nothing — whereas putting it in `deps` would rebuild every dependency on each commit.

`build.rs` deliberately does **not** shell out to git: the value must describe the source
that was compiled, and the container build has no git tree. CI already computes this exact
SHA for the `sha-<7>` image tag (#147), so this reuses that identity rather than inventing
a second one.

## Verified, not assumed

- `BUILD_COMMIT=testsha1234567 cargo build` → the string is present in the resulting
  binary.
- `docker buildx bake --print builder` → `{'BUILD_COMMIT': 'abc123def4567', 'BUILD_VERSION': 'dev'}`.

## Tests

- `build_info_gauge_matches_its_call_site` exercises the exact `with_label_values` call
  from `main`. That call runs before the controllers start, so an arity mismatch
  introduced by later editing the metric's labels would panic there and crash-loop the
  operator on rollout — worse than the missing observability this adds.
- `build_identity_is_never_empty` catches build.rs emitting an *empty* value, which
  compiles fine (unlike a missing one, which `env!` rejects) and would silently produce a
  metric labelled with the empty string.

Full suite green (1,385).

## Note for whoever reviews the rollout

The first deploy carrying this is the first one where `kobe_build_info` exists, so the
metric appears rather than changes. From the release after, it becomes the direct answer
to "what's running".