### PR TITLE
fix(instance): stop reporting lost optimistic races as reconcile errors

### DIFF
--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -175,7 +175,14 @@ pub async fn run_instance_controller<B: ClusterBackend + Clone + 'static>(
                     crate::metrics::RECONCILIATIONS_TOTAL
                         .with_label_values(&["instance", "error"])
                         .inc();
-                    error!("Instance reconciliation error: {e:?}");
+                    // `error_policy` already reported this at ERROR, with the
+                    // instance named and the error in its Display form. Logging
+                    // it again here as Debug meant every reconcile failure
+                    // appeared twice in two different shapes, which doubled the
+                    // volume and made counting incidents by eye unreliable
+                    // (#153). Kept at debug for the runtime-level detail the
+                    // Debug form carries; the metric above is the durable count.
+                    debug!("Instance reconciliation error (runtime detail): {e:?}");
                 }
             }
         });
@@ -832,7 +839,15 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                         }),
                         ..Default::default()
                     };
-                    instances_api.delete(&name, &delete_params).await?;
+                    // Fenced on uid + resourceVersion, so a concurrent write
+                    // makes this 409. That is the fence working: whoever wrote
+                    // first has already triggered a fresh reconcile, which will
+                    // re-decide the delete against the object as it now is.
+                    tolerate_lost_race(
+                        instances_api.delete(&name, &delete_params).await,
+                        &name,
+                        "fenced_delete",
+                    )?;
                     Ok(Action::await_change())
                 }
                 Err(e) => {
@@ -1047,6 +1062,40 @@ async fn evaluate_leased_instance<B: ClusterBackend + Clone>(
     }
 }
 
+/// Absorb a lost optimistic race on a fenced write.
+///
+/// Every write here is fenced on the uid and resourceVersion we read, so losing
+/// the race is the fence doing its job: another writer got there first, its
+/// write already produced a watch event, and the reconcile that event triggers
+/// operates on the newer object. Retrying against the stale read we hold could
+/// only fail the same way.
+///
+/// Before #153 these sites used a bare `?`, which turned that ordinary outcome
+/// into an `InstanceError`, surfaced it through `error_policy` at ERROR, and
+/// requeued. On int-pro that produced ~39 spurious error events a day on a
+/// healthy pool. Sites that already handled it (the phase patch and the fenced
+/// status patch) prove the intended shape; this generalises it.
+///
+/// Genuinely bad requests are NOT absorbed — see `optimistic_conflict`, which
+/// only treats a 422 as a lost race when it carries no field-level causes.
+fn tolerate_lost_race<T>(
+    result: Result<T, kube::Error>,
+    instance: &str,
+    write: &'static str,
+) -> Result<(), kube::Error> {
+    match result {
+        Ok(_) => Ok(()),
+        Err(err) if crate::controllers::lease::optimistic_conflict(&err) => {
+            debug!(
+                instance,
+                write, "fenced write lost the race; a newer reconcile owns this object"
+            );
+            Ok(())
+        }
+        Err(err) => Err(err),
+    }
+}
+
 async fn patch_instance_message_fenced<B: ClusterBackend>(
     ctx: &InstanceContext<B>,
     instance: &ClusterInstance,
@@ -1070,13 +1119,17 @@ async fn patch_instance_message_fenced<B: ClusterBackend>(
         .namespace()
         .unwrap_or_else(|| ctx.namespace.clone());
     let instances: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), &namespace);
-    instances
-        .patch_status(
-            &instance.name_any(),
-            &PatchParams::default(),
-            &Patch::<()>::Json(patch),
-        )
-        .await?;
+    tolerate_lost_race(
+        instances
+            .patch_status(
+                &instance.name_any(),
+                &PatchParams::default(),
+                &Patch::<()>::Json(patch),
+            )
+            .await,
+        &instance.name_any(),
+        "status_message",
+    )?;
     Ok(())
 }
 
@@ -1111,13 +1164,17 @@ async fn patch_exact_binding_status<B: ClusterBackend>(
         .namespace()
         .unwrap_or_else(|| ctx.namespace.clone());
     let instances: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), &namespace);
-    instances
-        .patch_status(
-            &instance.name_any(),
-            &PatchParams::default(),
-            &Patch::<()>::Json(patch),
-        )
-        .await?;
+    tolerate_lost_race(
+        instances
+            .patch_status(
+                &instance.name_any(),
+                &PatchParams::default(),
+                &Patch::<()>::Json(patch),
+            )
+            .await,
+        &instance.name_any(),
+        "exact_binding_status",
+    )?;
     Ok(())
 }
 
@@ -2093,13 +2150,17 @@ async fn record_teardown_receipt<B: ClusterBackend>(
         { "op": "test", "path": "/metadata/uid", "value": uid },
         { "op": "add", "path": "/status/teardownReceipt", "value": receipt }
     ]));
-    leases
-        .patch_status(
-            &lease.name_any(),
-            &PatchParams::default(),
-            &Patch::<()>::Json(patch),
-        )
-        .await?;
+    tolerate_lost_race(
+        leases
+            .patch_status(
+                &lease.name_any(),
+                &PatchParams::default(),
+                &Patch::<()>::Json(patch),
+            )
+            .await,
+        &lease.name_any(),
+        "teardown_receipt",
+    )?;
     Ok(())
 }
 
@@ -2529,14 +2590,17 @@ async fn add_finalizer(
         { "op": "add", "path": "/metadata/finalizers", "value": finalizers }
     ]))
     .expect("finalizer JSON Patch is static");
-    instances_api
-        .patch(
-            &instance.name_any(),
-            &PatchParams::default(),
-            &Patch::<()>::Json(patch),
-        )
-        .await?;
-    Ok(())
+    tolerate_lost_race(
+        instances_api
+            .patch(
+                &instance.name_any(),
+                &PatchParams::default(),
+                &Patch::<()>::Json(patch),
+            )
+            .await,
+        &instance.name_any(),
+        "add_finalizer",
+    )
 }
 
 /// Remove `finalizer` from the instance's `metadata.finalizers` list,
@@ -2572,14 +2636,17 @@ async fn remove_finalizer(
         { "op": "add", "path": "/metadata/finalizers", "value": remaining }
     ]))
     .expect("finalizer JSON Patch is static");
-    instances_api
-        .patch(
-            &instance.name_any(),
-            &PatchParams::default(),
-            &Patch::<()>::Json(patch),
-        )
-        .await?;
-    Ok(())
+    tolerate_lost_race(
+        instances_api
+            .patch(
+                &instance.name_any(),
+                &PatchParams::default(),
+                &Patch::<()>::Json(patch),
+            )
+            .await,
+        &instance.name_any(),
+        "remove_finalizer",
+    )
 }
 
 /// Stable, machine-readable name for a phase, used as a condition
@@ -2717,11 +2784,13 @@ async fn get_profile(client: &Client, name: &str, namespace: &str) -> Option<Clu
 }
 
 fn error_policy<B: ClusterBackend>(
-    _instance: Arc<ClusterInstance>,
+    instance: Arc<ClusterInstance>,
     error: &InstanceError,
     _ctx: Arc<InstanceContext<B>>,
 ) -> Action {
-    error!("Instance reconciliation error: {error}");
+    // The single ERROR for a failed reconcile. Named, so the object is
+    // identifiable without parsing it back out of a Debug blob.
+    error!(instance = %instance.name_any(), "Instance reconciliation error: {error}");
     Action::requeue(std::time::Duration::from_secs(30))
 }
 

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -1540,8 +1540,38 @@ fn instance_matches_binding_subject(instance: &ClusterInstance, binding: &LeaseB
             })
 }
 
+/// True when an API error means "someone else wrote first", not "this request
+/// was wrong".
+///
+/// Every fenced write in this repo is a JSON Patch whose leading `test` ops
+/// assert the uid and resourceVersion we read. The apiserver reports the two
+/// ways that fence can lose differently:
+///
+///   - **409 Conflict** — a failed `Preconditions` check (fenced delete/replace).
+///     Unambiguous: 409 only ever means a concurrent modification.
+///   - **422 Invalid** — a failed `test` op. Shares its status code with genuine
+///     request validation, which is why the code alone is not enough.
+///
+/// A 422 is only treated as a lost race when it carries **no field-level
+/// causes**. A failed `test` op yields the generic "the server rejected our
+/// request due to an error in our request" with `details.causes` empty; a real
+/// validation failure (schema violation, bad field) populates `causes` with the
+/// offending paths. Blanket-matching 422 would swallow that second class
+/// entirely and requeue forever against a request that can never succeed —
+/// the same silent-infinite-retry shape as #150. So when in doubt, this returns
+/// false and the error stays loud.
 pub(crate) fn optimistic_conflict(err: &kube::Error) -> bool {
-    matches!(err, kube::Error::Api(response) if response.code == 409 || response.code == 422)
+    let kube::Error::Api(response) = err else {
+        return false;
+    };
+    match response.code {
+        409 => true,
+        422 => response
+            .details
+            .as_ref()
+            .is_none_or(|details| details.causes.is_empty()),
+        _ => false,
+    }
 }
 
 pub(crate) fn json_patch(value: serde_json::Value) -> json_patch::Patch {
@@ -1904,6 +1934,74 @@ mod tests {
     use crate::testutil::MockBackend;
     use wiremock::matchers::{method, path, query_param};
     use wiremock::{Mock, MockServer, ResponseTemplate};
+
+    // -----------------------------------------------------------------------
+    // optimistic_conflict — which API failures mean "someone wrote first"
+    // -----------------------------------------------------------------------
+
+    fn api_error(code: u16, reason: &str, causes: Vec<&str>) -> kube::Error {
+        use kube::core::response::{Status, StatusCause, StatusDetails, StatusSummary};
+        kube::Error::Api(Box::new(Status {
+            status: Some(StatusSummary::Failure),
+            code,
+            message: "boom".to_string(),
+            reason: reason.to_string(),
+            details: Some(StatusDetails {
+                name: String::new(),
+                group: String::new(),
+                kind: String::new(),
+                uid: String::new(),
+                causes: causes
+                    .into_iter()
+                    .map(|field| StatusCause {
+                        field: field.to_string(),
+                        message: "invalid".to_string(),
+                        reason: "FieldValueInvalid".to_string(),
+                    })
+                    .collect(),
+                retry_after_seconds: 0,
+            }),
+            metadata: None,
+        }))
+    }
+
+    /// A failed `Preconditions` check is unambiguous — 409 only ever means a
+    /// concurrent modification.
+    #[test]
+    fn conflict_409_is_a_lost_race() {
+        assert!(optimistic_conflict(&api_error(409, "Conflict", vec![])));
+    }
+
+    /// A failed JSON-Patch `test` op returns 422 with no field-level causes.
+    /// This is the shape observed ~38×/day on int-pro (#153).
+    #[test]
+    fn invalid_422_without_causes_is_a_lost_race() {
+        assert!(optimistic_conflict(&api_error(422, "Invalid", vec![])));
+    }
+
+    /// The one that matters: a 422 carrying field-level causes is a genuinely
+    /// bad request, not a lost race. Retrying it can never succeed, so treating
+    /// it as a conflict would silently requeue forever against a request the
+    /// server will always reject — the failure shape of #150. It must stay
+    /// loud.
+    #[test]
+    fn invalid_422_with_causes_is_a_real_error() {
+        assert!(
+            !optimistic_conflict(&api_error(422, "Invalid", vec!["spec.servers"])),
+            "a validation failure must not be absorbed as a lost race"
+        );
+    }
+
+    /// Unrelated failures are untouched — a 404 or a 500 is not a lost race.
+    #[test]
+    fn other_status_codes_are_not_lost_races() {
+        assert!(!optimistic_conflict(&api_error(404, "NotFound", vec![])));
+        assert!(!optimistic_conflict(&api_error(
+            500,
+            "InternalError",
+            vec![]
+        )));
+    }
 
     // -----------------------------------------------------------------------
     // Helpers


### PR DESCRIPTION
Closes #153.

## The noise

24h on int-pro, operator pods only, on a pool that cycled ~30 instances cleanly with
no stuck members and a max restart count of 2:

| Signature | Lines/24h |
|---|---|
| `code: 409` — failed `Preconditions` check | 40 |
| `code: 422` — failed JSON-Patch `test` op | 38 |

≈39 actual events once double-logging is accounted for. All of them lost races on
fenced writes, reported as reconcile errors.

## Why they were errors

Every write in this controller is fenced on the uid and resourceVersion that were read.
Losing that fence means another writer got there first — and *that* write already
produced a watch event, so the reconcile it triggers operates on the newer object.
Retrying against the stale read we still hold could only fail the same way.

Two of the seven fenced sites already treated this as ordinary (the phase patch at 2043,
the fenced status patch at 2141). The other five plus the fenced delete used a bare `?`:

| Site | Was | Now |
|---|---|---|
| `patch_instance_message_fenced` | `.await?` | tolerated |
| `patch_exact_binding_status` | `.await?` | tolerated |
| `record_teardown_receipt` | `.await?` | tolerated |
| `add_finalizer` | `.await?` | tolerated |
| `remove_finalizer` | `.await?` | tolerated |
| fenced delete (`instance.rs:835`) | `.await?` | tolerated |

`add_finalizer`/`remove_finalizer` run on every instance create and teardown, which is
why the rate tracked instance lifecycles rather than incidents.

## 422 is not blanket-matched

This is the part worth reviewing carefully. 422 shares its status code with genuine
request validation, so `optimistic_conflict` now distinguishes:

```rust
match response.code {
    409 => true,                                    // only ever concurrent modification
    422 => response.details.as_ref()
        .is_none_or(|d| d.causes.is_empty()),       // failed `test` op vs bad request
    _   => false,
}
```

A failed `test` op yields the generic "the server rejected our request due to an error
in our request" with `details.causes` empty — the exact shape observed on int-pro. A real
validation failure populates `causes` with the offending field paths.

Absorbing that second class would requeue forever against a request the server can never
accept: silent infinite retry, the same failure shape as #150. The predicate returns
false when in doubt, so unexpected 422s stay loud.

## Double-logging

Every reconcile failure was logged twice, in two different shapes — Debug from the
controller stream (`instance.rs:178`) and Display from `error_policy` (`instance.rs:2784`).
`error_policy` keeps the single ERROR and now names the instance, so the object is
identifiable without parsing it back out of a Debug blob. The stream's runtime detail
drops to `debug`; `RECONCILIATIONS_TOTAL{result="error"}` is unchanged as the durable
count.

## Tests

- `invalid_422_with_causes_is_a_real_error` — the guard on the distinction above,
  **verified to FAIL against the previous blanket `409 || 422`**, so it pins the
  behaviour rather than passing vacuously.
- `invalid_422_without_causes_is_a_lost_race` — the int-pro shape.
- `conflict_409_is_a_lost_race`, `other_status_codes_are_not_lost_races` — the bounds.

Full suite green (1,387).

## Expected effect

Operator ERROR volume should drop from ~78 lines/day to near zero on a healthy pool,
leaving `RECONCILIATIONS_TOTAL{result="error"}` as the place contention shows up. Note
this makes the metric, not the log, the way to notice a *rising* conflict rate — which
is the right place for a rate signal anyway.