### PR TITLE
feat(pool): make drift detection see the rendered workload

### DIFF
--- a/docs/guides/upgrade-policy.md
+++ b/docs/guides/upgrade-policy.md
@@ -14,16 +14,39 @@ for your pool shape, and what to expect operationally.
 ## When does an upgrade fire?
 
 Any change that flips the pool's `spec_hash` makes existing members
-"drifted" and eligible for recycle. Three sources flow into the hash:
+"drifted" and eligible for recycle. Four sources flow into the hash:
 
 1. **User-visible spec edits** to the `ClusterPool` CR — cluster
    config, addons, bootstrap *names*.
-2. **Operator-level config bumps** — currently just
-   `KOBE_SYNC_IMAGE`, which only affects vkobe-backend pools.
+2. **Operator-level config bumps** — `KOBE_SYNC_IMAGE`, which only
+   affects vkobe-backend pools.
 3. **`BootstrapConfig` content edits** — the install manifest, the
    shell script, anything inside the referenced bootstrap CRs. This
    catches the case where you rev the bootstrap content without
    renaming the bootstrap reference.
+4. **The rendered workload itself** — a digest of the server
+   StatefulSet and agent Deployment the backend would build for this
+   pool. This is what makes an **operator upgrade** visible: a release
+   that changes how pods are rendered flips the hash even though the
+   `ClusterPool` CR is untouched.
+
+Source 4 exists because of a real gap (#149). v0.39.2 added a
+node-password volume to every k3s server pod (#146), but since the pool
+CR was unchanged the hash was byte-identical, no member was ever marked
+drifted, and idle members kept serving the old, brickable spec until
+they were deleted by hand. Sources 1–3 hash the *inputs* to rendering;
+source 4 hashes the *output*.
+
+It is currently implemented for the **k3s** backend. Other backends
+report no fingerprint and behave exactly as before — for them, an
+operator upgrade that changes rendering is still invisible to drift
+detection.
+
+> **Upgrading to the release that introduced source 4 flips every
+> pool's hash once**, because the hash gained an input. Expect a
+> one-time rolling recycle of idle members across all pools, capped by
+> `maxRecycling` and floor-protected by `minReadyDuringUpgrade`, and
+> visible as a `SpecDrift` wave in `kobe_instance_recycles_total`.
 
 To diff actual hashes against the operator's current expectation:
 

--- a/src/backend/k3s.rs
+++ b/src/backend/k3s.rs
@@ -27,6 +27,7 @@ use kube::Client;
 use kube::api::{
     Api, DeleteParams, ListParams, ObjectMeta, Patch, PatchParams, PostParams, PropagationPolicy,
 };
+use sha2::{Digest, Sha256};
 use std::collections::BTreeMap;
 use tracing::{debug, info, warn};
 
@@ -145,6 +146,16 @@ sleep infinity
 /// Path k3s reads its container-runtime registry config from on every node.
 /// (https://docs.k3s.io/installation/private-registry)
 const REGISTRIES_YAML_PATH: &str = "/etc/rancher/k3s/registries.yaml";
+
+/// Placeholder identity used only for `render_fingerprint`.
+///
+/// Never names a real object. Its only requirement is stability: change these
+/// and every pool's spec hash changes, triggering a fleet-wide recycle.
+const FINGERPRINT_NAME: &str = "kobe-render-fingerprint";
+const FINGERPRINT_NAMESPACE: &str = "kobe-render-fingerprint";
+/// Stand-in for the real datastore endpoint, whose value rotates and is
+/// per-cluster. Presence is what matters to rendering, not the value.
+const FINGERPRINT_DATASTORE_ENDPOINT: &str = "postgres://kobe-render-fingerprint";
 
 /// Path every k3s node keeps its cleartext node password at.
 ///
@@ -2238,7 +2249,65 @@ impl K3sBackend {
     }
 }
 
+/// Digest the rendered objects that make up a k3s cluster's workload.
+///
+/// Split out from `render_fingerprint` so tests can feed it a deliberately
+/// mutated render and prove the digest actually tracks the pod spec — i.e.
+/// that a change like #146's added node-password volume would be caught.
+///
+/// serde_json over the typed k8s objects is deterministic for a given input:
+/// field order follows the struct definitions and maps are BTreeMaps. A
+/// serialisation failure yields `None` rather than a sentinel digest, so the
+/// hash falls back to exactly its pre-#149 inputs instead of silently
+/// asserting "no drift".
+fn fingerprint_rendered(sts: &StatefulSet, deploy: &Option<Deployment>) -> Option<String> {
+    let mut hasher = Sha256::new();
+    hasher.update(serde_json::to_vec(sts).ok()?);
+    hasher.update(serde_json::to_vec(deploy).ok()?);
+    Some(format!("{:x}", hasher.finalize()))
+}
+
 impl ClusterBackend for K3sBackend {
+    /// Render the server StatefulSet and agent Deployment this pool would get,
+    /// and digest them. Any change to k3s rendering therefore changes the pool
+    /// spec hash, which is what makes an operator upgrade visible to drift
+    /// detection (#149).
+    ///
+    /// Rendered against a FIXED placeholder identity. The real name, namespace
+    /// and datastore endpoint are per-instance, so hashing them would make
+    /// every member's fingerprint unique and mark the whole pool drifted
+    /// forever. The datastore endpoint in particular carries rotating
+    /// credentials (`POSTGRES_URL`, hot-reloaded), so hashing the live value
+    /// would recycle every pool on each rotation. A placeholder is passed
+    /// rather than `None` so the endpoint-bearing code path is still rendered
+    /// — its presence changes the container args, and that difference is
+    /// exactly the kind of thing this is meant to notice.
+    ///
+    /// Replica counts come from `config` and are already in the input hash;
+    /// they are passed through so the rendered output stays a faithful
+    /// reflection of what `create` would build.
+    fn render_fingerprint(&self, config: &ClusterConfig) -> Option<String> {
+        let sts = Self::build_server_statefulset(
+            FINGERPRINT_NAME,
+            FINGERPRINT_NAMESPACE,
+            config,
+            Some(FINGERPRINT_DATASTORE_ENDPOINT),
+            config.servers.max(1),
+        );
+        let agents = config.agents.unwrap_or(0);
+        let deploy = (agents > 0).then(|| {
+            Self::build_agent_deployment(FINGERPRINT_NAME, FINGERPRINT_NAMESPACE, config, agents)
+        });
+
+        // serde_json over the typed k8s objects: field order follows the
+        // struct definitions and maps are BTreeMaps, so the encoding is
+        // deterministic for a given input. A serialisation failure must not be
+        // reported as "no drift" — it would silently restore the old blind
+        // spot — so it yields None, leaving the hash exactly as it was before
+        // this fingerprint existed.
+        fingerprint_rendered(&sts, &deploy)
+    }
+
     #[tracing::instrument(skip(self, config, addons, _owner_ref), fields(cluster = name, namespace))]
     async fn create(
         &self,
@@ -2636,6 +2705,78 @@ mod tests {
     // =================================================================
     // Pure function tests for resource builders
     // =================================================================
+
+    #[test]
+    fn render_fingerprint_is_deterministic() {
+        // A fingerprint that varies between calls would mark every member
+        // drifted on every reconcile and churn the pool forever, so this is a
+        // correctness requirement rather than a nicety.
+        let config = base_config();
+        let a = K3sBackend::build_server_statefulset("n", "ns", &config, Some("pg"), 1);
+        let b = K3sBackend::build_server_statefulset("n", "ns", &config, Some("pg"), 1);
+        assert_eq!(
+            fingerprint_rendered(&a, &None),
+            fingerprint_rendered(&b, &None),
+            "rendering the same config twice must digest identically"
+        );
+        assert!(fingerprint_rendered(&a, &None).is_some());
+    }
+
+    /// The property #149 is actually about: a change in RENDERING — not in the
+    /// ClusterPool spec — must change the fingerprint.
+    ///
+    /// Modelled on the real case. v0.39.2 (#146) added a `node-password` volume
+    /// to every k3s server pod; the pool spec was untouched, so the old
+    /// input-only hash was byte-identical and idle members kept the brickable
+    /// spec. Removing that volume from an otherwise identical render stands in
+    /// for "the renderer changed", and the digest must notice.
+    #[test]
+    fn render_fingerprint_tracks_the_rendered_pod_spec() {
+        let config = base_config();
+        let rendered = K3sBackend::build_server_statefulset("n", "ns", &config, Some("pg"), 1);
+
+        let mut without_volume = rendered.clone();
+        let volumes = without_volume
+            .spec
+            .as_mut()
+            .unwrap()
+            .template
+            .spec
+            .as_mut()
+            .unwrap()
+            .volumes
+            .as_mut()
+            .expect("server pod renders volumes");
+        let before = volumes.len();
+        volumes.retain(|v| v.name != "node-password");
+        assert_eq!(
+            before - 1,
+            volumes.len(),
+            "fixture must actually drop one volume"
+        );
+
+        assert_ne!(
+            fingerprint_rendered(&rendered, &None),
+            fingerprint_rendered(&without_volume, &None),
+            "a rendering change must flip the fingerprint — this is the #146 blind spot"
+        );
+    }
+
+    /// The agent Deployment is part of the workload, so a pool that renders one
+    /// must not digest the same as a pool that does not.
+    #[test]
+    fn render_fingerprint_covers_the_agent_deployment() {
+        let mut config = base_config();
+        config.agents = Some(2);
+        let sts = K3sBackend::build_server_statefulset("n", "ns", &config, Some("pg"), 1);
+        let deploy = K3sBackend::build_agent_deployment("n", "ns", &config, 2);
+
+        assert_ne!(
+            fingerprint_rendered(&sts, &Some(deploy)),
+            fingerprint_rendered(&sts, &None),
+            "agent Deployment must contribute to the fingerprint"
+        );
+    }
 
     #[test]
     fn test_build_server_statefulset_basic() {

--- a/src/backend/mod.rs
+++ b/src/backend/mod.rs
@@ -329,6 +329,22 @@ impl ClusterBackend for BackendDispatch {
         }
     }
 
+    /// Delegate rather than inherit the trait default.
+    ///
+    /// Every caller holds a `BackendDispatch`, so without this arm the default
+    /// `None` would shadow the concrete implementations and the fingerprint
+    /// would silently never be computed — the drift gap would look fixed while
+    /// behaving exactly as before.
+    fn render_fingerprint(&self, config: &ClusterConfig) -> Option<String> {
+        match self {
+            Self::K3s(b) => b.render_fingerprint(config),
+            Self::K0s(b) => b.render_fingerprint(config),
+            Self::Capi(b) => b.render_fingerprint(config),
+            Self::Vkobe(b) => b.render_fingerprint(config),
+            Self::Vcluster(b) => b.render_fingerprint(config),
+        }
+    }
+
     async fn check_health(&self, name: &str, namespace: &str) -> Result<bool> {
         match self {
             Self::K3s(b) => b.check_health(name, namespace).await,
@@ -653,6 +669,31 @@ pub trait ClusterBackend: Send + Sync {
     #[allow(dead_code)]
     fn supports_verified_destroy(&self) -> bool {
         false
+    }
+
+    /// Fingerprint of the workload this backend WOULD render for `config`,
+    /// or `None` when the backend cannot describe its rendering.
+    ///
+    /// This exists so pool drift detection can see changes that live in
+    /// rendering code rather than in the ClusterPool spec. `profile_spec_hash`
+    /// otherwise hashes only its INPUTS — pool fields, bootstrap content, and
+    /// the vkobe sidecar image — so an operator upgrade that alters the pod
+    /// spec produces a byte-identical hash and no member is ever marked
+    /// drifted. That is #149: v0.39.2 added a node-password volume to every
+    /// k3s server pod (#146) and idle members kept the old, brickable spec
+    /// until someone deleted them by hand.
+    ///
+    /// Implementations MUST render against a fixed placeholder identity, not a
+    /// real instance: per-instance values (names, namespaces, endpoints) would
+    /// otherwise make every member differ from every other and drift forever.
+    /// They MUST also be deterministic for a given `config` — a fingerprint
+    /// that varies between calls churns the whole pool on every reconcile.
+    ///
+    /// `None` keeps a backend's existing behaviour exactly: it contributes
+    /// nothing to the hash, rather than contributing a "None" that would
+    /// itself have to stay stable.
+    fn render_fingerprint(&self, _config: &ClusterConfig) -> Option<String> {
+        None
     }
 
     /// Check if a virtual cluster's API server is healthy.

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -1081,12 +1081,30 @@ async fn reconcile_profile(
         }
     }
 
+    // Computed ONCE per reconcile and threaded to every consumer — the drift
+    // comparison below and both stamp sites. Recomputing it independently at
+    // each site would risk stamped != compared, which recycles every member on
+    // every reconcile forever (bounded only by `maxRecycling`). One value
+    // cannot disagree with itself.
+    //
+    // `None` whenever no factory is configured or the backend has no
+    // fingerprint, which leaves the hash exactly as it was before #149.
+    let render_fingerprint: Option<String> = ctx
+        .factory
+        .as_ref()
+        .and_then(|factory| factory.backend_for(&profile).ok())
+        .and_then(|backend| {
+            use crate::backend::ClusterBackend;
+            backend.render_fingerprint(&profile.spec.cluster)
+        });
+
     let actions = compute_pool_actions(
         &profile,
         &pool_state,
         now,
         &ctx.render_ctx,
         &bootstrap_specs,
+        render_fingerprint.as_deref(),
     );
 
     // Check whether the backend datastore is degraded. When kine/etcd
@@ -1132,6 +1150,7 @@ async fn reconcile_profile(
                     cluster_name,
                     &ctx.render_ctx,
                     &bootstrap_specs,
+                    render_fingerprint.as_deref(),
                 )
                 .await?;
                 pool_state.clusters.insert(
@@ -1145,6 +1164,7 @@ async fn reconcile_profile(
                             &profile,
                             &ctx.render_ctx,
                             &bootstrap_specs,
+                            render_fingerprint.as_deref(),
                         )),
                         // Freshly created — it hasn't had a chance to report a
                         // scheduling block or crashloop yet; build_pool_state
@@ -1699,6 +1719,7 @@ async fn ensure_cluster_instance(
     cluster_name: &str,
     render_ctx: &crate::pool::RenderContext,
     bootstrap_specs: &std::collections::BTreeMap<String, crate::crd::BootstrapConfigSpec>,
+    render_fingerprint: Option<&str>,
 ) -> Result<(), ProfileError> {
     let mut labels = std::collections::BTreeMap::new();
     labels.insert("kobe.kunobi.ninja/pool".to_string(), profile.name_any());
@@ -1776,6 +1797,7 @@ async fn ensure_cluster_instance(
             profile,
             render_ctx,
             bootstrap_specs,
+            render_fingerprint,
         )),
         created_with: Some(provenance),
         ..Default::default()

--- a/src/pool/manager.rs
+++ b/src/pool/manager.rs
@@ -146,14 +146,50 @@ impl RenderContext {
 /// `compute_pool_actions` recycles unclaimed pool members on the next
 /// reconcile. Leased members keep running; they'll get the fresh hash
 /// when they're released and recycled.
+///
+/// `render_fingerprint` is the backend's digest of the workload it WOULD
+/// render for this pool ([`crate::backend::ClusterBackend::render_fingerprint`]),
+/// or `None` for backends that cannot describe their rendering. It closes
+/// #149: without it the hash sees only its INPUTS, so an operator upgrade that
+/// changes rendering — v0.39.2 adding a node-password volume to every k3s
+/// server pod (#146) — produced an identical hash and left idle members on the
+/// old spec until someone deleted them by hand.
+///
+/// It is ADDITIVE, deliberately. Addons and bootstrap content never appear in
+/// a pod spec (they are applied inside the guest), so replacing the input hash
+/// with the fingerprint would lose drift coverage this pool has today.
+///
+/// The parameter is positional and required rather than defaulted, so a caller
+/// that forgets it fails to compile. A site that stamped the hash without the
+/// fingerprint while another compared it with one would make stamped != compared
+/// on every reconcile — a permanent recycle loop bounded only by `maxRecycling`.
 pub fn profile_spec_hash(
     profile: &ClusterPool,
     render_ctx: &RenderContext,
     bootstrap_specs: &std::collections::BTreeMap<String, crate::crd::BootstrapConfigSpec>,
+    render_fingerprint: Option<&str>,
 ) -> SpecHash {
     use crate::crd::BackendType;
+    use sha2::{Digest, Sha256};
     use std::hash::{Hash, Hasher};
-    let mut hasher = std::collections::hash_map::DefaultHasher::new();
+
+    // A wrapper so the existing `Hash`-based folding below keeps working while
+    // the digest underneath is stable across Rust releases. `DefaultHasher` is
+    // explicitly NOT guaranteed stable between versions, so a toolchain bump
+    // could have silently flipped every pool's hash at once and triggered a
+    // fleet-wide recycle that looked intentional.
+    #[derive(Default)]
+    struct StableHasher(Sha256);
+    impl Hasher for StableHasher {
+        fn write(&mut self, bytes: &[u8]) {
+            self.0.update(bytes);
+        }
+        fn finish(&self) -> u64 {
+            let digest = self.0.clone().finalize();
+            u64::from_be_bytes(digest[..8].try_into().expect("sha256 yields 32 bytes"))
+        }
+    }
+    let mut hasher = StableHasher::default();
     // Hash the fields that affect how a cluster is created
     profile.spec.cluster.version.hash(&mut hasher);
     profile.spec.cluster.servers.hash(&mut hasher);
@@ -201,6 +237,15 @@ pub fn profile_spec_hash(
         render_ctx.kobe_sync_image.hash(&mut hasher);
     }
 
+    // What the backend would actually render. `None` contributes nothing, so a
+    // backend without a fingerprint keeps precisely its previous hash inputs
+    // rather than folding in a sentinel that would itself have to stay stable.
+    if let Some(fingerprint) = render_fingerprint {
+        fingerprint.hash(&mut hasher);
+    }
+
+    // Width and shape are load-bearing: `lease_binding` and
+    // `ClusterInstance.status.specHash` document a fixed 16-char hex digest.
     format!("{:016x}", hasher.finish())
 }
 
@@ -531,6 +576,7 @@ pub fn compute_pool_actions(
     now: chrono::DateTime<chrono::Utc>,
     render_ctx: &RenderContext,
     bootstrap_specs: &std::collections::BTreeMap<String, crate::crd::BootstrapConfigSpec>,
+    render_fingerprint: Option<&str>,
 ) -> Vec<PoolAction> {
     let spec = &profile.spec;
     let mut actions = Vec::new();
@@ -581,7 +627,7 @@ pub fn compute_pool_actions(
         0
     };
 
-    let current_hash = profile_spec_hash(profile, render_ctx, bootstrap_specs);
+    let current_hash = profile_spec_hash(profile, render_ctx, bootstrap_specs, render_fingerprint);
     let counts = count_states(state, Some(&current_hash));
     // Quarantined counts toward the ceiling. Its backend resources still
     // exist — that is the whole point, the cleanup handle is being held — so
@@ -1556,6 +1602,54 @@ mod tests {
 
     // --- Autoscaling: compute_pool_actions ---
 
+    /// The fingerprint must actually reach the hash — otherwise #149's fix is
+    /// wired up but inert.
+    #[test]
+    fn spec_hash_folds_in_the_render_fingerprint() {
+        let profile = make_profile(1, None);
+        let ctx = test_render_ctx();
+        let bs = Default::default();
+
+        let without = profile_spec_hash(&profile, &ctx, &bs, None);
+        let with_a = profile_spec_hash(&profile, &ctx, &bs, Some("render-a"));
+        let with_b = profile_spec_hash(&profile, &ctx, &bs, Some("render-b"));
+
+        assert_ne!(
+            without, with_a,
+            "a pool whose backend reports a fingerprint must not hash the same as one without"
+        );
+        assert_ne!(
+            with_a, with_b,
+            "a changed rendering must change the hash — this is the #146 blind spot"
+        );
+        assert_eq!(
+            with_a,
+            profile_spec_hash(&profile, &ctx, &bs, Some("render-a")),
+            "same inputs must hash identically"
+        );
+    }
+
+    /// Shape is load-bearing: `lease_binding` and `ClusterInstance.status.specHash`
+    /// both document a fixed-width 16-char hex digest. Moving off DefaultHasher
+    /// must not change that contract.
+    #[test]
+    fn spec_hash_is_16_hex_chars() {
+        let profile = make_profile(1, None);
+        for fingerprint in [None, Some("x")] {
+            let h = profile_spec_hash(
+                &profile,
+                &test_render_ctx(),
+                &Default::default(),
+                fingerprint,
+            );
+            assert_eq!(h.len(), 16, "expected 16 chars, got {h:?}");
+            assert!(
+                h.chars().all(|c| c.is_ascii_hexdigit()),
+                "expected hex, got {h:?}"
+            );
+        }
+    }
+
     fn make_profile(
         size: u32,
         scaling: Option<crate::crd::ScalingConfig>,
@@ -1634,6 +1728,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         // Should create up to MAX_BURST (2) clusters
@@ -1682,6 +1777,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert!(
@@ -1724,6 +1820,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert_eq!(
@@ -1761,6 +1858,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert_eq!(
@@ -1803,6 +1901,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert!(
@@ -1852,6 +1951,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert!(
@@ -1887,6 +1987,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert!(
@@ -1914,6 +2015,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert_eq!(
@@ -1953,6 +2055,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert!(actions.is_empty());
@@ -1987,6 +2090,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         let creates: Vec<_> = actions
@@ -2025,6 +2129,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         // At max_clusters=2 with 2 leased, no room to create
@@ -2087,6 +2192,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         // 2 ready, min_ready=1, one idle >30m → delete 1
@@ -2153,6 +2259,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         // Both idle only 5m, threshold is 30m — no deletes
@@ -2181,7 +2288,7 @@ mod tests {
         });
         let stale_hash = format!(
             "{}-stale",
-            profile_spec_hash(&profile, &test_render_ctx(), &Default::default())
+            profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None)
         );
 
         let mut clusters = HashMap::new();
@@ -2225,6 +2332,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         // Only the Ready (unclaimed) cluster should be deleted.
@@ -2254,8 +2362,8 @@ mod tests {
         let new_ctx = RenderContext::with_kobe_sync_image("zondax/kobe-sync:v0.12.3");
         let bs = std::collections::BTreeMap::new();
 
-        let old_hash = profile_spec_hash(&profile, &old_ctx, &bs);
-        let new_hash = profile_spec_hash(&profile, &new_ctx, &bs);
+        let old_hash = profile_spec_hash(&profile, &old_ctx, &bs, None);
+        let new_hash = profile_spec_hash(&profile, &new_ctx, &bs, None);
         assert_ne!(
             old_hash, new_hash,
             "vkobe pool must recompute its spec hash when KOBE_SYNC_IMAGE changes"
@@ -2278,8 +2386,8 @@ mod tests {
         let bs = std::collections::BTreeMap::new();
 
         assert_eq!(
-            profile_spec_hash(&profile, &old_ctx, &bs),
-            profile_spec_hash(&profile, &new_ctx, &bs),
+            profile_spec_hash(&profile, &old_ctx, &bs, None),
+            profile_spec_hash(&profile, &new_ctx, &bs, None),
             "k3s pool spec hash must NOT depend on the kobe-sync sidecar image"
         );
     }
@@ -2340,8 +2448,8 @@ mod tests {
         );
 
         let ctx = test_render_ctx();
-        let h1 = profile_spec_hash(&profile, &ctx, &bs_v1);
-        let h2 = profile_spec_hash(&profile, &ctx, &bs_v2);
+        let h1 = profile_spec_hash(&profile, &ctx, &bs_v1, None);
+        let h2 = profile_spec_hash(&profile, &ctx, &bs_v2, None);
         assert_ne!(
             h1, h2,
             "editing a referenced BootstrapConfig's content must flip the pool hash"
@@ -2370,8 +2478,8 @@ mod tests {
         );
 
         assert_eq!(
-            profile_spec_hash(&profile, &ctx, &Default::default()),
-            profile_spec_hash(&profile, &ctx, &bs_a),
+            profile_spec_hash(&profile, &ctx, &Default::default(), None),
+            profile_spec_hash(&profile, &ctx, &bs_a, None),
             "pool with no bootstraps must not be affected by unrelated entries in the resolved map"
         );
     }
@@ -2414,7 +2522,8 @@ mod tests {
     #[test]
     fn test_no_drift_when_spec_hash_matches() {
         let profile = make_profile(2, None);
-        let current_hash = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+        let current_hash =
+            profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None);
 
         let mut clusters = HashMap::new();
         clusters.insert(
@@ -2443,6 +2552,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         let deletes: Vec<_> = actions
@@ -2562,6 +2672,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         assert!(
@@ -2610,6 +2721,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         // The floor legitimately blocks deleting either member right now.
@@ -2735,6 +2847,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let creates: Vec<_> = actions
             .iter()
@@ -2757,6 +2870,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let creates: Vec<_> = actions
             .iter()
@@ -2785,6 +2899,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let creates: Vec<_> = actions
             .iter()
@@ -2810,6 +2925,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let creates: Vec<_> = actions
             .iter()
@@ -3006,6 +3122,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         let deletes: Vec<_> = actions
@@ -3026,7 +3143,7 @@ mod tests {
     #[test]
     fn rolling_drift_holds_recycle_when_floor_would_be_violated() {
         let profile = make_profile_with_upgrade(2, 1, 1, Some(2));
-        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None);
         let mut clusters = HashMap::new();
         clusters.insert(
             "pool-test-profile-1".into(),
@@ -3046,6 +3163,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3074,7 +3192,7 @@ mod tests {
     #[test]
     fn size_one_pool_with_surge_one_upgrades_with_zero_downtime() {
         let profile = make_profile_with_upgrade(1, 1, 1, None); // floor defaults to size=1
-        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None);
 
         // T0: 1 drifted Ready, no clean.
         let mut clusters = HashMap::new();
@@ -3091,6 +3209,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         assert_eq!(
             actions_t0
@@ -3124,6 +3243,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes_t1: Vec<_> = actions_t1
             .iter()
@@ -3170,6 +3290,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3220,6 +3341,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3325,6 +3447,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let creates = actions
             .iter()
@@ -3365,6 +3488,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3417,6 +3541,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3439,7 +3564,7 @@ mod tests {
     #[test]
     fn cert_expiring_ready_recycles_like_drift_leased_untouched() {
         let profile = make_profile_with_upgrade(2, 1, 1, Some(0));
-        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None);
 
         let expiring = ClusterEntry {
             state: ClusterState::Ready,
@@ -3483,6 +3608,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3504,7 +3630,7 @@ mod tests {
     #[test]
     fn soonest_expiring_member_recycles_first_under_cap() {
         let profile = make_profile_with_upgrade(2, 1, 1, Some(0)); // max_recycling=1
-        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None);
 
         let entry = |horizon: i64, age_secs: i64| ClusterEntry {
             state: ClusterState::Ready,
@@ -3533,6 +3659,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3572,7 +3699,7 @@ mod tests {
             max_surge: 1,
             min_ready_during_upgrade: Some(2),
         });
-        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default());
+        let current = profile_spec_hash(&profile, &test_render_ctx(), &Default::default(), None);
 
         // 3 Ready: 1 drifted + 2 clean. Above min_ready=2 with one
         // long-idle clean cluster — would normally scale-down.
@@ -3609,6 +3736,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         // pool-test-profile-1 (drifted) is a candidate for drift recycle,
         // but neither -2 nor -3 (clean, idle, above min_ready) should
@@ -3658,6 +3786,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3708,6 +3837,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
 
         let deletes: Vec<_> = actions
@@ -3766,6 +3896,7 @@ mod tests {
             chrono::Utc::now(),
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3890,6 +4021,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -3950,6 +4082,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -4026,6 +4159,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -4108,6 +4242,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()
@@ -4186,6 +4321,7 @@ mod tests {
             now,
             &test_render_ctx(),
             &Default::default(),
+            None,
         );
         let deletes: Vec<_> = actions
             .iter()


### PR DESCRIPTION
Closes #149.

## The gap

`profile_spec_hash` hashed only its **inputs**: ClusterPool spec fields, BootstrapConfig
content, and `KOBE_SYNC_IMAGE` (vkobe only). An operator upgrade that changed the code
*rendering* a pod produced a byte-identical hash — so no member was ever marked drifted,
and idle members kept the old spec indefinitely.

Concretely: v0.39.2 added a node-password volume to every k3s server pod (#146) precisely
because the old spec could brick a cluster on one restart. The pool CR was untouched, the
hash never moved, and int-pro's idle members had to be deleted **by hand**. vkobe pools
self-healed only incidentally, because the chart bumps `KOBE_SYNC_IMAGE` each release.

## The fix

`ClusterBackend::render_fingerprint` — a digest of the workload the backend *would* render
— folded into the hash. k3s renders its server StatefulSet + agent Deployment through the
existing pure builders; other backends return `None` and keep today's behaviour exactly.

**Additive, not a replacement.** #149 proposed hashing the rendered spec *instead of* the
inputs. That would have silently lost coverage: addons and bootstrap content are applied
inside the guest and never appear in a pod spec, so they must keep contributing. The
fingerprint is one more input.

## Three traps this deliberately avoids

**1. Per-instance values.** Rendered against a fixed placeholder identity, never a real
instance — otherwise every member's fingerprint differs from every other and the pool is
permanently drifted. The datastore endpoint matters twice: `POSTGRES_URL` carries
credentials that rotate under hot-reload, so hashing the live value would recycle every
pool on each rotation. A placeholder is passed rather than `None`, so the endpoint-bearing
branch still renders — its presence changes container args, exactly what this must notice.

**2. Stamp/compare divergence.** Computed **once** in `reconcile_profile` and threaded to
the drift comparison and both stamp sites. If one site hashed with a fingerprint and
another without, stamped ≠ compared on every reconcile — recycling every member forever,
bounded only by `maxRecycling`. That's the silent-infinite-loop shape of #150. The
parameter is positional and required, so a missed caller is a **compile error**.

**3. An inert feature.** `BackendDispatch` delegates explicitly rather than inheriting the
trait default. Every caller holds a dispatch, so without that arm the default `None` would
shadow the k3s impl and the whole thing would look wired up while behaving as before.

## Also: dropping DefaultHasher

Since every hash changes anyway, this is the free moment. `DefaultHasher`'s algorithm is
explicitly **not stable across Rust releases** — a toolchain bump could have flipped every
pool's hash at once and triggered a fleet-wide recycle that looked deliberate. Replaced
with SHA-256 truncated to 64 bits, preserving the `{:016x}` shape that `lease_binding.rs`
and `ClusterInstance.status.specHash` both document. One fleet turnover instead of two.

## Tests

- **`render_fingerprint_tracks_the_rendered_pod_spec`** — the one that matters. Removes
  the #146 node-password volume from an otherwise identical render and asserts the digest
  changes. That's the exact blind spot, tested directly.
- `render_fingerprint_is_deterministic` — a varying fingerprint would churn the pool every
  reconcile, so this is a correctness requirement.
- `render_fingerprint_covers_the_agent_deployment`
- `spec_hash_folds_in_the_render_fingerprint` — proves it reaches the hash rather than being wired but inert.
- `spec_hash_is_16_hex_chars` — the documented shape survives the hasher swap.

Full suite green (1,394).

## Rollout — please read before releasing

This adds an input, so **every pool's hash changes once**. Expect a one-time rolling
recycle of idle members across all pools on the release that carries it — capped by
`maxRecycling` (default 1), floor-protected by `minReadyDuringUpgrade`, and visible as a
`SpecDrift` wave in `kobe_instance_recycles_total`. Leased members are untouched and
recycle when released.

That turnover is also the acceptance proof: it's the mechanism that would have shipped
#146 automatically.

Scope note: k3s only. #149's acceptance line names k3s/k0s/capi; k3s is what runs in
production and what the incident came from, so it's the right first scope. k0s/capi keep
current behaviour and can adopt the trait method the same way.