### PR TITLE
chore: release v0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.40.0"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.40.0"
+version = "0.41.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.40.0
-appVersion: "0.40.0"
+version: 0.41.0
+appVersion: "0.41.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.40.0
+      image: docker.io/zondax/kobe-operator:v0.41.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.40.0
+      image: docker.io/zondax/kobe-sync:v0.41.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Version bump only — no behaviour change in this PR.

**Minor, not patch.** #156 changes drift semantics and #154 adds a metric, so the version
should say more than "bugfix".

Ships three changes since v0.40.0:

- **#156** — pool drift detection now sees the **rendered workload**, closing the gap
  (#149) that let v0.39.2's node-password fix (#146) sit undelivered on idle members until
  someone deleted them by hand.
- **#155** — lost optimistic races in the instance controller are no longer reported as
  reconcile errors, and each failure is logged once rather than twice.
- **#154** — the operator states its version and commit at startup and exports
  `kobe_build_info{version,commit}`.

## ⚠️ Operational note — read before merging

**#156 adds an input to the pool spec hash, so every pool's hash changes once on this
upgrade.** Expect a **one-time rolling recycle of idle members across all pools**:

- capped by `maxRecycling` (default 1 per pool)
- floor-protected by `minReadyDuringUpgrade`
- visible as a `SpecDrift` wave in `kobe_instance_recycles_total`
- leased members untouched; they recycle when released

That turnover is the intended behaviour and the acceptance proof for #149 — it is the
mechanism that would have shipped #146 automatically.

## Expected post-deploy signals

- `kobe_build_info{version="0.41.0",commit="..."}` appears (new metric, so it appears rather than changes)
- startup log gains `version` and `commit` fields
- a `SpecDrift` recycle wave, then quiet
- operator ERROR volume drops toward zero on a healthy pool, with `RECONCILIATIONS_TOTAL{result="error"}` becoming the place contention shows up

Moves the workspace version, chart `version`/`appVersion`, and the Artifact Hub image pins
in lockstep, which is what `version-consistency` gates at tag time.