### PR TITLE
fix(demo): detect the caller's IPv4 when scoping the Hetzner firewall

### DIFF
--- a/demo/hetzner/README.md
+++ b/demo/hetzner/README.md
@@ -58,7 +58,7 @@ KUBECONFIG=<that-path> kubectl get nodes      # works (TLS tunnel)
 | `node_count` | `1` | 1 = single-node. >1 = 1 server + (n-1) agents. |
 | `ssh_public_key_path` | `~/.ssh/id_ed25519.pub` | Same key the kobe AccessPolicy expects. |
 | `k3s_version` | `v1.31.3+k3s1` | Match the inner pool's k3s. |
-| `allowed_api_cidr` | (auto-detect) | Restricts 22 + 6443 to caller IP. Set to `0.0.0.0/0` for public access (not recommended). |
+| `allowed_api_cidr` | (auto-detect) | Restricts 22 + 6443 to the caller's public IPv4 (detected via `ipv4.icanhazip.com`). Set it explicitly if you have no IPv4 egress, or to `0.0.0.0/0` for public access (not recommended). |
 
 To use a `terraform.tfvars`:
 

--- a/demo/hetzner/terraform/main.tf
+++ b/demo/hetzner/terraform/main.tf
@@ -25,9 +25,14 @@ provider "hcloud" {
 }
 
 # Auto-detect caller's public IP unless allowed_api_cidr is set explicitly.
+# The v4-only host matters: the plain icanhazip.com name is dual-stack, so a
+# caller with working IPv6 gets an IPv6 address back and the "/32" below turns
+# it into a CIDR the Hetzner API rejects. Everything the demo does afterwards
+# (SSH, scp of the kubeconfig, the API tunnel) targets the server's IPv4
+# address anyway, so the IPv4 source is the one the firewall has to allow.
 data "http" "my_ip" {
   count = var.allowed_api_cidr == "" ? 1 : 0
-  url   = "https://icanhazip.com"
+  url   = "https://ipv4.icanhazip.com"
 }
 
 locals {

--- a/demo/hetzner/terraform/variables.tf
+++ b/demo/hetzner/terraform/variables.tf
@@ -39,7 +39,7 @@ variable "k3s_version" {
 }
 
 variable "allowed_api_cidr" {
-  description = "CIDR allowed on ports 22 + 6443. Empty = auto-detect caller's public IP via icanhazip.com. Set to \"0.0.0.0/0\" for public access (NOT recommended)."
+  description = "CIDR allowed on ports 22 + 6443. Empty = auto-detect the caller's public IPv4 via ipv4.icanhazip.com; set it explicitly if you have no IPv4 egress. Set to \"0.0.0.0/0\" for public access (NOT recommended)."
   type        = string
   default     = ""
 }


### PR DESCRIPTION
## Value

The Hetzner Cloud walkthrough (`demo/hetzner`) could not be completed by anyone whose machine has working IPv6. Terraform apply failed at the firewall with `... is not the start of the cidr block`, produced no outputs, and left the demo unusable.

## Problem

To keep ports 22 and 6443 closed to the internet, the terraform auto-detects the caller's public IP and scopes the firewall rules to it. The detection asked `icanhazip.com`, which is dual-stack. A caller with IPv6 connectivity got an IPv6 address back, the code appended `/32` regardless, and the Hetzner API rejected the resulting rule.

IPv4 is the family that matters here regardless of what the caller's network prefers: SSH, the scp that fetches the kubeconfig, and the API tunnel all target the server's `ipv4_address`, so the caller's IPv4 source address is the one the firewall has to admit. Simply widening the suffix to `/128` would have produced a valid rule that still blocked the demo.

## Solution

Ask a v4-only endpoint (`ipv4.icanhazip.com`). Terraform's `http` data source has no equivalent of `curl -4`, so the address family has to come from the endpoint itself.

Callers with no IPv4 egress now fail on detection with a clear terraform error rather than building a rule that locks them out, and set `allowed_api_cidr` explicitly instead. The variable description and the README variables table now say so.

Verified `ipv4.icanhazip.com` returns an IPv4 address from a dual-stack host, while the bare `icanhazip.com` name returns IPv6 on the same machine.
