### PR TITLE
fix(chart): pull the etcd dependency over OCI, not the Bitnami index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -175,7 +175,6 @@ jobs:
 
       - name: Verify Helm chart renders
         run: |
-          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency build charts/kobe/
           helm template kobe charts/kobe/ --debug > /dev/null
 
@@ -430,7 +429,6 @@ jobs:
           DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
         run: |
           helm registry login registry-1.docker.io -u "$DOCKERHUB_USER" -p "$DOCKERHUB_TOKEN"
-          helm repo add bitnami https://charts.bitnami.com/bitnami
           helm dependency build charts/kobe
           helm package charts/kobe
           helm push kobe-*.tgz oci://registry-1.docker.io/zondax

--- a/charts/kobe/Chart.lock
+++ b/charts/kobe/Chart.lock
@@ -1,6 +1,6 @@
 dependencies:
 - name: etcd
-  repository: https://charts.bitnami.com/bitnami
+  repository: oci://registry-1.docker.io/bitnamicharts
   version: 10.0.11
-digest: sha256:7deec92a4b827072e879b46df13cefd5b49d8ffb1b64ebc6eab42a22ba9b4bee
-generated: "2026-04-23T19:39:38.38688+02:00"
+digest: sha256:d2eb1bfd8262799e0c82b5823fd48ef5d7775174c02ba0cb16486d63b35376ba
+generated: "2026-08-24T11:46:54.629898269+02:00"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -117,5 +117,5 @@ annotations:
 dependencies:
   - name: etcd
     version: "~10.0"
-    repository: https://charts.bitnami.com/bitnami
+    repository: oci://registry-1.docker.io/bitnamicharts
     condition: etcd.bundled

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -505,9 +505,6 @@ async function loadImagesIntoKind(
 async function prepareHelm(): Promise<void> {
   step("Preparing Helm dependencies");
   const helm = await resolveTool("helm");
-  await runCommand([helm, "repo", "add", "bitnami", "https://charts.bitnami.com/bitnami"], {
-    allowFailure: true,
-  });
   await runCommand([helm, "dependency", "build", "./charts/kobe"], {
     step: "failed to build Helm chart dependencies",
   });


### PR DESCRIPTION
## Value

Installing the chart from a checkout failed outright on any machine that had never registered the Bitnami chart repository:

```
$ helm dependency build charts/kobe
Error: no repository definition for https://charts.bitnami.com/bitnami.
Please add the missing repos via 'helm repo add'
```

This is the first thing `./demo up` does, so the Hetzner demo stopped there before installing anything. It went unnoticed because anyone who has added the Bitnami repo at some point in the past never sees it.

## Problem

Helm resolves every dependency declared in `Chart.yaml` before it will install a chart, regardless of the condition gating it. Our `etcd` subchart is disabled by default and renders nothing, but it was declared against `https://charts.bitnami.com/bitnami` — and an index-based dependency can only be fetched from a repository the caller has already registered locally. An optional feature nobody was using was enough to block the install.

## Solution

Bitnami publishes the same charts as OCI artifacts, and OCI references are resolved straight from the registry with no local registration step. The dependency now points at `oci://registry-1.docker.io/bitnamicharts`.

Same etcd 10.0.11 as before, and the rendered output is byte-identical (verified with `diff` against a render from `main`). The repo registration in CI and in the e2e harness only existed to work around this, so it goes away too.

## Verification

With **zero Helm repositories configured**, which is the state that fails on `main`:

- `helm dependency build charts/kobe` pulls `registry-1.docker.io/bitnamicharts/etcd:10.0.11`
- `helm template` renders 18 objects, identical to the pre-change output
- `helm lint` passes, and both CI steps (`Verify Helm chart renders`, `helm package`) succeed

Also ran the full Hetzner demo end-to-end against a real CPX22 with this change applied: operator installed, ClusterPool warmed to 2/2, lease bound, workload deployed and `kubectl exec`'d into the leased cluster, then released and destroyed. Without the change, the same run stops at `./demo up`.
