### PR TITLE
fix: reject stale-bound Ready instances

### DIFF
--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -1165,14 +1165,16 @@ async fn reserve_ready_instance(
             instance
                 .status
                 .as_ref()
-                // A genuinely-free instance is Ready AND carries no leaseRef. The
-                // extra leaseRef check prevents a double-lease: if a stale write
-                // (e.g. the profile controller syncing an out-of-date in-memory
-                // phase) reverts an already-Leased instance to Ready while leaving
-                // its leaseRef set, selecting it here would bind the same cluster
-                // to a second tenant. Requiring leaseRef == None excludes that
-                // case while still admitting all genuinely-idle instances.
-                .map(|s| s.phase == ClusterInstancePhase::Ready && s.lease_ref.is_none())
+                // A genuinely-free instance is Ready AND carries neither
+                // reciprocal reservation handle. A stale write can leave either
+                // leaseRef or binding behind while reverting the phase to Ready;
+                // selecting that instance would either double-lease it or make the
+                // first occupied candidate block every free candidate after it.
+                .map(|s| {
+                    s.phase == ClusterInstancePhase::Ready
+                        && s.lease_ref.is_none()
+                        && s.binding.is_none()
+                })
                 .unwrap_or(false)
         })
         .collect();
@@ -2206,6 +2208,64 @@ mod tests {
         assert!(
             matches!(result, Ok(None)),
             "a Ready instance still carrying a leaseRef must not be reserved, got {result:?}"
+        );
+    }
+
+    #[tokio::test]
+    async fn reserve_skips_ready_instance_with_stale_binding() {
+        // A Ready instance can lose its display-only leaseRef while retaining
+        // the authoritative binding. It is not free and must not become the
+        // first candidate that prevents the scheduler trying later instances.
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+
+        let lease: ClusterLease = serde_json::from_value(serde_json::json!({
+            "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+            "kind": "ClusterLease",
+            "metadata": {
+                "name": "lease-new",
+                "namespace": "test-ns",
+                "uid": "lease-uid",
+                "resourceVersion": "10"
+            },
+            "spec": {
+                "poolRef": "test-profile",
+                "ttl": "1h",
+                "requester": { "type": "test:admin", "identity": "test" }
+            },
+            "status": { "phase": "Pending" }
+        }))
+        .unwrap();
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![serde_json::json!({
+                    "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                    "kind": "ClusterInstance",
+                    "metadata": {
+                        "name": "pool-test-1",
+                        "namespace": "test-ns",
+                        "labels": { "kobe.kunobi.ninja/pool": "test-profile" }
+                    },
+                    "spec": { "poolRef": { "name": "test-profile" } },
+                    "status": {
+                        "phase": "Ready",
+                        "leaseRef": null,
+                        "binding": exact_test_binding("lease-old", "lease-old-uid")
+                    }
+                })]),
+            ))
+            .mount(&server)
+            .await;
+
+        let result = reserve_ready_instance(&client, "test-ns", &lease).await;
+        assert!(
+            matches!(result, Ok(None)),
+            "a Ready instance still carrying a binding must not be reserved, got {result:?}"
         );
     }
 

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -613,6 +613,70 @@ mod cluster_instance_tests {
         );
     }
 
+    #[tokio::test]
+    async fn ready_with_reservation_handle_is_not_claimable_capacity() {
+        let (ctx, server) = test_profile_context().await;
+        let mut stale_binding = instance_response_json(
+            "pool-test-profile-0",
+            "test-profile",
+            ClusterInstancePhase::Ready,
+            None,
+            0,
+        );
+        stale_binding["status"]["binding"] = serde_json::json!({
+            "bindingId": "binding-old",
+            "lease": { "name": "lease-old", "uid": "lease-old-uid" },
+            "instance": {
+                "name": "pool-test-profile-0",
+                "uid": "instance-uid",
+                "observedGeneration": 1
+            },
+            "pool": { "name": "test-profile", "uid": "pool-uid" },
+            "backend": {
+                "type": "k3s",
+                "configDigest": "0000000000000000000000000000000000000000000000000000000000000000"
+            },
+            "instanceSpecDigest": "002a000000000000"
+        });
+
+        let mut stale_lease_ref = instance_response_json(
+            "pool-test-profile-1",
+            "test-profile",
+            ClusterInstancePhase::Ready,
+            None,
+            0,
+        );
+        stale_lease_ref["status"]["leaseRef"] =
+            serde_json::json!({ "name": "lease-old", "uid": "lease-old-uid" });
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances",
+            ))
+            .and(query_param(
+                "labelSelector",
+                "kobe.kunobi.ninja/pool=test-profile",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![stale_binding, stale_lease_ref]),
+            ))
+            .mount(&server)
+            .await;
+
+        let pool_state = build_pool_state(&ctx, "test-profile").await;
+        let counts = count_states(&pool_state, None);
+
+        assert_eq!(counts.ready, 0);
+        assert_eq!(counts.quarantined, 2);
+        assert!(
+            pool_state
+                .clusters
+                .values()
+                .all(|entry| entry.state == ClusterState::Quarantined),
+            "a Ready instance with either reservation handle must fail closed"
+        );
+    }
+
     /// A lease that binds mid-reconcile must not be undone by the
     /// end-of-reconcile status sync.
     ///
@@ -1519,7 +1583,16 @@ async fn build_pool_state(ctx: &ProfileContext, profile_name: &str) -> PoolState
     for instance in &instances {
         let cluster_name = instance.name_any();
         let status = instance.status.clone().unwrap_or_default();
-        let state = cluster_state_from_phase(&status.phase);
+        // Ready means claimable only when both reciprocal reservation handles
+        // are absent. If either survives a stale status write, fail closed in
+        // pool accounting so the member is neither advertised nor recycled.
+        let state = if status.phase == ClusterInstancePhase::Ready
+            && (status.lease_ref.is_some() || status.binding.is_some())
+        {
+            ClusterState::Quarantined
+        } else {
+            cluster_state_from_phase(&status.phase)
+        };
 
         // #189: a Creating instance whose backend reported its guest Pods are
         // Unschedulable stamps a known prefix on `status.message`. Surface it


### PR DESCRIPTION
## Summary

- require both `leaseRef` and `binding` to be absent before a Ready instance is considered free
- fail closed in pool accounting when a Ready instance retains either reservation handle
- add regressions for scheduler selection and advertised Ready capacity

## Verification

- `cargo fmt --all -- --check`
- `cargo clippy --workspace -- -D warnings`
- `cargo test --workspace`

Closes #162