### PR TITLE
chore: release v0.40.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2656,7 +2656,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2719,7 +2719,7 @@ dependencies = [
 
 [[package]]
 name = "kobectl"
-version = "0.40.0"
+version = "0.40.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.40.0"
+version = "0.40.1"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.40.0
-appVersion: "0.40.0"
+version: 0.40.1
+appVersion: "0.40.1"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.40.0
+      image: docker.io/zondax/kobe-operator:v0.40.1
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.40.0
+      image: docker.io/zondax/kobe-sync:v0.40.1
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Patch release for the stale-bound Ready instance scheduler fix in #163.

- bump workspace and lockfile to 0.40.1
- bump Helm chart version/appVersion and image annotations
- version consistency gate passes locally

Related: #162