### PR TITLE
feat(observability): expose saturation telemetry

### DIFF
--- a/charts/kobe/crds/clusterinstances.yaml
+++ b/charts/kobe/crds/clusterinstances.yaml
@@ -771,6 +771,16 @@ spec:
                 - lease
                 - pool
                 type: object
+              bootstrapStartedAt:
+                description: |-
+                  When the currently active bootstrap was first observed, in RFC3339.
+
+                  Retained after completion as lifecycle evidence; a later bootstrap
+                  overwrites it when `activeBootstrap` changes. `None` is omitted so a
+                  profile-controller status patch cannot erase an instance-controller
+                  timestamp in a Merge Patch race.
+                nullable: true
+                type: string
               bootstrapped:
                 default: false
                 description: Whether all configured bootstrap steps have completed successfully.

--- a/charts/kobe/templates/deployment.yaml
+++ b/charts/kobe/templates/deployment.yaml
@@ -66,6 +66,16 @@ spec:
               value: "0.0.0.0:{{ .Values.service.port }}"
             - name: RUST_LOG
               value: {{ .Values.logLevel | quote }}
+            {{- if .Values.telemetry.otlp.endpoint }}
+            - name: OTEL_EXPORTER_OTLP_ENDPOINT
+              value: {{ .Values.telemetry.otlp.endpoint | quote }}
+            - name: OTEL_SERVICE_NAME
+              value: {{ .Values.telemetry.otlp.serviceName | quote }}
+            {{- if .Values.telemetry.otlp.resourceAttributes }}
+            - name: OTEL_RESOURCE_ATTRIBUTES
+              value: {{ .Values.telemetry.otlp.resourceAttributes | quote }}
+            {{- end }}
+            {{- end }}
             - name: KOBE_SYNC_IMAGE
               value: {{ include "kobe.syncImage" . | quote }}
             - name: POOL_SERVICE_ACCOUNT

--- a/charts/kobe/values.yaml
+++ b/charts/kobe/values.yaml
@@ -125,6 +125,16 @@ signoz:
   path: /metrics
   # port: defaults to service.port (the http port serving /metrics)
 
+# Distributed tracing via OTLP/gRPC. Metrics continue to use the annotated
+# /metrics scrape above; set endpoint only when an OTLP collector is reachable.
+telemetry:
+  otlp:
+    endpoint: "" # e.g. http://signoz-otel-collector.signoz:4317
+    serviceName: kobe-operator
+    # Comma-separated OpenTelemetry resource attributes, for example:
+    # deployment.environment.name=production,k8s.cluster.name=zur1-worker1
+    resourceAttributes: ""
+
 # Prometheus-Operator ServiceMonitor. Only useful on clusters that actually run
 # a Prometheus selecting it; our SigNoz clusters use the `signoz.*` annotations
 # above instead, so leave this disabled there.

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -25,8 +25,8 @@ use crate::api::policy::{self, format_duration, is_pool_allowed, policy_for};
 use crate::backend::{BackendFactory, ClusterBackend};
 use crate::controllers::lease::extend_lease_ttl;
 use crate::crd::{
-    ClusterLease, ClusterLeaseCondition, ClusterLeaseSpec, ClusterPool, LeaseBinding, LeasePhase,
-    Requester,
+    CIDRClaim, CIDRClaimPhase, ClusterInstance, ClusterInstancePhase, ClusterLease,
+    ClusterLeaseCondition, ClusterLeaseSpec, ClusterPool, LeaseBinding, LeasePhase, Requester,
 };
 use crate::lease_binding::{BindingResolutionError, BindingResolveMode, resolve_lease_binding};
 use crate::metrics;
@@ -2627,11 +2627,50 @@ async fn metrics_handler<B: ClusterBackend>(State(state): State<AppState<B>>) ->
         }
     };
 
+    let leases_api: Api<ClusterLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let leases = match leases_api.list(&ListParams::default()).await {
+        Ok(leases) => leases,
+        Err(e) => {
+            tracing::warn!("Failed to list leases for metrics endpoint: {e}");
+            return (StatusCode::SERVICE_UNAVAILABLE, "failed to list leases").into_response();
+        }
+    };
+
+    let instances_api: Api<ClusterInstance> =
+        Api::namespaced(state.client.clone(), &state.namespace);
+    let instances = match instances_api.list(&ListParams::default()).await {
+        Ok(instances) => instances,
+        Err(e) => {
+            tracing::warn!("Failed to list instances for metrics endpoint: {e}");
+            return (StatusCode::SERVICE_UNAVAILABLE, "failed to list instances").into_response();
+        }
+    };
+
+    let claims_api: Api<CIDRClaim> = Api::namespaced(state.client.clone(), &state.namespace);
+    let claims = match claims_api.list(&ListParams::default()).await {
+        Ok(claims) => claims,
+        Err(e) => {
+            tracing::warn!("Failed to list CIDR claims for metrics endpoint: {e}");
+            return (
+                StatusCode::SERVICE_UNAVAILABLE,
+                "failed to list CIDR claims",
+            )
+                .into_response();
+        }
+    };
+
     metrics::POOL_CLUSTERS.reset();
     metrics::QUEUE_DEPTH.reset();
+    metrics::LEASE_OLDEST_PENDING_AGE_SECONDS.reset();
+    metrics::INSTANCE_OLDEST_CREATING_AGE_SECONDS.reset();
+
+    let mut oldest_pending = std::collections::HashMap::<String, i64>::new();
+    let mut oldest_creating = std::collections::HashMap::<String, i64>::new();
 
     for profile in profiles.iter() {
         let name = profile.name_any();
+        oldest_pending.insert(name.clone(), 0);
+        oldest_creating.insert(name.clone(), 0);
         let status = profile.status.clone().unwrap_or_default();
         metrics::POOL_CLUSTERS
             .with_label_values(&[name.as_str(), "creating"])
@@ -2652,6 +2691,66 @@ async fn metrics_handler<B: ClusterBackend>(State(state): State<AppState<B>>) ->
             .with_label_values(&[name.as_str()])
             .set(status.queue_depth as i64);
     }
+
+    let now_ms = chrono::Utc::now().timestamp_millis();
+    for lease in leases.iter() {
+        if lease.status.as_ref().map(|s| &s.phase) != Some(&LeasePhase::Pending) {
+            continue;
+        }
+        let age = lease
+            .metadata
+            .creation_timestamp
+            .as_ref()
+            .map(|ts| ((now_ms - ts.0.as_millisecond()).max(0)) / 1000)
+            .unwrap_or(0);
+        oldest_pending
+            .entry(lease.spec.pool_ref.clone())
+            .and_modify(|current| *current = (*current).max(age))
+            .or_insert(age);
+    }
+
+    for instance in instances.iter() {
+        let Some(status) = instance.status.as_ref() else {
+            continue;
+        };
+        if status.phase != ClusterInstancePhase::Creating {
+            continue;
+        }
+        let age = metrics::elapsed_secs_since_rfc3339(status.state_since.as_deref())
+            .unwrap_or(0.0)
+            .floor() as i64;
+        let profile = instance
+            .spec
+            .pool_ref
+            .as_ref()
+            .map(|reference| reference.name.clone())
+            .unwrap_or_else(|| "standalone".to_string());
+        oldest_creating
+            .entry(profile)
+            .and_modify(|current| *current = (*current).max(age))
+            .or_insert(age);
+    }
+
+    for (profile, age) in oldest_pending {
+        metrics::LEASE_OLDEST_PENDING_AGE_SECONDS
+            .with_label_values(&[profile.as_str()])
+            .set(age);
+    }
+    for (profile, age) in oldest_creating {
+        metrics::INSTANCE_OLDEST_CREATING_AGE_SECONDS
+            .with_label_values(&[profile.as_str()])
+            .set(age);
+    }
+
+    let allocated = claims
+        .iter()
+        .filter(|claim| {
+            claim.status.as_ref().map(|status| &status.phase) == Some(&CIDRClaimPhase::Bound)
+        })
+        .count() as i64;
+    metrics::IPAM_POOL_ALLOCATED
+        .with_label_values(&[] as &[&str])
+        .set(allocated);
 
     let body = metrics::gather();
     (
@@ -3657,6 +3756,15 @@ mod tests {
             .and(path_regex(
                 "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/.*/clusterpools",
             ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![exact_connect_pool_json()]),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path_regex(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/.*/(clusterleases|clusterinstances|cidrclaims)",
+            ))
             .respond_with(ResponseTemplate::new(200).set_body_json(&empty_list))
             .mount(&server)
             .await;
@@ -3680,6 +3788,97 @@ mod tests {
             ct.contains("text/plain"),
             "Expected text/plain content-type, got: {ct}"
         );
+
+        let body = response_text(resp).await;
+        assert!(body.contains("kobe_ipam_pool_allocated 0"));
+        assert!(body.contains("kobe_lease_oldest_pending_age_seconds"));
+        assert!(body.contains("kobe_instance_oldest_creating_age_seconds"));
+    }
+
+    #[tokio::test]
+    async fn test_metrics_exports_live_ages_and_ipam_occupancy() {
+        let (app, server) = test_app().await;
+        use wiremock::matchers::{method, path_regex};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let two_minutes_ago = (chrono::Utc::now() - chrono::Duration::minutes(2)).to_rfc3339();
+        let lists = [
+            (
+                "clusterpools",
+                crate::testutil::k8s_list_response(vec![exact_connect_pool_json()]),
+            ),
+            (
+                "clusterleases",
+                crate::testutil::k8s_list_response(vec![serde_json::json!({
+                    "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                    "kind": "ClusterLease",
+                    "metadata": { "name": "lease-waiting", "namespace": "test-ns", "creationTimestamp": two_minutes_ago },
+                    "spec": {
+                        "poolRef": "ci-small",
+                        "ttl": "1h",
+                        "requester": { "type": "test:ci", "identity": "test" }
+                    },
+                    "status": { "phase": "Pending" }
+                })]),
+            ),
+            (
+                "clusterinstances",
+                crate::testutil::k8s_list_response(vec![serde_json::json!({
+                    "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                    "kind": "ClusterInstance",
+                    "metadata": { "name": "ci-small-0", "namespace": "test-ns" },
+                    "spec": { "poolRef": { "name": "ci-small" } },
+                    "status": { "phase": "Creating", "stateSince": two_minutes_ago }
+                })]),
+            ),
+            (
+                "cidrclaims",
+                crate::testutil::k8s_list_response(vec![serde_json::json!({
+                    "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                    "kind": "CIDRClaim",
+                    "metadata": { "name": "ci-small-0", "namespace": "test-ns" },
+                    "spec": {},
+                    "status": { "phase": "Bound" }
+                })]),
+            ),
+        ];
+        for (resource, response) in lists {
+            Mock::given(method("GET"))
+                .and(path_regex(format!(
+                    "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/.*/{resource}"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(response))
+                .mount(&server)
+                .await;
+        }
+
+        let resp = app
+            .oneshot(
+                http::Request::builder()
+                    .uri("/metrics")
+                    .body(Body::empty())
+                    .unwrap(),
+            )
+            .await
+            .unwrap();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let body = response_text(resp).await;
+
+        let value = |series: &str| -> f64 {
+            body.lines()
+                .find(|line| line.starts_with(series))
+                .and_then(|line| line.rsplit_once(' '))
+                .and_then(|(_, value)| value.parse().ok())
+                .unwrap_or_else(|| panic!("missing metric series {series}"))
+        };
+        assert_eq!(value("kobe_ipam_pool_allocated"), 1.0);
+        for series in [
+            "kobe_lease_oldest_pending_age_seconds{profile=\"ci-small\"}",
+            "kobe_instance_oldest_creating_age_seconds{profile=\"ci-small\"}",
+        ] {
+            let age = value(series);
+            assert!((119.0..=122.0).contains(&age), "unexpected age {age}");
+        }
     }
 
     #[tokio::test]

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -105,6 +105,26 @@ fn observe_instance_create(
         .inc();
 }
 
+/// Record one terminal bootstrap duration from the durable activation
+/// timestamp. Missing fields mean no bootstrap was active (or the object
+/// predates this telemetry), so no misleading zero-duration sample is emitted.
+fn observe_instance_bootstrap(
+    instance: &ClusterInstance,
+    status: &ClusterInstanceStatus,
+    outcome: crate::metrics::InstanceCreateOutcome,
+) {
+    let (Some(bootstrap), Some(elapsed)) = (
+        status.active_bootstrap.as_deref(),
+        crate::metrics::elapsed_secs_since_rfc3339(status.bootstrap_started_at.as_deref()),
+    ) else {
+        return;
+    };
+
+    crate::metrics::INSTANCE_BOOTSTRAP_DURATION
+        .with_label_values(&[profile_label(instance), bootstrap, outcome.as_str()])
+        .observe(elapsed);
+}
+
 /// Increment the recycle counter with a typed reason. The Recycling
 /// transition itself is performed by the caller; this only records
 /// the metric.
@@ -341,6 +361,7 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                                 lease_ref: status.lease_ref.clone(),
                                 binding: status.binding.clone(),
                                 active_bootstrap: None,
+                                bootstrap_started_at: status.bootstrap_started_at.clone(),
                                 idle_since: status.idle_since.clone(),
                                 state_since: Some(chrono::Utc::now().to_rfc3339()),
                                 health_failures: status.health_failures,
@@ -451,6 +472,16 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
             if ready {
                 match reconcile_instance_bootstraps(&ctx, &config, &instance, &name, &ns).await {
                     Ok(Some(active_bootstrap)) => {
+                        let bootstrap_started_at = if status.active_bootstrap.as_deref()
+                            == Some(active_bootstrap.as_str())
+                        {
+                            status
+                                .bootstrap_started_at
+                                .clone()
+                                .or_else(|| Some(chrono::Utc::now().to_rfc3339()))
+                        } else {
+                            Some(chrono::Utc::now().to_rfc3339())
+                        };
                         let message = Some(format!("running bootstrap '{active_bootstrap}'"));
                         patch_instance_status(
                             &instances_api,
@@ -461,6 +492,7 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                                 bootstrapped: false,
                                 lease_ref: status.lease_ref,
                                 active_bootstrap: Some(active_bootstrap),
+                                bootstrap_started_at,
                                 idle_since: None,
                                 state_since: status.state_since,
                                 health_failures: 0,
@@ -473,6 +505,11 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                         Ok(Action::requeue(std::time::Duration::from_secs(5)))
                     }
                     Ok(None) => {
+                        observe_instance_bootstrap(
+                            &instance,
+                            &status,
+                            crate::metrics::InstanceCreateOutcome::Ready,
+                        );
                         observe_instance_create(
                             &instance,
                             &config.backend.backend_type,
@@ -504,6 +541,11 @@ async fn reconcile_instance<B: ClusterBackend + Clone + 'static>(
                         observe_instance_create(
                             &instance,
                             &config.backend.backend_type,
+                            crate::metrics::InstanceCreateOutcome::Failed,
+                        );
+                        observe_instance_bootstrap(
+                            &instance,
+                            &status,
                             crate::metrics::InstanceCreateOutcome::Failed,
                         );
                         // Bootstrap-specific counter so an alert can
@@ -2822,6 +2864,44 @@ mod tests {
             message: Some("hello".into()),
             ..Default::default()
         }
+    }
+
+    #[test]
+    fn bootstrap_duration_records_only_durable_active_bootstraps() {
+        let instance =
+            standalone_instance("bootstrap-metric", ClusterInstancePhase::Creating, true, 0);
+        let mut status = ClusterInstanceStatus {
+            active_bootstrap: Some("flux".into()),
+            bootstrap_started_at: Some(
+                (chrono::Utc::now() - chrono::Duration::seconds(10)).to_rfc3339(),
+            ),
+            ..Default::default()
+        };
+        let metric = crate::metrics::INSTANCE_BOOTSTRAP_DURATION.with_label_values(&[
+            "standalone",
+            "flux",
+            "ready",
+        ]);
+        let before = metric.get_sample_count();
+
+        observe_instance_bootstrap(
+            &instance,
+            &status,
+            crate::metrics::InstanceCreateOutcome::Ready,
+        );
+        assert_eq!(metric.get_sample_count(), before + 1);
+
+        status.bootstrap_started_at = None;
+        observe_instance_bootstrap(
+            &instance,
+            &status,
+            crate::metrics::InstanceCreateOutcome::Ready,
+        );
+        assert_eq!(
+            metric.get_sample_count(),
+            before + 1,
+            "missing durable start time must not emit a fake zero-duration sample"
+        );
     }
 
     #[test]

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -374,11 +374,13 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
                     .and_then(|p| p.status);
                 let (message, reason) = unsatisfiable_status(&lease.spec.pool_ref, &pool_status);
 
-                // Only count genuinely-unsatisfiable demand. A healthy-but-warming
-                // pool (reason=Warming) is a normal cold-start, not an exhaustion
-                // event — counting it on every ~5s requeue tick would swamp the
-                // alert signal with normal warm-ups (#189 review).
-                if reason != crate::metrics::LeaseUnsatisfiableReason::Warming {
+                // Count the edge, not every ~5s reconcile of the same Pending
+                // lease. Request-time preflight rejections are counted in the
+                // API; here we count only entry into an unsatisfiable condition
+                // or a change of reason. Warming is a normal cold-start.
+                if reason != crate::metrics::LeaseUnsatisfiableReason::Warming
+                    && entered_unsatisfiable_condition(&status.conditions, reason)
+                {
                     crate::metrics::LEASE_UNSATISFIABLE_TOTAL
                         .with_label_values(&[lease.spec.pool_ref.as_str(), reason.as_str()])
                         .inc();
@@ -1852,6 +1854,22 @@ pub fn derive_lease_conditions(
             message,
         ),
     ]
+}
+
+/// Whether this reconcile is entering a new unsatisfiable state.
+///
+/// A steady `Satisfiable=False` condition with the same typed reason is not a
+/// new demand event. This keeps `kobe_lease_unsatisfiable_total` independent of
+/// controller requeue frequency while still counting reason transitions.
+fn entered_unsatisfiable_condition(
+    previous: &[ClusterLeaseCondition],
+    reason: crate::metrics::LeaseUnsatisfiableReason,
+) -> bool {
+    !previous.iter().any(|condition| {
+        condition.condition_type == "Satisfiable"
+            && condition.status == "False"
+            && condition.reason == reason.condition_reason()
+    })
 }
 
 /// Build a human-readable lease `status.message` and classify the
@@ -4280,6 +4298,28 @@ mod tests {
         let sat = lease_cond(&conds, "Satisfiable");
         assert_eq!(sat.status, "False");
         assert_eq!(sat.reason, "Warming");
+    }
+
+    #[test]
+    fn unsatisfiable_metric_counts_edges_and_reason_changes_only() {
+        use crate::metrics::LeaseUnsatisfiableReason as R;
+        let previous = vec![ClusterLeaseCondition {
+            condition_type: "Satisfiable".into(),
+            status: "False".into(),
+            reason: "PoolExhausted".into(),
+            message: String::new(),
+            last_transition_time: None,
+        }];
+
+        assert!(!entered_unsatisfiable_condition(
+            &previous,
+            R::PoolExhausted
+        ));
+        assert!(entered_unsatisfiable_condition(
+            &previous,
+            R::CapacityBlocked
+        ));
+        assert!(entered_unsatisfiable_condition(&[], R::PoolExhausted));
     }
 
     #[test]

--- a/src/controllers/profile.rs
+++ b/src/controllers/profile.rs
@@ -971,6 +971,11 @@ async fn reconcile_profile(
     ctx: Arc<ProfileContext>,
 ) -> Result<Action, ProfileError> {
     let name = profile.name_any();
+    // The timer's Drop records `error` for every early `?` return. Keeping
+    // it here makes the full reconcile path observable without manually
+    // instrumenting each exit.
+    let reconcile_timer =
+        crate::metrics::Timer::start(&crate::metrics::POOL_RECONCILE_DURATION, [name.as_str()]);
     let ns = profile.namespace().unwrap_or_else(|| ctx.namespace.clone());
 
     info!(profile = %name, "Reconciling profile");
@@ -1487,6 +1492,7 @@ async fn reconcile_profile(
     // persisted (signals snapshotted above before `backoff` was consumed).
     emit_pool_failure_metrics(&name, &pool_failure_signals);
 
+    reconcile_timer.finish("ok");
     Ok(Action::requeue(std::time::Duration::from_secs(30)))
 }
 

--- a/src/crd/instance.rs
+++ b/src/crd/instance.rs
@@ -275,6 +275,15 @@ pub struct ClusterInstanceStatus {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub active_bootstrap: Option<String>,
 
+    /// When the currently active bootstrap was first observed, in RFC3339.
+    ///
+    /// Retained after completion as lifecycle evidence; a later bootstrap
+    /// overwrites it when `activeBootstrap` changes. `None` is omitted so a
+    /// profile-controller status patch cannot erase an instance-controller
+    /// timestamp in a Merge Patch race.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub bootstrap_started_at: Option<String>,
+
     /// When the instance became idle and eligible for scale-down.
     ///
     /// Intentionally NO `skip_serializing_if` (same reasoning as `lease_ref`):
@@ -528,6 +537,7 @@ mod tests {
             }),
             binding: None,
             active_bootstrap: Some("flux".into()),
+            bootstrap_started_at: Some("2026-01-02T03:03:00Z".into()),
             idle_since: Some("2026-01-02T03:04:05Z".into()),
             state_since: Some("2026-01-02T03:04:06Z".into()),
             health_failures: 3,
@@ -586,7 +596,8 @@ mod tests {
         }
     }
 
-    /// `spec_hash`, `created_with`, `message` and `active_bootstrap` are
+    /// `spec_hash`, `created_with`, `message`, `active_bootstrap` and
+    /// `bootstrap_started_at` are
     /// owned by another writer (the profile controller) or are purely
     /// informational. The instance controller round-trips them through
     /// every status patch, so a `None` MUST be omitted — emitting
@@ -603,6 +614,7 @@ mod tests {
             "binding",
             "message",
             "activeBootstrap",
+            "bootstrapStartedAt",
             "network",
         ] {
             assert!(
@@ -647,6 +659,7 @@ mod tests {
             keys,
             vec![
                 "activeBootstrap",
+                "bootstrapStartedAt",
                 "bootstrapped",
                 "conditions",
                 "createdWith",

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -1020,14 +1020,14 @@ impl LeaseUnsatisfiableReason {
     }
 }
 
-/// A lease could not be satisfied at request time (503 pre-flight) or remained
-/// unbound in the controller's no-Ready-cluster branch, keyed by the bounded
-/// [`LeaseUnsatisfiableReason`]. Makes a pool that "can never satisfy a lease"
-/// visible instead of leaving the lease hung in `Pending` forever.
+/// Unsatisfiable demand events: a request-time 503 pre-flight rejection, or a
+/// Pending lease entering an unsatisfiable condition / changing reason. The
+/// controller path is edge-triggered, so its ~5s requeue does not inflate the
+/// counter. Keyed by the bounded [`LeaseUnsatisfiableReason`].
 pub static LEASE_UNSATISFIABLE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(|| {
     register_int_counter_vec!(
         "kobe_lease_unsatisfiable_total",
-        "Leases that could not be satisfied, by profile and reason",
+        "Unsatisfiable demand events, by profile and reason",
         &["profile", "reason"]
     )
     .unwrap()

--- a/src/metrics.rs
+++ b/src/metrics.rs
@@ -103,6 +103,35 @@ pub static QUEUE_DEPTH: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     .unwrap()
 });
 
+/// Age in seconds of the oldest currently-Pending lease in each profile.
+///
+/// This complements [`QUEUE_DEPTH`]: depth answers "how many are waiting",
+/// while age distinguishes a harmless short burst from a queue that is no
+/// longer making progress. The `/metrics` inventory sweep sets it to zero
+/// when a profile has no pending leases.
+pub static LEASE_OLDEST_PENDING_AGE_SECONDS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "kobe_lease_oldest_pending_age_seconds",
+        "Age in seconds of the oldest currently-Pending lease",
+        &["profile"]
+    )
+    .unwrap()
+});
+
+/// Age in seconds of the oldest currently-Creating instance in each profile.
+///
+/// Age starts at the current phase's `stateSince`, not object creation, so a
+/// recycled object does not retain time spent in earlier lifecycle phases.
+/// The `/metrics` inventory sweep sets it to zero when no instance is Creating.
+pub static INSTANCE_OLDEST_CREATING_AGE_SECONDS: LazyLock<IntGaugeVec> = LazyLock::new(|| {
+    register_int_gauge_vec!(
+        "kobe_instance_oldest_creating_age_seconds",
+        "Age in seconds of the oldest currently-Creating instance",
+        &["profile"]
+    )
+    .unwrap()
+});
+
 /// Health check result counters.
 ///
 /// Labels: `profile`, `result` (pass, fail).
@@ -186,11 +215,9 @@ pub static INSTANCE_CREATE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
 /// Buckets cover 5s → 20min so we can tell apart "fast bootstrap",
 /// "slow but successful", and "hit the install timeout".
 ///
-/// **Currently registered but not observed**: needs a
-/// `status.bootstrapStartedAt` field on `ClusterInstanceStatus` to
-/// compute duration precisely; `state_since` is reused across many
-/// transitions and gives a wrong answer. Tracked as follow-up —
-/// declared now so alerts can reference it without churn.
+/// Observed from the durable `status.bootstrapStartedAt` timestamp at
+/// bootstrap success or failure. `stateSince` is deliberately not used: it
+/// also includes unrelated control-plane readiness time.
 pub static INSTANCE_BOOTSTRAP_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         "kobe_instance_bootstrap_duration_seconds",
@@ -209,12 +236,8 @@ pub static INSTANCE_BOOTSTRAP_DURATION: LazyLock<HistogramVec> = LazyLock::new(|
 /// Buckets sub-second to 5s; reconciles past 5s usually mean a kube
 /// API call timed out and we want the +Inf bucket to count those.
 ///
-/// **Currently registered but not observed**: instrumenting
-/// `reconcile_profile` cleanly requires either inner-function
-/// extraction (function is ~250 lines, scope blew up) or a
-/// procedural-macro wrapper. Tracked as follow-up — the metric is
-/// declared so dashboards / alerts can reference it without churn
-/// when the observer lands.
+/// Observed by an RAII timer in `reconcile_profile`; early `?` returns are
+/// recorded as `outcome="error"`, while successful reconciles are `ok`.
 pub static POOL_RECONCILE_DURATION: LazyLock<HistogramVec> = LazyLock::new(|| {
     register_histogram_vec!(
         "kobe_pool_reconcile_duration_seconds",
@@ -1092,12 +1115,8 @@ pub static IPAM_POOL_CAPACITY: LazyLock<IntGaugeVec> = LazyLock::new(|| {
 /// Number of `CIDRClaim`s currently `Bound`. Pair with
 /// `kobe_ipam_pool_capacity` for fill-ratio alerts.
 ///
-/// **Currently registered but not observed**: needs a periodic gauge
-/// sync against the live claim inventory. The IPAM controller's
-/// per-claim reconciles increment counters but don't have visibility
-/// into the global Bound count without an extra API call. Defer to a
-/// follow-up that adds a periodic sync sweep (similar to
-/// `sync_cluster_instance_statuses` in profile.rs).
+/// Updated by the `/metrics` inventory sweep, which already performs live API
+/// reads to avoid exporting stale per-replica inventory.
 pub static IPAM_POOL_ALLOCATED: LazyLock<IntGaugeVec> = LazyLock::new(|| {
     register_int_gauge_vec!(
         "kobe_ipam_pool_allocated",
@@ -1305,7 +1324,7 @@ pub static CONNECT_PROXY_CACHE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(||
 
 /// RAII timer for histograms with a 3-axis `[label1, label2, outcome]`
 /// shape. The outcome is decided at drop time via [`Timer::finish`];
-/// dropping without calling `finish()` records `outcome="aborted"`
+/// dropping without calling `finish()` records `outcome="error"`
 /// (the most common cause is a panic or `?` early-return through the
 /// Timer's lifetime, which is exactly what we want to count).
 ///
@@ -1317,13 +1336,6 @@ pub static CONNECT_PROXY_CACHE_TOTAL: LazyLock<IntCounterVec> = LazyLock::new(||
 /// timer.finish(InstanceCreateOutcome::Ready.as_str());
 /// ```
 ///
-/// Currently unused — the in-tree call sites instrument by computing
-/// elapsed-from-creation_timestamp at terminal transitions, which
-/// works without RAII. `Timer` is kept for the upcoming
-/// `POOL_RECONCILE_DURATION` instrumentation (where elapsed-from-
-/// creation_timestamp doesn't apply because reconcile isn't an
-/// object lifecycle).
-#[allow(dead_code)]
 pub struct Timer<'a, const N: usize> {
     histogram: &'a HistogramVec,
     base_labels: [&'a str; N],
@@ -1331,7 +1343,6 @@ pub struct Timer<'a, const N: usize> {
     finished: bool,
 }
 
-#[allow(dead_code)]
 impl<'a, const N: usize> Timer<'a, N> {
     pub fn start(histogram: &'a HistogramVec, base_labels: [&'a str; N]) -> Self {
         Self {
@@ -1358,7 +1369,7 @@ impl<'a, const N: usize> Timer<'a, N> {
 impl<const N: usize> Drop for Timer<'_, N> {
     fn drop(&mut self) {
         if !self.finished {
-            self.observe("aborted");
+            self.observe("error");
         }
     }
 }
@@ -1385,6 +1396,8 @@ pub fn init() {
     LazyLock::force(&CLAIMS_TOTAL);
     LazyLock::force(&CLAIM_BIND_DURATION);
     LazyLock::force(&QUEUE_DEPTH);
+    LazyLock::force(&LEASE_OLDEST_PENDING_AGE_SECONDS);
+    LazyLock::force(&INSTANCE_OLDEST_CREATING_AGE_SECONDS);
     LazyLock::force(&HEALTH_CHECKS_TOTAL);
     LazyLock::force(&RECONCILIATIONS_TOTAL);
     LazyLock::force(&PROVISION_METHOD);
@@ -1525,6 +1538,34 @@ mod tests {
         assert!(
             output.contains("test-profile"),
             "gather() should contain the label value 'test-profile' after increment"
+        );
+    }
+
+    /// A reconcile that exits normally records `ok`; an early return that
+    /// drops its timer records `error`, so slow failures do not disappear.
+    #[test]
+    fn timer_records_finished_and_error_paths() {
+        let profile = "_timer_test";
+        let ok_before = POOL_RECONCILE_DURATION
+            .with_label_values(&[profile, "ok"])
+            .get_sample_count();
+        Timer::start(&POOL_RECONCILE_DURATION, [profile]).finish("ok");
+        assert_eq!(
+            POOL_RECONCILE_DURATION
+                .with_label_values(&[profile, "ok"])
+                .get_sample_count(),
+            ok_before + 1
+        );
+
+        let error_before = POOL_RECONCILE_DURATION
+            .with_label_values(&[profile, "error"])
+            .get_sample_count();
+        drop(Timer::start(&POOL_RECONCILE_DURATION, [profile]));
+        assert_eq!(
+            POOL_RECONCILE_DURATION
+                .with_label_values(&[profile, "error"])
+                .get_sample_count(),
+            error_before + 1
         );
     }
 

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -6,7 +6,9 @@ use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitEx
 /// Initialize the tracing subscriber with optional OpenTelemetry export.
 ///
 /// When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, spans are exported via OTLP gRPC.
-/// When unset, only the fmt/JSON layer is active (current behavior preserved).
+/// The Helm chart exposes this through `telemetry.otlp`; `OTEL_SERVICE_NAME`
+/// and standard OpenTelemetry resource attributes distinguish deployments in
+/// a shared backend. When unset, only the fmt/JSON layer is active.
 ///
 /// Returns the tracer provider handle for graceful shutdown (flush on drop).
 pub fn init() -> Result<Option<SdkTracerProvider>> {


### PR DESCRIPTION
## Summary

- export oldest Pending lease age, oldest Creating instance age, and live IPAM allocation
- observe bootstrap and pool-reconcile durations with durable lifecycle timing
- count unsatisfiable Pending-lease transitions instead of every controller requeue
- expose opt-in Helm OTLP tracing configuration
- update the ClusterInstance CRD for bootstrap activation timestamps

## Validation

- `cargo test --all-targets --quiet` (121 + 142 + 900 + 238 passed)
- `cargo clippy --all-targets -- -D warnings`
- `cargo fmt --all -- --check`
- generated CRD matches the checked-in CRD
- `helm lint charts/kobe`
- Helm renders both default (OTLP absent) and configured (OTLP env present) paths