### PR TITLE
fix(reaper): clean stale nested k3s cgroups

### DIFF
--- a/charts/kobe/templates/daemonset-host-reaper.yaml
+++ b/charts/kobe/templates/daemonset-host-reaper.yaml
@@ -37,6 +37,10 @@ spec:
             - --live-set-path=/etc/kobe/live/instances
             - --reconcile-interval={{ .Values.hostReaper.reconcileInterval }}
             - --mtime-skip={{ .Values.hostReaper.mtimeSkip }}
+            {{- if .Values.hostReaper.cgroupCleanup.enabled }}
+            - --cgroup-root=/host-cgroup/k8s.io
+            - --cgroup-mtime-skip={{ .Values.hostReaper.cgroupCleanup.mtimeSkip }}
+            {{- end }}
             {{- if .Values.hostReaper.dryRun }}
             - --dry-run
             {{- end }}
@@ -64,6 +68,10 @@ spec:
             - name: live-set
               mountPath: /etc/kobe/live
               readOnly: true
+            {{- if .Values.hostReaper.cgroupCleanup.enabled }}
+            - name: host-cgroup
+              mountPath: /host-cgroup
+            {{- end }}
       volumes:
         - name: lease-root
           hostPath:
@@ -72,4 +80,10 @@ spec:
         - name: live-set
           configMap:
             name: kobe-live-instances
+        {{- if .Values.hostReaper.cgroupCleanup.enabled }}
+        - name: host-cgroup
+          hostPath:
+            path: /sys/fs/cgroup
+            type: Directory
+        {{- end }}
 {{- end }}

--- a/charts/kobe/values.yaml
+++ b/charts/kobe/values.yaml
@@ -330,6 +330,13 @@ hostReaper:
   leaseRoot: /var/lib/kobe/leases
   reconcileInterval: 30s
   mtimeSkip: 120s
+  # Nested privileged k3s members using the cgroupfs driver can leave empty
+  # `/sys/fs/cgroup/k8s.io/<container-id>` directories behind when recycled.
+  # Enough leaked directories exhaust the kernel cgroup hierarchy and prevent
+  # unrelated Pods from starting with `no space left on device`.
+  cgroupCleanup:
+    enabled: true
+    mtimeSkip: 5m
   dryRun: false
   # If true, the reaper container starts with KOBE_REAPER_DISABLE=1 set,
   # turning the sweep loop into a no-op (logs once per interval).

--- a/src/host_reaper_bin.rs
+++ b/src/host_reaper_bin.rs
@@ -24,6 +24,7 @@ mod reaper;
 use clap::Parser;
 use kube::Client;
 use reaper::{
+    cgroups::reap_empty_container_cgroups,
     sweep::{SweepParams, sweep_once},
     unmount::LibcUnmount,
 };
@@ -53,6 +54,14 @@ struct Args {
     /// Don't touch entries newer than this.
     #[arg(long, value_parser = parse_duration, default_value = "120s")]
     mtime_skip: Duration,
+
+    /// Host cgroup-v2 container root to clean. Omit to disable cgroup cleanup.
+    #[arg(long)]
+    cgroup_root: Option<PathBuf>,
+
+    /// Don't touch empty container cgroups newer than this.
+    #[arg(long, value_parser = parse_duration, default_value = "5m")]
+    cgroup_mtime_skip: Duration,
 
     /// Log what would happen, don't act.
     #[arg(long, default_value_t = false)]
@@ -101,6 +110,8 @@ async fn main() -> anyhow::Result<()> {
         live_set_path = ?args.live_set_path,
         reconcile_interval_secs = args.reconcile_interval.as_secs(),
         mtime_skip_secs = args.mtime_skip.as_secs(),
+        cgroup_root = ?args.cgroup_root,
+        cgroup_mtime_skip_secs = args.cgroup_mtime_skip.as_secs(),
         dry_run = args.dry_run,
         one_shot = args.one_shot,
         "kobe-host-reaper starting"
@@ -125,7 +136,7 @@ async fn main() -> anyhow::Result<()> {
     let skip_get = std::env::var("KOBE_REAPER_SKIP_GET").as_deref() == Ok("1");
 
     loop {
-        match sweep_once(
+        let lease_cleaned = match sweep_once(
             &client,
             &unmounter,
             &SweepParams {
@@ -139,9 +150,29 @@ async fn main() -> anyhow::Result<()> {
         )
         .await
         {
-            Ok(n) if n > 0 => info!(cleaned = n, "sweep tick done"),
-            Ok(_) => {}
-            Err(e) => warn!(error = %e, "sweep tick failed"),
+            Ok(n) => n,
+            Err(e) => {
+                warn!(error = %e, "lease-root sweep tick failed");
+                0
+            }
+        };
+        let cgroups_cleaned = match args.cgroup_root.as_deref() {
+            Some(root) => match reap_empty_container_cgroups(
+                root,
+                std::time::SystemTime::now(),
+                args.cgroup_mtime_skip,
+                args.dry_run,
+            ) {
+                Ok(n) => n,
+                Err(e) => {
+                    warn!(error = %e, "container cgroup sweep tick failed");
+                    0
+                }
+            },
+            None => 0,
+        };
+        if lease_cleaned > 0 || cgroups_cleaned > 0 {
+            info!(lease_cleaned, cgroups_cleaned, "sweep tick done");
         }
         if args.one_shot {
             break;

--- a/src/reaper/cgroups.rs
+++ b/src/reaper/cgroups.rs
@@ -1,0 +1,180 @@
+//! Reap stale cgroup-v2 directories left by nested k3s containerd instances.
+//!
+//! Privileged k3s pool members share the host cgroup hierarchy. With the
+//! cgroupfs driver, containerd creates `/sys/fs/cgroup/k8s.io/<container-id>`
+//! directories. Abrupt member teardown can leave those directories behind
+//! until the kernel's hierarchy-wide cgroup limit prevents any new Pod from
+//! starting. Cleanup is deliberately conservative: only aged, direct children
+//! named like full container IDs are considered, and the kernel must report
+//! the cgroup unpopulated with no processes before a non-recursive `rmdir`.
+
+use anyhow::{Context, Result};
+use std::fs;
+use std::path::Path;
+use std::time::{Duration, SystemTime};
+use tracing::{debug, info, warn};
+
+/// Remove aged, empty container cgroups directly below `root`.
+///
+/// `remove_dir` is intentionally non-recursive. Even after the explicit
+/// process/population checks, the kernel remains the final race-safe guard: a
+/// cgroup that gains a process or child before removal is rejected rather than
+/// disturbed.
+pub fn reap_empty_container_cgroups(
+    root: &Path,
+    now: SystemTime,
+    mtime_skip: Duration,
+    dry_run: bool,
+) -> Result<usize> {
+    if std::env::var("KOBE_REAPER_DISABLE").as_deref() == Ok("1") {
+        return Ok(0);
+    }
+    if !root.is_dir() {
+        debug!(?root, "container cgroup root not present, nothing to do");
+        return Ok(0);
+    }
+
+    let entries =
+        fs::read_dir(root).with_context(|| format!("read container cgroup root {root:?}"))?;
+    let mut cleaned = 0;
+    for entry in entries {
+        let entry = match entry {
+            Ok(entry) => entry,
+            Err(error) => {
+                warn!(%error, "read container cgroup entry failed (continuing)");
+                continue;
+            }
+        };
+        let path = entry.path();
+        let name = entry.file_name();
+        let Some(name) = name.to_str() else {
+            continue;
+        };
+        if !is_full_container_id(name) {
+            continue;
+        }
+        let file_type = match entry.file_type() {
+            Ok(file_type) => file_type,
+            Err(error) => {
+                warn!(?path, %error, "read cgroup file type failed (skipping)");
+                continue;
+            }
+        };
+        if !file_type.is_dir() || file_type.is_symlink() {
+            continue;
+        }
+        if !is_reapable(&path, now, mtime_skip) {
+            continue;
+        }
+        if dry_run {
+            info!(?path, "DRY RUN: would remove empty stale container cgroup");
+            continue;
+        }
+        match fs::remove_dir(&path) {
+            Ok(()) => {
+                cleaned += 1;
+                debug!(?path, "removed empty stale container cgroup");
+            }
+            Err(error) if error.kind() == std::io::ErrorKind::NotFound => {}
+            Err(error) => {
+                // Expected when a process/child raced into the cgroup. The
+                // non-recursive removal is the final safety gate.
+                debug!(?path, %error, "container cgroup removal refused; keeping it");
+            }
+        }
+    }
+    Ok(cleaned)
+}
+
+fn is_full_container_id(name: &str) -> bool {
+    name.len() == 64
+        && name
+            .bytes()
+            .all(|b| b.is_ascii_digit() || (b'a'..=b'f').contains(&b))
+}
+
+fn is_reapable(path: &Path, now: SystemTime, mtime_skip: Duration) -> bool {
+    let modified = match fs::metadata(path).and_then(|metadata| metadata.modified()) {
+        Ok(modified) => modified,
+        Err(_) => return false,
+    };
+    if now
+        .duration_since(modified)
+        .is_ok_and(|age| age < mtime_skip)
+    {
+        return false;
+    }
+
+    let events = match fs::read_to_string(path.join("cgroup.events")) {
+        Ok(events) => events,
+        Err(_) => return false,
+    };
+    let unpopulated = events
+        .lines()
+        .any(|line| line.split_whitespace().eq(["populated", "0"]));
+    if !unpopulated {
+        return false;
+    }
+
+    fs::read_to_string(path.join("cgroup.procs")).is_ok_and(|processes| processes.trim().is_empty())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    fn container_dir(tmp: &TempDir, name: &str, events: &str, procs: &str) -> std::path::PathBuf {
+        let path = tmp.path().join(name);
+        fs::create_dir(&path).unwrap();
+        fs::write(path.join("cgroup.events"), events).unwrap();
+        fs::write(path.join("cgroup.procs"), procs).unwrap();
+        path
+    }
+
+    #[test]
+    fn full_container_id_requires_64_lower_hex_characters() {
+        assert!(is_full_container_id(&"a".repeat(64)));
+        assert!(!is_full_container_id(&"a".repeat(63)));
+        assert!(!is_full_container_id(&"A".repeat(64)));
+        assert!(!is_full_container_id(&"g".repeat(64)));
+    }
+
+    #[test]
+    fn reapable_requires_unpopulated_and_empty_processes() {
+        let tmp = TempDir::new().unwrap();
+        let empty = container_dir(&tmp, &"a".repeat(64), "populated 0\nfrozen 0\n", "");
+        let populated = container_dir(&tmp, &"b".repeat(64), "populated 1\n", "42\n");
+        let inconsistent = container_dir(&tmp, &"c".repeat(64), "populated 0\n", "42\n");
+        let now = SystemTime::now();
+
+        assert!(is_reapable(&empty, now, Duration::ZERO));
+        assert!(!is_reapable(&populated, now, Duration::ZERO));
+        assert!(!is_reapable(&inconsistent, now, Duration::ZERO));
+    }
+
+    #[test]
+    fn reapable_respects_mtime_gate_and_missing_kernel_files() {
+        let tmp = TempDir::new().unwrap();
+        let fresh = container_dir(&tmp, &"d".repeat(64), "populated 0\n", "");
+        let missing = tmp.path().join("e".repeat(64));
+        fs::create_dir(&missing).unwrap();
+        let now = SystemTime::now();
+
+        assert!(!is_reapable(&fresh, now, Duration::from_secs(300)));
+        assert!(!is_reapable(&missing, now, Duration::ZERO));
+    }
+
+    #[test]
+    fn dry_run_identifies_but_does_not_remove_candidate() {
+        let tmp = TempDir::new().unwrap();
+        let path = container_dir(&tmp, &"f".repeat(64), "populated 0\n", "");
+
+        let cleaned =
+            reap_empty_container_cgroups(tmp.path(), SystemTime::now(), Duration::ZERO, true)
+                .unwrap();
+
+        assert_eq!(cleaned, 0);
+        assert!(path.exists());
+    }
+}

--- a/src/reaper/mod.rs
+++ b/src/reaper/mod.rs
@@ -1,8 +1,10 @@
 //! kobe-host-reaper: unmounts and removes stale subtrees under the
-//! kobe lease-root host path (`/var/lib/kobe/leases/` by default).
+//! kobe lease-root host path (`/var/lib/kobe/leases/` by default), and reaps
+//! aged empty cgroups left by nested k3s containerd instances.
 //!
 //! See `docs/superpowers/specs/2026-05-26-kobe-host-reaper-design.md`.
 
+pub mod cgroups;
 pub mod classify;
 pub mod mounts;
 pub mod sweep;


### PR DESCRIPTION
## Problem\n\nPrivileged nested k3s members using cgroupfs leave empty `/sys/fs/cgroup/k8s.io/<container-id>` directories after churn. On int-pro, physical-server2 reached 65,429 leaked entries and the host cgroup hierarchy ceiling, causing Pod creation to fail with `no space left on device`. physical-server1 had 31,626 aged empty entries.\n\n## Fix\n\nExtend `kobe-host-reaper` to remove only direct children that:\n\n- are 64-character lowercase hex container IDs\n- are older than 5 minutes\n- report `populated 0` in `cgroup.events`\n- have an empty `cgroup.procs`\n\nRemoval uses non-recursive `rmdir`, leaving the kernel as the final race-safe guard. The chart explicitly mounts host cgroupfs and enables cleanup by default.\n\n## Validation\n\n- `cargo check --bin kobe-host-reaper`\n- `cargo test reaper::cgroups` (4 passed)\n- `cargo clippy --bin kobe-host-reaper -- -D warnings`\n- `helm lint charts/kobe`\n- rendered DaemonSet includes the cgroup root, age gate, and host mount