### PR TITLE
feat(lease): add opaque caller metadata

### DIFF
--- a/charts/kobe/crds/clusterleases.yaml
+++ b/charts/kobe/crds/clusterleases.yaml
@@ -46,6 +46,17 @@ spec:
                 - VerifiedDestroy
                 nullable: true
                 type: string
+              metadata:
+                description: |-
+                  Caller-supplied descriptive context for this lease.
+
+                  Kobe stores this JSON object as opaque, untrusted data. It never affects
+                  authorization, quota, priority, scheduling, or lifecycle decisions. The
+                  HTTP API bounds its encoded size and nesting depth before creation, and
+                  no lease API mutates it afterwards. Do not place credentials or other
+                  secrets here: lease owners and cluster administrators can read it.
+                type: object
+                x-kubernetes-preserve-unknown-fields: true
               poolRef:
                 description: Which profile's pool to lease from.
                 type: string

--- a/crates/kobectl/src/commands/lease_create.rs
+++ b/crates/kobectl/src/commands/lease_create.rs
@@ -1,5 +1,6 @@
 use anyhow::Result;
 use serde::{Deserialize, Serialize};
+use serde_json::Value as JsonValue;
 use serde_yaml_ng::Value;
 use std::path::PathBuf;
 use std::time::{Duration, Instant};
@@ -20,6 +21,8 @@ pub struct LeaseCreateCommand<'a> {
     pub kubeconfig_path: Option<&'a str>,
     /// #107 P2: optional alias for the lease.
     pub name: Option<&'a str>,
+    /// Optional inline JSON object or `@path` containing caller metadata.
+    pub metadata_json: Option<&'a str>,
     /// #107 P3: with `name`, reuse+extend an existing active lease of that name.
     pub ensure: bool,
     /// #107 P3: heartbeat-extend the lease until interrupted.
@@ -38,6 +41,8 @@ pub(crate) struct LeaseAcceptedResponse {
     queue_position: u32,
     #[serde(default)]
     pub(crate) effective_ttl: Option<String>,
+    #[serde(default)]
+    pub(crate) metadata: Option<JsonValue>,
 }
 
 #[derive(Serialize)]
@@ -55,6 +60,8 @@ struct LeaseCreateOutput {
     effective_ttl: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     kubeconfig_path: Option<String>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<JsonValue>,
 }
 
 const CLUSTER_CAPABILITIES: &[&str] = &["kubeconfig", "extend", "release"];
@@ -67,12 +74,14 @@ pub(crate) async fn create_lease_request(
     pool: &str,
     ttl: &str,
     alias: Option<&str>,
+    metadata: Option<&JsonValue>,
 ) -> Result<LeaseAcceptedResponse> {
     let endpoint = config.endpoint.as_str();
     let body_json = serde_json::json!({
         "profile": pool,
         "ttl": ttl,
         "alias": alias,
+        "metadata": metadata,
     });
     let body_bytes = serde_json::to_vec(&body_json)?;
     // Body signing not yet supported server-side (extractor doesn't have body access).
@@ -111,6 +120,7 @@ pub(crate) async fn create_lease_request(
 pub async fn lease_create(command: LeaseCreateCommand<'_>) -> Result<()> {
     let config = CliConfig::load()?;
     let config = config.resolve(command.target_override, command.endpoint_override)?;
+    let metadata = parse_metadata_json(command.metadata_json)?;
 
     // Determine which lease to operate on: an existing active one (#107 P3
     // `--ensure` idempotent renew), else a fresh create.
@@ -179,6 +189,9 @@ pub async fn lease_create(command: LeaseCreateCommand<'_>) -> Result<()> {
                 if command.kubeconfig_path.is_some() {
                     anyhow::bail!("Sandbox leases do not provide a kubeconfig");
                 }
+                if metadata.is_some() {
+                    anyhow::bail!("Sandbox leases do not accept --metadata-json");
+                }
                 return super::sandbox::lease(
                     &config,
                     super::sandbox::LeaseCommand {
@@ -193,8 +206,14 @@ pub async fn lease_create(command: LeaseCreateCommand<'_>) -> Result<()> {
                 )
                 .await;
             }
-            let accepted =
-                create_lease_request(&config, &pool.name, command.ttl, command.name).await?;
+            let accepted = create_lease_request(
+                &config,
+                &pool.name,
+                command.ttl,
+                command.name,
+                metadata.as_ref(),
+            )
+            .await?;
             if command.no_wait {
                 return emit_pending_output(&accepted, command.output);
             }
@@ -333,6 +352,7 @@ fn emit_pending_output(accepted: &LeaseAcceptedResponse, output: OutputFormat) -
             queue_position: accepted.queue_position,
             effective_ttl: accepted.effective_ttl.clone(),
             kubeconfig_path: None,
+            metadata: accepted.metadata.clone(),
         })?,
     }
 
@@ -373,10 +393,35 @@ fn emit_ready_output(
             queue_position: ready.queue_position,
             effective_ttl,
             kubeconfig_path: Some(kubeconfig_path.display().to_string()),
+            metadata: ready.metadata.clone(),
         })?,
     }
 
     Ok(())
+}
+
+/// Parse `--metadata-json` from an inline object or `@path` without assigning
+/// any meaning to its keys. The server remains authoritative for size and
+/// nesting bounds, but rejecting non-objects locally avoids a network roundtrip.
+pub(crate) fn parse_metadata_json(input: Option<&str>) -> Result<Option<JsonValue>> {
+    let Some(input) = input else {
+        return Ok(None);
+    };
+    let raw = if let Some(path) = input.strip_prefix('@') {
+        if path.is_empty() {
+            anyhow::bail!("--metadata-json @PATH requires a file path");
+        }
+        std::fs::read_to_string(path)
+            .map_err(|error| anyhow::anyhow!("failed to read metadata JSON from {path}: {error}"))?
+    } else {
+        input.to_string()
+    };
+    let metadata: JsonValue = serde_json::from_str(&raw)
+        .map_err(|error| anyhow::anyhow!("invalid --metadata-json: {error}"))?;
+    if !metadata.is_object() {
+        anyhow::bail!("--metadata-json must contain a JSON object");
+    }
+    Ok(Some(metadata))
 }
 
 pub(crate) async fn wait_for_usable_lease(
@@ -592,6 +637,7 @@ mod tests {
             cluster_name: Some("pool-ci-small-1".to_string()),
             expires_at: Some("2026-01-01T00:00:00Z".to_string()),
             queue_position: 0,
+            metadata: None,
             kubeconfig: Some("apiVersion: v1".to_string()),
         };
 
@@ -623,6 +669,30 @@ mod tests {
         assert_eq!(parse_cli_duration(""), None);
         assert_eq!(parse_cli_duration("10"), None);
         assert_eq!(parse_cli_duration("5d"), None);
+    }
+
+    #[test]
+    fn metadata_json_accepts_inline_objects_and_files() {
+        let inline = parse_metadata_json(Some(r#"{"actor":"lenij","pr":3835}"#))
+            .unwrap()
+            .unwrap();
+        assert_eq!(inline["actor"], "lenij");
+        assert_eq!(inline["pr"], 3835);
+
+        let directory = tempfile::tempdir().unwrap();
+        let path = directory.path().join("metadata.json");
+        std::fs::write(&path, r#"{"purpose":"e2e"}"#).unwrap();
+        let from_file = parse_metadata_json(Some(&format!("@{}", path.display())))
+            .unwrap()
+            .unwrap();
+        assert_eq!(from_file["purpose"], "e2e");
+    }
+
+    #[test]
+    fn metadata_json_rejects_invalid_json_and_non_objects() {
+        assert!(parse_metadata_json(Some("not-json")).is_err());
+        assert!(parse_metadata_json(Some("[]")).is_err());
+        assert!(parse_metadata_json(Some("@")).is_err());
     }
 
     #[test]

--- a/crates/kobectl/src/commands/leases.rs
+++ b/crates/kobectl/src/commands/leases.rs
@@ -28,6 +28,9 @@ pub(crate) struct LeaseSummary {
     /// Caller-supplied alias (#107 P2), selectable interchangeably with the id.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub alias: Option<String>,
+    /// Caller-supplied descriptive JSON metadata.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub metadata: Option<serde_json::Value>,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -46,6 +49,8 @@ pub(crate) struct LeaseDetail {
     pub expires_at: Option<String>,
     #[serde(default)]
     pub queue_position: u32,
+    #[serde(default)]
+    pub metadata: Option<serde_json::Value>,
     #[serde(default)]
     pub kubeconfig: Option<String>,
 }

--- a/crates/kobectl/src/commands/purge.rs
+++ b/crates/kobectl/src/commands/purge.rs
@@ -395,6 +395,7 @@ mod tests {
             requester: None,
             kubeconfig_path: None,
             alias: None,
+            metadata: None,
         };
 
         assert!(is_active_lease(&base));
@@ -426,6 +427,7 @@ mod tests {
             requester: None,
             kubeconfig_path: None,
             alias: None,
+            metadata: None,
         };
         let sandbox = LeaseSummary {
             id: "sandbox-agent".to_string(),
@@ -454,6 +456,7 @@ mod tests {
             requester: None,
             kubeconfig_path: None,
             alias: None,
+            metadata: None,
         };
         let leases = vec![
             LeaseSummary {

--- a/crates/kobectl/src/commands/select.rs
+++ b/crates/kobectl/src/commands/select.rs
@@ -175,6 +175,7 @@ mod tests {
             requester: None,
             kubeconfig_path: None,
             alias: None,
+            metadata: None,
         }
     }
 

--- a/crates/kobectl/src/commands/status.rs
+++ b/crates/kobectl/src/commands/status.rs
@@ -252,6 +252,7 @@ async fn enrich_leases(
                 requester: lease.requester,
                 kubeconfig_path,
                 alias: lease.alias,
+                metadata: detail.metadata.or(lease.metadata),
             }),
             Err(_) => enriched.push(LeaseSummary {
                 kubeconfig_path,

--- a/crates/kobectl/src/commands/with_lease.rs
+++ b/crates/kobectl/src/commands/with_lease.rs
@@ -10,13 +10,14 @@ use tokio::sync::oneshot;
 use super::OutputFormat;
 use super::config::{CliConfig, ResolvedConfig};
 use super::keepalive::heartbeat_until;
-use super::lease_create::{create_lease_request, wait_for_usable_lease};
+use super::lease_create::{create_lease_request, parse_metadata_json, wait_for_usable_lease};
 use super::pools::fetch_pool_for_config_with_output;
 use super::release::release_lease;
 
 pub struct WithLeaseCommand<'a> {
     pub pool: Option<&'a str>,
     pub ttl: &'a str,
+    pub metadata_json: Option<&'a str>,
     pub cmd: &'a [String],
     pub target_override: Option<&'a str>,
     pub endpoint_override: Option<&'a str>,
@@ -57,7 +58,9 @@ pub async fn with_lease(command: WithLeaseCommand<'_>) -> Result<()> {
     if verbose {
         eprintln!("Leasing '{}' for the wrapped command...", pool.name);
     }
-    let accepted = create_lease_request(&config, &pool.name, command.ttl, None).await?;
+    let metadata = parse_metadata_json(command.metadata_json)?;
+    let accepted =
+        create_lease_request(&config, &pool.name, command.ttl, None, metadata.as_ref()).await?;
     let lease_id = accepted.id.clone();
 
     // Everything past creation must release the lease, even on error or signal.

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -130,9 +130,14 @@ enum Commands {
         /// reference it by name later: `kobe extend pr-106 30m`.
         #[arg(long, value_name = "NAME")]
         name: Option<String>,
+        /// Attach an opaque JSON object to the lease. Pass inline JSON or
+        /// `@path` to read it from a file. Metadata is descriptive only.
+        #[arg(long, value_name = "JSON|@PATH")]
+        metadata_json: Option<String>,
         /// Idempotent (#107 P3): with --name, reuse the existing active lease of
         /// that name (extending its TTL) instead of failing on the duplicate —
         /// "lease again means renew". Safe to call unconditionally at job start.
+        /// Reused leases keep their original metadata.
         #[arg(long, requires = "name")]
         ensure: bool,
         /// Heartbeat-extend the lease until interrupted (#107 P3). Re-extends by
@@ -150,6 +155,10 @@ enum Commands {
         /// Lease TTL / heartbeat window
         #[arg(long, default_value = "1h")]
         ttl: String,
+        /// Attach an opaque JSON object to the lease. Pass inline JSON or
+        /// `@path` to read it from a file. Metadata is descriptive only.
+        #[arg(long, value_name = "JSON|@PATH")]
+        metadata_json: Option<String>,
         /// Command to run (after `--`), with the lease kubeconfig in KUBECONFIG.
         #[arg(last = true, required = true)]
         cmd: Vec<String>,
@@ -381,6 +390,7 @@ async fn main() -> anyhow::Result<()> {
             wait_timeout,
             kubeconfig,
             name,
+            metadata_json,
             ensure,
             keepalive,
         } => {
@@ -391,6 +401,7 @@ async fn main() -> anyhow::Result<()> {
                 wait_timeout: wait_timeout.as_deref(),
                 kubeconfig_path: kubeconfig.as_deref(),
                 name: name.as_deref(),
+                metadata_json: metadata_json.as_deref(),
                 ensure,
                 keepalive,
                 target_override: target,
@@ -399,10 +410,16 @@ async fn main() -> anyhow::Result<()> {
             })
             .await
         }
-        Commands::WithLease { pool, ttl, cmd } => {
+        Commands::WithLease {
+            pool,
+            ttl,
+            metadata_json,
+            cmd,
+        } => {
             commands::with_lease(commands::WithLeaseCommand {
                 pool: pool.as_deref(),
                 ttl: &ttl,
+                metadata_json: metadata_json.as_deref(),
                 cmd: &cmd,
                 target_override: target,
                 endpoint_override: endpoint,

--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -50,7 +50,16 @@ Creates a lease from the specified pool. Returns `202 Accepted` immediately with
 ```json
 {
   "profile": "ci-small",
-  "ttl": "30m"
+  "ttl": "30m",
+  "alias": "pr-3835",
+  "metadata": {
+    "github": {
+      "actor": "lenij",
+      "pullRequest": 3835,
+      "runId": 123456789
+    },
+    "purpose": "e2e"
+  }
 }
 ```
 
@@ -58,6 +67,15 @@ Creates a lease from the specified pool. Returns `202 Accepted` immediately with
 |---|---|---|---|
 | `profile` | string | Yes | Pool name to lease from |
 | `ttl` | string | No | Requested TTL (e.g. `"30m"`, `"1h"`). Defaults to the pool's `spec.ttl`. Capped by AccessPolicy `maxTtl`. |
+| `alias` | string | No | DNS-label name unique among the requester's active leases. |
+| `metadata` | object | No | Opaque caller context. Maximum 8 KiB encoded JSON, 32 top-level keys, four nesting levels, and 128 JSON values. |
+
+`metadata` is descriptive, untrusted, and creation-time only: the lease API
+does not expose an update operation. It never affects authorization, quota,
+priority, scheduling, or lifecycle behavior. Do not include credentials or
+secrets: the lease owner and cluster administrators can read it. Shared pool
+listings redact another tenant's metadata together with its requester identity
+and alias.
 
 **Response** — `202 Accepted`
 
@@ -67,7 +85,16 @@ Creates a lease from the specified pool. Returns `202 Accepted` immediately with
   "phase": "Pending",
   "profile": "ci-small",
   "queue_position": 0,
-  "effective_ttl": "30m"
+  "effective_ttl": "30m",
+  "alias": "pr-3835",
+  "metadata": {
+    "github": {
+      "actor": "lenij",
+      "pullRequest": 3835,
+      "runId": 123456789
+    },
+    "purpose": "e2e"
+  }
 }
 ```
 
@@ -89,7 +116,7 @@ Once bound, `GET /v1/leases/:id` returns:
 
 | Status | Meaning |
 |---|---|
-| `400` | Invalid profile name or TTL format |
+| `400` | Invalid profile name, alias, TTL, or metadata |
 | `403` | Profile not allowed for your identity |
 | `429` | Concurrent lease limit reached, or server overloaded |
 

--- a/docs/kobe-docs/commands/reference.mdx
+++ b/docs/kobe-docs/commands/reference.mdx
@@ -85,7 +85,7 @@ Removes the stored session token and credentials from the local config. The next
 ## `kobe lease`
 
 ```sh
-kobe lease <pool> [--ttl <duration>] [--kubeconfig <path>] [--no-wait]
+kobe lease <pool> [--ttl <duration>] [--kubeconfig <path>] [--metadata-json <json|@path>] [--no-wait]
 ```
 
 Creates a lease from the specified pool. The pool's `resourceKind` determines
@@ -97,6 +97,8 @@ kobe lease ci-small
 kobe lease ci-small --ttl 30m
 kobe lease ci-small --kubeconfig /tmp/kube.yaml
 kobe lease agents --ttl 30m
+kobe lease ci-small --metadata-json '{"github":{"actor":"lenij","pullRequest":3835}}'
+kobe lease ci-small --metadata-json @lease-metadata.json
 kobe lease ci-small --no-wait
 ```
 
@@ -110,6 +112,11 @@ Prints the lease ID, resource kind, capabilities, and expiry on success.
 | `--kubeconfig` | `~/.kube/kobe-<id>` | Cluster resources only: path to write the kubeconfig. |
 | `--no-wait` | disabled | Return after creating the lease instead of waiting for readiness. |
 | `--wait-timeout` | unset | Maximum time to wait for the lease to become usable. |
+| `--metadata-json` | unset | Opaque descriptive JSON object, passed inline or read from `@path`. Metadata is bounded by the server and never affects lease behavior. |
+
+Metadata is stored with the lease and returned to its owner. Do not include
+credentials or secrets; cluster administrators can inspect it.
+When `--ensure` reuses an existing named lease, that lease keeps its original metadata.
 
 ---
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -421,6 +421,10 @@ struct CreateLeaseRequest {
     /// it can name "which lease" in scripts (`kobe extend pr-106 30m`).
     #[serde(default)]
     alias: Option<String>,
+    /// Optional caller-supplied descriptive JSON. This is stored verbatim but
+    /// has no authorization, scheduling, or lifecycle semantics.
+    #[serde(default)]
+    metadata: Option<serde_json::Value>,
 }
 
 #[derive(Serialize)]
@@ -442,6 +446,10 @@ struct LeaseResponse {
     effective_ttl: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     alias: Option<String>,
+    /// Caller-supplied descriptive metadata. Present only on the owner's lease
+    /// responses; shared pool listings redact it for other tenants.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
     /// Human-readable explanation of the lease's current state (#189), echoed
     /// from `ClusterLeaseStatus.message` — primarily why a Pending lease has
     /// not bound yet (pool health). Omitted when empty.
@@ -456,6 +464,68 @@ struct LeaseResponse {
 
 fn is_zero(v: &u32) -> bool {
     *v == 0
+}
+
+const MAX_LEASE_METADATA_BYTES: usize = 8 * 1024;
+const MAX_LEASE_METADATA_TOP_LEVEL_KEYS: usize = 32;
+const MAX_LEASE_METADATA_DEPTH: usize = 4;
+const MAX_LEASE_METADATA_NODES: usize = 128;
+
+/// Validate the caller-controlled lease metadata envelope before persisting it.
+///
+/// The byte bound protects the CRD and API responses; the shape bounds keep a
+/// small payload from becoming pathologically nested. Values remain opaque and
+/// untrusted after validation: no controller may derive behavior from them.
+fn validate_lease_metadata(metadata: &serde_json::Value) -> Result<(), String> {
+    let object = metadata
+        .as_object()
+        .ok_or_else(|| "Metadata must be a JSON object".to_string())?;
+
+    if object.len() > MAX_LEASE_METADATA_TOP_LEVEL_KEYS {
+        return Err(format!(
+            "Metadata may contain at most {MAX_LEASE_METADATA_TOP_LEVEL_KEYS} top-level keys"
+        ));
+    }
+
+    let encoded_len = serde_json::to_vec(metadata)
+        .map_err(|error| format!("Metadata could not be encoded: {error}"))?
+        .len();
+    if encoded_len > MAX_LEASE_METADATA_BYTES {
+        return Err(format!(
+            "Metadata may be at most {MAX_LEASE_METADATA_BYTES} bytes when encoded as JSON"
+        ));
+    }
+
+    fn visit(value: &serde_json::Value, depth: usize, nodes: &mut usize) -> Result<(), String> {
+        if depth > MAX_LEASE_METADATA_DEPTH {
+            return Err(format!(
+                "Metadata may be nested at most {MAX_LEASE_METADATA_DEPTH} levels deep"
+            ));
+        }
+        *nodes += 1;
+        if *nodes > MAX_LEASE_METADATA_NODES {
+            return Err(format!(
+                "Metadata may contain at most {MAX_LEASE_METADATA_NODES} JSON values"
+            ));
+        }
+        match value {
+            serde_json::Value::Array(values) => {
+                for value in values {
+                    visit(value, depth + 1, nodes)?;
+                }
+            }
+            serde_json::Value::Object(values) => {
+                for value in values.values() {
+                    visit(value, depth + 1, nodes)?;
+                }
+            }
+            _ => {}
+        }
+        Ok(())
+    }
+
+    let mut nodes = 0;
+    visit(metadata, 1, &mut nodes)
 }
 
 #[derive(Serialize)]
@@ -477,6 +547,10 @@ struct LeaseSummary {
     /// Caller-supplied alias, if any (#107 P2).
     #[serde(skip_serializing_if = "Option::is_none")]
     alias: Option<String>,
+    /// Caller-supplied descriptive metadata. Redacted alongside `requester`
+    /// and `alias` when a shared-pool listing contains another tenant's lease.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    metadata: Option<serde_json::Value>,
 }
 
 /// Query parameters for `GET /v1/leases` (#107 P2).
@@ -1140,6 +1214,20 @@ async fn create_lease<B: ClusterBackend>(
             .into_response();
     }
 
+    if let Some(metadata) = req.metadata.as_ref()
+        && let Err(detail) = validate_lease_metadata(metadata)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "Invalid lease metadata".to_string(),
+                detail: Some(detail),
+                reason: None,
+            }),
+        )
+            .into_response();
+    }
+
     let ttl_str = req.ttl.as_deref().unwrap_or("1h");
     let requested_ttl = match parse_duration(ttl_str) {
         Some(d) => d,
@@ -1265,6 +1353,7 @@ async fn create_lease<B: ClusterBackend>(
         &identity,
         policy.default_priority,
         req.alias.as_deref(),
+        req.metadata.clone(),
     );
 
     if let Err(e) = leases_api.create(&PostParams::default(), &lease).await {
@@ -1361,6 +1450,7 @@ async fn create_lease<B: ClusterBackend>(
         diagnostics_url: None,
         effective_ttl: None,
         alias: req.alias.clone(),
+        metadata: req.metadata,
         message: None,
         conditions: Vec::new(),
     };
@@ -1406,6 +1496,7 @@ async fn list_leases<B: ClusterBackend>(
                         diagnostics_url: status.diagnostics_url,
                         requester: None,
                         alias,
+                        metadata: c.spec.metadata.as_deref().cloned(),
                     }
                 })
                 .collect();
@@ -1541,6 +1632,7 @@ async fn get_lease<B: ClusterBackend>(
                     diagnostics_url: status.diagnostics_url,
                     effective_ttl: None,
                     alias,
+                    metadata: lease.spec.metadata.map(|metadata| *metadata),
                     // #189: surface why a Pending lease isn't binding (pool health).
                     message: status.message,
                     // #189: structured conditions companion to `message`.
@@ -2609,32 +2701,7 @@ async fn list_pool_leases<B: ClusterBackend>(
                     let status = c.status.clone().unwrap_or_default();
                     matches!(status.phase, LeasePhase::Pending | LeasePhase::Bound)
                 })
-                .map(|c| {
-                    let status = c.status.clone().unwrap_or_default();
-                    // Only disclose the requester identity for the caller's OWN
-                    // leases. A pool can be shared across tenants (the shipped
-                    // GitHub policy grants every repo the `e2e-*` pattern), so
-                    // returning every requester would let any one tenant enumerate
-                    // the others' identities. The pool-utilization view (counts,
-                    // phases, expiries) is preserved; only foreign identities are
-                    // redacted.
-                    let own = c.spec.requester.identity == identity.identity;
-                    let requester = own.then(|| c.spec.requester.identity.clone());
-                    // Scope the alias like the requester: never expose another
-                    // tenant's caller-chosen lease name.
-                    let alias = if own { lease_alias(c) } else { None };
-                    LeaseSummary {
-                        id: c.name_any(),
-                        phase: status.phase.to_string(),
-                        profile: c.spec.pool_ref.clone(),
-                        cluster_name: status.cluster_name,
-                        expires_at: status.expires_at,
-                        queue_position: status.queue_position,
-                        diagnostics_url: None,
-                        requester,
-                        alias,
-                    }
-                })
+                .map(|c| pool_lease_summary(c, &identity.identity))
                 .collect();
 
             (StatusCode::OK, Json(summaries)).into_response()
@@ -2644,6 +2711,28 @@ async fn list_pool_leases<B: ClusterBackend>(
             "Failed to list pool leases",
             e,
         ),
+    }
+}
+
+/// Summarize one active pool lease without crossing tenant boundaries.
+/// Utilization fields are shared, while requester-controlled identity, alias,
+/// and metadata are disclosed only when the caller owns the lease.
+fn pool_lease_summary(lease: &ClusterLease, caller_identity: &str) -> LeaseSummary {
+    let status = lease.status.clone().unwrap_or_default();
+    let own = lease.spec.requester.identity == caller_identity;
+    LeaseSummary {
+        id: lease.name_any(),
+        phase: status.phase.to_string(),
+        profile: lease.spec.pool_ref.clone(),
+        cluster_name: status.cluster_name,
+        expires_at: status.expires_at,
+        queue_position: status.queue_position,
+        diagnostics_url: None,
+        requester: own.then(|| lease.spec.requester.identity.clone()),
+        alias: own.then(|| lease_alias(lease)).flatten(),
+        metadata: own
+            .then(|| lease.spec.metadata.as_deref().cloned())
+            .flatten(),
     }
 }
 
@@ -3117,6 +3206,7 @@ fn lease_alias(lease: &ClusterLease) -> Option<String> {
     lease.metadata.labels.as_ref()?.get(ALIAS_LABEL).cloned()
 }
 
+#[allow(clippy::too_many_arguments)]
 fn build_lease_crd(
     lease_id: &str,
     namespace: &str,
@@ -3125,6 +3215,7 @@ fn build_lease_crd(
     identity: &AuthIdentity,
     priority: u32,
     alias: Option<&str>,
+    metadata: Option<serde_json::Value>,
 ) -> ClusterLease {
     let mut labels = std::collections::BTreeMap::new();
     labels.insert("kobe.kunobi.ninja/profile".to_string(), profile.to_string());
@@ -3150,6 +3241,7 @@ fn build_lease_crd(
                 requester_type: identity.requester_type.clone(),
                 identity: identity.identity.clone(),
             },
+            metadata: metadata.map(Box::new),
             priority,
             // Callers cannot request verified teardown: it is an internal
             // composition detail of #74's child placement, not tenant-facing
@@ -3429,6 +3521,7 @@ mod tests {
             &identity,
             80,
             None,
+            None,
         );
 
         assert_eq!(claim.spec.pool_ref, "e2e-basic");
@@ -3454,7 +3547,16 @@ mod tests {
     #[test]
     fn test_build_lease_crd_stamps_alias_label() {
         let identity = test_identity();
-        let claim = build_lease_crd("lease-1", "ns", "p", "1h", &identity, 50, Some("pr-106"));
+        let claim = build_lease_crd(
+            "lease-1",
+            "ns",
+            "p",
+            "1h",
+            &identity,
+            50,
+            Some("pr-106"),
+            None,
+        );
         assert_eq!(
             claim
                 .metadata
@@ -3470,7 +3572,16 @@ mod tests {
     #[test]
     fn test_build_lease_crd_labels() {
         let identity = test_identity();
-        let claim = build_lease_crd("lease-xyz", "ns1", "e2e-full", "30m", &identity, 50, None);
+        let claim = build_lease_crd(
+            "lease-xyz",
+            "ns1",
+            "e2e-full",
+            "30m",
+            &identity,
+            50,
+            None,
+            None,
+        );
 
         let labels = claim
             .metadata
@@ -3490,9 +3601,90 @@ mod tests {
     }
 
     #[test]
+    fn lease_metadata_is_preserved_without_becoming_a_kubernetes_label() {
+        let identity = test_identity();
+        let metadata = serde_json::json!({
+            "github": {"actor": "lenij", "pullRequest": 3835, "runId": 123456789},
+            "purpose": "e2e"
+        });
+        let lease = build_lease_crd(
+            "lease-metadata",
+            "ns",
+            "ci",
+            "1h",
+            &identity,
+            50,
+            None,
+            Some(metadata.clone()),
+        );
+
+        assert_eq!(lease.spec.metadata.as_deref(), Some(&metadata));
+        assert_eq!(
+            lease.metadata.labels.as_ref().map(|labels| labels.len()),
+            Some(2)
+        );
+    }
+
+    #[test]
+    fn lease_metadata_validation_accepts_bounded_json_objects() {
+        let metadata = serde_json::json!({
+            "github": {"actor": "lenij", "pr": 3835},
+            "tags": ["e2e", "pull-request"]
+        });
+        assert_eq!(validate_lease_metadata(&metadata), Ok(()));
+        assert_eq!(validate_lease_metadata(&serde_json::json!({})), Ok(()));
+    }
+
+    #[test]
+    fn lease_metadata_validation_rejects_unbounded_or_non_object_values() {
+        assert!(validate_lease_metadata(&serde_json::json!(["not", "an", "object"])).is_err());
+
+        let too_deep = serde_json::json!({"a": {"b": {"c": {"d": true}}}});
+        assert!(validate_lease_metadata(&too_deep).is_err());
+
+        let too_many_values = serde_json::json!({"values": vec![0; MAX_LEASE_METADATA_NODES]});
+        assert!(validate_lease_metadata(&too_many_values).is_err());
+
+        let too_large = serde_json::json!({"value": "x".repeat(MAX_LEASE_METADATA_BYTES)});
+        assert!(validate_lease_metadata(&too_large).is_err());
+
+        let too_many_keys = serde_json::Value::Object(
+            (0..=MAX_LEASE_METADATA_TOP_LEVEL_KEYS)
+                .map(|index| (format!("key-{index}"), serde_json::Value::Null))
+                .collect(),
+        );
+        assert!(validate_lease_metadata(&too_many_keys).is_err());
+    }
+
+    #[test]
+    fn pool_lease_summary_redacts_foreign_metadata_with_identity_and_alias() {
+        let identity = test_identity();
+        let lease = build_lease_crd(
+            "lease-private",
+            "ns",
+            "ci",
+            "1h",
+            &identity,
+            50,
+            Some("pr-3835"),
+            Some(serde_json::json!({"actor": "lenij"})),
+        );
+
+        let own = pool_lease_summary(&lease, &identity.identity);
+        assert_eq!(own.requester.as_deref(), Some(identity.identity.as_str()));
+        assert_eq!(own.alias.as_deref(), Some("pr-3835"));
+        assert_eq!(own.metadata, Some(serde_json::json!({"actor": "lenij"})));
+
+        let foreign = pool_lease_summary(&lease, "repo:other/repo:ref:refs/heads/main");
+        assert!(foreign.requester.is_none());
+        assert!(foreign.alias.is_none());
+        assert!(foreign.metadata.is_none());
+    }
+
+    #[test]
     fn test_build_lease_crd_status_is_none() {
         let identity = test_identity();
-        let claim = build_lease_crd("lease-001", "ns", "dev", "2h", &identity, 100, None);
+        let claim = build_lease_crd("lease-001", "ns", "dev", "2h", &identity, 100, None, None);
 
         // The CRD is created without status; the controller sets it later
         assert!(
@@ -3504,8 +3696,8 @@ mod tests {
     #[test]
     fn test_build_lease_crd_different_priority() {
         let identity = test_identity();
-        let claim_low = build_lease_crd("c1", "ns", "p", "1h", &identity, 10, None);
-        let claim_high = build_lease_crd("c2", "ns", "p", "1h", &identity, 200, None);
+        let claim_low = build_lease_crd("c1", "ns", "p", "1h", &identity, 10, None, None);
+        let claim_high = build_lease_crd("c2", "ns", "p", "1h", &identity, 200, None, None);
 
         assert_eq!(claim_low.spec.priority, 10);
         assert_eq!(claim_high.spec.priority, 200);
@@ -5050,6 +5242,27 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn create_lease_rejects_invalid_metadata_before_cluster_calls() {
+        let (state, server) = preflight_state().await;
+        let response = create_lease::<crate::testutil::MockBackend>(
+            State(state),
+            test_identity(),
+            Json(CreateLeaseRequest {
+                profile: "e2e-basic".to_string(),
+                ttl: None,
+                alias: None,
+                metadata: Some(serde_json::json!(["not", "an", "object"])),
+            }),
+        )
+        .await;
+
+        assert_eq!(response.status(), StatusCode::BAD_REQUEST);
+        let body = response_json(response).await;
+        assert_eq!(body["error"].as_str(), Some("Invalid lease metadata"));
+        assert!(server.received_requests().await.unwrap().is_empty());
+    }
+
+    #[tokio::test]
     async fn test_create_lease_against_failing_pool_returns_503_with_retry_after_and_reason() {
         use wiremock::matchers::{method, path, path_regex};
         use wiremock::{Mock, ResponseTemplate};
@@ -5094,6 +5307,7 @@ mod tests {
                 profile: "e2e-basic".to_string(),
                 ttl: None,
                 alias: None,
+                metadata: None,
             }),
         )
         .await;
@@ -5166,6 +5380,10 @@ mod tests {
             .mount(&server)
             .await;
 
+        let metadata = serde_json::json!({
+            "github": {"actor": "lenij", "pullRequest": 3835},
+            "purpose": "e2e"
+        });
         let response = create_lease::<crate::testutil::MockBackend>(
             State(state),
             test_identity(),
@@ -5173,6 +5391,7 @@ mod tests {
                 profile: "e2e-basic".to_string(),
                 ttl: None,
                 alias: None,
+                metadata: Some(metadata.clone()),
             }),
         )
         .await;
@@ -5188,6 +5407,17 @@ mod tests {
         );
         let body = response_json(response).await;
         assert_eq!(body["phase"].as_str(), Some("Pending"));
+        assert_eq!(body["metadata"], metadata);
+
+        let create = server
+            .received_requests()
+            .await
+            .unwrap()
+            .into_iter()
+            .find(|request| request.method == http::Method::POST)
+            .expect("the accepted request must create one ClusterLease");
+        let created: serde_json::Value = serde_json::from_slice(&create.body).unwrap();
+        assert_eq!(created["spec"]["metadata"], metadata);
     }
 
     #[test]

--- a/src/controllers/sandbox_child.rs
+++ b/src/controllers/sandbox_child.rs
@@ -473,6 +473,7 @@ pub fn build_internal_cluster_lease(
             pool_ref: cluster_pool_ref.to_string(),
             ttl: format!("{}s", lifetime.as_secs()),
             requester,
+            metadata: None,
             priority: default_internal_priority(),
             cleanup_mode: Some(CleanupMode::VerifiedDestroy),
         },

--- a/src/crd/lease.rs
+++ b/src/crd/lease.rs
@@ -68,6 +68,19 @@ pub struct ClusterLeaseSpec {
     /// Identity of the requester.
     pub requester: Requester,
 
+    /// Caller-supplied descriptive context for this lease.
+    ///
+    /// Kobe stores this JSON object as opaque, untrusted data. It never affects
+    /// authorization, quota, priority, scheduling, or lifecycle decisions. The
+    /// HTTP API bounds its encoded size and nesting depth before creation, and
+    /// no lease API mutates it afterwards. Do not place credentials or other
+    /// secrets here: lease owners and cluster administrators can read it.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    #[schemars(schema_with = "crate::crd::json_object_schema")]
+    // Keep recursive caller data behind a pointer so controller async frames
+    // do not grow with serde_json::Value's enum representation.
+    pub metadata: Option<Box<serde_json::Value>>,
+
     /// Lease priority for queue ordering.
     /// Higher values are served first.
     #[serde(default = "default_priority")]


### PR DESCRIPTION
## Summary

- add optional opaque JSON metadata to ClusterLease.spec
- accept inline JSON or @path via kobe lease and kobe with-lease
- return metadata to the lease owner while redacting it from foreign shared-pool listings
- bound metadata to 8 KiB, 32 top-level keys, four levels, and 128 values
- regenerate the ClusterLease CRD and document the API and CLI contract

## Semantics

- descriptive and untrusted; never affects authorization, quota, priority, scheduling, or lifecycle
- creation-time only through the lease API
- existing named leases reused with --ensure retain their original metadata
- callers should not store secrets because cluster administrators can inspect the CRD

## Validation

- cargo test -p kobe-operator --bin kobe-operator (1,413 passed)
- cargo test -p kobectl (103 unit and 20 integration passed)
- cargo check --workspace --all-targets
- cargo fmt --all -- --check
- regenerated CRD matches the checked-in manifest
- git diff --check
