### PR TITLE
feat(cli): unify pooled resource operations

### DIFF
--- a/crates/kobectl/src/commands/lease_create.rs
+++ b/crates/kobectl/src/commands/lease_create.rs
@@ -6,9 +6,9 @@ use std::time::{Duration, Instant};
 
 use super::config::CliConfig;
 use super::extend::extend_lease;
-use super::leases::LeaseDetail;
+use super::leases::{LeaseDetail, LeaseSummary, fetch_lease};
 use super::picker::{PickerItem, run_picker};
-use super::pools::fetch_pools_for_config;
+use super::pools::{PoolSummary, fetch_pool_for_config_with_output, fetch_pools_for_config};
 use super::state::record_kubeconfig;
 use super::{OutputFormat, authed_client, get_auth_header, print_json, with_auth};
 
@@ -45,6 +45,8 @@ pub(crate) struct LeaseAcceptedResponse {
 struct LeaseCreateOutput {
     id: String,
     phase: String,
+    resource_kind: &'static str,
+    capabilities: &'static [&'static str],
     profile: String,
     cluster_name: Option<String>,
     expires_at: Option<String>,
@@ -54,6 +56,8 @@ struct LeaseCreateOutput {
     #[serde(skip_serializing_if = "Option::is_none")]
     kubeconfig_path: Option<String>,
 }
+
+const CLUSTER_CAPABILITIES: &[&str] = &["kubeconfig", "extend", "release"];
 
 /// POST `/v1/leases` and return the accepted (Pending) lease. Shared by the
 /// `lease` command and `with-lease` (#107 P3). `alias` becomes the lease's
@@ -110,26 +114,87 @@ pub async fn lease_create(command: LeaseCreateCommand<'_>) -> Result<()> {
 
     // Determine which lease to operate on: an existing active one (#107 P3
     // `--ensure` idempotent renew), else a fresh create.
-    let (lease_id, profile, effective_ttl, renewed) = match ensure_existing(&config, &command)
-        .await?
+    let existing = ensure_existing(&config, &command).await?;
+    if let Some(existing) = existing.as_ref()
+        && existing.is_sandbox()
     {
-        Some((id, profile)) => {
+        if command.kubeconfig_path.is_some() {
+            anyhow::bail!("Sandbox leases do not provide a kubeconfig");
+        }
+        let expires = extend_lease(&config, &existing.id, command.ttl).await?;
+        if command.output == OutputFormat::Text {
+            eprintln!(
+                "Lease '{}' already active as {} — renewed (expires {expires})",
+                command.name.unwrap_or_default(),
+                existing.id
+            );
+        }
+        let detail = fetch_lease(&config, &existing.id).await?;
+        super::sandbox::emit_lease_output(
+            &detail.id,
+            &detail.phase,
+            &detail.profile,
+            Some(command.ttl),
+            command.name,
+            detail.expires_at.as_deref(),
+            command.output,
+        )?;
+        if command.keepalive {
+            let stop = async {
+                let _ = tokio::signal::ctrl_c().await;
+            };
+            super::keepalive::heartbeat_until(
+                &config,
+                &existing.id,
+                command.ttl,
+                stop,
+                command.output == OutputFormat::Text,
+            )
+            .await?;
+        }
+        return Ok(());
+    }
+
+    let (lease_id, profile, effective_ttl, renewed) = match existing {
+        Some(existing) => {
             // Reuse + extend instead of failing the duplicate alias.
-            let expires = extend_lease(&config, &id, command.ttl).await?;
+            let expires = extend_lease(&config, &existing.id, command.ttl).await?;
             if command.output == OutputFormat::Text {
                 eprintln!(
-                    "Lease '{}' already active as {id} — renewed (expires {expires})",
-                    command.name.unwrap_or_default()
+                    "Lease '{}' already active as {} — renewed (expires {expires})",
+                    command.name.unwrap_or_default(),
+                    existing.id
                 );
             }
-            (id, profile, None, true)
+            (existing.id, existing.profile, None, true)
         }
         None => {
             let pool = match command.pool {
-                Some(pool) => pool.to_string(),
+                Some(pool) => {
+                    fetch_pool_for_config_with_output(&config, pool, command.output).await?
+                }
                 None => select_pool_for_lease(&config, command.output).await?,
             };
-            let accepted = create_lease_request(&config, &pool, command.ttl, command.name).await?;
+            if pool.is_sandbox() {
+                if command.kubeconfig_path.is_some() {
+                    anyhow::bail!("Sandbox leases do not provide a kubeconfig");
+                }
+                return super::sandbox::lease(
+                    &config,
+                    super::sandbox::LeaseCommand {
+                        pool: &pool.name,
+                        ttl: Some(command.ttl),
+                        alias: command.name,
+                        no_wait: command.no_wait,
+                        wait_timeout: command.wait_timeout,
+                        keepalive: command.keepalive,
+                        output: command.output,
+                    },
+                )
+                .await;
+            }
+            let accepted =
+                create_lease_request(&config, &pool.name, command.ttl, command.name).await?;
             if command.no_wait {
                 return emit_pending_output(&accepted, command.output);
             }
@@ -189,35 +254,33 @@ pub async fn lease_create(command: LeaseCreateCommand<'_>) -> Result<()> {
 async fn ensure_existing(
     config: &super::config::ResolvedConfig,
     command: &LeaseCreateCommand<'_>,
-) -> Result<Option<(String, String)>> {
+) -> Result<Option<LeaseSummary>> {
     if !command.ensure {
         return Ok(None);
     }
     let Some(name) = command.name else {
         return Ok(None);
     };
-    Ok(super::leases::find_active_lease_by_alias(config, name)
-        .await?
-        .map(|l| (l.id, l.profile)))
+    super::leases::find_active_lease_by_alias(config, name).await
 }
 
 async fn select_pool_for_lease(
     config: &super::config::ResolvedConfig,
     output: OutputFormat,
-) -> Result<String> {
+) -> Result<PoolSummary> {
     let pools = fetch_pools_for_config(config).await?;
     if pools.is_empty() {
         anyhow::bail!("No pools available");
     }
 
     if output == OutputFormat::Json {
-        return Ok(pools[0].name.clone());
+        return Ok(pools[0].clone());
     }
 
     let items: Vec<PickerItem> = pools
         .iter()
         .map(|pool| PickerItem {
-            primary: pool.name.clone(),
+            primary: format!("{}  {}", pool.name, pool.resource_kind),
             secondary: format!(
                 "ready={} leased={} creating={} queue={}  {}",
                 pool.ready,
@@ -241,7 +304,7 @@ async fn select_pool_for_lease(
         "Use ↑/↓ and Enter. Press q or Esc to cancel.",
         &items,
     )?;
-    Ok(pools[idx].name.clone())
+    Ok(pools[idx].clone())
 }
 
 fn emit_pending_output(accepted: &LeaseAcceptedResponse, output: OutputFormat) -> Result<()> {
@@ -249,6 +312,7 @@ fn emit_pending_output(accepted: &LeaseAcceptedResponse, output: OutputFormat) -
         OutputFormat::Text => {
             println!("Lease:   {}", accepted.id);
             println!("Pool:    {}", accepted.profile);
+            println!("Kind:    Cluster");
             println!("Status:  pending");
             if accepted.queue_position > 0 {
                 println!("Queue:   #{}", accepted.queue_position);
@@ -256,10 +320,13 @@ fn emit_pending_output(accepted: &LeaseAcceptedResponse, output: OutputFormat) -
             if let Some(ttl) = accepted.effective_ttl.as_deref() {
                 println!("TTL:     {ttl}");
             }
+            println!("Actions: {}", CLUSTER_CAPABILITIES.join(", "));
         }
         OutputFormat::Json => print_json(&LeaseCreateOutput {
             id: accepted.id.clone(),
             phase: accepted.phase.clone(),
+            resource_kind: "Cluster",
+            capabilities: CLUSTER_CAPABILITIES,
             profile: accepted.profile.clone(),
             cluster_name: None,
             expires_at: None,
@@ -283,6 +350,7 @@ fn emit_ready_output(
             println!("Cluster: {}", ready.cluster_name.as_deref().unwrap_or("-"));
             println!("Lease:   {}", ready.id);
             println!("Pool:    {}", ready.profile);
+            println!("Kind:    Cluster");
             if let Some(expires_at) = ready.expires_at.as_deref() {
                 println!("Expires: {expires_at}");
             }
@@ -290,12 +358,15 @@ fn emit_ready_output(
                 println!("TTL:     {ttl}");
             }
             println!("Config:  {}", kubeconfig_path.display());
+            println!("Actions: {}", CLUSTER_CAPABILITIES.join(", "));
             println!();
             println!("export KUBECONFIG={}", kubeconfig_path.display());
         }
         OutputFormat::Json => print_json(&LeaseCreateOutput {
             id: ready.id.clone(),
             phase: ready.phase.clone(),
+            resource_kind: "Cluster",
+            capabilities: CLUSTER_CAPABILITIES,
             profile: ready.profile.clone(),
             cluster_name: ready.cluster_name.clone(),
             expires_at: ready.expires_at.clone(),
@@ -515,6 +586,8 @@ mod tests {
         let detail = LeaseDetail {
             id: "lease-1".to_string(),
             phase: "Bound".to_string(),
+            resource_kind: "Cluster".to_string(),
+            capabilities: vec!["kubeconfig".to_string()],
             profile: "ci-small".to_string(),
             cluster_name: Some("pool-ci-small-1".to_string()),
             expires_at: Some("2026-01-01T00:00:00Z".to_string()),

--- a/crates/kobectl/src/commands/leases.rs
+++ b/crates/kobectl/src/commands/leases.rs
@@ -2,13 +2,18 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use super::config::ResolvedConfig;
-use super::{authed_client, get_auth_header, with_auth};
+use super::{OutputFormat, authed_client, get_auth_header, get_auth_header_for_output, with_auth};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LeaseSummary {
     pub id: String,
     pub phase: String,
+    #[serde(default = "default_resource_kind")]
+    pub resource_kind: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(alias = "pool")]
     pub profile: String,
     #[serde(default)]
     pub cluster_name: Option<String>,
@@ -29,6 +34,11 @@ pub(crate) struct LeaseSummary {
 pub(crate) struct LeaseDetail {
     pub id: String,
     pub phase: String,
+    #[serde(default = "default_resource_kind")]
+    pub resource_kind: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
+    #[serde(alias = "pool")]
     pub profile: String,
     #[serde(default)]
     pub cluster_name: Option<String>,
@@ -38,6 +48,16 @@ pub(crate) struct LeaseDetail {
     pub queue_position: u32,
     #[serde(default)]
     pub kubeconfig: Option<String>,
+}
+
+fn default_resource_kind() -> String {
+    "Cluster".to_string()
+}
+
+impl LeaseSummary {
+    pub(crate) fn is_sandbox(&self) -> bool {
+        self.resource_kind.eq_ignore_ascii_case("sandbox") || self.id.starts_with("sandbox-")
+    }
 }
 
 pub(crate) async fn fetch_leases_path(
@@ -59,6 +79,80 @@ pub(crate) async fn fetch_leases_path(
     Ok(response.json().await?)
 }
 
+async fn fetch_sandbox_leases_with_output(
+    config: &ResolvedConfig,
+    output: OutputFormat,
+) -> Result<Vec<LeaseSummary>> {
+    let path = "/v1/sandbox-leases";
+    let endpoint = config.endpoint.as_str();
+    let token = get_auth_header_for_output(config, "GET", path, b"", output).await?;
+    let response = with_auth(
+        super::authed_client().get(format!("{endpoint}{path}")),
+        &token,
+    )
+    .send()
+    .await?;
+    let status = response.status();
+    if matches!(status.as_u16(), 403 | 404 | 501) {
+        return Ok(Vec::new());
+    }
+    if !status.is_success() {
+        anyhow::bail!("Failed to list Sandbox leases (HTTP {status})");
+    }
+    let mut leases: Vec<LeaseSummary> = response.json().await?;
+    for lease in &mut leases {
+        lease.resource_kind = "Sandbox".to_string();
+        lease.capabilities = vec![
+            "exec".to_string(),
+            "cancel".to_string(),
+            "logs".to_string(),
+            "attach".to_string(),
+            "port-forward".to_string(),
+            "extend".to_string(),
+            "release".to_string(),
+        ];
+    }
+    Ok(leases)
+}
+
+/// Return every lease kind through one client-side inventory. The server keeps
+/// kind-specific storage and authorization routes; callers should not need to
+/// know that to select, inspect, extend, or release a lease.
+pub(crate) async fn fetch_all_leases(config: &ResolvedConfig) -> Result<Vec<LeaseSummary>> {
+    fetch_all_leases_with_output(config, OutputFormat::Text).await
+}
+
+pub(crate) async fn fetch_all_leases_with_output(
+    config: &ResolvedConfig,
+    output: OutputFormat,
+) -> Result<Vec<LeaseSummary>> {
+    let mut leases = if output == OutputFormat::Text {
+        fetch_leases_path(config, "/v1/leases").await?
+    } else {
+        let path = "/v1/leases";
+        let endpoint = config.endpoint.as_str();
+        let token = get_auth_header_for_output(config, "GET", path, b"", output).await?;
+        let response = with_auth(authed_client().get(format!("{endpoint}{path}")), &token)
+            .send()
+            .await?;
+        if !response.status().is_success() {
+            anyhow::bail!("Failed to list leases (HTTP {})", response.status());
+        }
+        response.json().await?
+    };
+    for lease in &mut leases {
+        lease.resource_kind = "Cluster".to_string();
+        lease.capabilities = vec![
+            "kubeconfig".to_string(),
+            "extend".to_string(),
+            "release".to_string(),
+        ];
+    }
+    leases.extend(fetch_sandbox_leases_with_output(config, output).await?);
+    leases.sort_by(|left, right| left.id.cmp(&right.id));
+    Ok(leases)
+}
+
 /// A lease is terminal once it no longer refers to a live/pending cluster.
 pub(crate) fn is_terminal_phase(phase: &str) -> bool {
     matches!(
@@ -74,7 +168,7 @@ pub(crate) async fn find_active_lease_by_alias(
     config: &ResolvedConfig,
     alias: &str,
 ) -> Result<Option<LeaseSummary>> {
-    let found = fetch_leases_path(config, "/v1/leases")
+    let found = fetch_all_leases(config)
         .await?
         .into_iter()
         .find(|l| l.alias.as_deref() == Some(alias) && !is_terminal_phase(&l.phase));
@@ -82,7 +176,12 @@ pub(crate) async fn find_active_lease_by_alias(
 }
 
 pub(crate) async fn fetch_lease(config: &ResolvedConfig, lease_id: &str) -> Result<LeaseDetail> {
-    let path = format!("/v1/leases/{lease_id}");
+    let sandbox = lease_id.starts_with("sandbox-");
+    let path = if sandbox {
+        format!("/v1/sandbox-leases/{lease_id}")
+    } else {
+        format!("/v1/leases/{lease_id}")
+    };
     let endpoint = config.endpoint.as_str();
     let token = get_auth_header(config, "GET", &path, b"").await?;
 
@@ -98,7 +197,20 @@ pub(crate) async fn fetch_lease(config: &ResolvedConfig, lease_id: &str) -> Resu
         );
     }
 
-    Ok(response.json().await?)
+    let mut detail: LeaseDetail = response.json().await?;
+    if sandbox {
+        detail.resource_kind = "Sandbox".to_string();
+        detail.capabilities = vec![
+            "exec".to_string(),
+            "cancel".to_string(),
+            "logs".to_string(),
+            "attach".to_string(),
+            "port-forward".to_string(),
+            "extend".to_string(),
+            "release".to_string(),
+        ];
+    }
+    Ok(detail)
 }
 
 pub(crate) fn format_relative_time(iso: &str) -> String {

--- a/crates/kobectl/src/commands/mod.rs
+++ b/crates/kobectl/src/commands/mod.rs
@@ -35,6 +35,81 @@ pub use status::status;
 pub use version::version;
 pub use with_lease::{WithLeaseCommand, with_lease};
 
+/// Resolve a pool before any mutating shortcut and verify that the selected
+/// resource kind exposes the requested operation.
+pub async fn require_pool_capability(
+    pool: &str,
+    capability: &str,
+    target_override: Option<&str>,
+    endpoint_override: Option<&str>,
+    output: OutputFormat,
+) -> anyhow::Result<()> {
+    let config = config::CliConfig::load()?.resolve(target_override, endpoint_override)?;
+    let pool = pools::fetch_pool_for_config_with_output(&config, pool, output).await?;
+    if !pool.supports(capability) {
+        anyhow::bail!(
+            "pool {} allocates {} resources, which do not support {capability}; available capabilities: {}",
+            pool.name,
+            pool.resource_kind,
+            pool.capabilities.join(", ")
+        );
+    }
+    Ok(())
+}
+
+/// Resolve an exact ID, alias, or unique pool selector and reject an
+/// incompatible operation before it reaches a kind-specific route.
+pub async fn require_lease_capability(
+    selector: &str,
+    capability: &str,
+    target_override: Option<&str>,
+    endpoint_override: Option<&str>,
+    output: OutputFormat,
+) -> anyhow::Result<String> {
+    let config = config::CliConfig::load()?.resolve(target_override, endpoint_override)?;
+    let leases = leases::fetch_all_leases_with_output(&config, output).await?;
+    let by_id: Vec<_> = leases.iter().filter(|lease| lease.id == selector).collect();
+    let by_alias: Vec<_> = leases
+        .iter()
+        .filter(|lease| lease.alias.as_deref() == Some(selector))
+        .collect();
+    let by_pool: Vec<_> = leases
+        .iter()
+        .filter(|lease| lease.profile == selector)
+        .collect();
+    let matches = if !by_id.is_empty() {
+        by_id
+    } else if !by_alias.is_empty() {
+        by_alias
+    } else {
+        by_pool
+    };
+    let lease = match matches.as_slice() {
+        [lease] => lease,
+        [] => anyhow::bail!("no lease matches '{selector}'"),
+        many => anyhow::bail!(
+            "'{selector}' matches multiple leases: {}",
+            many.iter()
+                .map(|lease| lease.id.as_str())
+                .collect::<Vec<_>>()
+                .join(", ")
+        ),
+    };
+    if !lease
+        .capabilities
+        .iter()
+        .any(|candidate| candidate == capability)
+    {
+        anyhow::bail!(
+            "lease {} is a {} resource and does not support {capability}; available capabilities: {}",
+            lease.id,
+            lease.resource_kind,
+            lease.capabilities.join(", ")
+        );
+    }
+    Ok(lease.id.clone())
+}
+
 use config::{AuthMode, ResolvedConfig};
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -82,6 +157,19 @@ pub(crate) async fn get_auth_header_noninteractive(
 ) -> anyhow::Result<Option<String>> {
     get_auth_header_with_interaction(config, method, path, body, AuthInteraction::NonInteractive)
         .await
+}
+
+pub(crate) async fn get_auth_header_for_output(
+    config: &ResolvedConfig,
+    method: &str,
+    path: &str,
+    body: &[u8],
+    output: OutputFormat,
+) -> anyhow::Result<Option<String>> {
+    match output {
+        OutputFormat::Text => get_auth_header(config, method, path, body).await,
+        OutputFormat::Json => get_auth_header_noninteractive(config, method, path, body).await,
+    }
 }
 
 async fn get_auth_header_with_interaction(

--- a/crates/kobectl/src/commands/pools.rs
+++ b/crates/kobectl/src/commands/pools.rs
@@ -4,7 +4,7 @@ use std::collections::HashMap;
 
 use super::config::ResolvedConfig;
 use super::leases::LeaseSummary;
-use super::{authed_client, get_auth_header, with_auth};
+use super::{OutputFormat, authed_client, get_auth_header, get_auth_header_for_output, with_auth};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -22,6 +22,12 @@ pub(crate) struct PoolPolicySummary {
 #[serde(rename_all = "camelCase")]
 pub(crate) struct PoolSummary {
     pub name: String,
+    /// Resource allocated by this pool. Older endpoints omitted the field and
+    /// served Cluster pools only, so Cluster is the compatibility default.
+    #[serde(default = "default_resource_kind")]
+    pub resource_kind: String,
+    #[serde(default)]
+    pub capabilities: Vec<String>,
     #[serde(default)]
     pub phase: Option<String>,
     pub ready: u32,
@@ -41,6 +47,39 @@ pub(crate) struct PoolSummary {
     pub policy: Option<PoolPolicySummary>,
 }
 
+fn default_resource_kind() -> String {
+    "Cluster".to_string()
+}
+
+impl PoolSummary {
+    pub(crate) fn is_sandbox(&self) -> bool {
+        self.resource_kind.eq_ignore_ascii_case("sandbox")
+    }
+
+    pub(crate) fn supports(&self, capability: &str) -> bool {
+        if self.capabilities.is_empty() {
+            return if self.is_sandbox() {
+                matches!(
+                    capability,
+                    "lease"
+                        | "exec"
+                        | "cancel"
+                        | "logs"
+                        | "attach"
+                        | "port-forward"
+                        | "extend"
+                        | "release"
+                )
+            } else {
+                matches!(capability, "lease" | "kubeconfig" | "extend" | "release")
+            };
+        }
+        self.capabilities
+            .iter()
+            .any(|candidate| candidate == capability)
+    }
+}
+
 pub(crate) async fn fetch_pools_for_config(config: &ResolvedConfig) -> Result<Vec<PoolSummary>> {
     let endpoint = config.endpoint.as_str();
     let token = get_auth_header(config, "GET", "/v1/pools", b"").await?;
@@ -54,6 +93,32 @@ pub(crate) async fn fetch_pools_for_config(config: &ResolvedConfig) -> Result<Ve
         anyhow::bail!("Failed to list pools (HTTP {})", response.status());
     }
 
+    Ok(response.json().await?)
+}
+
+pub(crate) async fn fetch_pool_for_config_with_output(
+    config: &ResolvedConfig,
+    name: &str,
+    output: OutputFormat,
+) -> Result<PoolSummary> {
+    let endpoint = config.endpoint.as_str();
+    let path = format!("/v1/pools/{name}");
+    let token = get_auth_header_for_output(config, "GET", &path, b"", output).await?;
+    let response = with_auth(
+        super::authed_client().get(format!("{endpoint}{path}")),
+        &token,
+    )
+    .send()
+    .await?;
+    let status = response.status();
+    if !status.is_success() {
+        let body = response.text().await.unwrap_or_default();
+        let message = serde_json::from_str::<serde_json::Value>(&body)
+            .ok()
+            .and_then(|value| value["error"].as_str().map(str::to_string))
+            .unwrap_or(body);
+        anyhow::bail!("Failed to resolve pool {name} (HTTP {status}): {message}");
+    }
     Ok(response.json().await?)
 }
 
@@ -103,7 +168,7 @@ pub(crate) fn print_pool_table(pools: &[PoolSummary], leases: &[LeaseSummary], i
         }
 
         let phase = pool.phase.as_deref().unwrap_or("Unknown");
-        println!("{indent}{}  {phase}", pool.name);
+        println!("{indent}{}  {}  {phase}", pool.name, pool.resource_kind);
         println!(
             "{indent}  ready {}  leased {}  creating {}  recycling {}  quarantined {}  queue {}",
             pool.ready,
@@ -115,6 +180,9 @@ pub(crate) fn print_pool_table(pools: &[PoolSummary], leases: &[LeaseSummary], i
         );
         if let Some(policy) = format_policy(pool) {
             println!("{indent}  {policy}");
+        }
+        if !pool.capabilities.is_empty() {
+            println!("{indent}  actions {}", pool.capabilities.join(", "));
         }
         if let Some(count) = recycling_leases.get(&pool.name)
             && *count > 0
@@ -142,11 +210,28 @@ mod tests {
         .expect("legacy pool payload should deserialize");
 
         assert_eq!(pool.leased, 1);
+        assert_eq!(pool.resource_kind, "Cluster");
+        assert!(pool.supports("kubeconfig"));
         assert_eq!(pool.creating, 0);
         assert_eq!(pool.recycling, 0);
         assert_eq!(pool.unhealthy, 0);
         assert_eq!(pool.queue_depth, 0);
         assert!(pool.policy.is_none());
+    }
+
+    #[test]
+    fn typed_pool_exposes_only_advertised_capabilities() {
+        let pool: PoolSummary = serde_json::from_value(serde_json::json!({
+            "name": "agents",
+            "resourceKind": "Sandbox",
+            "capabilities": ["lease", "exec", "logs"],
+            "ready": 1,
+            "leased": 0
+        }))
+        .unwrap();
+        assert!(pool.is_sandbox());
+        assert!(pool.supports("exec"));
+        assert!(!pool.supports("kubeconfig"));
     }
 
     #[test]

--- a/crates/kobectl/src/commands/purge.rs
+++ b/crates/kobectl/src/commands/purge.rs
@@ -4,7 +4,7 @@ use std::collections::BTreeSet;
 use std::path::PathBuf;
 
 use super::config::CliConfig;
-use super::leases::{LeaseSummary, fetch_leases_path};
+use super::leases::{LeaseSummary, fetch_all_leases};
 use super::state::{
     endpoint_kubeconfigs, find_orphan_kubeconfigs, forget_endpoint_kubeconfigs, forget_kubeconfig,
     local_kubeconfig_candidates, remove_kubeconfig,
@@ -28,7 +28,7 @@ pub async fn purge(
     let config = CliConfig::load()?;
     let config = config.resolve(target_override, endpoint_override)?;
 
-    let leases = fetch_leases_path(&config, "/v1/leases").await?;
+    let leases = fetch_all_leases(&config).await?;
     let active_leases: Vec<LeaseSummary> = leases
         .iter()
         .filter(|l| is_active_lease(l))
@@ -65,14 +65,16 @@ pub async fn purge(
     let client = authed_client();
     let mut released = Vec::new();
     for lease in &active_leases {
-        let path = format!("/v1/leases/{}", lease.id);
+        let path = release_path(lease);
         let token = get_auth_header(&config, "DELETE", &path, b"").await?;
         let response = with_auth(client.delete(format!("{endpoint}{path}")), &token)
             .send()
             .await?;
         match response.status().as_u16() {
             200..=299 | 404 => {
-                let _ = remove_kubeconfig(endpoint, &lease.id);
+                if !lease.is_sandbox() {
+                    let _ = remove_kubeconfig(endpoint, &lease.id);
+                }
                 released.push(lease.id.clone());
             }
             status => anyhow::bail!("Failed to purge lease {} (HTTP {status})", lease.id),
@@ -124,6 +126,14 @@ pub async fn purge(
     }
 
     Ok(())
+}
+
+fn release_path(lease: &LeaseSummary) -> String {
+    if lease.is_sandbox() {
+        format!("/v1/sandbox-leases/{}", lease.id)
+    } else {
+        format!("/v1/leases/{}", lease.id)
+    }
 }
 
 /// Remove only kubeconfigs whose lease no longer exists server-side. Active
@@ -376,6 +386,8 @@ mod tests {
         let base = LeaseSummary {
             id: "lease-1".to_string(),
             phase: "Bound".to_string(),
+            resource_kind: "Cluster".to_string(),
+            capabilities: vec!["kubeconfig".to_string()],
             profile: "ci".to_string(),
             cluster_name: None,
             expires_at: None,
@@ -401,6 +413,31 @@ mod tests {
     }
 
     #[test]
+    fn purge_dispatches_release_by_resource_kind() {
+        let cluster = LeaseSummary {
+            id: "lease-cluster".to_string(),
+            phase: "Bound".to_string(),
+            resource_kind: "Cluster".to_string(),
+            capabilities: vec!["release".to_string()],
+            profile: "ci".to_string(),
+            cluster_name: None,
+            expires_at: None,
+            queue_position: 0,
+            requester: None,
+            kubeconfig_path: None,
+            alias: None,
+        };
+        let sandbox = LeaseSummary {
+            id: "sandbox-agent".to_string(),
+            resource_kind: "Sandbox".to_string(),
+            profile: "agents".to_string(),
+            ..cluster.clone()
+        };
+        assert_eq!(release_path(&cluster), "/v1/leases/lease-cluster");
+        assert_eq!(release_path(&sandbox), "/v1/sandbox-leases/sandbox-agent");
+    }
+
+    #[test]
     fn live_lease_ids_treats_recycling_as_live() {
         // Recycling leases must be considered live for orphan detection,
         // otherwise we delete a kubeconfig whose cluster is still mid-teardown
@@ -408,6 +445,8 @@ mod tests {
         let base = LeaseSummary {
             id: String::new(),
             phase: String::new(),
+            resource_kind: "Cluster".to_string(),
+            capabilities: vec!["kubeconfig".to_string()],
             profile: "ci".to_string(),
             cluster_name: None,
             expires_at: None,

--- a/crates/kobectl/src/commands/release.rs
+++ b/crates/kobectl/src/commands/release.rs
@@ -2,27 +2,48 @@ use anyhow::Result;
 use serde::Serialize;
 
 use super::config::{CliConfig, ResolvedConfig};
+use super::extend::is_sandbox_lease;
 use super::select::{OnAmbiguous, resolve_lease_id};
 use super::state::remove_kubeconfig;
 use super::{OutputFormat, authed_client, get_auth_header, print_json, with_auth};
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum ReleaseOutcome {
+    Released,
+    NotFound,
+}
+
 /// Release a lease by id over `DELETE /v1/leases/{id}`, treating 404 as success
 /// (already gone). Also drops the local kubeconfig record. Used by `with-lease`
 /// (#107 P3) for guaranteed cleanup on exit.
-pub(crate) async fn release_lease(config: &ResolvedConfig, lease_id: &str) -> Result<()> {
+pub(crate) async fn release_lease(
+    config: &ResolvedConfig,
+    lease_id: &str,
+) -> Result<ReleaseOutcome> {
     let endpoint = config.endpoint.as_str();
-    let path = format!("/v1/leases/{lease_id}");
+    let sandbox = is_sandbox_lease(lease_id);
+    let path = if sandbox {
+        format!("/v1/sandbox-leases/{lease_id}")
+    } else {
+        format!("/v1/leases/{lease_id}")
+    };
     let token = get_auth_header(config, "DELETE", &path, b"").await?;
     let client = authed_client();
     let response = with_auth(client.delete(format!("{endpoint}{path}")), &token)
         .send()
         .await?;
-    let _ = remove_kubeconfig(&config.endpoint, lease_id);
     let status = response.status();
-    if !status.is_success() && status.as_u16() != 404 {
+    let outcome = if status.is_success() {
+        ReleaseOutcome::Released
+    } else if status.as_u16() == 404 {
+        ReleaseOutcome::NotFound
+    } else {
         anyhow::bail!("Failed to release lease {lease_id} (HTTP {status})");
+    };
+    if !sandbox {
+        let _ = remove_kubeconfig(&config.endpoint, lease_id);
     }
-    Ok(())
+    Ok(outcome)
 }
 
 #[derive(Serialize)]
@@ -48,53 +69,22 @@ pub async fn release(
         Some(id) => id.to_string(),
         None => resolve_lease_id(&config, None, output, OnAmbiguous::FirstActive).await?,
     };
-    let endpoint = config.endpoint.as_str();
-    let path = format!("/v1/leases/{selected_lease}");
-    let token = get_auth_header(&config, "DELETE", &path, b"").await?;
-
-    let client = authed_client();
-    let response = with_auth(
-        client.delete(format!("{endpoint}/v1/leases/{selected_lease}")),
-        &token,
-    )
-    .send()
-    .await?;
-
-    if response.status().is_success() {
-        if let Err(err) = remove_kubeconfig(&config.endpoint, &selected_lease) {
-            eprintln!(
-                "Warning: failed to remove local kubeconfig for {}: {err}",
-                selected_lease
-            );
+    let outcome = release_lease(&config, &selected_lease).await?;
+    match (outcome, output) {
+        (ReleaseOutcome::Released, OutputFormat::Text) => {
+            println!("Released lease {}", selected_lease)
         }
-        match output {
-            OutputFormat::Text => println!("Released lease {}", selected_lease),
-            OutputFormat::Json => print_json(&ReleaseOutput {
-                lease_id: &selected_lease,
-                status: "released",
-            })?,
-        }
-    } else if response.status().as_u16() == 404 {
-        if let Err(err) = remove_kubeconfig(&config.endpoint, &selected_lease) {
-            eprintln!(
-                "Warning: failed to remove local kubeconfig for {}: {err}",
-                selected_lease
-            );
-        }
-        match output {
-            OutputFormat::Text => {
-                println!(
-                    "Lease {} not found (already released or expired)",
-                    selected_lease
-                )
-            }
-            OutputFormat::Json => print_json(&ReleaseOutput {
-                lease_id: &selected_lease,
-                status: "not_found",
-            })?,
-        }
-    } else {
-        anyhow::bail!("Failed to release lease (HTTP {})", response.status());
+        (ReleaseOutcome::NotFound, OutputFormat::Text) => println!(
+            "Lease {} not found (already released or expired)",
+            selected_lease
+        ),
+        (outcome, OutputFormat::Json) => print_json(&ReleaseOutput {
+            lease_id: &selected_lease,
+            status: match outcome {
+                ReleaseOutcome::Released => "released",
+                ReleaseOutcome::NotFound => "not_found",
+            },
+        })?,
     }
 
     Ok(())

--- a/crates/kobectl/src/commands/sandbox.rs
+++ b/crates/kobectl/src/commands/sandbox.rs
@@ -1,8 +1,8 @@
-//! `kobe sandbox` — exec, logs, cancel, and run (#84).
+//! Capability adapters for `kobe exec`, `logs`, `cancel`, and `run` (#84).
 //!
 //! # Two audiences, one contract
 //!
-//! A human runs `kobe sandbox exec` and reads the output. An agent runs the
+//! A human runs `kobe exec` and reads the output. An agent runs the
 //! same command with `--output json` and parses it. The agent is the harder
 //! consumer and the one that decides the design: it needs the **exact remote
 //! exit code**, stdout and stderr kept apart, and a transport failure that
@@ -89,8 +89,8 @@ pub struct ExecOutput {
 
 pub const SANDBOX_CLI_API_VERSION: &str = "kobe.sandbox/v1";
 
-/// Emit a machine-readable sandbox CLI failure when command dispatch itself
-/// fails. Human diagnostics never share stderr with `--output json`.
+/// Emit a machine-readable executable-resource failure when command dispatch
+/// itself fails. Human diagnostics never share stderr with `--output json`.
 pub fn emit_cli_error(error: &anyhow::Error) -> Result<()> {
     emit_client_error(&format!("{error:#}"), CLI_FAILURE_EXIT)
 }
@@ -98,8 +98,8 @@ pub fn emit_cli_error(error: &anyhow::Error) -> Result<()> {
 /// Emit a stable machine envelope for a command-line syntax error.
 ///
 /// Clap normally exits before `main` and writes human diagnostics to stderr.
-/// The entry point diverts only `sandbox ... --output json` parse failures here
-/// so machine mode keeps the same versioned shape even before dispatch.
+/// The entry point diverts executable-resource `--output json` parse failures
+/// here so machine mode keeps the same versioned shape before dispatch.
 pub fn emit_cli_parse_error(error: &str, process_exit_code: i32) -> Result<()> {
     emit_client_error(error, process_exit_code)
 }
@@ -192,7 +192,7 @@ pub async fn exec(
     let config = config.resolve(target_override, endpoint_override)?;
 
     if argv.is_empty() {
-        anyhow::bail!("a command is required: kobe sandbox exec <lease> -- <argv...>");
+        anyhow::bail!("a command is required: kobe exec <lease> -- <argv...>");
     }
 
     let result = exec_once(
@@ -312,7 +312,7 @@ where
 /// Print the result in the requested form.
 ///
 /// Text mode writes the command's own stdout and stderr to *this* process's
-/// stdout and stderr, so `kobe sandbox exec ... | grep` behaves the way anyone
+/// stdout and stderr, so `kobe exec ... | grep` behaves the way anyone
 /// would expect. JSON mode keeps them as separate fields for the same reason:
 /// a consumer that cannot tell a tool's diagnostics from its output cannot
 /// parse either.
@@ -384,15 +384,51 @@ struct CreateLeaseBody<'a> {
     pool: &'a str,
     #[serde(skip_serializing_if = "Option::is_none")]
     ttl: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    alias: Option<&'a str>,
     idempotency_key: &'a str,
 }
 
-#[derive(Debug, Deserialize)]
+#[derive(Debug, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 struct SandboxLeaseResponse {
     id: String,
     phase: String,
+    #[serde(default)]
+    pool: String,
+    #[serde(default)]
+    ttl: String,
+    #[serde(default)]
+    effective_ttl: Option<String>,
+    #[serde(default)]
+    alias: Option<String>,
+    #[serde(default)]
+    expires_at: Option<String>,
 }
+
+#[derive(Debug, Serialize)]
+#[serde(rename_all = "camelCase")]
+struct LeaseOutput<'a> {
+    api_version: &'static str,
+    id: &'a str,
+    phase: &'a str,
+    pool: &'a str,
+    resource_kind: &'static str,
+    capabilities: &'static [&'static str],
+    ttl: Option<&'a str>,
+    alias: Option<&'a str>,
+    expires_at: Option<&'a str>,
+}
+
+const SANDBOX_CAPABILITIES: &[&str] = &[
+    "exec",
+    "cancel",
+    "logs",
+    "attach",
+    "port-forward",
+    "extend",
+    "release",
+];
 
 /// One stable schema for every `sandbox run --output json` outcome.
 ///
@@ -614,6 +650,135 @@ pub struct RunCommand<'a> {
     pub output: OutputFormat,
 }
 
+/// Persistent Sandbox allocation behind the resource-neutral `kobe lease`
+/// command. Storage and admission remain Sandbox-specific; the public
+/// lifecycle does not.
+pub(crate) struct LeaseCommand<'a> {
+    pub pool: &'a str,
+    pub ttl: Option<&'a str>,
+    pub alias: Option<&'a str>,
+    pub no_wait: bool,
+    pub wait_timeout: Option<&'a str>,
+    pub keepalive: bool,
+    pub output: OutputFormat,
+}
+
+pub(crate) async fn lease(config: &ResolvedConfig, command: LeaseCommand<'_>) -> Result<()> {
+    let key = new_idempotency_key();
+    let expected_lease = lease_id_for_create_key(&key);
+    let post_started = std::cell::Cell::new(false);
+    let lease_id = match create_sandbox_lease(
+        config,
+        CreateLeaseBody {
+            pool: command.pool,
+            ttl: command.ttl,
+            alias: command.alias,
+            idempotency_key: &key,
+        },
+        &expected_lease,
+        command.output,
+        &post_started,
+    )
+    .await
+    {
+        Ok(lease) => lease,
+        Err(failure) if failure.may_have_committed => {
+            anyhow::bail!(
+                "Sandbox lease {expected_lease} may have been created: {:#}",
+                failure.error
+            )
+        }
+        Err(failure) => return Err(failure.error),
+    };
+
+    if command.no_wait {
+        return emit_lease_output(
+            &lease_id,
+            "Pending",
+            command.pool,
+            command.ttl,
+            command.alias,
+            None,
+            command.output,
+        );
+    }
+
+    if command.output == OutputFormat::Text {
+        eprintln!("Waiting for lease {lease_id} to become ready...");
+    }
+    let ready_timeout = match command.wait_timeout {
+        Some(value) => super::lease_create::parse_cli_duration(value)
+            .ok_or_else(|| anyhow::anyhow!("Invalid --wait-timeout '{value}'"))?,
+        None => READY_TIMEOUT,
+    };
+    let ready = wait_until_ready(config, &lease_id, command.output, ready_timeout)
+        .await
+        .map_err(|error| anyhow::anyhow!(error.message()))?;
+    emit_lease_output(
+        &ready.id,
+        &ready.phase,
+        command.pool,
+        ready.effective_ttl.as_deref().or(command.ttl),
+        ready.alias.as_deref().or(command.alias),
+        ready.expires_at.as_deref(),
+        command.output,
+    )?;
+
+    if command.keepalive {
+        let ttl = command.ttl.unwrap_or(ready.ttl.as_str());
+        if ttl.is_empty() {
+            anyhow::bail!("Sandbox lease did not report a TTL for --keepalive");
+        }
+        let stop = async {
+            let _ = tokio::signal::ctrl_c().await;
+        };
+        super::keepalive::heartbeat_until(
+            config,
+            &lease_id,
+            ttl,
+            stop,
+            command.output == OutputFormat::Text,
+        )
+        .await?;
+    }
+    Ok(())
+}
+
+pub(crate) fn emit_lease_output(
+    id: &str,
+    phase: &str,
+    pool: &str,
+    ttl: Option<&str>,
+    alias: Option<&str>,
+    expires_at: Option<&str>,
+    output: OutputFormat,
+) -> Result<()> {
+    match output {
+        OutputFormat::Text => {
+            println!("Lease:   {id}");
+            println!("Pool:    {pool}");
+            println!("Kind:    Sandbox");
+            println!("Status:  {}", phase.to_ascii_lowercase());
+            if let Some(expires_at) = expires_at {
+                println!("Expires: {expires_at}");
+            }
+            println!("Actions: {}", SANDBOX_CAPABILITIES.join(", "));
+            Ok(())
+        }
+        OutputFormat::Json => print_json(&LeaseOutput {
+            api_version: SANDBOX_CLI_API_VERSION,
+            id,
+            phase,
+            pool,
+            resource_kind: "Sandbox",
+            capabilities: SANDBOX_CAPABILITIES,
+            ttl,
+            alias,
+            expires_at,
+        }),
+    }
+}
+
 /// Create, execute and release as one bounded, signal-aware state machine.
 ///
 /// The first SIGINT/SIGTERM changes the command outcome but never skips cleanup.
@@ -635,8 +800,7 @@ pub async fn run(command: RunCommand<'_>) -> Result<i32> {
     } = command;
     let mut envelope = RunEnvelope::empty();
     if argv.is_empty() {
-        envelope.error =
-            Some("a command is required: kobe sandbox run <pool> -- <argv...>".to_string());
+        envelope.error = Some("a command is required: kobe run <pool> -- <argv...>".to_string());
         return emit_run_envelope(&envelope, output);
     }
     let config = match CliConfig::load()
@@ -662,9 +826,12 @@ pub async fn run(command: RunCommand<'_>) -> Result<i32> {
     let post_started = std::cell::Cell::new(false);
     let create = create_sandbox_lease(
         &config,
-        pool,
-        ttl,
-        &create_key,
+        CreateLeaseBody {
+            pool,
+            ttl,
+            alias: None,
+            idempotency_key: &create_key,
+        },
         &expected_lease,
         output,
         &post_started,
@@ -825,7 +992,7 @@ async fn run_in_lease(
     timeout: Option<&str>,
     output: OutputFormat,
 ) -> std::result::Result<ExecutionResponse, RunExecutionError> {
-    wait_until_ready(config, lease, output).await?;
+    let _ = wait_until_ready(config, lease, output, READY_TIMEOUT).await?;
     exec_once_for_run(
         config,
         lease,
@@ -895,20 +1062,14 @@ enum CreateHeaderFailure {
 
 async fn create_sandbox_lease(
     config: &ResolvedConfig,
-    pool: &str,
-    ttl: Option<&str>,
-    idempotency_key: &str,
+    request: CreateLeaseBody<'_>,
     expected_lease: &str,
     output: OutputFormat,
     post_started: &std::cell::Cell<bool>,
 ) -> std::result::Result<String, CreateFailure> {
     let path = "/v1/sandbox-leases";
-    let body = serde_json::to_vec(&CreateLeaseBody {
-        pool,
-        ttl,
-        idempotency_key,
-    })
-    .map_err(|error| CreateFailure::definite(anyhow::Error::from(error)))?;
+    let body = serde_json::to_vec(&request)
+        .map_err(|error| CreateFailure::definite(anyhow::Error::from(error)))?;
     let deadline = tokio::time::Instant::now() + CREATE_TIMEOUT;
 
     let mut attempt = 0;
@@ -1148,8 +1309,9 @@ async fn wait_until_ready(
     config: &ResolvedConfig,
     lease: &str,
     output: OutputFormat,
-) -> std::result::Result<(), RunExecutionError> {
-    let deadline = tokio::time::Instant::now() + READY_TIMEOUT;
+    ready_timeout: std::time::Duration,
+) -> std::result::Result<SandboxLeaseResponse, RunExecutionError> {
+    let deadline = tokio::time::Instant::now() + ready_timeout;
     loop {
         let path = format!("/v1/sandbox-leases/{lease}");
         let token = tokio::time::timeout_at(
@@ -1193,7 +1355,7 @@ async fn wait_until_ready(
             .context("could not parse the sandbox lease response")
             .map_err(RunExecutionError::Failure)?;
         match current.phase.as_str() {
-            "Ready" => return Ok(()),
+            "Ready" => return Ok(current),
             "Released" | "Expired" | "Quarantined" => {
                 return Err(RunExecutionError::Failure(anyhow::anyhow!(
                     "sandbox {lease} ended in {} before it was ready",
@@ -1982,7 +2144,12 @@ mod tests {
             ssh_fingerprint: None,
         };
         let started = tokio::time::Instant::now();
-        let result = wait_until_ready(&config, "sandbox-stalled", OutputFormat::Json);
+        let result = wait_until_ready(
+            &config,
+            "sandbox-stalled",
+            OutputFormat::Json,
+            READY_TIMEOUT,
+        );
         tokio::pin!(result);
         while !request_seen.load(std::sync::atomic::Ordering::SeqCst) {
             tokio::select! {

--- a/crates/kobectl/src/commands/sandbox_transport.rs
+++ b/crates/kobectl/src/commands/sandbox_transport.rs
@@ -1,4 +1,4 @@
-//! `kobe sandbox attach` and `port-forward` — the client half (#84).
+//! `kobe attach` and `port-forward` — the executable-resource client half (#84).
 //!
 //! # Framing
 //!

--- a/crates/kobectl/src/commands/select.rs
+++ b/crates/kobectl/src/commands/select.rs
@@ -10,7 +10,7 @@ use anyhow::Result;
 use super::OutputFormat;
 use super::config::ResolvedConfig;
 use super::leases::{
-    LeaseSummary, fetch_leases_path, lease_cluster_label, lease_phase_label, lease_when_label,
+    LeaseSummary, fetch_all_leases, lease_cluster_label, lease_phase_label, lease_when_label,
 };
 use super::picker::{PickerItem, run_picker};
 
@@ -111,7 +111,7 @@ pub(crate) async fn resolve_lease_id(
     output: OutputFormat,
     on_ambiguous: OnAmbiguous,
 ) -> Result<String> {
-    let active: Vec<LeaseSummary> = fetch_leases_path(config, "/v1/leases")
+    let active: Vec<LeaseSummary> = fetch_all_leases(config)
         .await?
         .into_iter()
         .filter(is_active)
@@ -130,7 +130,8 @@ pub(crate) async fn resolve_lease_id(
                         lease_when_label(lease)
                     ),
                     secondary: format!(
-                        "phase: {}   cluster: {}",
+                        "kind: {}   phase: {}   resource: {}",
+                        lease.resource_kind,
                         lease_phase_label(lease),
                         lease_cluster_label(lease)
                     ),
@@ -165,6 +166,8 @@ mod tests {
         LeaseSummary {
             id: id.to_string(),
             phase: phase.to_string(),
+            resource_kind: "Cluster".to_string(),
+            capabilities: vec!["kubeconfig".to_string()],
             profile: profile.to_string(),
             cluster_name: None,
             expires_at: None,

--- a/crates/kobectl/src/commands/status.rs
+++ b/crates/kobectl/src/commands/status.rs
@@ -3,7 +3,7 @@ use serde::Serialize;
 
 use super::config::{AuthMode, CliConfig};
 use super::leases::{
-    LeaseSummary, fetch_lease, fetch_leases_path, lease_cluster_label, lease_phase_label,
+    LeaseSummary, fetch_all_leases, fetch_lease, lease_cluster_label, lease_phase_label,
     lease_when_label,
 };
 use super::pools::{PoolSummary, fetch_pools_for_config, print_pool_table};
@@ -111,9 +111,7 @@ pub async fn status(
             Ok(pools) => (pools, None),
             Err(err) => (Vec::new(), Some(err.to_string())),
         };
-        let leases = fetch_leases_path(&config, "/v1/leases")
-            .await
-            .unwrap_or_default();
+        let leases = fetch_all_leases(&config).await.unwrap_or_default();
         (pools, pools_error, leases)
     };
     let leases = enrich_leases(&config, leases).await;
@@ -186,13 +184,16 @@ pub async fn status(
     } else {
         for lease in &leases {
             println!(
-                "  {:<24}  {:<12}  {:<8}  {}",
+                "  {:<32}  {:<12}  {:<9}  {:<12}  {}",
                 lease.id,
                 lease.profile,
+                lease.resource_kind,
                 lease_phase_label(lease),
                 lease_when_label(lease)
             );
-            println!("    cluster: {}", lease_cluster_label(lease));
+            if !lease.is_sandbox() {
+                println!("    cluster: {}", lease_cluster_label(lease));
+            }
             if let Some(kubeconfig_path) = lease.kubeconfig_path.as_deref() {
                 println!("    config:  {kubeconfig_path}");
             }
@@ -238,6 +239,8 @@ async fn enrich_leases(
             Ok(detail) => enriched.push(LeaseSummary {
                 id: detail.id,
                 phase: detail.phase,
+                resource_kind: detail.resource_kind,
+                capabilities: detail.capabilities,
                 profile: detail.profile,
                 cluster_name: detail.cluster_name.or(lease.cluster_name),
                 expires_at: detail.expires_at.or(lease.expires_at),

--- a/crates/kobectl/src/commands/with_lease.rs
+++ b/crates/kobectl/src/commands/with_lease.rs
@@ -11,6 +11,7 @@ use super::OutputFormat;
 use super::config::{CliConfig, ResolvedConfig};
 use super::keepalive::heartbeat_until;
 use super::lease_create::{create_lease_request, wait_for_usable_lease};
+use super::pools::fetch_pool_for_config_with_output;
 use super::release::release_lease;
 
 pub struct WithLeaseCommand<'a> {
@@ -38,17 +39,25 @@ pub async fn with_lease(command: WithLeaseCommand<'_>) -> Result<()> {
 
     // with-lease is non-interactive (it wraps a command), so the pool must be
     // explicit rather than prompted.
-    let pool = command
+    let pool_name = command
         .pool
         .context("with-lease requires a pool: kobe with-lease <pool> --ttl 1h -- <cmd>")?;
+    let pool = fetch_pool_for_config_with_output(&config, pool_name, command.output).await?;
+    if !pool.supports("kubeconfig") {
+        anyhow::bail!(
+            "pool {} allocates {} resources, which do not support with-lease; use `kobe run` for executable resources",
+            pool.name,
+            pool.resource_kind
+        );
+    }
     if command.cmd.is_empty() {
         anyhow::bail!("with-lease requires a command after `--`");
     }
 
     if verbose {
-        eprintln!("Leasing '{pool}' for the wrapped command...");
+        eprintln!("Leasing '{}' for the wrapped command...", pool.name);
     }
-    let accepted = create_lease_request(&config, pool, command.ttl, None).await?;
+    let accepted = create_lease_request(&config, &pool.name, command.ttl, None).await?;
     let lease_id = accepted.id.clone();
 
     // Everything past creation must release the lease, even on error or signal.

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -6,7 +6,7 @@ use commands::OutputFormat;
 #[derive(Parser)]
 #[command(
     name = "kobe",
-    about = "Kubernetes cluster pool manager",
+    about = "Pooled resource lease manager",
     version = commands::cli_version()
 )]
 struct Cli {
@@ -45,7 +45,63 @@ enum Commands {
         #[arg(long)]
         device: bool,
     },
-    /// Sandbox operations: run commands in a leased agent environment.
+    /// Lease an executable resource, run one command, and release it.
+    Run {
+        pool: String,
+        #[arg(long)]
+        ttl: Option<String>,
+        #[arg(long)]
+        cwd: Option<String>,
+        #[arg(long)]
+        timeout: Option<String>,
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
+    /// Run a command in a lease that supports `exec`.
+    Exec {
+        lease: String,
+        #[arg(long)]
+        cwd: Option<String>,
+        #[arg(long)]
+        timeout: Option<String>,
+        #[arg(last = true, required = true)]
+        command: Vec<String>,
+    },
+    /// Read logs from a lease that supports `logs`.
+    Logs {
+        lease: String,
+        #[arg(long, conflicts_with = "tail")]
+        execution: Option<String>,
+        #[arg(long, requires = "execution")]
+        follow: bool,
+        #[arg(long, conflicts_with = "execution")]
+        tail: Option<i64>,
+    },
+    /// Cancel an execution owned by a compatible lease.
+    Cancel {
+        lease: String,
+        #[arg(long)]
+        execution: String,
+    },
+    /// Attach to a lease that supports `attach`.
+    Attach {
+        lease: String,
+        #[arg(long)]
+        container: Option<String>,
+        #[arg(long)]
+        no_tty: bool,
+        #[arg(last = true)]
+        command: Vec<String>,
+    },
+    /// Forward a declared port from a compatible lease.
+    PortForward {
+        lease: String,
+        spec: String,
+        #[arg(long, default_value = "127.0.0.1")]
+        bind: String,
+    },
+    /// Deprecated compatibility namespace for the original Sandbox CLI.
+    #[command(hide = true)]
     Sandbox {
         #[command(subcommand)]
         action: SandboxAction,
@@ -54,9 +110,9 @@ enum Commands {
     /// tokens at the IdP (RFC 7009) so a leaked token can't outlive
     /// `kobe logout`.
     Logout,
-    /// Lease a cluster from a pool and wait until it is ready
+    /// Lease a resource from a pool and wait until it is ready
     Lease {
-        /// Pool name (e.g. ci-small)
+        /// Pool name (e.g. ci-small or agents)
         pool: Option<String>,
         /// Lease TTL
         #[arg(long, default_value = "1h")]
@@ -67,7 +123,7 @@ enum Commands {
         /// Maximum time to wait for the lease to become usable (e.g. 30s, 5m, 1h)
         #[arg(long, value_name = "DURATION", conflicts_with = "no_wait")]
         wait_timeout: Option<String>,
-        /// Write kubeconfig to this path (default: ~/.kube/kobe-{pool}-{short-lease}.yaml)
+        /// Cluster resources only: write kubeconfig to this path
         #[arg(long = "kubeconfig", value_name = "PATH")]
         kubeconfig: Option<String>,
         /// Name this lease (#107 P2). Unique among your active leases, so you can
@@ -84,7 +140,7 @@ enum Commands {
         #[arg(long, conflicts_with = "no_wait")]
         keepalive: bool,
     },
-    /// Run a command while holding a lease, auto-releasing on exit (#107 P3).
+    /// Run a command with a kubeconfig-capable lease, then release it (#107 P3).
     ///
     /// Creates a lease, heartbeat-extends it for the command's lifetime, then
     /// releases it (even on failure/signal). `kobe with-lease --ttl 1h -- kubectl get pods`.
@@ -110,12 +166,12 @@ enum Commands {
         #[arg(long, default_value = "30m")]
         ttl: String,
     },
-    /// Release a cluster lease
+    /// Release a lease
     Release {
         /// Lease ID
         lease_id: Option<String>,
     },
-    /// Release all active leases and remove local Kobe lease kubeconfigs
+    /// Release all active leases and remove local cluster kubeconfigs
     Purge {
         /// Skip the confirmation prompt
         #[arg(long, short = 'y')]
@@ -135,11 +191,7 @@ enum Commands {
     },
 }
 
-/// Sandbox operations.
-///
-/// Separate from cluster leases on purpose: a Sandbox is one agent
-/// environment, not a cluster, and nothing here can produce a kubeconfig or a
-/// credential for the cluster underneath it.
+/// Kind-specific adapters retained behind the hidden compatibility namespace.
 #[derive(Subcommand)]
 enum SandboxAction {
     /// Run a command in an existing sandbox and return its exact exit code.
@@ -203,8 +255,7 @@ enum SandboxAction {
         lease: String,
         #[arg(long)]
         container: Option<String>,
-        /// Run without a terminal. Useful when piping input, where raw mode
-        /// would be meaningless.
+        /// Run without allocating a terminal.
         #[arg(long)]
         no_tty: bool,
         /// Command to run instead of attaching. Everything after `--`.
@@ -307,7 +358,7 @@ async fn main() -> anyhow::Result<()> {
         {
             error.exit()
         }
-        Err(error) if requests_sandbox_json(&args) => {
+        Err(error) if requests_resource_json(&args) => {
             let code = error.exit_code();
             commands::sandbox::emit_cli_parse_error(&error.to_string(), code)?;
             std::process::exit(code)
@@ -362,112 +413,134 @@ async fn main() -> anyhow::Result<()> {
         Commands::Extend { target: lease, ttl } => {
             commands::extend(lease.as_deref(), &ttl, target, endpoint, output).await
         }
-        // These return the REMOTE command's exit code, so the process exits
-        // with it rather than with a generic success. `set -e` in a caller's
-        // script depends on exactly this.
-        Commands::Sandbox { action } => {
-            let code = match action {
-                SandboxAction::Exec {
-                    lease,
-                    cwd,
-                    timeout,
-                    command,
-                } => {
-                    commands::sandbox::exec(
-                        &lease,
-                        &command,
-                        cwd.as_deref(),
-                        timeout.as_deref(),
-                        target,
-                        endpoint,
-                        output,
-                    )
-                    .await
-                }
+        Commands::Run {
+            pool,
+            ttl,
+            cwd,
+            timeout,
+            command,
+        } => {
+            if let Err(error) =
+                commands::require_pool_capability(&pool, "exec", target, endpoint, output).await
+            {
+                exit_resource_error(error, output);
+            }
+            dispatch_resource_action(
                 SandboxAction::Run {
                     pool,
                     ttl,
                     cwd,
                     timeout,
                     command,
-                } => {
-                    commands::sandbox::run(commands::sandbox::RunCommand {
-                        pool: &pool,
-                        ttl: ttl.as_deref(),
-                        argv: &command,
-                        cwd: cwd.as_deref(),
-                        timeout: timeout.as_deref(),
-                        target_override: target,
-                        endpoint_override: endpoint,
-                        output,
-                    })
+                },
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        Commands::Exec {
+            lease,
+            cwd,
+            timeout,
+            command,
+        } => {
+            let lease =
+                commands::require_lease_capability(&lease, "exec", target, endpoint, output)
                     .await
-                }
+                    .unwrap_or_else(|error| exit_resource_error(error, output));
+            dispatch_resource_action(
+                SandboxAction::Exec {
+                    lease,
+                    cwd,
+                    timeout,
+                    command,
+                },
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        Commands::Logs {
+            lease,
+            execution,
+            follow,
+            tail,
+        } => {
+            let lease =
+                commands::require_lease_capability(&lease, "logs", target, endpoint, output)
+                    .await
+                    .unwrap_or_else(|error| exit_resource_error(error, output));
+            dispatch_resource_action(
                 SandboxAction::Logs {
                     lease,
                     execution,
                     follow,
                     tail,
-                } => commands::sandbox::logs(
-                    &lease,
-                    tail,
-                    execution.as_deref(),
-                    follow,
-                    target,
-                    endpoint,
-                    output,
-                )
-                .await
-                .map(|()| 0),
-                SandboxAction::Cancel { lease, execution } => {
-                    commands::sandbox::cancel(&lease, &execution, target, endpoint, output)
-                        .await
-                        .map(|()| 0)
-                }
+                },
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        Commands::Cancel { lease, execution } => {
+            let lease =
+                commands::require_lease_capability(&lease, "cancel", target, endpoint, output)
+                    .await
+                    .unwrap_or_else(|error| exit_resource_error(error, output));
+            dispatch_resource_action(
+                SandboxAction::Cancel { lease, execution },
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        Commands::Attach {
+            lease,
+            container,
+            no_tty,
+            command,
+        } => {
+            let lease =
+                commands::require_lease_capability(&lease, "attach", target, endpoint, output)
+                    .await
+                    .unwrap_or_else(|error| exit_resource_error(error, output));
+            dispatch_resource_action(
                 SandboxAction::Attach {
                     lease,
                     container,
                     no_tty,
                     command,
-                } => {
-                    commands::sandbox_transport::attach(
-                        &lease,
-                        &command,
-                        container.as_deref(),
-                        !no_tty,
-                        target,
-                        endpoint,
-                        output,
-                    )
-                    .await
-                }
-                SandboxAction::PortForward { lease, spec, bind } => {
-                    match commands::sandbox_transport::split_forward_spec(&spec) {
-                        Ok((local, remote)) => {
-                            commands::sandbox_transport::port_forward(
-                                &lease, local, &remote, &bind, target, endpoint, output,
-                            )
-                            .await
-                        }
-                        Err(error) => Err(error),
-                    }
-                }
-            };
-            match code {
-                Ok(0) => Ok(()),
-                Ok(code) => std::process::exit(code),
-                Err(error) => {
-                    if output == OutputFormat::Json {
-                        // Machine mode owns stdout exclusively; mixing a human
-                        // stderr diagnostic into an agent pipeline makes the
-                        // invocation impossible to consume deterministically.
-                        let _ = commands::sandbox::emit_cli_error(&error);
-                    } else {
-                        eprintln!("kobe: {error:#}");
-                    }
-                    std::process::exit(commands::sandbox::CLI_FAILURE_EXIT)
-                }
-            }
+                },
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        Commands::PortForward { lease, spec, bind } => {
+            let lease = commands::require_lease_capability(
+                &lease,
+                "port-forward",
+                target,
+                endpoint,
+                output,
+            )
+            .await
+            .unwrap_or_else(|error| exit_resource_error(error, output));
+            dispatch_resource_action(
+                SandboxAction::PortForward { lease, spec, bind },
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        Commands::Sandbox { action } => {
+            dispatch_resource_action(action, target, endpoint, output).await
         }
         Commands::Release { lease_id } => {
             commands::release(lease_id.as_deref(), target, endpoint, output).await
@@ -518,7 +591,120 @@ async fn main() -> anyhow::Result<()> {
     }
 }
 
-fn requests_sandbox_json(args: &[std::ffi::OsString]) -> bool {
+/// Dispatch one capability-specific resource action. Kind-specific API routes
+/// stay behind this boundary; the public command hierarchy remains flat.
+async fn dispatch_resource_action(
+    action: SandboxAction,
+    target: Option<&str>,
+    endpoint: Option<&str>,
+    output: OutputFormat,
+) -> anyhow::Result<()> {
+    // These return the REMOTE command's exit code, so the process exits with
+    // it rather than with generic success. `set -e` depends on exactly this.
+    let code = match action {
+        SandboxAction::Exec {
+            lease,
+            cwd,
+            timeout,
+            command,
+        } => {
+            commands::sandbox::exec(
+                &lease,
+                &command,
+                cwd.as_deref(),
+                timeout.as_deref(),
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        SandboxAction::Run {
+            pool,
+            ttl,
+            cwd,
+            timeout,
+            command,
+        } => {
+            commands::sandbox::run(commands::sandbox::RunCommand {
+                pool: &pool,
+                ttl: ttl.as_deref(),
+                argv: &command,
+                cwd: cwd.as_deref(),
+                timeout: timeout.as_deref(),
+                target_override: target,
+                endpoint_override: endpoint,
+                output,
+            })
+            .await
+        }
+        SandboxAction::Logs {
+            lease,
+            execution,
+            follow,
+            tail,
+        } => commands::sandbox::logs(
+            &lease,
+            tail,
+            execution.as_deref(),
+            follow,
+            target,
+            endpoint,
+            output,
+        )
+        .await
+        .map(|()| 0),
+        SandboxAction::Cancel { lease, execution } => {
+            commands::sandbox::cancel(&lease, &execution, target, endpoint, output)
+                .await
+                .map(|()| 0)
+        }
+        SandboxAction::Attach {
+            lease,
+            container,
+            no_tty,
+            command,
+        } => {
+            commands::sandbox_transport::attach(
+                &lease,
+                &command,
+                container.as_deref(),
+                !no_tty,
+                target,
+                endpoint,
+                output,
+            )
+            .await
+        }
+        SandboxAction::PortForward { lease, spec, bind } => {
+            match commands::sandbox_transport::split_forward_spec(&spec) {
+                Ok((local, remote)) => {
+                    commands::sandbox_transport::port_forward(
+                        &lease, local, &remote, &bind, target, endpoint, output,
+                    )
+                    .await
+                }
+                Err(error) => Err(error),
+            }
+        }
+    };
+    match code {
+        Ok(0) => Ok(()),
+        Ok(code) => std::process::exit(code),
+        Err(error) => exit_resource_error(error, output),
+    }
+}
+
+fn exit_resource_error(error: anyhow::Error, output: OutputFormat) -> ! {
+    if output == OutputFormat::Json {
+        let _ = commands::sandbox::emit_cli_error(&error);
+    } else {
+        eprintln!("kobe: {error:#}");
+    }
+    std::process::exit(commands::sandbox::CLI_FAILURE_EXIT)
+}
+
+fn requests_resource_json(args: &[std::ffi::OsString]) -> bool {
     let args: Vec<_> = args
         .iter()
         .map(|argument| argument.to_string_lossy())
@@ -566,7 +752,10 @@ fn requests_sandbox_json(args: &[std::ffi::OsString]) -> bool {
             index += 1;
             continue;
         }
-        return argument == "sandbox";
+        return matches!(
+            argument.as_ref(),
+            "sandbox" | "run" | "exec" | "logs" | "cancel" | "attach" | "port-forward"
+        );
     }
     false
 }
@@ -586,21 +775,23 @@ mod tests {
     use super::*;
 
     #[test]
-    fn sandbox_json_parse_errors_are_detected_before_clap_exits() {
+    fn resource_json_parse_errors_are_detected_before_clap_exits() {
         for args in [
+            vec!["kobe", "run", "agents", "--output", "json"],
+            vec!["kobe", "--output=json", "exec", "lease-1"],
             vec!["kobe", "sandbox", "run", "agents", "--output", "json"],
             vec!["kobe", "--output=json", "sandbox", "run", "agents"],
             vec!["kobe", "sandbox", "run", "agents", "-o=json"],
             vec!["kobe", "sandbox", "run", "agents", "-ojson"],
         ] {
             let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-            assert!(requests_sandbox_json(&args));
+            assert!(requests_resource_json(&args));
         }
         let text: Vec<std::ffi::OsString> = ["kobe", "sandbox", "run", "agents"]
             .into_iter()
             .map(Into::into)
             .collect();
-        assert!(!requests_sandbox_json(&text));
+        assert!(!requests_resource_json(&text));
         for args in [
             vec!["kobe", "--target", "sandbox", "status", "--output", "json"],
             vec![
@@ -608,7 +799,7 @@ mod tests {
             ],
         ] {
             let args: Vec<std::ffi::OsString> = args.into_iter().map(Into::into).collect();
-            assert!(!requests_sandbox_json(&args));
+            assert!(!requests_resource_json(&args));
         }
     }
 
@@ -618,7 +809,6 @@ mod tests {
     fn execution_logs_accept_execution_and_follow_options() {
         let cli = Cli::try_parse_from([
             "kobe",
-            "sandbox",
             "logs",
             "sandbox-1",
             "--execution",
@@ -627,17 +817,14 @@ mod tests {
         ])
         .unwrap();
 
-        let Commands::Sandbox {
-            action:
-                SandboxAction::Logs {
-                    lease,
-                    execution,
-                    follow,
-                    tail,
-                },
+        let Commands::Logs {
+            lease,
+            execution,
+            follow,
+            tail,
         } = cli.command
         else {
-            panic!("expected sandbox logs")
+            panic!("expected resource logs")
         };
         assert_eq!(lease, "sandbox-1");
         assert_eq!(execution.as_deref(), Some("sbxe-1"));
@@ -652,7 +839,6 @@ mod tests {
         assert!(
             Cli::try_parse_from([
                 "kobe",
-                "sandbox",
                 "logs",
                 "sandbox-1",
                 "--execution",
@@ -662,6 +848,18 @@ mod tests {
             ])
             .is_err()
         );
-        assert!(Cli::try_parse_from(["kobe", "sandbox", "logs", "sandbox-1", "--follow"]).is_err());
+        assert!(Cli::try_parse_from(["kobe", "logs", "sandbox-1", "--follow"]).is_err());
+    }
+
+    #[test]
+    fn legacy_sandbox_namespace_remains_parseable_but_hidden() {
+        let cli =
+            Cli::try_parse_from(["kobe", "sandbox", "exec", "sandbox-1", "--", "true"]).unwrap();
+        assert!(matches!(
+            cli.command,
+            Commands::Sandbox {
+                action: SandboxAction::Exec { .. }
+            }
+        ));
     }
 }

--- a/crates/kobectl/tests/sandbox_cli.rs
+++ b/crates/kobectl/tests/sandbox_cli.rs
@@ -278,6 +278,68 @@ fn run_server(
 }
 
 #[test]
+fn flat_exec_routes_an_executable_lease_without_a_kind_namespace() {
+    let server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(stream, 200, &[], "[]"),
+            ("GET", "/v1/sandbox-leases") => reply(
+                stream,
+                200,
+                &[],
+                &json!([{
+                "id": "sandbox-test",
+                "phase": "Ready",
+                "pool": "agents",
+                "alias": "dev"
+                }])
+                .to_string(),
+            ),
+            ("POST", "/v1/sandbox-leases/sandbox-test/executions") => {
+                reply(stream, 200, &[], &execution_body("Succeeded", Some(0)))
+            }
+            _ => panic!("unexpected flat exec request: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(
+        &server.endpoint(),
+        &["exec", "dev", "--", "/agent", "status"],
+    );
+    let output = wait_output(child);
+    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(String::from_utf8_lossy(&output.stdout), "out\n");
+    assert_eq!(String::from_utf8_lossy(&output.stderr), "err\n");
+}
+
+#[test]
+fn flat_exec_rejects_a_cluster_lease_by_capability() {
+    let server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(
+                stream,
+                200,
+                &[],
+                &json!([{
+                    "id": "lease-cluster",
+                    "phase": "Bound",
+                    "profile": "ci-small"
+                }])
+                .to_string(),
+            ),
+            ("GET", "/v1/sandbox-leases") => reply(stream, 403, &[], ""),
+            _ => panic!("unsupported capability must not reach execution: {request:?}"),
+        }
+    });
+    let (_directory, child) =
+        spawn_child(&server.endpoint(), &["exec", "lease-cluster", "--", "true"]);
+    let output = wait_output(child);
+    assert_eq!(output.status.code(), Some(125));
+    assert!(output.stdout.is_empty());
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(stderr.contains("does not support exec"), "{stderr}");
+    assert!(stderr.contains("kubeconfig, extend, release"), "{stderr}");
+}
+
+#[test]
 fn run_uses_one_json_envelope_for_terminal_and_release_outcomes() {
     for (remote_state, remote_exit, release_status, expected_exit, outcome, released) in [
         ("Succeeded", Some(0), 204, 0, "success", true),

--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -176,7 +176,9 @@ Returns `404` if no bundle exists.
 
 ## `GET /v1/pools`
 
-Lists all pools accessible to your identity, including their policy and capacity summary.
+Lists every pool accessible to your identity, regardless of resource kind.
+`resourceKind` identifies what a lease allocates and `capabilities` identifies
+the operations available to the caller.
 
 **Response** — `200 OK`
 
@@ -184,6 +186,8 @@ Lists all pools accessible to your identity, including their policy and capacity
 [
   {
     "name": "ci-small",
+    "resourceKind": "Cluster",
+    "capabilities": ["lease", "kubeconfig", "extend", "release"],
     "phase": "Healthy",
     "ready": 3,
     "leased": 1,
@@ -212,6 +216,8 @@ Returns status for a single pool.
 ```json
 {
   "name": "ci-small",
+  "resourceKind": "Cluster",
+  "capabilities": ["lease", "kubeconfig", "extend", "release"],
   "phase": "Healthy",
   "ready": 3,
   "leased": 1,

--- a/docs/kobe-docs/commands/reference.mdx
+++ b/docs/kobe-docs/commands/reference.mdx
@@ -11,16 +11,16 @@ description: All kobe CLI commands with flags and examples.
 |---|---|
 | `kobe status` | Show endpoint status, auth methods, and pool summary |
 | `kobe version` | Show CLI and endpoint versions |
-| `kobe sandbox run` | Create a sandbox, run one command, release it ([details](/commands/sandbox)) |
-| `kobe sandbox exec` | Run a command in a sandbox you already hold |
-| `kobe sandbox logs` | Read sandbox output or follow one execution's retained stdout/stderr |
-| `kobe sandbox cancel` | Cancel a running execution |
-| `kobe sandbox attach` | Open an interactive session in a sandbox |
-| `kobe sandbox port-forward` | Forward a declared sandbox port to a local one |
+| `kobe run` | Lease an executable resource, run one command, release it ([details](/commands/sandbox)) |
+| `kobe exec` | Run a command in a lease that supports `exec` |
+| `kobe logs` | Read output from a lease that supports `logs` |
+| `kobe cancel` | Cancel a running execution |
+| `kobe attach` | Open an interactive session through an `attach` capability |
+| `kobe port-forward` | Forward a declared port through a `port-forward` capability |
 | `kobe login` | Authenticate with the kobe service |
 | `kobe logout` | Remove stored credentials |
-| `kobe lease <pool>` | Lease a cluster from a pool |
-| `kobe release <lease-id>` | Release a leased cluster |
+| `kobe lease <pool>` | Lease the resource provided by a pool |
+| `kobe release <lease-id>` | Release a lease |
 | `kobe config view` | Print current configuration |
 | `kobe config edit` | Open the configuration TUI |
 | `kobe config list` | List named targets |
@@ -88,24 +88,27 @@ Removes the stored session token and credentials from the local config. The next
 kobe lease <pool> [--ttl <duration>] [--kubeconfig <path>] [--no-wait]
 ```
 
-Creates a lease from the specified pool. By default the CLI waits until the lease is `Bound` and writes the kubeconfig to disk.
+Creates a lease from the specified pool. The pool's `resourceKind` determines
+what is allocated and which actions are available. Cluster leases write a
+kubeconfig; executable resources expose actions such as `exec` and `logs`.
 
 ```sh
 kobe lease ci-small
 kobe lease ci-small --ttl 30m
 kobe lease ci-small --kubeconfig /tmp/kube.yaml
+kobe lease agents --ttl 30m
 kobe lease ci-small --no-wait
 ```
 
-Prints the lease ID and expiry on success. The cluster is ready to use as soon as the command returns.
+Prints the lease ID, resource kind, capabilities, and expiry on success.
 
 **Flags**
 
 | Flag | Default | Description |
 |---|---|---|
 | `--ttl` | pool default | Requested lease TTL. Capped by AccessPolicy `maxTtl`. |
-| `--kubeconfig` | `~/.kube/kobe-<id>` | Path to write the kubeconfig. |
-| `--no-wait` | disabled | Return after creating the lease instead of waiting for kubeconfig. |
+| `--kubeconfig` | `~/.kube/kobe-<id>` | Cluster resources only: path to write the kubeconfig. |
+| `--no-wait` | disabled | Return after creating the lease instead of waiting for readiness. |
 | `--wait-timeout` | unset | Maximum time to wait for the lease to become usable. |
 
 ---
@@ -126,7 +129,9 @@ The current CLI does not expose a standalone `kobe leases` command anymore. Use 
 kobe release <lease-id>
 ```
 
-Releases a lease immediately. The cluster is destroyed and a replacement is queued in the pool. Use this when your CI job finishes before the TTL expires — it helps the pool refill faster for subsequent jobs.
+Releases a lease immediately. Kobe performs the cleanup required by that
+resource kind and makes the pool capacity reusable. Use this when work finishes
+before the TTL expires.
 
 ```sh
 kobe release lease-a1b2c3d4e5f6

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -1,21 +1,22 @@
 ---
-title: Sandbox commands
-description: Run commands inside a leased agent sandbox, from a shell or from an agent.
+title: Executable resource commands
+description: Lease and operate resources according to the capabilities exposed by their pool.
 ---
 
-# Sandbox commands
+# Executable resource commands
 
-A **sandbox** is one agent environment leased from a `SandboxPool`. These
-commands run work inside it. None of them produces a kubeconfig, a token, or
-any other credential for the cluster underneath — a sandbox lease is the right
-to run commands in one container, and nothing more.
+A pool declares its `resourceKind` and capabilities. The lease lifecycle is
+common to every resource: `kobe lease`, `status`, `extend`, and `release`.
+Commands such as `exec`, `logs`, and `attach` work when the selected lease
+advertises the matching capability. A Sandbox is one such executable resource;
+it never exposes credentials for the Kubernetes cluster underneath it.
 
-## `kobe sandbox run`
+## `kobe run`
 
 Create a sandbox, run one command in it, and release it.
 
 ```bash
-kobe sandbox run agents --ttl 30m -- /agent analyse ./repo
+kobe run agents --ttl 30m -- /agent analyse ./repo
 ```
 
 This is the command to reach for from CI or a script: it owns the create,
@@ -40,7 +41,7 @@ response-body reads, and polling waits all consume that same bound.
 
 ```bash
 set -e
-kobe sandbox run agents -- /agent test   # non-zero here fails the script
+kobe run agents -- /agent test   # non-zero here fails the script
 ```
 
 **Cleanup is reported separately from the result.** If the command succeeded
@@ -71,13 +72,13 @@ A cleanup failure never rewrites a remote exit code: a command that returned
 `0` still returns `0`, while the warning remains in `cleanup` (and on stderr in
 text mode). Headless callers should check both.
 
-## `kobe sandbox exec`
+## `kobe exec`
 
 Run a command in a sandbox you already hold.
 
 ```bash
-kobe sandbox exec sandbox-a1b2c3d4e5f60718293a4b5c -- /agent status
-kobe sandbox exec sandbox-a1b2c3d4e5f60718293a4b5c --cwd /work --timeout 5m -- ./build.sh
+kobe exec sandbox-a1b2c3d4e5f60718293a4b5c -- /agent status
+kobe exec sandbox-a1b2c3d4e5f60718293a4b5c --cwd /work --timeout 5m -- ./build.sh
 ```
 
 `argv` is sent **as-is**. There is no shell, so there are no quoting rules of
@@ -85,22 +86,22 @@ Kobe's own to learn — and no way for an argument to become a shell operator:
 
 ```bash
 # Runs a program whose name contains a semicolon. It does not run two commands.
-kobe sandbox exec sandbox-a1b2c3d4e5f60718293a4b5c -- './weird;name'
+kobe exec sandbox-a1b2c3d4e5f60718293a4b5c -- './weird;name'
 ```
 
 If you need a shell, ask for one explicitly — then its quoting is yours to
 reason about:
 
 ```bash
-kobe sandbox exec sandbox-a1b2c3d4e5f60718293a4b5c -- /bin/sh -lc 'a && b'
+kobe exec sandbox-a1b2c3d4e5f60718293a4b5c -- /bin/sh -lc 'a && b'
 ```
 
-## `kobe sandbox logs`
+## `kobe logs`
 
 A bounded tail of the sandbox's own output.
 
 ```bash
-kobe sandbox logs sandbox-a1b2c3d4e5f60718293a4b5c --tail 500
+kobe logs sandbox-a1b2c3d4e5f60718293a4b5c --tail 500
 ```
 
 The tail is capped server-side. Asking for more than the cap returns the cap
@@ -110,8 +111,8 @@ Pass an execution id to recover its retained stdout and stderr after a
 disconnect:
 
 ```bash
-kobe sandbox logs sandbox-a1b2c3d4e5f60718293a4b5c --execution sbxe-91c4
-kobe sandbox logs sandbox-a1b2c3d4e5f60718293a4b5c --execution sbxe-91c4 --follow
+kobe logs sandbox-a1b2c3d4e5f60718293a4b5c --execution sbxe-91c4
+kobe logs sandbox-a1b2c3d4e5f60718293a4b5c --execution sbxe-91c4 --follow
 ```
 
 Follow mode resumes stdout and stderr from separate offsets and stops only
@@ -121,10 +122,10 @@ follow mode emits one compact, versioned object per line (NDJSON); each object
 carries `state`, `stdout`, and `stderr` windows with `nextOffset`, `more`, and
 `truncated`.
 
-## `kobe sandbox cancel`
+## `kobe cancel`
 
 ```bash
-kobe sandbox cancel sandbox-a1b2c3d4e5f60718293a4b5c --execution sbxe-91c4
+kobe cancel sandbox-a1b2c3d4e5f60718293a4b5c --execution sbxe-91c4
 ```
 
 Reports the state that **actually** applies. An execution that had already
@@ -137,7 +138,7 @@ Use `--output json`. The fields are versioned by `apiVersion`, which changes
 only on a breaking change:
 
 ```bash
-result=$(kobe sandbox run agents --output json -- /agent analyse)
+result=$(kobe run agents --output json -- /agent analyse)
 code=$?
 
 echo "$result" | jq -r '.stdout'
@@ -152,7 +153,7 @@ independent by design.
 `stdout` and `stderr` are always separate fields. A consumer that cannot tell
 a tool's diagnostics from its output cannot reliably parse either.
 
-For `sandbox run`, JSON mode always emits exactly one
+For `run`, JSON mode always emits exactly one
 `kobe.sandbox/v1` envelope to stdout, including client and command-line syntax
 errors. Human diagnostics are not mixed into stderr. JSON mode is also
 non-interactive: it never opens an OIDC browser login or asks whether to trust
@@ -202,14 +203,14 @@ An `Unknown` state means Kobe could not establish what happened: the command
 may have run, so an automatic retry may repeat its effects. Deciding what to do
 is yours.
 
-## `kobe sandbox attach`
+## `kobe attach`
 
 An interactive session inside the sandbox.
 
 ```bash
-kobe sandbox attach dev                      # attach to the running process
-kobe sandbox attach dev -- /bin/bash         # start a shell instead
-kobe sandbox attach dev --no-tty < input.txt # pipe input, no terminal
+kobe attach dev                      # attach to the running process
+kobe attach dev -- /bin/bash         # start a shell instead
+kobe attach dev --no-tty -- command  # run without allocating a terminal
 ```
 
 The terminal goes into raw mode, so **Ctrl-C reaches your workload** rather
@@ -226,13 +227,13 @@ released, or a limit was reached — `kobe` prints the reason and exits `125`:
 kobe: session ended: idle_timeout
 ```
 
-## `kobe sandbox port-forward`
+## `kobe port-forward`
 
 Forward a **pool-declared** port to a local one.
 
 ```bash
-kobe sandbox port-forward dev 8080:http    # by declared name
-kobe sandbox port-forward dev 8080:3000    # by declared number
+kobe port-forward dev 8080:http    # by declared name
+kobe port-forward dev 8080:3000    # by declared number
 ```
 
 Only ports the pool published resolve. Anything else is refused — without
@@ -246,7 +247,7 @@ and the sandbox behind it is yours alone.
 
 With `--output json`, the listener and per-connection failures are flushed as
 versioned NDJSON events on stdout; authentication is non-interactive and no
-human diagnostics are written to stderr. `sandbox attach` is interactive and
+human diagnostics are written to stderr. `attach` is interactive and
 therefore rejects JSON mode with a structured client error.
 
 One connection is forwarded at a time. Each local connection needs its own
@@ -266,7 +267,7 @@ Any command that takes a lease id also takes an **alias** — the name you gave
 the sandbox when you created it:
 
 ```bash
-kobe sandbox exec dev -- /agent status
+kobe exec dev -- /agent status
 ```
 
 Aliases are yours. Two people using `dev` never collide: resolution is scoped

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -21,13 +21,13 @@ use crate::api::connect::{
     BackendAccess, backend_access_from_kubeconfig, build_backend_tls_config,
     build_connect_kubeconfig, ensure_lease_connect_token, validate_lease_connect_token,
 };
-use crate::api::policy::{self, format_duration, is_pool_allowed, policy_for};
+use crate::api::policy::{self, format_duration, is_pool_allowed, is_sandbox_allowed, policy_for};
 use crate::backend::{BackendFactory, ClusterBackend};
 use crate::controllers::lease::extend_lease_ttl;
 use crate::crd::{
     CIDRClaim, CIDRClaimPhase, ClusterInstance, ClusterInstancePhase, ClusterLease,
-    ClusterLeaseCondition, ClusterLeaseSpec, ClusterPool, ClusterPoolPhase, LeaseBinding,
-    LeasePhase, Requester,
+    ClusterLeaseCondition, ClusterLeaseSpec, ClusterPool, LeaseBinding, LeasePhase, Requester,
+    SandboxPool, SandboxVerb,
 };
 use crate::lease_binding::{BindingResolutionError, BindingResolveMode, resolve_lease_binding};
 use crate::metrics;
@@ -522,8 +522,10 @@ struct PoolPolicyResponse {
 #[serde(rename_all = "camelCase")]
 struct ProfileResponse {
     name: String,
+    resource_kind: &'static str,
+    capabilities: Vec<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    phase: Option<ClusterPoolPhase>,
+    phase: Option<String>,
     ready: u32,
     leased: u32,
     creating: u32,
@@ -601,11 +603,17 @@ fn pool_policy_response(profile: &ClusterPool) -> PoolPolicyResponse {
     }
 }
 
-fn profile_response(profile: &ClusterPool) -> ProfileResponse {
+fn profile_response(profile: &ClusterPool, policy: &policy::Policy) -> ProfileResponse {
     let status = profile.status.clone().unwrap_or_default();
+    let mut capabilities = vec!["lease", "kubeconfig", "release"];
+    if policy.max_extensions > 0 {
+        capabilities.push("extend");
+    }
     ProfileResponse {
         name: profile.name_any(),
-        phase: status.phase,
+        resource_kind: "Cluster",
+        capabilities,
+        phase: status.phase.map(|phase| format!("{phase:?}")),
         ready: status.ready,
         leased: status.leased,
         creating: status.creating,
@@ -614,6 +622,57 @@ fn profile_response(profile: &ClusterPool) -> ProfileResponse {
         quarantined: status.quarantined,
         queue_depth: status.queue_depth,
         policy: pool_policy_response(profile),
+    }
+}
+
+fn sandbox_pool_response(pool: &SandboxPool, policy: &policy::Policy) -> ProfileResponse {
+    let status = pool.status.clone().unwrap_or_default();
+    let mut capabilities = vec!["lease"];
+    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::Exec, policy) {
+        capabilities.extend(["exec", "cancel", "attach"]);
+    }
+    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::Logs, policy) {
+        capabilities.push("logs");
+    }
+    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::PortForward, policy) {
+        capabilities.push("port-forward");
+    }
+    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::Release, policy) {
+        capabilities.push("release");
+    }
+    if policy
+        .sandbox
+        .as_ref()
+        .is_some_and(|grant| grant.max_extensions > 0)
+    {
+        capabilities.push("extend");
+    }
+    let phase = if crate::sandbox::require_current_sandbox_pool_ready(pool).is_ok() {
+        "Ready"
+    } else {
+        "NotReady"
+    };
+    ProfileResponse {
+        name: pool.name_any(),
+        resource_kind: "Sandbox",
+        capabilities,
+        phase: Some(phase.to_string()),
+        ready: status.ready,
+        leased: status.allocated,
+        creating: 0,
+        recycling: 0,
+        unhealthy: 0,
+        quarantined: status.quarantined,
+        queue_depth: 0,
+        policy: PoolPolicyResponse {
+            mode: "sandbox".to_string(),
+            ttl: pool.spec.default_ttl.clone(),
+            warm_target: pool.spec.warm_capacity,
+            max_clusters: None,
+            scale_up_threshold: None,
+            scale_down_after: None,
+            queue_timeout: Some(pool.spec.provisioning_timeout.clone()),
+        },
     }
 }
 
@@ -2408,15 +2467,43 @@ async fn list_pools<B: ClusterBackend>(
     identity: AuthIdentity,
 ) -> Response {
     let profiles_api: Api<ClusterPool> = Api::namespaced(state.client.clone(), &state.namespace);
+    let policy = policy_for(&identity);
 
     match profiles_api.list(&ListParams::default()).await {
         Ok(profiles) => {
-            let policy = policy_for(&identity);
-            let response: Vec<ProfileResponse> = profiles
+            let mut response: Vec<ProfileResponse> = profiles
                 .iter()
                 .filter(|p| is_pool_allowed(&p.name_any(), &policy))
-                .map(profile_response)
+                .map(|profile| profile_response(profile, &policy))
                 .collect();
+
+            if state.sandbox_enabled {
+                let sandbox_pools: Api<SandboxPool> =
+                    Api::namespaced(state.client.clone(), &state.namespace);
+                match sandbox_pools.list(&ListParams::default()).await {
+                    Ok(pools) => response.extend(
+                        pools
+                            .iter()
+                            .filter(|pool| {
+                                is_sandbox_allowed(&pool.name_any(), SandboxVerb::Lease, &policy)
+                            })
+                            .map(|pool| sandbox_pool_response(pool, &policy)),
+                    ),
+                    Err(error) => {
+                        return infra_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to list Sandbox pools",
+                            error,
+                        );
+                    }
+                }
+            }
+
+            response.sort_by(|left, right| {
+                left.name
+                    .cmp(&right.name)
+                    .then(left.resource_kind.cmp(right.resource_kind))
+            });
 
             (StatusCode::OK, Json(response)).into_response()
         }
@@ -2435,28 +2522,67 @@ async fn get_pool<B: ClusterBackend>(
     Path(name): Path<String>,
 ) -> Response {
     let policy = policy_for(&identity);
-    if !is_pool_allowed(&name, &policy) {
-        return StatusCode::FORBIDDEN.into_response();
-    }
-
     let profiles_api: Api<ClusterPool> = Api::namespaced(state.client.clone(), &state.namespace);
+    let cluster = match profiles_api.get_opt(&name).await {
+        Ok(cluster) => cluster,
+        Err(error) => {
+            return infra_error(
+                StatusCode::INTERNAL_SERVER_ERROR,
+                "Failed to get Cluster pool",
+                error,
+            );
+        }
+    };
+    let sandbox = if state.sandbox_enabled {
+        let pools: Api<SandboxPool> = Api::namespaced(state.client.clone(), &state.namespace);
+        match pools.get_opt(&name).await {
+            Ok(pool) => pool,
+            Err(error) => {
+                return infra_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to get Sandbox pool",
+                    error,
+                );
+            }
+        }
+    } else {
+        None
+    };
 
-    match profiles_api.get(&name).await {
-        Ok(profile) => (StatusCode::OK, Json(profile_response(&profile))).into_response(),
-        Err(kube::Error::Api(ref ae)) if ae.code == 404 => (
+    let cluster_allowed = cluster.as_ref().filter(|_| is_pool_allowed(&name, &policy));
+    let sandbox_allowed = sandbox
+        .as_ref()
+        .filter(|_| is_sandbox_allowed(&name, SandboxVerb::Lease, &policy));
+    match (cluster_allowed, sandbox_allowed) {
+        (Some(_), Some(_)) => (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: format!(
+                    "Pool name '{name}' is ambiguous across Cluster and Sandbox resources"
+                ),
+                detail: Some("Pool names must be unique across resource kinds".to_string()),
+                reason: None,
+            }),
+        )
+            .into_response(),
+        (Some(profile), None) => {
+            (StatusCode::OK, Json(profile_response(profile, &policy))).into_response()
+        }
+        (None, Some(pool)) => {
+            (StatusCode::OK, Json(sandbox_pool_response(pool, &policy))).into_response()
+        }
+        (None, None) if cluster.is_some() || sandbox.is_some() => {
+            StatusCode::FORBIDDEN.into_response()
+        }
+        (None, None) => (
             StatusCode::NOT_FOUND,
             Json(ErrorResponse {
-                error: "Profile not found".to_string(),
+                error: "Pool not found".to_string(),
                 detail: None,
                 reason: None,
             }),
         )
             .into_response(),
-        Err(e) => infra_error(
-            StatusCode::INTERNAL_SERVER_ERROR,
-            "Failed to get profile",
-            e,
-        ),
     }
 }
 


### PR DESCRIPTION
## Summary

- expose Cluster and Sandbox pools through one typed pool inventory
- make lease, status, extend, release, and purge work across resource kinds
- promote run, exec, logs, cancel, attach, and port-forward to capability-driven top-level commands
- retain the old sandbox namespace as hidden compatibility
- reject unsupported operations before calling a kind-specific backend

## Validation

- cargo test -p kobectl: 104 unit tests and 22 integration tests passed
- cargo clippy -p kobectl --all-targets -- -D warnings
- cargo clippy -p kobe-operator --all-targets -- -D warnings
- operator pool route auth test passed
- git diff --check