### PR TITLE
fix(lifecycle): prove progress after lost races

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,7 +14,7 @@ on:
       - "charts/**"
       - "Cargo.toml"
       - "Cargo.lock"
-      - "Justfile"
+      - "justfile"
       - "docker/**"
       - "docker-bake.hcl"
       - "hack/**"
@@ -203,6 +203,51 @@ jobs:
               exit 1
             }
           done
+
+  lifecycle-state-machine:
+    name: Lifecycle State Machine (Kani + mutations)
+    runs-on: kunobi-runners
+    # Bare ARC runners intentionally carry no compiler/linker. Use the same
+    # build environment as the main Rust gate so installing Kani has `cc`.
+    container:
+      image: rust:1.94-bookworm
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v7
+
+      # The pure crate deliberately supports Rust 1.93: Kani 0.67's verifier
+      # toolchain is one release behind Kobe's 1.94.1 operator MSRV. The
+      # operator imports this exact function, so the proof cannot drift into a
+      # second model that production never calls.
+      # The upstream composite action executes its installer from the ARC host
+      # action path, which is not mounted into job containers. Install the same
+      # pinned verifier directly so the proof runs in the controlled image.
+      - name: Install pinned Kani verifier
+        run: |
+          cargo install kani-verifier --version 0.67.0 --locked
+          cargo-kani setup
+
+      - name: Prove exact-binding recovery invariants
+        run: |
+          cargo kani \
+            -p kobe-state-machine \
+            --harness recovery_apply_requires_the_exact_leased_subject \
+            --harness teardown_phases_are_never_reopened_by_recovery \
+            --harness bound_publication_requires_two_exact_reciprocal_sides \
+            --harness terminal_leases_never_publish_bound
+
+      # Mutation testing checks the tests themselves: every viable mutation of
+      # a production decision branch must be caught. Keep this narrow so it is
+      # a seconds-scale required gate rather than a second workspace test run.
+      - name: Mutation-test every recovery decision branch
+        run: |
+          if ! command -v cargo-mutants >/dev/null 2>&1; then
+            cargo install cargo-mutants --version 27.0.0 --locked
+          fi
+          cargo mutants \
+            -p kobe-state-machine \
+            --re 'exact_binding_(recovery|finalization)' \
+            --timeout 60
 
   # Real API-server contract for SandboxLease status and the admission ledger.
   # Unit tests pin JSON Patch/CEL/object shape; this job proves Kubernetes
@@ -546,11 +591,12 @@ jobs:
     # dispatch a branch to test it, and only main / a release tag ships.
     # Dispatch on main still publishes, which is the remedy for tags left
     # pointing somewhere wrong.
-    needs: [checks, version-consistency]
+    needs: [checks, lifecycle-state-machine, version-consistency]
     if: >-
       ${{ always() && github.event_name != 'pull_request'
           && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))
           && needs.checks.result == 'success'
+          && needs['lifecycle-state-machine'].result == 'success'
           && (!startsWith(github.ref, 'refs/tags/v') || needs['version-consistency'].result == 'success') }}
     runs-on: kunobi-runners
     timeout-minutes: 20

--- a/.gitignore
+++ b/.gitignore
@@ -12,6 +12,7 @@ target/
 
 docs/plans/
 .worktrees/
+/mutants.out*/
 
 tarpaulin-report.json
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2683,6 +2683,7 @@ dependencies = [
  "jsonwebtoken 9.3.1",
  "k8s-openapi",
  "kobe-runner",
+ "kobe-state-machine",
  "kube",
  "kunobi-auth",
  "kunobi-ha",
@@ -2733,6 +2734,10 @@ dependencies = [
  "serde",
  "serde_json",
 ]
+
+[[package]]
+name = "kobe-state-machine"
+version = "0.40.1"
 
 [[package]]
 name = "kobectl"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 # The thin CLI crate `kobectl` (binary `kobe`) is a separate member so it can
 # be published to crates.io with a slim dependency tree. The operator stays the
 # root package (it is the bulk of the code and what the container images build).
-members = ["crates/kobectl", "crates/kobe-runner"]
+members = ["crates/kobectl", "crates/kobe-runner", "crates/kobe-state-machine"]
 resolver = "3"
 
 # Single source of truth for the release version, shared by the operator and the
@@ -71,6 +71,7 @@ serde_json = "1"
 serde_yaml_ng = "0.10"
 toml = "0.8"
 json-patch = "4"
+kobe-state-machine = { path = "crates/kobe-state-machine" }
 sha2 = "0.10"
 # Sandbox attach query parsing: repeated `command=` keys must collect into
 # argv, which axum's Query (serde_urlencoded) cannot express.

--- a/crates/kobe-state-machine/Cargo.toml
+++ b/crates/kobe-state-machine/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "kobe-state-machine"
+version.workspace = true
+edition.workspace = true
+rust-version = "1.93"
+license.workspace = true
+description = "Pure, model-checkable lifecycle state machines for Kobe"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(kani)'] }

--- a/crates/kobe-state-machine/src/lib.rs
+++ b/crates/kobe-state-machine/src/lib.rs
@@ -1,0 +1,347 @@
+#![forbid(unsafe_code)]
+
+/// Lifecycle phases relevant to recovery of an exact lease-to-instance
+/// binding. The operator maps its wire-level CRD enum into this closed set.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum InstancePhase {
+    Creating,
+    Ready,
+    Leased,
+    Recycling,
+    Unhealthy,
+    Failed,
+    Quarantined,
+}
+
+/// What the current object says about the binding the reconcile originally
+/// observed.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum BindingState {
+    Expected,
+    Absent,
+    Foreign,
+}
+
+/// Recovery intent selected from an authoritative lease observation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryTransition {
+    RecycleTerminalLease,
+    ReleaseOrphan,
+}
+
+/// Decision for the next fenced write.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum RecoveryDecision {
+    Apply,
+    AlreadyApplied,
+    Superseded,
+}
+
+/// Lease phases relevant to publishing an exact reciprocal reservation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum LeasePhase {
+    Pending,
+    Bound,
+    Released,
+    Expired,
+    Recycling,
+    Quarantined,
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum FinalizationDecision {
+    PublishBound,
+    AlreadyBound,
+    Superseded,
+}
+
+/// Cross-object state machine for the crash-safe `Pending -> Bound` commit.
+/// Access is published only when both objects still carry the exact intent.
+pub fn exact_binding_finalization(
+    lease_phase: LeasePhase,
+    lease_binding: BindingState,
+    instance_phase: InstancePhase,
+    instance_binding: BindingState,
+) -> FinalizationDecision {
+    match (lease_phase, lease_binding, instance_phase, instance_binding) {
+        (
+            LeasePhase::Pending,
+            BindingState::Expected,
+            InstancePhase::Leased,
+            BindingState::Expected,
+        ) => FinalizationDecision::PublishBound,
+        (
+            LeasePhase::Bound,
+            BindingState::Expected,
+            InstancePhase::Leased,
+            BindingState::Expected,
+        ) => FinalizationDecision::AlreadyBound,
+        _ => FinalizationDecision::Superseded,
+    }
+}
+
+/// Pure state machine for exact-binding recovery.
+///
+/// Only a `Leased` instance carrying the expected reciprocal binding may enter
+/// a recovery transition. A retry may observe its own completed write. Every
+/// foreign binding and every teardown phase is fail-closed.
+pub fn exact_binding_recovery(
+    phase: InstancePhase,
+    binding: BindingState,
+    lease_ref_absent: bool,
+    transition: RecoveryTransition,
+) -> RecoveryDecision {
+    match (transition, phase, binding, lease_ref_absent) {
+        (
+            RecoveryTransition::RecycleTerminalLease,
+            InstancePhase::Leased,
+            BindingState::Expected,
+            _,
+        )
+        | (RecoveryTransition::ReleaseOrphan, InstancePhase::Leased, BindingState::Expected, _) => {
+            RecoveryDecision::Apply
+        }
+        (
+            RecoveryTransition::RecycleTerminalLease,
+            InstancePhase::Recycling,
+            BindingState::Expected,
+            _,
+        )
+        | (RecoveryTransition::ReleaseOrphan, InstancePhase::Ready, BindingState::Absent, true) => {
+            RecoveryDecision::AlreadyApplied
+        }
+        _ => RecoveryDecision::Superseded,
+    }
+}
+
+#[cfg(kani)]
+mod proofs {
+    use super::*;
+
+    fn arbitrary_phase(selector: u8) -> InstancePhase {
+        match selector % 7 {
+            0 => InstancePhase::Creating,
+            1 => InstancePhase::Ready,
+            2 => InstancePhase::Leased,
+            3 => InstancePhase::Recycling,
+            4 => InstancePhase::Unhealthy,
+            5 => InstancePhase::Failed,
+            _ => InstancePhase::Quarantined,
+        }
+    }
+
+    fn arbitrary_binding(selector: u8) -> BindingState {
+        match selector % 3 {
+            0 => BindingState::Expected,
+            1 => BindingState::Absent,
+            _ => BindingState::Foreign,
+        }
+    }
+
+    fn arbitrary_lease_phase(selector: u8) -> LeasePhase {
+        match selector % 6 {
+            0 => LeasePhase::Pending,
+            1 => LeasePhase::Bound,
+            2 => LeasePhase::Released,
+            3 => LeasePhase::Expired,
+            4 => LeasePhase::Recycling,
+            _ => LeasePhase::Quarantined,
+        }
+    }
+
+    #[kani::proof]
+    fn recovery_apply_requires_the_exact_leased_subject() {
+        let phase = arbitrary_phase(kani::any());
+        let binding = arbitrary_binding(kani::any());
+        let transition = if kani::any() {
+            RecoveryTransition::RecycleTerminalLease
+        } else {
+            RecoveryTransition::ReleaseOrphan
+        };
+        let decision = exact_binding_recovery(phase, binding, kani::any(), transition);
+
+        if decision == RecoveryDecision::Apply {
+            assert_eq!(phase, InstancePhase::Leased);
+            assert_eq!(binding, BindingState::Expected);
+        }
+    }
+
+    #[kani::proof]
+    fn teardown_phases_are_never_reopened_by_recovery() {
+        let phase = match kani::any::<u8>() % 4 {
+            0 => InstancePhase::Recycling,
+            1 => InstancePhase::Quarantined,
+            2 => InstancePhase::Failed,
+            _ => InstancePhase::Unhealthy,
+        };
+        let transition = if kani::any() {
+            RecoveryTransition::RecycleTerminalLease
+        } else {
+            RecoveryTransition::ReleaseOrphan
+        };
+        let decision = exact_binding_recovery(
+            phase,
+            arbitrary_binding(kani::any()),
+            kani::any(),
+            transition,
+        );
+
+        assert_ne!(decision, RecoveryDecision::Apply);
+    }
+
+    #[kani::proof]
+    fn bound_publication_requires_two_exact_reciprocal_sides() {
+        let lease_phase = arbitrary_lease_phase(kani::any());
+        let lease_binding = arbitrary_binding(kani::any());
+        let instance_phase = arbitrary_phase(kani::any());
+        let instance_binding = arbitrary_binding(kani::any());
+        let decision = exact_binding_finalization(
+            lease_phase,
+            lease_binding,
+            instance_phase,
+            instance_binding,
+        );
+
+        if decision == FinalizationDecision::PublishBound {
+            assert_eq!(lease_phase, LeasePhase::Pending);
+            assert_eq!(lease_binding, BindingState::Expected);
+            assert_eq!(instance_phase, InstancePhase::Leased);
+            assert_eq!(instance_binding, BindingState::Expected);
+        }
+    }
+
+    #[kani::proof]
+    fn terminal_leases_never_publish_bound() {
+        let lease_phase = match kani::any::<u8>() % 4 {
+            0 => LeasePhase::Released,
+            1 => LeasePhase::Expired,
+            2 => LeasePhase::Recycling,
+            _ => LeasePhase::Quarantined,
+        };
+        let decision = exact_binding_finalization(
+            lease_phase,
+            arbitrary_binding(kani::any()),
+            arbitrary_phase(kani::any()),
+            arbitrary_binding(kani::any()),
+        );
+        assert_ne!(decision, FinalizationDecision::PublishBound);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn recovery_matrix_is_exhaustive_and_fail_closed() {
+        let phases = [
+            InstancePhase::Creating,
+            InstancePhase::Ready,
+            InstancePhase::Leased,
+            InstancePhase::Recycling,
+            InstancePhase::Unhealthy,
+            InstancePhase::Failed,
+            InstancePhase::Quarantined,
+        ];
+        let bindings = [
+            BindingState::Expected,
+            BindingState::Absent,
+            BindingState::Foreign,
+        ];
+        let transitions = [
+            RecoveryTransition::RecycleTerminalLease,
+            RecoveryTransition::ReleaseOrphan,
+        ];
+
+        for phase in phases {
+            for binding in bindings {
+                for lease_ref_absent in [false, true] {
+                    for transition in transitions {
+                        let actual =
+                            exact_binding_recovery(phase, binding, lease_ref_absent, transition);
+                        let expected = match (transition, phase, binding, lease_ref_absent) {
+                            (_, InstancePhase::Leased, BindingState::Expected, _) => {
+                                RecoveryDecision::Apply
+                            }
+                            (
+                                RecoveryTransition::RecycleTerminalLease,
+                                InstancePhase::Recycling,
+                                BindingState::Expected,
+                                _,
+                            )
+                            | (
+                                RecoveryTransition::ReleaseOrphan,
+                                InstancePhase::Ready,
+                                BindingState::Absent,
+                                true,
+                            ) => RecoveryDecision::AlreadyApplied,
+                            _ => RecoveryDecision::Superseded,
+                        };
+                        assert_eq!(
+                            actual, expected,
+                            "phase={phase:?} binding={binding:?} lease_ref_absent={lease_ref_absent} transition={transition:?}"
+                        );
+                    }
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn finalization_matrix_is_exhaustive_and_fail_closed() {
+        let lease_phases = [
+            LeasePhase::Pending,
+            LeasePhase::Bound,
+            LeasePhase::Released,
+            LeasePhase::Expired,
+            LeasePhase::Recycling,
+            LeasePhase::Quarantined,
+        ];
+        let instance_phases = [
+            InstancePhase::Creating,
+            InstancePhase::Ready,
+            InstancePhase::Leased,
+            InstancePhase::Recycling,
+            InstancePhase::Unhealthy,
+            InstancePhase::Failed,
+            InstancePhase::Quarantined,
+        ];
+        let bindings = [
+            BindingState::Expected,
+            BindingState::Absent,
+            BindingState::Foreign,
+        ];
+
+        for lease_phase in lease_phases {
+            for lease_binding in bindings {
+                for instance_phase in instance_phases {
+                    for instance_binding in bindings {
+                        let actual = exact_binding_finalization(
+                            lease_phase,
+                            lease_binding,
+                            instance_phase,
+                            instance_binding,
+                        );
+                        let expected =
+                            match (lease_phase, lease_binding, instance_phase, instance_binding) {
+                                (
+                                    LeasePhase::Pending,
+                                    BindingState::Expected,
+                                    InstancePhase::Leased,
+                                    BindingState::Expected,
+                                ) => FinalizationDecision::PublishBound,
+                                (
+                                    LeasePhase::Bound,
+                                    BindingState::Expected,
+                                    InstancePhase::Leased,
+                                    BindingState::Expected,
+                                ) => FinalizationDecision::AlreadyBound,
+                                _ => FinalizationDecision::Superseded,
+                            };
+                        assert_eq!(actual, expected);
+                    }
+                }
+            }
+        }
+    }
+}

--- a/justfile
+++ b/justfile
@@ -28,6 +28,19 @@ lint:
 test:
     cargo test
 
+# Prove the exact-binding recovery matrix with Kani. The model lives in a
+# minimal shared crate so Kani verifies the same function the operator calls.
+[group('test')]
+test-instance-state-machine-kani:
+    cargo kani -p kobe-state-machine --harness recovery_apply_requires_the_exact_leased_subject --harness teardown_phases_are_never_reopened_by_recovery --harness bound_publication_requires_two_exact_reciprocal_sides --harness terminal_leases_never_publish_bound
+
+# Mutation gate for every production branch in the exact-binding recovery
+# function. A viable mutant surviving this command means the matrix tests are
+# not strong enough.
+[group('test')]
+test-instance-state-machine-mutations:
+    cargo mutants -p kobe-state-machine --re 'exact_binding_(recovery|finalization)' --timeout 60
+
 # Build all binaries (operator + kobe-sync + cli)
 [group('build')]
 build:

--- a/src/controllers/instance.rs
+++ b/src/controllers/instance.rs
@@ -9,6 +9,9 @@ use k8s_openapi::api::batch::v1::{Job, JobSpec};
 use k8s_openapi::api::core::v1::{
     Container, EnvVar, PodSpec, PodTemplateSpec, SecretVolumeSource, Volume, VolumeMount,
 };
+use kobe_state_machine::{
+    BindingState, InstancePhase, RecoveryDecision, RecoveryTransition, exact_binding_recovery,
+};
 use kube::api::{Api, DeleteParams, Patch, PatchParams, PostParams, Preconditions};
 use kube::core::ObjectMeta;
 use kube::runtime::controller::{Action, Controller};
@@ -1328,18 +1331,22 @@ async fn evaluate_leased_instance<B: ClusterBackend + Clone>(
                     phase = %lease_status.phase,
                     "Exact bound lease is terminating; recycling instance"
                 );
-                observe_recycle(instance, crate::metrics::RecycleReason::LeaseReleased);
-                let mut next = status.clone();
-                next.phase = ClusterInstancePhase::Recycling;
-                next.idle_since = None;
-                next.state_since = Some(chrono::Utc::now().to_rfc3339());
-                next.message = Some(format!(
-                    "recycling: exact lease '{}' is {}",
-                    binding.lease.name, lease_status.phase
-                ));
                 // Keep lease_ref + binding until verified teardown deletes the
                 // exact instance; they are cleanup handles, not idle state.
-                patch_exact_binding_status(ctx, instance, binding, next).await?;
+                let outcome = patch_exact_binding_transition(
+                    ctx,
+                    instance,
+                    binding,
+                    ExactBindingTransition::RecycleTerminalLease {
+                        lease_name: binding.lease.name.clone(),
+                        lease_phase: lease_status.phase,
+                        transitioned_at: chrono::Utc::now().to_rfc3339(),
+                    },
+                )
+                .await?;
+                if outcome == ExactBindingWriteOutcome::Applied {
+                    observe_recycle(instance, crate::metrics::RecycleReason::LeaseReleased);
+                }
                 return Ok(Action::requeue(std::time::Duration::from_secs(10)));
             }
 
@@ -1361,14 +1368,15 @@ async fn evaluate_leased_instance<B: ClusterBackend + Clone>(
                 reason = "exact_lease_gone",
                 "Releasing only the exact orphan reservation"
             );
-            let mut next = status.clone();
-            next.phase = ClusterInstancePhase::Ready;
-            next.lease_ref = None;
-            next.binding = None;
-            next.idle_since = Some(chrono::Utc::now().to_rfc3339());
-            next.state_since = Some(chrono::Utc::now().to_rfc3339());
-            next.message = Some("ready; exact orphan reservation released".into());
-            patch_exact_binding_status(ctx, instance, binding, next).await?;
+            patch_exact_binding_transition(
+                ctx,
+                instance,
+                binding,
+                ExactBindingTransition::ReleaseOrphan {
+                    transitioned_at: chrono::Utc::now().to_rfc3339(),
+                },
+            )
+            .await?;
             Ok(Action::requeue(std::time::Duration::from_secs(5)))
         }
         Err(err) => {
@@ -1460,49 +1468,199 @@ async fn patch_instance_message_fenced<B: ClusterBackend>(
     Ok(())
 }
 
-async fn patch_exact_binding_status<B: ClusterBackend>(
+const EXACT_BINDING_WRITE_ATTEMPTS: usize = 3;
+
+fn recovery_phase(phase: &ClusterInstancePhase) -> InstancePhase {
+    match phase {
+        ClusterInstancePhase::Creating => InstancePhase::Creating,
+        ClusterInstancePhase::Ready => InstancePhase::Ready,
+        ClusterInstancePhase::Leased => InstancePhase::Leased,
+        ClusterInstancePhase::Recycling => InstancePhase::Recycling,
+        ClusterInstancePhase::Unhealthy => InstancePhase::Unhealthy,
+        ClusterInstancePhase::Failed => InstancePhase::Failed,
+        ClusterInstancePhase::Quarantined => InstancePhase::Quarantined,
+    }
+}
+
+#[derive(Debug, Clone)]
+enum ExactBindingTransition {
+    RecycleTerminalLease {
+        lease_name: String,
+        lease_phase: LeasePhase,
+        transitioned_at: String,
+    },
+    ReleaseOrphan {
+        transitioned_at: String,
+    },
+}
+
+impl ExactBindingTransition {
+    fn kind(&self) -> RecoveryTransition {
+        match self {
+            Self::RecycleTerminalLease { .. } => RecoveryTransition::RecycleTerminalLease,
+            Self::ReleaseOrphan { .. } => RecoveryTransition::ReleaseOrphan,
+        }
+    }
+
+    fn apply(&self, current: &ClusterInstanceStatus) -> ClusterInstanceStatus {
+        let mut next = current.clone();
+        match self {
+            Self::RecycleTerminalLease {
+                lease_name,
+                lease_phase,
+                transitioned_at,
+            } => {
+                next.phase = ClusterInstancePhase::Recycling;
+                next.idle_since = None;
+                next.state_since = Some(transitioned_at.clone());
+                next.message = Some(format!(
+                    "recycling: exact lease '{lease_name}' is {lease_phase}"
+                ));
+            }
+            Self::ReleaseOrphan { transitioned_at } => {
+                next.phase = ClusterInstancePhase::Ready;
+                next.lease_ref = None;
+                next.binding = None;
+                next.idle_since = Some(transitioned_at.clone());
+                next.state_since = Some(transitioned_at.clone());
+                next.message = Some("ready; exact orphan reservation released".into());
+            }
+        }
+        next
+    }
+
+    /// Emit only fields owned by this lifecycle transition. Replacing the
+    /// complete status makes an otherwise safe retry depend on the serialized
+    /// shape of every unrelated status field; a focused JSON Patch keeps the
+    /// exact UID/RV/binding fences without reopening that livelock surface.
+    fn patch_operations(&self, next: &ClusterInstanceStatus) -> Vec<serde_json::Value> {
+        let mut operations = vec![
+            serde_json::json!({ "op": "add", "path": "/status/phase", "value": next.phase }),
+            serde_json::json!({ "op": "add", "path": "/status/idleSince", "value": next.idle_since }),
+            serde_json::json!({ "op": "add", "path": "/status/stateSince", "value": next.state_since }),
+            serde_json::json!({ "op": "add", "path": "/status/message", "value": next.message }),
+            serde_json::json!({ "op": "add", "path": "/status/conditions", "value": next.conditions }),
+        ];
+        if matches!(self, Self::ReleaseOrphan { .. }) {
+            operations.push(serde_json::json!({
+                "op": "add",
+                "path": "/status/leaseRef",
+                "value": null
+            }));
+            operations.push(serde_json::json!({
+                "op": "remove",
+                "path": "/status/binding"
+            }));
+        }
+        operations
+    }
+}
+
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum ExactBindingWriteOutcome {
+    Applied,
+    AlreadyApplied,
+    Superseded,
+}
+
+/// Apply one exact-binding state transition and prove progress after a lost
+/// optimistic race.
+///
+/// A 409/422 is not treated as success: the controller re-reads the object,
+/// re-evaluates the pure transition matrix, and retries against the fresh
+/// resourceVersion. This prevents a quiet livelock when no competing write
+/// actually committed (the failure mode that exhausted the int-pro pool).
+async fn patch_exact_binding_transition<B: ClusterBackend>(
     ctx: &InstanceContext<B>,
     instance: &ClusterInstance,
     binding: &crate::crd::LeaseBinding,
-    mut next: ClusterInstanceStatus,
-) -> Result<(), InstanceError> {
-    let uid = instance
+    transition: ExactBindingTransition,
+) -> Result<ExactBindingWriteOutcome, InstanceError> {
+    let expected_uid = instance
         .metadata
         .uid
-        .as_deref()
+        .clone()
         .ok_or_else(|| anyhow::anyhow!("instance missing UID"))?;
-    let rv = instance
-        .resource_version()
-        .ok_or_else(|| anyhow::anyhow!("instance missing resourceVersion"))?;
-    let prev = instance
-        .status
-        .as_ref()
-        .map(|current| current.conditions.as_slice())
-        .unwrap_or(&[]);
-    next.conditions = derive_instance_conditions(&next, prev, &chrono::Utc::now().to_rfc3339());
-    let patch: json_patch::Patch = serde_json::from_value(serde_json::json!([
-        { "op": "test", "path": "/metadata/uid", "value": uid },
-        { "op": "test", "path": "/metadata/resourceVersion", "value": rv },
-        { "op": "test", "path": "/status/binding", "value": binding },
-        { "op": "add", "path": "/status", "value": next }
-    ]))
-    .expect("exact binding JSON Patch is static");
     let namespace = instance
         .namespace()
         .unwrap_or_else(|| ctx.namespace.clone());
     let instances: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), &namespace);
-    tolerate_lost_race(
-        instances
+    let mut current = instance.clone();
+
+    for attempt in 1..=EXACT_BINDING_WRITE_ATTEMPTS {
+        if current.metadata.uid.as_deref() != Some(expected_uid.as_str()) {
+            return Ok(ExactBindingWriteOutcome::Superseded);
+        }
+        let status = current.status.as_ref().cloned().unwrap_or_default();
+        let binding_state = match status.binding.as_ref() {
+            Some(observed) if observed == binding => BindingState::Expected,
+            None => BindingState::Absent,
+            Some(_) => BindingState::Foreign,
+        };
+        match exact_binding_recovery(
+            recovery_phase(&status.phase),
+            binding_state,
+            status.lease_ref.is_none(),
+            transition.kind(),
+        ) {
+            RecoveryDecision::AlreadyApplied => {
+                return Ok(ExactBindingWriteOutcome::AlreadyApplied);
+            }
+            RecoveryDecision::Superseded => {
+                return Ok(ExactBindingWriteOutcome::Superseded);
+            }
+            RecoveryDecision::Apply => {}
+        }
+
+        let rv = current
+            .resource_version()
+            .ok_or_else(|| anyhow::anyhow!("instance missing resourceVersion"))?;
+        let mut next = transition.apply(&status);
+        next.conditions =
+            derive_instance_conditions(&next, &status.conditions, &chrono::Utc::now().to_rfc3339());
+        let mut operations = vec![
+            serde_json::json!(
+            { "op": "test", "path": "/metadata/uid", "value": expected_uid }
+            ),
+            serde_json::json!(
+            { "op": "test", "path": "/metadata/resourceVersion", "value": rv }
+            ),
+            serde_json::json!(
+            { "op": "test", "path": "/status/phase", "value": status.phase }
+            ),
+            serde_json::json!(
+            { "op": "test", "path": "/status/binding", "value": binding }
+            ),
+        ];
+        operations.extend(transition.patch_operations(&next));
+        let patch: json_patch::Patch = serde_json::from_value(serde_json::Value::Array(operations))
+            .expect("exact binding JSON Patch is static");
+
+        match instances
             .patch_status(
-                &instance.name_any(),
+                &current.name_any(),
                 &PatchParams::default(),
                 &Patch::<()>::Json(patch),
             )
-            .await,
-        &instance.name_any(),
-        "exact_binding_status",
-    )?;
-    Ok(())
+            .await
+        {
+            Ok(_) => return Ok(ExactBindingWriteOutcome::Applied),
+            Err(error)
+                if crate::controllers::lease::optimistic_conflict(&error)
+                    && attempt < EXACT_BINDING_WRITE_ATTEMPTS =>
+            {
+                debug!(
+                    instance = %current.name_any(),
+                    attempt,
+                    "exact-binding write lost a race; re-reading before retry"
+                );
+                current = instances.get(&current.name_any()).await?;
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    unreachable!("bounded exact-binding write loop always returns")
 }
 
 /// Inject a per-backend default readiness gate when a pool declares
@@ -4323,6 +4481,62 @@ mod tests {
         assert!(!reservation_grace_elapsed(Some("garbage"), now, grace));
     }
 
+    #[test]
+    fn exact_binding_transitions_preserve_or_clear_only_owned_state() {
+        let binding = teardown_surface_binding();
+        let current = ClusterInstanceStatus {
+            phase: ClusterInstancePhase::Leased,
+            provisioned: true,
+            bootstrapped: true,
+            lease_ref: Some(binding.lease.clone()),
+            binding: Some(binding.clone()),
+            spec_hash: Some("immutable-spec-hash".into()),
+            teardown_identities: vec!["pv-uid".into()],
+            ..Default::default()
+        };
+        let recycled = ExactBindingTransition::RecycleTerminalLease {
+            lease_name: binding.lease.name.clone(),
+            lease_phase: LeasePhase::Expired,
+            transitioned_at: "2026-08-27T10:00:00Z".into(),
+        }
+        .apply(&current);
+        assert_eq!(recycled.phase, ClusterInstancePhase::Recycling);
+        assert_eq!(recycled.binding, current.binding);
+        assert_eq!(recycled.lease_ref, current.lease_ref);
+        assert_eq!(recycled.spec_hash, current.spec_hash);
+        assert_eq!(recycled.teardown_identities, current.teardown_identities);
+        let recycle_patch = ExactBindingTransition::RecycleTerminalLease {
+            lease_name: binding.lease.name.clone(),
+            lease_phase: LeasePhase::Expired,
+            transitioned_at: "2026-08-27T10:00:00Z".into(),
+        }
+        .patch_operations(&recycled);
+        assert!(recycle_patch.iter().all(|operation| {
+            operation["path"] != "/status/binding"
+                && operation["path"] != "/status/leaseRef"
+                && operation["path"] != "/status"
+        }));
+
+        let release_transition = ExactBindingTransition::ReleaseOrphan {
+            transitioned_at: "2026-08-27T10:00:00Z".into(),
+        };
+        let released = release_transition.apply(&current);
+        assert_eq!(released.phase, ClusterInstancePhase::Ready);
+        assert!(released.binding.is_none());
+        assert!(released.lease_ref.is_none());
+        assert_eq!(released.spec_hash, current.spec_hash);
+        assert_eq!(released.teardown_identities, current.teardown_identities);
+        let release_patch = release_transition.patch_operations(&released);
+        assert!(release_patch.iter().any(|operation| {
+            operation["op"] == "remove" && operation["path"] == "/status/binding"
+        }));
+        assert!(release_patch.iter().any(|operation| {
+            operation["op"] == "add"
+                && operation["path"] == "/status/leaseRef"
+                && operation["value"].is_null()
+        }));
+    }
+
     async fn test_instance_context() -> (Arc<InstanceContext<MockBackend>>, MockServer, MockBackend)
     {
         let _ = rustls::crypto::ring::default_provider().install_default();
@@ -4446,6 +4660,212 @@ mod tests {
             }
         }))
         .unwrap()
+    }
+
+    fn leased_surface_instance(
+        binding: &crate::crd::LeaseBinding,
+        resource_version: &str,
+    ) -> ClusterInstance {
+        let mut instance = teardown_surface_instance(binding);
+        instance.metadata.resource_version = Some(resource_version.into());
+        let status = instance.status.as_mut().unwrap();
+        status.phase = ClusterInstancePhase::Leased;
+        status.provisioned = true;
+        status.bootstrapped = true;
+        status.message = Some("ready".into());
+        instance
+    }
+
+    #[tokio::test]
+    async fn exact_binding_transition_rereads_and_retries_a_lost_race() {
+        let (ctx, server, _) = test_instance_context().await;
+        let binding = teardown_surface_binding();
+        let stale = leased_surface_instance(&binding, "24");
+        let fresh = leased_surface_instance(&binding, "25");
+        let mut recycled = fresh.clone();
+        recycled.metadata.resource_version = Some("26".into());
+        recycled.status.as_mut().unwrap().phase = ClusterInstancePhase::Recycling;
+        let endpoint = format!(
+            "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances/{}",
+            binding.instance.name
+        );
+
+        Mock::given(method("PATCH"))
+            .and(path(format!("{endpoint}/status")))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "reason": "Invalid",
+                "message": "the server rejected our request due to an error in our request",
+                "details": { "causes": [] },
+                "code": 422
+            })))
+            .with_priority(1)
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(endpoint.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&fresh))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(format!("{endpoint}/status")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&recycled))
+            .with_priority(2)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let outcome = patch_exact_binding_transition(
+            &ctx,
+            &stale,
+            &binding,
+            ExactBindingTransition::RecycleTerminalLease {
+                lease_name: binding.lease.name.clone(),
+                lease_phase: LeasePhase::Expired,
+                transitioned_at: "2026-08-27T10:00:00Z".into(),
+            },
+        )
+        .await
+        .expect("fresh exact subject must make progress");
+        assert_eq!(outcome, ExactBindingWriteOutcome::Applied);
+
+        let patches: Vec<serde_json::Value> = server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|request| request.method.as_str() == "PATCH")
+            .map(|request| serde_json::from_slice(&request.body).unwrap())
+            .collect();
+        assert_eq!(patches.len(), 2);
+        for (patch, resource_version) in patches.iter().zip(["24", "25"]) {
+            assert!(patch.as_array().unwrap().iter().any(|operation| {
+                operation["op"] == "test"
+                    && operation["path"] == "/metadata/resourceVersion"
+                    && operation["value"] == resource_version
+            }));
+            assert_eq!(
+                patch
+                    .as_array()
+                    .unwrap()
+                    .iter()
+                    .find(|operation| {
+                        operation["op"] == "add" && operation["path"] == "/status/phase"
+                    })
+                    .unwrap()["value"],
+                "Recycling"
+            );
+        }
+    }
+
+    #[tokio::test]
+    async fn exact_binding_transition_fails_loudly_after_bounded_conflicts() {
+        let (ctx, server, _) = test_instance_context().await;
+        let binding = teardown_surface_binding();
+        let stale = leased_surface_instance(&binding, "24");
+        let fresh = leased_surface_instance(&binding, "25");
+        let endpoint = format!(
+            "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances/{}",
+            binding.instance.name
+        );
+        Mock::given(method("PATCH"))
+            .and(path(format!("{endpoint}/status")))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "reason": "Invalid",
+                "message": "fence lost",
+                "details": { "causes": [] },
+                "code": 422
+            })))
+            .expect(EXACT_BINDING_WRITE_ATTEMPTS as u64)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&fresh))
+            .expect((EXACT_BINDING_WRITE_ATTEMPTS - 1) as u64)
+            .mount(&server)
+            .await;
+
+        let result = patch_exact_binding_transition(
+            &ctx,
+            &stale,
+            &binding,
+            ExactBindingTransition::RecycleTerminalLease {
+                lease_name: binding.lease.name.clone(),
+                lease_phase: LeasePhase::Released,
+                transitioned_at: "2026-08-27T10:00:00Z".into(),
+            },
+        )
+        .await;
+        assert!(
+            result.is_err(),
+            "repeated conflicts must not become success"
+        );
+    }
+
+    #[tokio::test]
+    async fn exact_binding_transition_never_retries_over_a_foreign_binding() {
+        let (ctx, server, _) = test_instance_context().await;
+        let binding = teardown_surface_binding();
+        let stale = leased_surface_instance(&binding, "24");
+        let mut replacement_binding = binding.clone();
+        replacement_binding.binding_id = "replacement-binding".into();
+        let replacement = leased_surface_instance(&replacement_binding, "25");
+        let endpoint = format!(
+            "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances/{}",
+            binding.instance.name
+        );
+        Mock::given(method("PATCH"))
+            .and(path(format!("{endpoint}/status")))
+            .respond_with(ResponseTemplate::new(409).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "reason": "Conflict",
+                "message": "fence lost",
+                "code": 409
+            })))
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&replacement))
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        let outcome = patch_exact_binding_transition(
+            &ctx,
+            &stale,
+            &binding,
+            ExactBindingTransition::RecycleTerminalLease {
+                lease_name: binding.lease.name.clone(),
+                lease_phase: LeasePhase::Released,
+                transitioned_at: "2026-08-27T10:00:00Z".into(),
+            },
+        )
+        .await
+        .expect("foreign bindings are a safe supersession");
+        assert_eq!(outcome, ExactBindingWriteOutcome::Superseded);
+        assert_eq!(
+            server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| request.method.as_str() == "PATCH")
+                .count(),
+            1
+        );
     }
 
     #[test]

--- a/src/controllers/lease.rs
+++ b/src/controllers/lease.rs
@@ -2,6 +2,10 @@ use std::collections::{HashMap, HashSet};
 use std::sync::{Arc, Mutex};
 
 use futures::StreamExt;
+use kobe_state_machine::{
+    BindingState as ModelBindingState, FinalizationDecision, InstancePhase as ModelInstancePhase,
+    LeasePhase as ModelLeasePhase, exact_binding_finalization,
+};
 use kube::api::{Api, DeleteParams, ListParams, Patch, PatchParams, Preconditions};
 use kube::runtime::controller::{Action, Controller};
 use kube::runtime::watcher::Config;
@@ -1183,7 +1187,15 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
     {
         match backfill_legacy_binding(&ctx.client, &ns, &lease).await? {
             Some(binding) => {
-                let bound = finalize_binding(&ctx, &ns, &binding, created_at_for(&lease)).await?;
+                // Keep the retrying finalizer future off the already-large
+                // reconcile state machine's stack frame.
+                let bound = Box::pin(finalize_binding(
+                    &ctx,
+                    &ns,
+                    &binding,
+                    created_at_for(&lease),
+                ))
+                .await?;
                 remove_from_queue(&ctx.queues, &lease.spec.pool_ref, &name).await;
                 return Ok(Action::requeue(std::time::Duration::from_secs(if bound {
                     60
@@ -1302,7 +1314,9 @@ async fn reconcile_lease<B: ClusterBackend + Clone + 'static>(
                 // write fails or the process stops, the next reconcile sees
                 // the same lease-side intent and finishes the same pair. It
                 // must not roll back on an uncertain response.
-                let bound = finalize_binding(&ctx, &ns, &binding, created_at).await?;
+                // Keep the retrying finalizer future off the already-large
+                // reconcile state machine's stack frame.
+                let bound = Box::pin(finalize_binding(&ctx, &ns, &binding, created_at)).await?;
                 remove_from_queue(&ctx.queues, &lease.spec.pool_ref, &name).await;
                 Ok(Action::requeue(std::time::Duration::from_secs(if bound {
                     60
@@ -2055,6 +2069,42 @@ async fn sandbox_composition_finalization_is_authorized<B: ClusterBackend>(
     }
 }
 
+const FINALIZE_BINDING_ATTEMPTS: usize = 3;
+
+fn model_lease_phase(phase: &LeasePhase) -> ModelLeasePhase {
+    match phase {
+        LeasePhase::Pending => ModelLeasePhase::Pending,
+        LeasePhase::Bound => ModelLeasePhase::Bound,
+        LeasePhase::Released => ModelLeasePhase::Released,
+        LeasePhase::Expired => ModelLeasePhase::Expired,
+        LeasePhase::Recycling => ModelLeasePhase::Recycling,
+        LeasePhase::Quarantined => ModelLeasePhase::Quarantined,
+    }
+}
+
+fn model_instance_phase(phase: &ClusterInstancePhase) -> ModelInstancePhase {
+    match phase {
+        ClusterInstancePhase::Creating => ModelInstancePhase::Creating,
+        ClusterInstancePhase::Ready => ModelInstancePhase::Ready,
+        ClusterInstancePhase::Leased => ModelInstancePhase::Leased,
+        ClusterInstancePhase::Recycling => ModelInstancePhase::Recycling,
+        ClusterInstancePhase::Unhealthy => ModelInstancePhase::Unhealthy,
+        ClusterInstancePhase::Failed => ModelInstancePhase::Failed,
+        ClusterInstancePhase::Quarantined => ModelInstancePhase::Quarantined,
+    }
+}
+
+fn model_binding_state(
+    observed: Option<&LeaseBinding>,
+    expected: &LeaseBinding,
+) -> ModelBindingState {
+    match observed {
+        Some(binding) if binding == expected => ModelBindingState::Expected,
+        None => ModelBindingState::Absent,
+        Some(_) => ModelBindingState::Foreign,
+    }
+}
+
 /// Complete a previously persisted two-sided reservation.
 ///
 /// Returns `true` only when `Bound` is already or successfully published. If a
@@ -2070,145 +2120,190 @@ async fn finalize_binding<B: ClusterBackend>(
     created_at: chrono::DateTime<chrono::Utc>,
 ) -> Result<bool, LeaseError> {
     let leases_api: Api<ClusterLease> = Api::namespaced(ctx.client.clone(), namespace);
-    let lease = leases_api.get(&binding.lease.name).await?;
-    if lease.metadata.uid.as_deref() != binding.lease.uid.as_deref() {
-        return Err(LeaseError::Lifecycle(anyhow::anyhow!(
-            "lease UID changed while finalizing binding"
-        )));
-    }
-    let status = lease.status.clone().unwrap_or_default();
-    let already_bound =
-        status.phase == LeasePhase::Bound && status.binding.as_ref() == Some(binding);
-    if !already_bound
-        && (status.phase != LeasePhase::Pending || status.binding.as_ref() != Some(binding))
-    {
-        return Err(LeaseError::Lifecycle(anyhow::anyhow!(
-            "lease binding intent changed before finalization"
-        )));
-    }
-    if !sandbox_composition_finalization_is_authorized(
-        ctx,
-        namespace,
-        &leases_api,
-        &lease,
-        binding,
-        already_bound,
-    )
-    .await?
-    {
-        return Ok(false);
-    }
-
     let instances: Api<ClusterInstance> = Api::namespaced(ctx.client.clone(), namespace);
-    let instance = instances.get(&binding.instance.name).await?;
-    if !instance_matches_binding_subject(&instance, binding)
-        || instance.status.as_ref().is_none_or(|status| {
-            status.phase != ClusterInstancePhase::Leased || status.binding.as_ref() != Some(binding)
-        })
-    {
-        return Err(LeaseError::Lifecycle(anyhow::anyhow!(
-            "instance reciprocal binding changed before finalization"
-        )));
-    }
-    validate_binding_eligibility(ctx.factory.as_ref(), namespace, &lease, &instance, binding)
-        .await
-        .map_err(LeaseError::Lifecycle)?;
-    if binding.cleanup_mode.requires_receipt() {
-        crate::api::connect::ensure_lease_connect_token(&ctx.client, namespace, &lease, binding)
+    for attempt in 1..=FINALIZE_BINDING_ATTEMPTS {
+        let lease = leases_api.get(&binding.lease.name).await?;
+        if lease.metadata.uid.as_deref() != binding.lease.uid.as_deref() {
+            return Err(LeaseError::Lifecycle(anyhow::anyhow!(
+                "lease UID changed while finalizing binding"
+            )));
+        }
+        let status = lease.status.clone().unwrap_or_default();
+        let lease_binding_state = model_binding_state(status.binding.as_ref(), binding);
+        let already_bound =
+            status.phase == LeasePhase::Bound && lease_binding_state == ModelBindingState::Expected;
+        if !already_bound
+            && (status.phase != LeasePhase::Pending
+                || lease_binding_state != ModelBindingState::Expected)
+        {
+            return Err(LeaseError::Lifecycle(anyhow::anyhow!(
+                "lease binding intent changed before finalization"
+            )));
+        }
+        if !sandbox_composition_finalization_is_authorized(
+            ctx,
+            namespace,
+            &leases_api,
+            &lease,
+            binding,
+            already_bound,
+        )
+        .await?
+        {
+            return Ok(false);
+        }
+        let instance = instances.get(&binding.instance.name).await?;
+        if !instance_matches_binding_subject(&instance, binding) {
+            return Err(LeaseError::Lifecycle(anyhow::anyhow!(
+                "instance reciprocal binding changed before finalization"
+            )));
+        }
+        let instance_status = instance.status.clone().unwrap_or_default();
+        let decision = exact_binding_finalization(
+            model_lease_phase(&status.phase),
+            model_binding_state(status.binding.as_ref(), binding),
+            model_instance_phase(&instance_status.phase),
+            model_binding_state(instance_status.binding.as_ref(), binding),
+        );
+        if decision == FinalizationDecision::Superseded {
+            return Err(LeaseError::Lifecycle(anyhow::anyhow!(
+                "exact reciprocal binding changed before finalization"
+            )));
+        }
+        debug_assert_eq!(
+            already_bound,
+            decision == FinalizationDecision::AlreadyBound
+        );
+        validate_binding_eligibility(ctx.factory.as_ref(), namespace, &lease, &instance, binding)
             .await
             .map_err(LeaseError::Lifecycle)?;
-    }
-    if already_bound {
-        return Ok(true);
-    }
+        if binding.cleanup_mode.requires_receipt() {
+            crate::api::connect::ensure_lease_connect_token(
+                &ctx.client,
+                namespace,
+                &lease,
+                binding,
+            )
+            .await
+            .map_err(LeaseError::Lifecycle)?;
+        }
+        if already_bound {
+            return Ok(true);
+        }
 
-    let lease_uid = binding
-        .lease
-        .uid
-        .as_deref()
-        .ok_or_else(|| anyhow::anyhow!("binding missing lease UID"))?;
-    let lease_rv = lease
-        .resource_version()
-        .ok_or_else(|| anyhow::anyhow!("lease missing resourceVersion"))?;
-    let ttl = parse_duration(&lease.spec.ttl).unwrap_or_else(|| chrono::Duration::hours(1));
-    let now = chrono::Utc::now();
-    let expires_at = now + ttl;
-    let max_extensions = ctx
-        .authenticator
-        .policy_for_requester_type(&lease.spec.requester.requester_type)
-        .await
-        .map(|policy| policy.max_extensions)
-        .unwrap_or(2);
-    let mut new_status = ClusterLeaseStatus {
-        phase: LeasePhase::Bound,
-        cluster_name: Some(binding.instance.name.clone()),
-        binding: Some(binding.clone()),
-        bound_at: Some(now.to_rfc3339()),
-        expires_at: Some(expires_at.to_rfc3339()),
-        queue_position: 0,
-        diagnostics_url: None,
-        extensions_count: 0,
-        max_extensions,
-        message: None,
-        conditions: Vec::new(),
-        teardown_receipt: None,
-        teardown_evidence: None,
-        teardown_attempt_id: None,
-        connect_token_creation: status.connect_token_creation.clone(),
-        unbound_release_verified_at: None,
-        teardown_acknowledgement: None,
-    };
-    new_status.conditions =
-        derive_lease_conditions(&new_status, &status.conditions, None, &now.to_rfc3339());
+        let lease_uid = binding
+            .lease
+            .uid
+            .as_deref()
+            .ok_or_else(|| anyhow::anyhow!("binding missing lease UID"))?;
+        let lease_rv = lease
+            .resource_version()
+            .ok_or_else(|| anyhow::anyhow!("lease missing resourceVersion"))?;
+        let ttl = parse_duration(&lease.spec.ttl).unwrap_or_else(|| chrono::Duration::hours(1));
+        let now = chrono::Utc::now();
+        let expires_at = now + ttl;
+        let max_extensions = ctx
+            .authenticator
+            .policy_for_requester_type(&lease.spec.requester.requester_type)
+            .await
+            .map(|policy| policy.max_extensions)
+            .unwrap_or(2);
+        let mut new_status = ClusterLeaseStatus {
+            phase: LeasePhase::Bound,
+            cluster_name: Some(binding.instance.name.clone()),
+            binding: Some(binding.clone()),
+            bound_at: Some(now.to_rfc3339()),
+            expires_at: Some(expires_at.to_rfc3339()),
+            queue_position: 0,
+            diagnostics_url: None,
+            extensions_count: 0,
+            max_extensions,
+            message: None,
+            conditions: Vec::new(),
+            teardown_receipt: None,
+            teardown_evidence: None,
+            teardown_attempt_id: None,
+            connect_token_creation: status.connect_token_creation.clone(),
+            unbound_release_verified_at: None,
+            teardown_acknowledgement: None,
+        };
+        new_status.conditions =
+            derive_lease_conditions(&new_status, &status.conditions, None, &now.to_rfc3339());
 
-    // Re-read the outer and exact live pool immediately before publishing
-    // `Bound`. This closes replacement races during instance/token validation.
-    if !sandbox_composition_finalization_is_authorized(
-        ctx,
-        namespace,
-        &leases_api,
-        &lease,
-        binding,
-        false,
-    )
-    .await?
-    {
-        return Ok(false);
-    }
-
-    let patch = json_patch(serde_json::json!([
-        { "op": "test", "path": "/metadata/uid", "value": lease_uid },
-        { "op": "test", "path": "/metadata/resourceVersion", "value": lease_rv },
-        { "op": "test", "path": "/status/phase", "value": "Pending" },
-        { "op": "test", "path": "/status/binding", "value": binding },
-        { "op": "add", "path": "/status", "value": new_status }
-    ]));
-    leases_api
-        .patch_status(
-            &binding.lease.name,
-            &PatchParams::default(),
-            &Patch::<()>::Json(patch),
+        // Re-read the outer and exact live pool immediately before publishing
+        // `Bound`. This closes replacement races during instance/token validation.
+        if !sandbox_composition_finalization_is_authorized(
+            ctx,
+            namespace,
+            &leases_api,
+            &lease,
+            binding,
+            false,
         )
-        .await?;
+        .await?
+        {
+            return Ok(false);
+        }
 
-    let bind_duration = (chrono::Utc::now() - created_at).num_milliseconds() as f64 / 1000.0;
-    crate::metrics::CLAIM_BIND_DURATION
-        .with_label_values(&[lease.spec.pool_ref.as_str()])
-        .observe(bind_duration);
-    crate::metrics::LEASE_QUEUE_WAIT_SECONDS
-        .with_label_values(&[lease.spec.pool_ref.as_str(), "bound"])
-        .observe(bind_duration);
-    crate::metrics::CLAIMS_TOTAL
-        .with_label_values(&[lease.spec.pool_ref.as_str(), "bound"])
-        .inc();
-    info!(
-        lease = %binding.lease.name,
-        cluster = %binding.instance.name,
-        expires_at = %expires_at,
-        bind_seconds = bind_duration,
-        "Lease bound to exact ClusterInstance"
-    );
-    Ok(true)
+        let mut operations = vec![
+            serde_json::json!({ "op": "test", "path": "/metadata/uid", "value": lease_uid }),
+            serde_json::json!({ "op": "test", "path": "/metadata/resourceVersion", "value": lease_rv }),
+            serde_json::json!({ "op": "test", "path": "/status/phase", "value": "Pending" }),
+            serde_json::json!({ "op": "test", "path": "/status/binding", "value": binding }),
+            serde_json::json!({ "op": "add", "path": "/status/phase", "value": "Bound" }),
+            serde_json::json!({ "op": "add", "path": "/status/clusterName", "value": binding.instance.name }),
+            serde_json::json!({ "op": "add", "path": "/status/boundAt", "value": new_status.bound_at }),
+            serde_json::json!({ "op": "add", "path": "/status/expiresAt", "value": new_status.expires_at }),
+            serde_json::json!({ "op": "add", "path": "/status/queuePosition", "value": 0 }),
+            serde_json::json!({ "op": "add", "path": "/status/extensionsCount", "value": 0 }),
+            serde_json::json!({ "op": "add", "path": "/status/maxExtensions", "value": max_extensions }),
+            serde_json::json!({ "op": "add", "path": "/status/conditions", "value": new_status.conditions }),
+        ];
+        if status.message.is_some() {
+            operations.push(serde_json::json!({ "op": "remove", "path": "/status/message" }));
+        }
+        let patch = json_patch(serde_json::Value::Array(operations));
+        match leases_api
+            .patch_status(
+                &binding.lease.name,
+                &PatchParams::default(),
+                &Patch::<()>::Json(patch),
+            )
+            .await
+        {
+            Ok(_) => {
+                let bind_duration =
+                    (chrono::Utc::now() - created_at).num_milliseconds() as f64 / 1000.0;
+                crate::metrics::CLAIM_BIND_DURATION
+                    .with_label_values(&[lease.spec.pool_ref.as_str()])
+                    .observe(bind_duration);
+                crate::metrics::LEASE_QUEUE_WAIT_SECONDS
+                    .with_label_values(&[lease.spec.pool_ref.as_str(), "bound"])
+                    .observe(bind_duration);
+                crate::metrics::CLAIMS_TOTAL
+                    .with_label_values(&[lease.spec.pool_ref.as_str(), "bound"])
+                    .inc();
+                info!(
+                    lease = %binding.lease.name,
+                    cluster = %binding.instance.name,
+                    expires_at = %expires_at,
+                    bind_seconds = bind_duration,
+                    "Lease bound to exact ClusterInstance"
+                );
+                return Ok(true);
+            }
+            Err(error) if optimistic_conflict(&error) && attempt < FINALIZE_BINDING_ATTEMPTS => {
+                debug!(
+                    lease = %binding.lease.name,
+                    attempt,
+                    "binding finalization lost a race; re-reading both sides before retry"
+                );
+            }
+            Err(error) => return Err(error.into()),
+        }
+    }
+
+    unreachable!("bounded binding-finalization loop always returns")
 }
 
 /// Message stamped on a lease whose binding could not be verified.
@@ -4921,6 +5016,107 @@ mod tests {
                 "binding": binding
             }
         })
+    }
+
+    #[tokio::test]
+    async fn finalize_binding_rereads_both_sides_and_retries_a_lost_race() {
+        let (ctx, server) = test_lease_context().await;
+        let binding = exact_test_binding("lease-finalize", "lease-finalize-uid");
+        let stale = exact_pending_lease_for_binding(&binding);
+        let mut fresh = stale.clone();
+        fresh["metadata"]["resourceVersion"] = "11".into();
+        let mut bound = fresh.clone();
+        bound["metadata"]["resourceVersion"] = "12".into();
+        bound["status"]["phase"] = "Bound".into();
+        bound["status"]["clusterName"] = binding.instance.name.clone().into();
+        let instance = exact_instance_for_binding(Some(&binding), "Leased");
+        let lease_endpoint = format!(
+            "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterleases/{}",
+            binding.lease.name
+        );
+        let instance_endpoint = format!(
+            "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterinstances/{}",
+            binding.instance.name
+        );
+
+        Mock::given(method("GET"))
+            .and(path(lease_endpoint.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&stale))
+            .with_priority(1)
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(lease_endpoint.clone()))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&fresh))
+            .with_priority(2)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(instance_endpoint))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&instance))
+            .expect(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(format!("{lease_endpoint}/status")))
+            .respond_with(ResponseTemplate::new(422).set_body_json(serde_json::json!({
+                "apiVersion": "v1",
+                "kind": "Status",
+                "status": "Failure",
+                "reason": "Invalid",
+                "message": "fence lost",
+                "details": { "causes": [] },
+                "code": 422
+            })))
+            .with_priority(1)
+            .up_to_n_times(1)
+            .expect(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("PATCH"))
+            .and(path(format!("{lease_endpoint}/status")))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&bound))
+            .with_priority(2)
+            .expect(1)
+            .mount(&server)
+            .await;
+
+        assert!(
+            finalize_binding(&ctx, "test-ns", &binding, chrono::Utc::now())
+                .await
+                .expect("fresh reciprocal pair must finalize")
+        );
+        let patches: Vec<serde_json::Value> = server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .into_iter()
+            .filter(|request| request.method.as_str() == "PATCH")
+            .map(|request| serde_json::from_slice(&request.body).unwrap())
+            .collect();
+        assert_eq!(patches.len(), 2);
+        for (patch, resource_version) in patches.iter().zip(["10", "11"]) {
+            let operations = patch.as_array().unwrap();
+            assert!(operations.iter().any(|operation| {
+                operation["op"] == "test"
+                    && operation["path"] == "/metadata/resourceVersion"
+                    && operation["value"] == resource_version
+            }));
+            assert!(operations.iter().any(|operation| {
+                operation["op"] == "add"
+                    && operation["path"] == "/status/phase"
+                    && operation["value"] == "Bound"
+            }));
+            assert!(
+                operations
+                    .iter()
+                    .all(|operation| operation["path"] != "/status"),
+                "finalization must not replace unrelated status fields"
+            );
+        }
     }
 
     #[tokio::test]


### PR DESCRIPTION
## Summary

- stop treating 409 and ambiguous 422 lifecycle writes as successful progress
- re-read both lease and instance, re-evaluate an exact-binding state machine, and retry with fresh UID/resourceVersion fences
- patch only transition-owned status fields so retries cannot overwrite unrelated lifecycle evidence
- add a shared pure state-machine crate used by production, exhaustive matrix tests, four Kani proofs, and a mutation gate

## Incident

The int-pro ci-k3s-kunobi pool reached 20/20 leased while every owning lease was terminal. The operator logged recycling every 10 seconds, but its status write returned 422 and was silently accepted as a lost race. No write landed and no watch event could wake a different path, producing a livelock. The same pattern also blocked Pending to Bound finalization.

## Validation

- cargo test --workspace
- cargo clippy --workspace --all-targets -- -D warnings
- 4 Kani harnesses verified, 0 failures
- cargo-mutants: 4 caught, 2 unviable, 0 missed
- version consistency tests: 11 passed
- rebased onto current origin/main