### PR TITLE
test(cli): cover unified resource command matrix

### DIFF
--- a/crates/kobectl/src/commands/extend.rs
+++ b/crates/kobectl/src/commands/extend.rs
@@ -107,11 +107,10 @@ pub async fn extend(
     // Mutating command: never act on an arbitrary lease when the choice is
     // ambiguous and we cannot prompt.
     //
-    // An explicit Sandbox lease id resolves itself. Sending it through the
-    // cluster resolver would fail with "no active lease matching", because
-    // that resolver only lists `/v1/leases`. Sandbox alias and pool
-    // resolution, and the interactive picker, still cover cluster leases
-    // only — they need a unified listing, which belongs with `kobe status`.
+    // An explicit Sandbox lease id resolves itself even after it disappears
+    // from the active inventory. Every other value goes through the unified
+    // lease selector, which matches active ids, aliases and unique pool names
+    // across both resource kinds.
     let lease_id = match target {
         Some(target) if is_sandbox_lease(target) => target.to_string(),
         target => resolve_lease_id(&config, target, output, OnAmbiguous::Reject).await?,

--- a/crates/kobectl/src/commands/release.rs
+++ b/crates/kobectl/src/commands/release.rs
@@ -61,12 +61,17 @@ pub async fn release(
 ) -> Result<()> {
     let config = CliConfig::load()?;
     let config = config.resolve(target_override, endpoint_override)?;
-    // An explicit id is used verbatim (the server handles 404 gracefully, so
-    // releasing a just-expired id still works). Otherwise resolve against the
-    // active leases, falling back to the first one in non-interactive mode to
-    // preserve the prior behavior.
+    // Generated ids identify their kind and remain usable after the lease has
+    // disappeared from the active inventory, so keep sending those verbatim.
+    // Every other explicit value is a selector: resolve aliases and unique
+    // pool names across all lease kinds before choosing the DELETE endpoint.
+    // This keeps `kobe release dev` symmetric with `exec dev` and `extend dev`
+    // without giving up idempotent release of an already-expired concrete id.
     let selected_lease = match lease_id {
-        Some(id) => id.to_string(),
+        Some(id) if is_self_identifying_lease_id(id) => id.to_string(),
+        Some(selector) => {
+            resolve_lease_id(&config, Some(selector), output, OnAmbiguous::Reject).await?
+        }
         None => resolve_lease_id(&config, None, output, OnAmbiguous::FirstActive).await?,
     };
     let outcome = release_lease(&config, &selected_lease).await?;
@@ -88,4 +93,8 @@ pub async fn release(
     }
 
     Ok(())
+}
+
+fn is_self_identifying_lease_id(value: &str) -> bool {
+    value.starts_with("lease-") || is_sandbox_lease(value)
 }

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -161,6 +161,7 @@ enum Commands {
     /// (or, with `--output json`, the command errors and lists candidates).
     Extend {
         /// Lease id or pool to extend (optional when you hold one lease)
+        #[arg(id = "lease_selector")]
         target: Option<String>,
         /// Duration to add to the current expiry (e.g. 30m, 1h)
         #[arg(long, default_value = "30m")]
@@ -861,5 +862,25 @@ mod tests {
                 action: SandboxAction::Exec { .. }
             }
         ));
+    }
+
+    #[test]
+    fn extend_selector_is_distinct_from_the_global_target() {
+        let cli = Cli::try_parse_from([
+            "kobe",
+            "--target",
+            "production",
+            "extend",
+            "dev",
+            "--ttl",
+            "30m",
+        ])
+        .unwrap();
+        assert_eq!(cli.target.as_deref(), Some("production"));
+        let Commands::Extend { target, ttl } = cli.command else {
+            panic!("expected extend")
+        };
+        assert_eq!(target.as_deref(), Some("dev"));
+        assert_eq!(ttl, "30m");
     }
 }

--- a/crates/kobectl/tests/sandbox_cli.rs
+++ b/crates/kobectl/tests/sandbox_cli.rs
@@ -175,6 +175,33 @@ fn execution_body(state: &str, exit_code: Option<i32>) -> String {
     .to_string()
 }
 
+fn pool_body(name: &str, resource_kind: &str, capabilities: &[&str]) -> String {
+    json!({
+        "name": name,
+        "resourceKind": resource_kind,
+        "capabilities": capabilities,
+        "phase": "Ready",
+        "ready": 1,
+        "leased": 0,
+        "creating": 0,
+        "recycling": 0,
+        "unhealthy": 0,
+        "quarantined": 0,
+        "queueDepth": 0
+    })
+    .to_string()
+}
+
+fn sandbox_inventory() -> String {
+    json!([{
+        "id": "sandbox-test",
+        "phase": "Ready",
+        "pool": "agents",
+        "alias": "dev"
+    }])
+    .to_string()
+}
+
 fn spawn_child(endpoint: &str, args: &[&str]) -> (tempfile::TempDir, Child) {
     spawn_child_with_auth(endpoint, "none", args)
 }
@@ -245,7 +272,18 @@ fn run_server(
     let state = state.to_string();
     let server = Server::start(move |request, stream| {
         let mut current = observed.lock().unwrap();
-        if request.method == "POST" && request.path == "/v1/sandbox-leases" {
+        if request.method == "GET" && request.path == "/v1/pools/agents" {
+            reply(
+                stream,
+                200,
+                &[],
+                &pool_body(
+                    "agents",
+                    "Sandbox",
+                    &["lease", "exec", "logs", "cancel", "attach", "port-forward"],
+                ),
+            );
+        } else if request.method == "POST" && request.path == "/v1/sandbox-leases" {
             current.creates += 1;
             let (_, lease) = keyed_lease(&request.body);
             current.lease = Some(lease.clone());
@@ -305,7 +343,13 @@ fn flat_exec_routes_an_executable_lease_without_a_kind_namespace() {
         &["exec", "dev", "--", "/agent", "status"],
     );
     let output = wait_output(child);
-    assert_eq!(output.status.code(), Some(0));
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
     assert_eq!(String::from_utf8_lossy(&output.stdout), "out\n");
     assert_eq!(String::from_utf8_lossy(&output.stderr), "err\n");
 }
@@ -340,6 +384,308 @@ fn flat_exec_rejects_a_cluster_lease_by_capability() {
 }
 
 #[test]
+fn flat_release_resolves_a_sandbox_alias_before_dispatch() {
+    let server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(stream, 200, &[], "[]"),
+            ("GET", "/v1/sandbox-leases") => reply(
+                stream,
+                200,
+                &[],
+                &json!([{
+                    "id": "sandbox-test",
+                    "phase": "Ready",
+                    "pool": "agents",
+                    "alias": "dev"
+                }])
+                .to_string(),
+            ),
+            ("DELETE", "/v1/sandbox-leases/sandbox-test") => reply(stream, 204, &[], ""),
+            _ => panic!("release must resolve the alias before dispatch: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(&server.endpoint(), &["release", "dev"]);
+    let output = wait_output(child);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(String::from_utf8_lossy(&output.stdout).contains("sandbox-test"));
+}
+
+#[test]
+fn flat_capability_commands_resolve_aliases_without_a_kind_namespace() {
+    let server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(stream, 200, &[], "[]"),
+            ("GET", "/v1/sandbox-leases") => reply(stream, 200, &[], &sandbox_inventory()),
+            ("GET", "/v1/sandbox-leases/sandbox-test/logs?tail=5") => {
+                reply(stream, 200, &[], "sandbox log\n")
+            }
+            ("DELETE", "/v1/sandbox-leases/sandbox-test/executions/sbxe-test") => {
+                reply(stream, 200, &[], &execution_body("Cancelled", None))
+            }
+            _ => panic!("unexpected flat capability request: {request:?}"),
+        }
+    });
+
+    for (args, expected) in [
+        (vec!["logs", "dev", "--tail", "5"], "sandbox log"),
+        (
+            vec!["cancel", "dev", "--execution", "sbxe-test"],
+            "sbxe-test is Cancelled",
+        ),
+    ] {
+        let (_directory, child) = spawn_child(&server.endpoint(), &args);
+        let output = wait_output(child);
+        assert_eq!(
+            output.status.code(),
+            Some(0),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stderr)
+        );
+        assert!(
+            String::from_utf8_lossy(&output.stdout).contains(expected),
+            "{args:?}: {}",
+            String::from_utf8_lossy(&output.stdout)
+        );
+    }
+
+    let (_directory, child) =
+        spawn_child(&server.endpoint(), &["attach", "dev", "--output", "json"]);
+    let output = wait_output(child);
+    assert_eq!(output.status.code(), Some(125));
+    assert!(output.stderr.is_empty());
+    let envelope: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(envelope["outcome"], "clientError");
+    assert!(envelope["error"].as_str().unwrap().contains("interactive"));
+}
+
+#[test]
+fn flat_lease_dispatches_from_the_pool_resource_kind() {
+    let cluster_server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/pools/ci") => reply(
+                stream,
+                200,
+                &[],
+                &pool_body("ci", "Cluster", &["lease", "kubeconfig", "release"]),
+            ),
+            ("POST", "/v1/leases") => reply(
+                stream,
+                202,
+                &[],
+                &json!({
+                    "id": "lease-cluster",
+                    "phase": "Pending",
+                    "profile": "ci",
+                    "queuePosition": 1,
+                    "effectiveTtl": "1h"
+                })
+                .to_string(),
+            ),
+            _ => panic!("unexpected Cluster lease request: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(
+        &cluster_server.endpoint(),
+        &["lease", "ci", "--no-wait", "--output", "json"],
+    );
+    let output = wait_output(child);
+    assert_eq!(output.status.code(), Some(0));
+    let created: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(created["resourceKind"], "Cluster");
+    assert_eq!(created["id"], "lease-cluster");
+
+    let sandbox_server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/pools/agents") => reply(
+                stream,
+                200,
+                &[],
+                &pool_body("agents", "Sandbox", &["lease", "exec", "release"]),
+            ),
+            ("POST", "/v1/sandbox-leases") => {
+                let (_, lease) = keyed_lease(&request.body);
+                let location = format!("/v1/sandbox-leases/{lease}");
+                reply(
+                    stream,
+                    202,
+                    &[("Location", &location)],
+                    &lease_body(&lease, "Pending"),
+                );
+            }
+            _ => panic!("unexpected Sandbox lease request: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(
+        &sandbox_server.endpoint(),
+        &["lease", "agents", "--no-wait", "--output", "json"],
+    );
+    let output = wait_output(child);
+    assert_eq!(output.status.code(), Some(0));
+    let created: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(created["resourceKind"], "Sandbox");
+    assert!(created["id"].as_str().unwrap().starts_with("sandbox-"));
+}
+
+#[test]
+fn flat_extend_and_purge_route_both_resource_kinds() {
+    let extend_server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(stream, 200, &[], "[]"),
+            ("GET", "/v1/sandbox-leases") => reply(stream, 200, &[], &sandbox_inventory()),
+            ("PATCH", "/v1/sandbox-leases/sandbox-test") => reply(
+                stream,
+                200,
+                &[],
+                &json!({ "expiresAt": "2030-01-01T00:00:00Z" }).to_string(),
+            ),
+            _ => panic!("unexpected extend request: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(
+        &extend_server.endpoint(),
+        &["extend", "dev", "--ttl", "30m", "--output", "json"],
+    );
+    let output = wait_output(child);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let extended: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(extended["leaseId"], "sandbox-test");
+
+    let deleted = Arc::new(Mutex::new(Vec::<String>::new()));
+    let observed = Arc::clone(&deleted);
+    let purge_server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(
+                stream,
+                200,
+                &[],
+                &json!([{
+                    "id": "lease-cluster",
+                    "phase": "Bound",
+                    "profile": "ci"
+                }])
+                .to_string(),
+            ),
+            ("GET", "/v1/sandbox-leases") => reply(stream, 200, &[], &sandbox_inventory()),
+            ("DELETE", "/v1/leases/lease-cluster")
+            | ("DELETE", "/v1/sandbox-leases/sandbox-test") => {
+                observed.lock().unwrap().push(request.path);
+                reply(stream, 204, &[], "");
+            }
+            _ => panic!("unexpected purge request: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(
+        &purge_server.endpoint(),
+        &["purge", "--yes", "--output", "json"],
+    );
+    let output = wait_output(child);
+    assert_eq!(output.status.code(), Some(0));
+    let purged: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(purged["releasedLeases"].as_array().unwrap().len(), 2);
+    let deleted = deleted.lock().unwrap();
+    assert!(deleted.contains(&"/v1/leases/lease-cluster".to_string()));
+    assert!(deleted.contains(&"/v1/sandbox-leases/sandbox-test".to_string()));
+}
+
+#[test]
+fn flat_status_reports_one_mixed_pool_and_lease_inventory() {
+    let server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/status") => {
+                reply(stream, 200, &[], &json!({ "version": "test" }).to_string())
+            }
+            ("GET", "/v1/pools") => reply(
+                stream,
+                200,
+                &[],
+                &json!([
+                    serde_json::from_str::<Value>(&pool_body(
+                        "agents",
+                        "Sandbox",
+                        &["lease", "exec", "release"]
+                    ))
+                    .unwrap(),
+                    serde_json::from_str::<Value>(&pool_body(
+                        "ci",
+                        "Cluster",
+                        &["lease", "kubeconfig", "release"]
+                    ))
+                    .unwrap()
+                ])
+                .to_string(),
+            ),
+            ("GET", "/v1/leases") => reply(
+                stream,
+                200,
+                &[],
+                &json!([{
+                    "id": "lease-cluster",
+                    "phase": "Bound",
+                    "profile": "ci"
+                }])
+                .to_string(),
+            ),
+            ("GET", "/v1/sandbox-leases") => reply(stream, 200, &[], &sandbox_inventory()),
+            ("GET", "/v1/leases/lease-cluster") => reply(
+                stream,
+                200,
+                &[],
+                &json!({
+                    "id": "lease-cluster",
+                    "phase": "Bound",
+                    "profile": "ci",
+                    "clusterName": "pool-ci-1"
+                })
+                .to_string(),
+            ),
+            ("GET", "/v1/sandbox-leases/sandbox-test") => reply(
+                stream,
+                200,
+                &[],
+                &json!({
+                    "id": "sandbox-test",
+                    "phase": "Ready",
+                    "pool": "agents"
+                })
+                .to_string(),
+            ),
+            _ => panic!("unexpected status request: {request:?}"),
+        }
+    });
+    let (_directory, child) = spawn_child(&server.endpoint(), &["status", "--output", "json"]);
+    let output = wait_output(child);
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "stdout={} stderr={}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr)
+    );
+    let status: Value = serde_json::from_slice(&output.stdout).unwrap();
+    assert_eq!(status["pools"].as_array().unwrap().len(), 2);
+    assert_eq!(status["leases"].as_array().unwrap().len(), 2);
+    let kinds: HashSet<_> = status["leases"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .filter_map(|lease| lease["resourceKind"].as_str())
+        .collect();
+    assert_eq!(kinds, HashSet::from(["Cluster", "Sandbox"]));
+}
+
+#[test]
 fn run_uses_one_json_envelope_for_terminal_and_release_outcomes() {
     for (remote_state, remote_exit, release_status, expected_exit, outcome, released) in [
         ("Succeeded", Some(0), 204, 0, "success", true),
@@ -351,9 +697,7 @@ fn run_uses_one_json_envelope_for_terminal_and_release_outcomes() {
         let (server, requests) = run_server(remote_state, remote_exit, release_status);
         let (_directory, child) = spawn_child(
             &server.endpoint(),
-            &[
-                "sandbox", "run", "agents", "--output", "json", "--", "/agent",
-            ],
+            &["run", "agents", "--output", "json", "--", "/agent"],
         );
         let output = wait_output(child);
         assert_eq!(output.status.code(), Some(expected_exit), "{remote_state}");
@@ -663,15 +1007,19 @@ fn json_parse_errors_use_the_versioned_envelope_and_never_stderr() {
 fn json_attach_is_refused_and_port_forward_errors_are_machine_events() {
     let calls = Arc::new(Mutex::new(0usize));
     let observed = Arc::clone(&calls);
-    let server = Server::start(move |_request, stream| {
-        *observed.lock().unwrap() += 1;
-        reply(stream, 403, &[], "forward denied");
+    let server = Server::start(move |request, stream| {
+        match (request.method.as_str(), request.path.as_str()) {
+            ("GET", "/v1/leases") => reply(stream, 200, &[], "[]"),
+            ("GET", "/v1/sandbox-leases") => reply(stream, 200, &[], &sandbox_inventory()),
+            _ => {
+                *observed.lock().unwrap() += 1;
+                reply(stream, 403, &[], "forward denied");
+            }
+        }
     });
 
-    let (_directory, child) = spawn_child(
-        &server.endpoint(),
-        &["sandbox", "attach", "sandbox-test", "--output", "json"],
-    );
+    let (_directory, child) =
+        spawn_child(&server.endpoint(), &["attach", "dev", "--output", "json"]);
     let output = wait_output(child);
     assert_eq!(output.status.code(), Some(125));
     assert!(output.stderr.is_empty());
@@ -683,14 +1031,7 @@ fn json_attach_is_refused_and_port_forward_errors_are_machine_events() {
 
     let (_directory, mut child) = spawn_child(
         &server.endpoint(),
-        &[
-            "sandbox",
-            "port-forward",
-            "sandbox-test",
-            "0:http",
-            "--output",
-            "json",
-        ],
+        &["port-forward", "dev", "0:http", "--output", "json"],
     );
     let stdout = child.stdout.take().unwrap();
     let (line_tx, line_rx) = mpsc::channel();

--- a/crates/kobectl/tests/sandbox_cli.rs
+++ b/crates/kobectl/tests/sandbox_cli.rs
@@ -1442,17 +1442,24 @@ fn queued_second_signal_cannot_skip_the_release_request() {
     open(&response_gate);
     let output = wait_output(child);
     open(&observation_gate);
-    assert_eq!(output.status.code(), Some(130));
     assert!(output.stderr.is_empty());
     let json: Value = serde_json::from_slice(&output.stdout).unwrap();
-    assert_eq!(json["signal"], "SIGINT");
     assert_eq!(json["cleanup"]["released"], false);
-    assert!(
-        json["cleanup"]["error"]
-            .as_str()
-            .unwrap()
-            .contains("second SIGTERM")
-    );
+    let cleanup_error = json["cleanup"]["error"].as_str().unwrap();
+    // Different pending Unix signals have no cross-signal delivery order.
+    // Whichever one the runtime observes first remains the process outcome;
+    // the other must interrupt only the observation after DELETE was sent.
+    match json["signal"].as_str().unwrap() {
+        "SIGINT" => {
+            assert_eq!(output.status.code(), Some(130));
+            assert!(cleanup_error.contains("second SIGTERM"));
+        }
+        "SIGTERM" => {
+            assert_eq!(output.status.code(), Some(143));
+            assert!(cleanup_error.contains("second SIGINT"));
+        }
+        signal => panic!("unexpected signal outcome: {signal}"),
+    }
     assert!(
         deleted.load(Ordering::SeqCst),
         "the queued second signal must not skip DELETE"

--- a/crates/kobectl/tests/sandbox_cli.rs
+++ b/crates/kobectl/tests/sandbox_cli.rs
@@ -1420,7 +1420,7 @@ fn queued_second_signal_cannot_skip_the_release_request() {
             panic!("signals before create response must skip execution: {request:?}");
         }
     });
-    let (_directory, child) = spawn_child(
+    let (_directory, mut child) = spawn_child(
         &server.endpoint(),
         &[
             "sandbox", "run", "agents", "--output", "json", "--", "/agent",
@@ -1428,6 +1428,16 @@ fn queued_second_signal_cannot_skip_the_release_request() {
     );
     stage_rx.recv_timeout(WAIT).unwrap();
     signal(&child, libc::SIGINT);
+    // SIGINT and SIGTERM are distinct POSIX signals, but their delivery order
+    // is not the order of two adjacent kill(2) calls. Give the runtime one
+    // scheduling turn to consume the intended first signal before queueing the
+    // second; otherwise this test sometimes asserts SIGINT while legitimately
+    // observing SIGTERM first on a loaded CI runner.
+    thread::sleep(Duration::from_millis(100));
+    assert!(
+        child.try_wait().unwrap().is_none(),
+        "the first signal must keep waiting for the create response and cleanup"
+    );
     signal(&child, libc::SIGTERM);
     open(&response_gate);
     let output = wait_output(child);

--- a/hack/e2e.test.ts
+++ b/hack/e2e.test.ts
@@ -331,10 +331,10 @@ test("the pty wrapper passes argv through without a shell in between", () => {
   // Every argument stays its own argv element. Building one shell string
   // instead would make a lease alias containing a quote executable, and the
   // aliases are caller-supplied.
-  const cmd = ptyCommand("python3", ["kobe", "sandbox", "attach", "it's mine"]);
+  const cmd = ptyCommand("python3", ["kobe", "attach", "it's mine"]);
 
   expect(cmd.slice(0, 2)).toEqual(["python3", "-c"]);
-  expect(cmd.slice(3)).toEqual(["kobe", "sandbox", "attach", "it's mine"]);
+  expect(cmd.slice(3)).toEqual(["kobe", "attach", "it's mine"]);
 });
 
 test("the pty wrapper exits with the attached command's own status", () => {

--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -215,7 +215,7 @@ type Args = {
   settleMs: number;
   /// Substring the attached session must produce for the run to pass.
   expect?: string;
-  /// Exit code `kobe sandbox attach` must terminate with.
+  /// Exit code `kobe attach` must terminate with.
   expectExit?: number;
   /// HTTP status an upgraded port-forward handshake must be refused with.
   expectHttpStatus?: number;
@@ -225,7 +225,7 @@ type Args = {
   resizeAfter?: string;
   /// Pool-declared remote port driven by the port-forward harness.
   remotePort: string;
-  /// Argv handed to `kobe sandbox attach ... -- <argv>`, after a bare `--`.
+  /// Argv handed to `kobe attach ... -- <argv>`, after a bare `--`.
   attachArgv: string[];
 };
 
@@ -670,10 +670,10 @@ function printHelpAndExit(): never {
   info("  bun run ./hack/e2e.ts attach-pty --lease ID [--send KEYS]... [--expect TEXT] [--expect-exit N]");
   info("                                   [--resize WIDTHxHEIGHT --resize-after TEXT]");
   info("                                   [--kobe PATH] [--settle MS] [--send-delay MS] [-- ARGV...]");
-  info("      Drive `kobe sandbox attach` through a real pty. --send accepts \\r \\n \\t \\e \\xNN.");
+  info("      Drive `kobe attach` through a real pty. --send accepts \\r \\n \\t \\e \\xNN.");
   info("");
   info("  bun run ./hack/e2e.ts port-forward --lease ID [--port NAME] [--expect TEXT] [--kobe PATH]");
-  info("      Drive a real loopback connection through `kobe sandbox port-forward`.");
+  info("      Drive a real loopback connection through `kobe port-forward`.");
   process.exit(0);
 }
 
@@ -3163,7 +3163,7 @@ const PTY_SPAWN = "import os,pty,sys; sys.exit(os.waitstatus_to_exitcode(pty.spa
 ///
 /// The resize is deliberately out-of-band. Sending an escape sequence through
 /// stdin would test a shell convention, not the terminal-size ioctl that
-/// `kobe sandbox attach` observes and forwards on channel 4.
+/// `kobe attach` observes and forwards on channel 4.
 const RESIZABLE_PTY_SPAWN = String.raw`
 import fcntl, os, pty, select, signal, struct, sys, termios
 
@@ -3209,7 +3209,7 @@ sys.exit(os.waitstatus_to_exitcode(status))
 
 /// Wrap a command so it runs with a controlling terminal.
 ///
-/// A pty is not a convenience here, it is the only option. `kobe sandbox attach`
+/// A pty is not a convenience here, it is the only option. `kobe attach`
 /// reads keys through crossterm's event stream, which uses stdin only when
 /// `isatty(0)` and otherwise opens `/dev/tty` — so a pipe on stdin is not read
 /// at all, and in CI, where there is no controlling terminal to fall back to,
@@ -3267,7 +3267,6 @@ async function attachPty(args: Args): Promise<void> {
     args.kobeBin,
     "--target",
     args.cliTarget,
-    "sandbox",
     "attach",
     args.lease,
     ...(args.attachArgv.length > 0 ? ["--", ...args.attachArgv] : []),
@@ -3383,7 +3382,7 @@ async function attachPty(args: Args): Promise<void> {
     throw new Error(`the attached session never produced ${JSON.stringify(args.expect)} within ${args.timeoutSeconds}s`);
   }
   if (args.expectExit !== undefined && exitCode !== args.expectExit) {
-    throw new Error(`kobe sandbox attach exited ${exitCode}, expected ${args.expectExit}`);
+    throw new Error(`kobe attach exited ${exitCode}, expected ${args.expectExit}`);
   }
   step("Attached session satisfied every assertion");
 }
@@ -3414,7 +3413,6 @@ async function portForward(args: Args): Promise<void> {
     args.kobeBin,
     "--target",
     args.cliTarget,
-    "sandbox",
     "port-forward",
     args.lease,
     `0:${args.remotePort}`,
@@ -3460,12 +3458,12 @@ async function portForward(args: Args): Promise<void> {
       address = forwardingAddress(stdout, args.lease, args.remotePort);
       if (address) break;
       if (exited !== undefined) {
-        throw new Error(`kobe sandbox port-forward exited ${exited} before listening:\n${stdout}${stderr}`);
+        throw new Error(`kobe port-forward exited ${exited} before listening:\n${stdout}${stderr}`);
       }
       await Bun.sleep(100);
     }
     if (!address) {
-      throw new Error(`kobe sandbox port-forward did not listen within ${args.timeoutSeconds}s:\n${stdout}${stderr}`);
+      throw new Error(`kobe port-forward did not listen within ${args.timeoutSeconds}s:\n${stdout}${stderr}`);
     }
 
     if (args.expectHttpStatus !== undefined) {

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -4672,6 +4672,136 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn list_pools_returns_mixed_kinds_with_effective_capabilities() {
+        use crate::api::policy::SandboxPolicy;
+        use crate::crd::{SandboxResourceCeiling, SandboxVerb};
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = wiremock::MockServer::start().await;
+        let client = crate::testutil::mock_k8s_client(&server);
+        let state = AppState {
+            client,
+            backend: crate::testutil::MockBackend::new(),
+            namespace: "test-ns".to_string(),
+            sandbox_reservation_namespace: "test-ns".to_string(),
+            sandbox_serving_replica: None,
+            authenticator: Arc::new(crate::api::auth::JwtAuthenticator::new("test".to_string())),
+            factory: None,
+            datastore: Default::default(),
+            connect_cache: Default::default(),
+            sandbox_admission_limiter: Default::default(),
+            shutdown: tokio_util::sync::CancellationToken::new(),
+            sandbox_enabled: true,
+        };
+
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterpools",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![exact_connect_pool_json()]),
+            ))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(
+                crate::testutil::k8s_list_response(vec![serde_json::json!({
+                    "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                    "kind": "SandboxPool",
+                    "metadata": {
+                        "name": "agent-small",
+                        "namespace": "test-ns",
+                        "uid": "sandbox-pool-uid",
+                        "generation": 1
+                    },
+                    "spec": {
+                        "warmCapacity": 1,
+                        "defaultTtl": "1h",
+                        "maxTtl": "4h",
+                        "provisioningTimeout": "10m",
+                        "placement": { "type": "management" },
+                        "template": {
+                            "defaultContainer": "agent",
+                            "containers": [{
+                                "name": "agent",
+                                "image": "example.invalid/agent@sha256:abc",
+                                "resources": {
+                                    "requests": {
+                                        "cpu": "500m",
+                                        "memory": "512Mi",
+                                        "ephemeralStorage": "512Mi"
+                                    },
+                                    "limits": {
+                                        "cpu": "1",
+                                        "memory": "1Gi",
+                                        "ephemeralStorage": "1Gi"
+                                    }
+                                }
+                            }],
+                            "exposedPorts": [{
+                                "name": "http",
+                                "container": "agent",
+                                "port": 3000
+                            }]
+                        },
+                        "isolation": { "tier": "trusted-runc" },
+                        "readiness": {
+                            "canary": { "argv": ["/bin/true"], "timeout": "30s" }
+                        }
+                    }
+                })]),
+            ))
+            .mount(&server)
+            .await;
+
+        let mut identity = test_identity();
+        identity.policy.allowed_pools = vec!["ci-*".to_string()];
+        identity.policy.sandbox = Some(SandboxPolicy {
+            allowed_pools: vec!["agent-*".to_string()],
+            verbs: vec![
+                SandboxVerb::Lease,
+                SandboxVerb::Exec,
+                SandboxVerb::Logs,
+                SandboxVerb::Release,
+            ],
+            max_ttl: chrono::Duration::hours(4),
+            max_concurrent_leases: 2,
+            max_extensions: 0,
+            resource_ceiling: SandboxResourceCeiling {
+                max_cpu: "2".to_string(),
+                max_memory: "2Gi".to_string(),
+            },
+        });
+
+        let response = list_pools::<crate::testutil::MockBackend>(State(state), identity).await;
+        assert_eq!(response.status(), StatusCode::OK);
+        let body = response_json(response).await;
+        let pools = body.as_array().unwrap();
+        assert_eq!(pools.len(), 2);
+        assert_eq!(pools[0]["name"], "agent-small");
+        assert_eq!(pools[0]["resourceKind"], "Sandbox");
+        let sandbox_capabilities = pools[0]["capabilities"].as_array().unwrap();
+        for capability in ["lease", "exec", "cancel", "attach", "logs", "release"] {
+            assert!(sandbox_capabilities.contains(&serde_json::json!(capability)));
+        }
+        assert!(!sandbox_capabilities.contains(&serde_json::json!("port-forward")));
+        assert!(!sandbox_capabilities.contains(&serde_json::json!("extend")));
+        assert_eq!(pools[1]["name"], "ci-small");
+        assert_eq!(pools[1]["resourceKind"], "Cluster");
+        assert!(
+            pools[1]["capabilities"]
+                .as_array()
+                .unwrap()
+                .contains(&serde_json::json!("kubeconfig"))
+        );
+    }
+
+    #[tokio::test]
     async fn test_get_lease_requires_auth() {
         let (app, _server) = test_app().await;
 

--- a/tests/sandbox_conformance.rs
+++ b/tests/sandbox_conformance.rs
@@ -352,6 +352,30 @@ impl Api {
         let value = serde_json::from_str(&text).unwrap_or(Value::Null);
         Ok((status, value))
     }
+
+    /// Open a real WebSocket handshake and report only how it was answered.
+    ///
+    /// The headers matter. A plain GET is rejected by Axum's WebSocket
+    /// extractor before Kobe ever resolves the lease, so it proves nothing
+    /// about tenant isolation. A well-formed upgrade reaches Kobe's own
+    /// authorization, which is the boundary under test. Nothing here speaks
+    /// the WebSocket protocol — the status alone carries the property.
+    async fn upgrade_status(&self, path: &str) -> anyhow::Result<(reqwest::StatusCode, String)> {
+        let response = self
+            .client
+            .get(format!("{}{path}", self.endpoint))
+            .bearer_auth(&self.token)
+            .header(reqwest::header::CONNECTION, "Upgrade")
+            .header(reqwest::header::UPGRADE, "websocket")
+            .header("Sec-WebSocket-Version", "13")
+            // Any 16 random bytes, base64-encoded. The value is never checked
+            // by a request that is meant to be refused before it upgrades.
+            .header("Sec-WebSocket-Key", "dGhlIHNhbXBsZSBub25jZQ==")
+            .send()
+            .await?;
+        let status = response.status();
+        Ok((status, response.text().await.unwrap_or_default()))
+    }
 }
 
 /// A sandbox that releases itself, whatever the scenario does.
@@ -966,15 +990,31 @@ both_placements!(
             );
         }
 
-        // Streaming operations use a real WebSocket handshake. A plain HTTP
-        // GET could be rejected by Axum before Kobe resolves the lease and
-        // would therefore prove nothing about tenant isolation.
+        // Streaming operations upgrade before they carry data, so the
+        // handshake is where isolation has to hold. These go straight at the
+        // API with well-formed upgrade headers: the unified CLI now resolves
+        // a lease against the caller's own leases first (see below), so
+        // driving these through it would never reach the server and would
+        // leave the upgrade path unproven.
         //
-        // Exit 125, not 1: attach never passes a remote exit through (there
-        // is no remote command), and the CLI's contract reserves 125 for its
-        // own failures precisely so they cannot collide with a command's
-        // exit. The isolation property is carried by the REQUIRED 404 in the
-        // output — the denial must be indistinguishable from absence.
+        // 404 and never 403, for the same reason as above: a 403 confirms the
+        // lease exists, which is enough to enumerate another tenant's leases
+        // by guessing ids.
+        for path in [format!("{lease}/attach"), format!("{lease}/port-forward")] {
+            let (status, response) = stranger.upgrade_status(&path).await?;
+            anyhow::ensure!(
+                status.as_u16() == 404,
+                "upgrade {path} answered HTTP {status} to a stranger, expected 404: {response}"
+            );
+        }
+
+        // And the CLI refuses before it ever opens a connection. Resolution is
+        // scoped to the caller's own leases, so a stranger's selector matches
+        // nothing and the denial stays indistinguishable from absence.
+        //
+        // Exit 125, not 1: attach never passes a remote exit through (there is
+        // no remote command), and the CLI's contract reserves 125 for its own
+        // failures precisely so they cannot collide with a command's exit.
         let attach = harness(&[
             "attach-pty",
             "--target",
@@ -982,7 +1022,7 @@ both_placements!(
             "--lease",
             &sandbox.id,
             "--expect",
-            "404",
+            "no lease matches",
             "--expect-exit",
             "125",
             "--timeout",
@@ -994,27 +1034,13 @@ both_placements!(
         ])
         .await?;
         anyhow::ensure!(
-            attach.contains("404"),
+            attach.contains("no lease matches"),
             "stranger attach did not fail as an undiscoverable lease: {attach}"
         );
-        let forward = harness(&[
-            "port-forward",
-            "--target",
-            "e2e-other",
-            "--lease",
-            &sandbox.id,
-            "--port",
-            "http",
-            "--expect-http-status",
-            "404",
-            "--timeout",
-            "30",
-        ])
-        .await?;
-        anyhow::ensure!(
-            forward.contains("HTTP 404"),
-            "stranger port-forward did not fail as an undiscoverable lease: {forward}"
-        );
+        // No second CLI leg for port-forward: it refuses in the same
+        // resolution step as attach, before any transport is chosen, so it
+        // would re-prove this line rather than add to it. Its server-side
+        // refusal is asserted against the upgrade above.
 
         // And the sandbox is untouched: the stranger's exec did not run.
         let (_, evidence) = sandbox

--- a/tests/sandbox_conformance.rs
+++ b/tests/sandbox_conformance.rs
@@ -1000,7 +1000,16 @@ both_placements!(
         // 404 and never 403, for the same reason as above: a 403 confirms the
         // lease exists, which is enough to enumerate another tenant's leases
         // by guessing ids.
-        for path in [format!("{lease}/attach"), format!("{lease}/port-forward")] {
+        //
+        // port-forward also requires `?port=`: Axum extracts the query before
+        // the handler runs, so a request without it 400s on deserialize and
+        // never reaches prepare_upgrade. That 400 is the same for every id
+        // (real or guessed) and proves nothing about isolation — same trap as
+        // a plain GET vs a WebSocket upgrade.
+        for path in [
+            format!("{lease}/attach"),
+            format!("{lease}/port-forward?port=http"),
+        ] {
             let (status, response) = stranger.upgrade_status(&path).await?;
             anyhow::ensure!(
                 status.as_u16() == 404,


### PR DESCRIPTION
Closes #171
Part of #70

## What changed

- Adds a table-driven mock-API matrix for the resource-neutral `lease`, `run`, `status`, `extend`, `release`, `purge`, `exec`, `logs`, `cancel`, `attach`, and `port-forward` commands.
- Proves Cluster and Sandbox dispatch from pool/lease metadata, including mixed inventory and capability rejection.
- Moves the live attach/port-forward harness to the public top-level syntax while retaining the hidden legacy namespace parser test.
- Adds an operator-level mixed `/v1/pools` test for policy-derived capabilities.

## Defects found red-before-fix

- `kobe release dev` sent `DELETE /v1/leases/dev` instead of resolving the Sandbox alias. Release now resolves non-generated selectors across the unified inventory while preserving idempotent release by concrete generated id.
- `kobe extend dev` collided with global `--target` in Clap and tried to select a configuration target named `dev`. The positional now has a distinct parser id.

## Validation

- `cargo test -p kobectl` — 105 unit + 27 CLI integration tests passed.
- `cargo test -p kobe-operator list_pools_returns_mixed_kinds_with_effective_capabilities -- --nocapture` — passed.
- `cargo clippy -p kobectl --all-targets -- -D warnings` — passed.
- `cargo clippy -p kobe-operator --all-targets -- -D warnings` — passed.
- `mise exec -- bun test hack/e2e.test.ts` — 26 passed.
- `cargo fmt --all -- --check` and `git diff --check` — passed.

Public command examples already use the unified syntax; no documentation rewrite was required.
