### PR TITLE
feat(api): admit every pool kind on POST /v1/leases

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,17 +73,14 @@ When a client leases a cluster, Kobe binds one from the warm pool instantly. Whe
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `POST` | `/v1/leases` | Create a lease from a pool (returns `202` + a `Pending` lease) |
-| `GET` | `/v1/leases` | List your active leases |
-| `GET` | `/v1/leases/:id` | Get a lease (includes the kubeconfig once `Bound`) |
+| `POST` | `/v1/leases` | Create a lease from a pool. The server picks Cluster vs Sandbox from the pool. |
+| `GET` | `/v1/leases` | List your active leases of every kind |
+| `GET` | `/v1/leases/:id` | Get a lease (kubeconfig once a Cluster lease is `Bound`) |
 | `DELETE` | `/v1/leases/:id` | Release a lease |
 | `PATCH` | `/v1/leases/:id` | Extend a lease TTL |
 | `GET` | `/v1/pools` | List available pools with status |
 | `GET` | `/v1/pools/:name` | Get a specific pool's status |
-| `POST` | `/v1/sandbox-leases` | Create caller-safe Sandbox lease intent |
-| `GET` | `/v1/sandbox-leases` | List your Sandbox leases |
-| `GET` | `/v1/sandbox-leases/:id` | Get a Sandbox lease's lifecycle state |
-| `DELETE` | `/v1/sandbox-leases/:id` | Request Sandbox lease release |
+| `POST` | `/v1/sandbox-leases` | Compatibility alias for `POST /v1/leases` |
 | `GET` | `/v1/status` | Endpoint status + auth methods (no auth required) |
 
 See [docs/kobe-docs/api/reference.mdx](docs/kobe-docs/api/reference.mdx) for full request/response shapes.

--- a/crates/kobectl/src/commands/lease_create.rs
+++ b/crates/kobectl/src/commands/lease_create.rs
@@ -36,6 +36,10 @@ pub struct LeaseCreateCommand<'a> {
 pub(crate) struct LeaseAcceptedResponse {
     pub(crate) id: String,
     phase: String,
+    #[serde(default, rename = "resourceKind")]
+    #[allow(dead_code)]
+    resource_kind: Option<String>,
+    #[serde(alias = "pool")]
     pub(crate) profile: String,
     #[serde(default)]
     queue_position: u32,

--- a/crates/kobectl/src/commands/leases.rs
+++ b/crates/kobectl/src/commands/leases.rs
@@ -145,15 +145,33 @@ pub(crate) async fn fetch_all_leases_with_output(
         }
         response.json().await?
     };
+    let unified = leases
+        .iter()
+        .any(|lease| lease.resource_kind.eq_ignore_ascii_case("sandbox"));
     for lease in &mut leases {
-        lease.resource_kind = "Cluster".to_string();
-        lease.capabilities = vec![
-            "kubeconfig".to_string(),
-            "extend".to_string(),
-            "release".to_string(),
-        ];
+        if lease.resource_kind.is_empty() {
+            lease.resource_kind = if lease.id.starts_with("sandbox-") {
+                "Sandbox".to_string()
+            } else {
+                "Cluster".to_string()
+            };
+        }
+        if lease.capabilities.is_empty() && !lease.is_sandbox() {
+            lease.capabilities = vec![
+                "kubeconfig".to_string(),
+                "extend".to_string(),
+                "release".to_string(),
+            ];
+        }
     }
-    leases.extend(fetch_sandbox_leases_with_output(config, output).await?);
+    if !unified {
+        let extra = fetch_sandbox_leases_with_output(config, output).await?;
+        for lease in extra {
+            if !leases.iter().any(|existing| existing.id == lease.id) {
+                leases.push(lease);
+            }
+        }
+    }
     leases.sort_by(|left, right| left.id.cmp(&right.id));
     Ok(leases)
 }

--- a/crates/kobectl/src/commands/version.rs
+++ b/crates/kobectl/src/commands/version.rs
@@ -29,14 +29,10 @@ fn parse_dotted_version(raw: &str) -> Option<(u64, u64, u64)> {
 }
 
 /// Warn on stderr when this binary is older than the operator it talks to.
-/// Lease routing for Sandbox pools landed in 0.40.2; an older CLI will POST
-/// `/v1/leases` for every pool name.
 pub(crate) fn warn_if_cli_behind_endpoint(endpoint_version: &str) {
     let cli = cli_version();
     if cli_is_behind_endpoint(cli, endpoint_version) {
-        eprintln!(
-            "warning: CLI {cli} is older than endpoint {endpoint_version}; `kobe lease` may mis-route pool kinds. Upgrade the CLI."
-        );
+        eprintln!("warning: CLI {cli} is older than endpoint {endpoint_version}. Upgrade the CLI.");
     }
 }
 

--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -14,16 +14,16 @@ signature.
 
 | Method | Endpoint | Auth | Description |
 |---|---|---|---|
-| `POST` | `/v1/leases` | Required | Create a lease from a pool |
-| `GET` | `/v1/leases` | Required | List your active leases |
+| `POST` | `/v1/leases` | Required | Create a lease from a pool (any kind) |
+| `GET` | `/v1/leases` | Required | List your active leases of every kind |
 | `GET` | `/v1/leases/:id` | Required | Get a specific lease |
 | `DELETE` | `/v1/leases/:id` | Required | Release a lease |
 | `PATCH` | `/v1/leases/:id` | Required | Extend a lease TTL |
-| `GET` | `/v1/leases/:id/diagnostics` | Required | Get diagnostics bundle URL |
+| `GET` | `/v1/leases/:id/diagnostics` | Required | Get diagnostics bundle URL (Cluster) |
 | `GET` | `/v1/pools` | Required | List available pools |
 | `GET` | `/v1/pools/:name` | Required | Get a specific pool's status |
 | `GET` | `/v1/pools/:name/leases` | Required | List leases for a specific pool |
-| `POST` | `/v1/sandbox-leases` | Required | Create a Sandbox lease from a SandboxPool |
+| `POST` | `/v1/sandbox-leases` | Required | Compatibility alias for `POST /v1/leases` |
 | `GET` | `/v1/sandbox-leases` | Required | List your Sandbox leases |
 | `GET` | `/v1/sandbox-leases/:id` | Required | Get one Sandbox lease |
 | `PATCH` | `/v1/sandbox-leases/:id` | Required | Extend a Sandbox lease TTL |
@@ -43,7 +43,12 @@ signature.
 
 ## `POST /v1/leases`
 
-Creates a lease from the specified pool. Returns `202 Accepted` immediately with the lease ID and `Pending` phase. Poll `GET /v1/leases/:id` until the phase is `Bound` and `kubeconfig` is populated.
+Creates a lease from the named pool. The server looks up the pool and admits
+the matching resource kind. Clients do not choose Cluster vs Sandbox URLs.
+
+Returns `202 Accepted` with the lease id, `resourceKind`, and `Pending` phase.
+Poll `GET /v1/leases/:id` until the lease is usable: `Bound` with `kubeconfig`
+for Cluster, `Ready` for Sandbox.
 
 **Request body**
 
@@ -65,10 +70,12 @@ Creates a lease from the specified pool. Returns `202 Accepted` immediately with
 
 | Field | Type | Required | Description |
 |---|---|---|---|
-| `profile` | string | Yes | Pool name to lease from |
+| `profile` | string | One of `profile` or `pool` | Pool name. `pool` is an alias used by Sandbox clients. |
+| `pool` | string | One of `profile` or `pool` | Same as `profile`. If both are set they must match. |
 | `ttl` | string | No | Requested TTL (e.g. `"30m"`, `"1h"`). Defaults to the pool's `spec.ttl`. Capped by AccessPolicy `maxTtl`. |
 | `alias` | string | No | DNS-label name unique among the requester's active leases. |
-| `metadata` | object | No | Opaque caller context. Maximum 8 KiB encoded JSON, 32 top-level keys, four nesting levels, and 128 JSON values. |
+| `metadata` | object | No | Opaque caller context. Cluster leases only. Maximum 8 KiB encoded JSON, 32 top-level keys, four nesting levels, and 128 JSON values. |
+| `idempotencyKey` | string | No | Sandbox create recovery key. Ignored for Cluster pools. |
 
 `metadata` is descriptive, untrusted, and creation-time only: the lease API
 does not expose an update operation. It never affects authorization, quota,
@@ -82,6 +89,7 @@ and alias.
 ```json
 {
   "id": "lease-a1b2c3d4e5f6",
+  "resourceKind": "Cluster",
   "phase": "Pending",
   "profile": "ci-small",
   "queue_position": 0,
@@ -105,6 +113,7 @@ Once bound, `GET /v1/leases/:id` returns:
 ```json
 {
   "id": "lease-a1b2c3d4e5f6",
+  "resourceKind": "Cluster",
   "phase": "Bound",
   "profile": "ci-small",
   "kubeconfig": "apiVersion: v1\nclusters:\n...",
@@ -118,15 +127,20 @@ Once bound, `GET /v1/leases/:id` returns:
 |---|---|
 | `400` | Invalid profile name, alias, TTL, or metadata |
 | `403` | Profile not allowed for your identity |
-| `404` | No Cluster pool with that name |
-| `409` | The name is a Sandbox pool (`reason: wrong_resource_kind`). Use `POST /v1/sandbox-leases`; `kobe lease` selects the route from the pool kind. |
+| `404` | No pool with that name |
+| `409` | The name exists as both a Cluster pool and a Sandbox pool (`reason: wrong_resource_kind`) |
 | `429` | Concurrent lease limit reached, or server overloaded |
+
+`POST /v1/sandbox-leases` is a compatibility alias for this same create. Prefer
+`POST /v1/leases`. Kind-specific verbs (`exec`, `logs`, `attach`, `port-forward`,
+`executions`) are also served under `/v1/leases/:id/...`.
 
 ---
 
 ## `GET /v1/leases`
 
-Lists all active leases belonging to your identity.
+Lists your active Cluster and Sandbox leases. Each item includes `resourceKind`
+and `capabilities`.
 
 **Response** — `200 OK`
 
@@ -325,13 +339,14 @@ bounded reason exists. The closed set:
 | `expiry_derivation_mismatch` | no |
 | `conflict_retryable` | yes, against current state |
 | `teardown_quarantined` | no — resolve cleanup first |
-| `wrong_resource_kind` | no — this name is a Cluster pool; `POST /v1/leases` |
+| `wrong_resource_kind` | no — the pool name is ambiguous across kinds |
 
 ### `POST /v1/sandbox-leases`
 
-Creates caller-safe Sandbox intent and returns `202 Accepted`. The response
-includes `Location: /v1/sandbox-leases/:id`; poll that URL until the lease is
-ready or terminal.
+Compatibility alias for `POST /v1/leases`. Prefer `/v1/leases`. This path
+still accepts the Sandbox body (`pool`, `idempotencyKey`) and still returns
+`Location: /v1/sandbox-leases/:id`. A Cluster pool name is admitted as a
+Cluster lease rather than rejected.
 
 ```json
 {
@@ -351,6 +366,7 @@ while recovering that request. It remains optional for older clients.
 ```json
 {
   "id": "sandbox-a1b2c3d4e5f60718293a4b5c",
+  "resourceKind": "Sandbox",
   "phase": "Pending",
   "pool": "agent-small",
   "ttl": "30m",
@@ -396,7 +412,7 @@ the connection failed before headers, the same keyed POST may be repeated.
 | `400` | Invalid pool name, alias, or TTL |
 | `403` | Missing Sandbox `lease` permission or resource ceiling exceeded |
 | `404` | An allowed SandboxPool does not exist |
-| `409` | Alias is already active, an idempotency key is bound to different intent, or the name is a Cluster pool (`reason: wrong_resource_kind`) |
+| `409` | Alias is already active, an idempotency key is bound to different intent, or the pool name is ambiguous across kinds |
 | `429` | Sandbox concurrency limit reached, or the per-principal admission rate limit was hit |
 | `503` | Pool configuration or Kubernetes admission cannot be verified |
 

--- a/docs/kobe-docs/commands/reference.mdx
+++ b/docs/kobe-docs/commands/reference.mdx
@@ -108,7 +108,7 @@ While waiting, the CLI names the resource kind and what "ready" means
 prints `kobe release <id>`; it does not release the lease.
 
 If the CLI version is older than the operator, `kobe status` and `kobe lease`
-print a warning: older CLIs POST `/v1/leases` for every pool name.
+print a warning.
 
 **Flags**
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -411,25 +411,74 @@ async fn request_logging(mut request: axum::extract::Request, next: Next) -> Res
 
 // --- Request/Response types ---
 
-#[derive(Deserialize)]
-struct CreateLeaseRequest {
-    profile: String,
+#[derive(Deserialize, Default)]
+pub(crate) struct CreateLeaseRequest {
+    /// Cluster-lease historical field. Sandbox clients send `pool`. Either is
+    /// accepted; if both are set they must match.
     #[serde(default)]
-    ttl: Option<String>,
+    pub(crate) profile: Option<String>,
+    #[serde(default)]
+    pub(crate) pool: Option<String>,
+    #[serde(default)]
+    pub(crate) ttl: Option<String>,
     /// Optional caller-supplied alias (#107 P2). Stored as the label
     /// `kobe.kunobi.ninja/alias`; unique among the requester's ACTIVE leases so
     /// it can name "which lease" in scripts (`kobe extend pr-106 30m`).
     #[serde(default)]
-    alias: Option<String>,
+    pub(crate) alias: Option<String>,
     /// Optional caller-supplied descriptive JSON. This is stored verbatim but
-    /// has no authorization, scheduling, or lifecycle semantics.
+    /// has no authorization, scheduling, or lifecycle semantics. Rejected for
+    /// Sandbox pools.
     #[serde(default)]
-    metadata: Option<serde_json::Value>,
+    pub(crate) metadata: Option<serde_json::Value>,
+    /// Sandbox create idempotency key. Ignored for Cluster pools.
+    #[serde(default, rename = "idempotencyKey", alias = "idempotency_key")]
+    pub(crate) idempotency_key: Option<String>,
+}
+
+impl CreateLeaseRequest {
+    fn pool_name(&self) -> Result<String, Response> {
+        let profile = self
+            .profile
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty());
+        let pool = self
+            .pool
+            .as_deref()
+            .map(str::trim)
+            .filter(|name| !name.is_empty());
+        match (profile, pool) {
+            (Some(profile), Some(pool)) if profile != pool => Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "profile and pool must name the same pool".to_string(),
+                    detail: None,
+                    reason: None,
+                }),
+            )
+                .into_response()),
+            (Some(name), _) | (_, Some(name)) => Ok(name.to_string()),
+            (None, None) => Err((
+                StatusCode::BAD_REQUEST,
+                Json(ErrorResponse {
+                    error: "Pool name is required".to_string(),
+                    detail: Some("Provide `profile` or `pool`".to_string()),
+                    reason: None,
+                }),
+            )
+                .into_response()),
+        }
+    }
 }
 
 #[derive(Serialize)]
 struct LeaseResponse {
     id: String,
+    #[serde(rename = "resourceKind")]
+    resource_kind: &'static str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    capabilities: Vec<&'static str>,
     #[serde(skip_serializing_if = "Option::is_none")]
     kubeconfig: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
@@ -532,6 +581,10 @@ fn validate_lease_metadata(metadata: &serde_json::Value) -> Result<(), String> {
 struct LeaseSummary {
     id: String,
     phase: String,
+    #[serde(rename = "resourceKind")]
+    resource_kind: &'static str,
+    #[serde(skip_serializing_if = "Vec::is_empty")]
+    capabilities: Vec<&'static str>,
     profile: String,
     #[serde(skip_serializing_if = "Option::is_none")]
     cluster_name: Option<String>,
@@ -679,16 +732,44 @@ fn pool_policy_response(profile: &ClusterPool) -> PoolPolicyResponse {
     }
 }
 
-fn profile_response(profile: &ClusterPool, policy: &policy::Policy) -> ProfileResponse {
-    let status = profile.status.clone().unwrap_or_default();
+fn cluster_lease_capabilities(policy: &policy::Policy) -> Vec<&'static str> {
     let mut capabilities = vec!["lease", "kubeconfig", "release"];
     if policy.max_extensions > 0 {
         capabilities.push("extend");
     }
+    capabilities
+}
+
+fn sandbox_lease_capabilities(pool: &str, policy: &policy::Policy) -> Vec<&'static str> {
+    let mut capabilities = vec!["lease"];
+    if is_sandbox_allowed(pool, SandboxVerb::Exec, policy) {
+        capabilities.extend(["exec", "cancel", "attach"]);
+    }
+    if is_sandbox_allowed(pool, SandboxVerb::Logs, policy) {
+        capabilities.push("logs");
+    }
+    if is_sandbox_allowed(pool, SandboxVerb::PortForward, policy) {
+        capabilities.push("port-forward");
+    }
+    if is_sandbox_allowed(pool, SandboxVerb::Release, policy) {
+        capabilities.push("release");
+    }
+    if policy
+        .sandbox
+        .as_ref()
+        .is_some_and(|grant| grant.max_extensions > 0)
+    {
+        capabilities.push("extend");
+    }
+    capabilities
+}
+
+fn profile_response(profile: &ClusterPool, policy: &policy::Policy) -> ProfileResponse {
+    let status = profile.status.clone().unwrap_or_default();
     ProfileResponse {
         name: profile.name_any(),
         resource_kind: "Cluster",
-        capabilities,
+        capabilities: cluster_lease_capabilities(policy),
         phase: status.phase.map(|phase| format!("{phase:?}")),
         ready: status.ready,
         leased: status.leased,
@@ -703,26 +784,6 @@ fn profile_response(profile: &ClusterPool, policy: &policy::Policy) -> ProfileRe
 
 fn sandbox_pool_response(pool: &SandboxPool, policy: &policy::Policy) -> ProfileResponse {
     let status = pool.status.clone().unwrap_or_default();
-    let mut capabilities = vec!["lease"];
-    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::Exec, policy) {
-        capabilities.extend(["exec", "cancel", "attach"]);
-    }
-    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::Logs, policy) {
-        capabilities.push("logs");
-    }
-    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::PortForward, policy) {
-        capabilities.push("port-forward");
-    }
-    if is_sandbox_allowed(&pool.name_any(), SandboxVerb::Release, policy) {
-        capabilities.push("release");
-    }
-    if policy
-        .sandbox
-        .as_ref()
-        .is_some_and(|grant| grant.max_extensions > 0)
-    {
-        capabilities.push("extend");
-    }
     let phase = if crate::sandbox::require_current_sandbox_pool_ready(pool).is_ok() {
         "Ready"
     } else {
@@ -731,7 +792,7 @@ fn sandbox_pool_response(pool: &SandboxPool, policy: &policy::Policy) -> Profile
     ProfileResponse {
         name: pool.name_any(),
         resource_kind: "Sandbox",
-        capabilities,
+        capabilities: sandbox_lease_capabilities(&pool.name_any(), policy),
         phase: Some(phase.to_string()),
         ready: status.ready,
         leased: status.allocated,
@@ -1158,15 +1219,45 @@ fn backend_request_url(
 
 // --- Route handlers ---
 
+pub(crate) enum CreatePoolKind {
+    Cluster,
+    Sandbox,
+    Ambiguous,
+    Missing,
+}
+
+pub(crate) async fn resolve_create_pool_kind<B: ClusterBackend>(
+    state: &AppState<B>,
+    name: &str,
+) -> Result<CreatePoolKind, kube::Error> {
+    let clusters: Api<ClusterPool> = Api::namespaced(state.client.clone(), &state.namespace);
+    let cluster = clusters.get_opt(name).await?;
+    let sandbox = if state.sandbox_enabled {
+        let sandboxes: Api<SandboxPool> = Api::namespaced(state.client.clone(), &state.namespace);
+        sandboxes.get_opt(name).await?
+    } else {
+        None
+    };
+    Ok(match (cluster.is_some(), sandbox.is_some()) {
+        (true, true) => CreatePoolKind::Ambiguous,
+        (true, false) => CreatePoolKind::Cluster,
+        (false, true) => CreatePoolKind::Sandbox,
+        (false, false) => CreatePoolKind::Missing,
+    })
+}
+
 #[tracing::instrument(skip_all)]
-async fn create_lease<B: ClusterBackend>(
+pub(crate) async fn create_lease<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
     Json(req): Json<CreateLeaseRequest>,
 ) -> Response {
-    let policy = policy_for(&identity);
+    let profile = match req.pool_name() {
+        Ok(name) => name,
+        Err(response) => return response,
+    };
 
-    if !is_valid_k8s_name(&req.profile) {
+    if !is_valid_k8s_name(&profile) {
         return (
             StatusCode::BAD_REQUEST,
             Json(ErrorResponse {
@@ -1181,14 +1272,89 @@ async fn create_lease<B: ClusterBackend>(
             .into_response();
     }
 
-    if !is_pool_allowed(&req.profile, &policy) {
+    if let Some(metadata) = req.metadata.as_ref()
+        && let Err(detail) = validate_lease_metadata(metadata)
+    {
+        return (
+            StatusCode::BAD_REQUEST,
+            Json(ErrorResponse {
+                error: "Invalid lease metadata".to_string(),
+                detail: Some(detail),
+                reason: None,
+            }),
+        )
+            .into_response();
+    }
+
+    // Kind is server-owned. The client POSTs `/v1/leases`; we look up the pool
+    // and admit the matching CRD. Two HTTP trees made old/buggy clients create
+    // a ClusterLease for a Sandbox pool that then queued forever.
+    match resolve_create_pool_kind(&state, &profile).await {
+        Err(error) => {
+            return infra_error(
+                StatusCode::SERVICE_UNAVAILABLE,
+                "Unable to read pool",
+                error,
+            );
+        }
+        Ok(CreatePoolKind::Ambiguous) => {
+            return (
+                StatusCode::CONFLICT,
+                Json(ErrorResponse {
+                    error: format!(
+                        "Pool name '{profile}' is ambiguous across Cluster and Sandbox resources"
+                    ),
+                    detail: Some("Pool names must be unique across resource kinds".to_string()),
+                    reason: Some(ErrorReason::WrongResourceKind),
+                }),
+            )
+                .into_response();
+        }
+        Ok(CreatePoolKind::Missing) => {
+            return (
+                StatusCode::NOT_FOUND,
+                Json(ErrorResponse {
+                    error: format!("Pool '{profile}' not found"),
+                    detail: None,
+                    reason: None,
+                }),
+            )
+                .into_response();
+        }
+        Ok(CreatePoolKind::Sandbox) => {
+            if req.metadata.is_some() {
+                return (
+                    StatusCode::BAD_REQUEST,
+                    Json(ErrorResponse {
+                        error: "Sandbox leases do not accept metadata".to_string(),
+                        detail: None,
+                        reason: None,
+                    }),
+                )
+                    .into_response();
+            }
+            return crate::api::sandbox::create_sandbox_lease(
+                State(state),
+                identity,
+                Json(crate::api::sandbox::CreateSandboxLeaseRequest {
+                    pool: profile,
+                    ttl: req.ttl,
+                    alias: req.alias,
+                    idempotency_key: req.idempotency_key,
+                }),
+            )
+            .await;
+        }
+        Ok(CreatePoolKind::Cluster) => {}
+    }
+
+    let policy = policy_for(&identity);
+
+    if !is_pool_allowed(&profile, &policy) {
         return (
             StatusCode::FORBIDDEN,
             Json(ErrorResponse {
-                error: format!(
-                    "Profile '{}' not allowed for your identity type",
-                    req.profile
-                ),
+                error: format!("Profile '{profile}' not allowed for your identity type"),
                 detail: None,
                 reason: None,
             }),
@@ -1210,20 +1376,6 @@ async fn create_lease<B: ClusterBackend>(
                     "Alias must be a valid DNS label (lowercase alphanumeric and hyphens, 1-63 chars)"
                         .to_string(),
                 ),
-                reason: None,
-            }),
-        )
-            .into_response();
-    }
-
-    if let Some(metadata) = req.metadata.as_ref()
-        && let Err(detail) = validate_lease_metadata(metadata)
-    {
-        return (
-            StatusCode::BAD_REQUEST,
-            Json(ErrorResponse {
-                error: "Invalid lease metadata".to_string(),
-                detail: Some(detail),
                 reason: None,
             }),
         )
@@ -1331,56 +1483,15 @@ async fn create_lease<B: ClusterBackend>(
     // forever (fixed-size pools have no queue_timeout). A `Failing` pool — or a
     // `Backoff` pool with no schedulable headroom (zero Ready and at capacity) —
     // returns 503 + Retry-After + a machine-readable `reason`; a healthy-but-
-    // empty warm pool keeps the 202 Pending below.
-    //
-    // A missing ClusterPool used to fall through and still create the lease.
-    // POST /v1/leases with a Sandbox pool name then queued forever. Reject
-    // that here: 409 when the name is a Sandbox pool, 404 when it is neither.
+    // empty warm pool keeps the 202 Pending below. Missing pools are rejected
+    // above in `resolve_create_pool_kind`.
     {
         let pools_api: Api<ClusterPool> = Api::namespaced(state.client.clone(), &state.namespace);
-        match pools_api.get_opt(&req.profile).await {
-            Ok(Some(pool)) => {
-                if let Some(unavailable) = pool_preflight_rejection(&req.profile, &pool) {
+        match pools_api.get(&profile).await {
+            Ok(pool) => {
+                if let Some(unavailable) = pool_preflight_rejection(&profile, &pool) {
                     return unavailable;
                 }
-            }
-            Ok(None) => {
-                if state.sandbox_enabled {
-                    let sandboxes: Api<SandboxPool> =
-                        Api::namespaced(state.client.clone(), &state.namespace);
-                    match sandboxes.get_opt(&req.profile).await {
-                        Ok(Some(_)) => {
-                            return (
-                                StatusCode::CONFLICT,
-                                Json(ErrorResponse {
-                                    error: format!("Pool '{}' is a Sandbox pool", req.profile),
-                                    detail: Some(
-                                        "POST /v1/leases creates Cluster leases. Use POST /v1/sandbox-leases; `kobe lease` selects the route from the pool kind.".to_string(),
-                                    ),
-                                    reason: Some(ErrorReason::WrongResourceKind),
-                                }),
-                            )
-                                .into_response();
-                        }
-                        Ok(None) => {}
-                        Err(e) => {
-                            return infra_error(
-                                StatusCode::SERVICE_UNAVAILABLE,
-                                "Unable to verify pool kind",
-                                e,
-                            );
-                        }
-                    }
-                }
-                return (
-                    StatusCode::NOT_FOUND,
-                    Json(ErrorResponse {
-                        error: format!("Cluster pool '{}' not found", req.profile),
-                        detail: None,
-                        reason: None,
-                    }),
-                )
-                    .into_response();
             }
             Err(e) => {
                 return infra_error(
@@ -1400,7 +1511,7 @@ async fn create_lease<B: ClusterBackend>(
     let lease = build_lease_crd(
         &lease_id,
         &state.namespace,
-        &req.profile,
+        &profile,
         &ttl_formatted,
         &identity,
         policy.default_priority,
@@ -1480,12 +1591,12 @@ async fn create_lease<B: ClusterBackend>(
     }
 
     metrics::CLAIMS_TOTAL
-        .with_label_values(&[req.profile.as_str(), "created"])
+        .with_label_values(&[profile.as_str(), "created"])
         .inc();
 
     info!(
         lease_id = %lease_id,
-        profile = %req.profile,
+        profile = %profile,
         identity = %identity.identity,
         priority = policy.default_priority,
         "Lease created, queued for binding"
@@ -1493,11 +1604,13 @@ async fn create_lease<B: ClusterBackend>(
 
     let mut resp = LeaseResponse {
         id: lease_id,
+        resource_kind: "Cluster",
+        capabilities: cluster_lease_capabilities(&policy),
         kubeconfig: None,
         cluster_name: None,
         expires_at: None,
         phase: "Pending".to_string(),
-        profile: req.profile,
+        profile,
         queue_position: 0,
         diagnostics_url: None,
         effective_ttl: None,
@@ -1527,7 +1640,8 @@ async fn list_leases<B: ClusterBackend>(
 
     match leases_api.list(&lp).await {
         Ok(claims) => {
-            let my_claims: Vec<LeaseSummary> = claims
+            let policy = policy_for(&identity);
+            let mut my_claims: Vec<LeaseSummary> = claims
                 .iter()
                 .filter(|c| c.spec.requester.identity == identity.identity)
                 // #107 P2: optional ?alias= filter (exact match on the alias label).
@@ -1541,6 +1655,8 @@ async fn list_leases<B: ClusterBackend>(
                     LeaseSummary {
                         id: c.name_any(),
                         phase: status.phase.to_string(),
+                        resource_kind: "Cluster",
+                        capabilities: cluster_lease_capabilities(&policy),
                         profile: c.spec.pool_ref.clone(),
                         cluster_name: status.cluster_name,
                         expires_at: status.expires_at,
@@ -1552,6 +1668,44 @@ async fn list_leases<B: ClusterBackend>(
                     }
                 })
                 .collect();
+
+            if state.sandbox_enabled {
+                match crate::api::sandbox::caller_sandbox_summaries(&state, &identity).await {
+                    Ok(sandboxes) => {
+                        my_claims.extend(sandboxes.into_iter().filter_map(|lease| {
+                            if params
+                                .alias
+                                .as_ref()
+                                .is_some_and(|alias| lease.alias.as_deref() != Some(alias.as_str()))
+                            {
+                                return None;
+                            }
+                            Some(LeaseSummary {
+                                id: lease.id,
+                                phase: lease.phase,
+                                resource_kind: "Sandbox",
+                                capabilities: sandbox_lease_capabilities(&lease.pool, &policy),
+                                profile: lease.pool,
+                                cluster_name: None,
+                                expires_at: lease.expires_at,
+                                queue_position: 0,
+                                diagnostics_url: None,
+                                requester: None,
+                                alias: lease.alias,
+                                metadata: None,
+                            })
+                        }));
+                    }
+                    Err(error) => {
+                        return infra_error(
+                            StatusCode::INTERNAL_SERVER_ERROR,
+                            "Failed to list Sandbox leases",
+                            error,
+                        );
+                    }
+                }
+            }
+            my_claims.sort_by(|left, right| left.id.cmp(&right.id));
 
             (StatusCode::OK, Json(my_claims)).into_response()
         }
@@ -1570,6 +1724,9 @@ async fn get_lease<B: ClusterBackend>(
     Path(id): Path<String>,
     headers: HeaderMap,
 ) -> Response {
+    if state.sandbox_enabled && crate::api::sandbox_access::looks_like_lease_id(&id) {
+        return crate::api::sandbox::get_sandbox_lease(State(state), identity, Path(id)).await;
+    }
     let leases_api: Api<ClusterLease> = Api::namespaced(state.client.clone(), &state.namespace);
 
     match leases_api.get(&id).await {
@@ -1675,6 +1832,8 @@ async fn get_lease<B: ClusterBackend>(
                 StatusCode::OK,
                 Json(LeaseResponse {
                     id,
+                    resource_kind: "Cluster",
+                    capabilities: cluster_lease_capabilities(&policy_for(&identity)),
                     kubeconfig,
                     cluster_name: status.cluster_name,
                     expires_at: status.expires_at,
@@ -2369,6 +2528,9 @@ async fn release_lease<B: ClusterBackend>(
     identity: AuthIdentity,
     Path(id): Path<String>,
 ) -> Response {
+    if state.sandbox_enabled && crate::api::sandbox_access::looks_like_lease_id(&id) {
+        return crate::api::sandbox::release_sandbox_lease(State(state), identity, Path(id)).await;
+    }
     let leases_api: Api<ClusterLease> = Api::namespaced(state.client.clone(), &state.namespace);
 
     let lease = match leases_api.get(&id).await {
@@ -2479,6 +2641,17 @@ async fn extend_lease<B: ClusterBackend>(
     Path(id): Path<String>,
     Json(req): Json<ExtendLeaseRequest>,
 ) -> Response {
+    if state.sandbox_enabled && crate::api::sandbox_access::looks_like_lease_id(&id) {
+        return crate::api::sandbox::extend_sandbox_lease(
+            State(state),
+            identity,
+            Path(id),
+            Json(crate::api::sandbox::ExtendSandboxLeaseRequest {
+                extend_ttl: req.extend_ttl,
+            }),
+        )
+        .await;
+    }
     let leases_api: Api<ClusterLease> = Api::namespaced(state.client.clone(), &state.namespace);
     // Carry the UID of the object we authorized into the mutation, so the
     // extend cannot land on a same-named lease created after this check.
@@ -2558,6 +2731,17 @@ async fn get_diagnostics<B: ClusterBackend>(
     identity: AuthIdentity,
     Path(id): Path<String>,
 ) -> Response {
+    if crate::api::sandbox_access::looks_like_lease_id(&id) {
+        return (
+            StatusCode::CONFLICT,
+            Json(ErrorResponse {
+                error: "Diagnostics are a Cluster lease capability".to_string(),
+                detail: Some("This id is a Sandbox lease".to_string()),
+                reason: Some(ErrorReason::WrongResourceKind),
+            }),
+        )
+            .into_response();
+    }
     let leases_api: Api<ClusterLease> = Api::namespaced(state.client.clone(), &state.namespace);
 
     match leases_api.get(&id).await {
@@ -2738,6 +2922,40 @@ async fn list_pool_leases<B: ClusterBackend>(
     Path(pool_name): Path<String>,
 ) -> Response {
     let policy = policy_for(&identity);
+    let sandbox_ok =
+        state.sandbox_enabled && is_sandbox_allowed(&pool_name, SandboxVerb::Lease, &policy);
+    if sandbox_ok && !is_pool_allowed(&pool_name, &policy) {
+        match crate::api::sandbox::caller_sandbox_summaries(&state, &identity).await {
+            Ok(leases) => {
+                let summaries: Vec<LeaseSummary> = leases
+                    .into_iter()
+                    .filter(|lease| lease.pool == pool_name)
+                    .map(|lease| LeaseSummary {
+                        id: lease.id,
+                        phase: lease.phase,
+                        resource_kind: "Sandbox",
+                        capabilities: sandbox_lease_capabilities(&lease.pool, &policy),
+                        profile: lease.pool,
+                        cluster_name: None,
+                        expires_at: lease.expires_at,
+                        queue_position: 0,
+                        diagnostics_url: None,
+                        requester: None,
+                        alias: lease.alias,
+                        metadata: None,
+                    })
+                    .collect();
+                return (StatusCode::OK, Json(summaries)).into_response();
+            }
+            Err(error) => {
+                return infra_error(
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    "Failed to list Sandbox pool leases",
+                    error,
+                );
+            }
+        }
+    }
     if !is_pool_allowed(&pool_name, &policy) {
         return StatusCode::FORBIDDEN.into_response();
     }
@@ -2775,6 +2993,8 @@ fn pool_lease_summary(lease: &ClusterLease, caller_identity: &str) -> LeaseSumma
     LeaseSummary {
         id: lease.name_any(),
         phase: status.phase.to_string(),
+        resource_kind: "Cluster",
+        capabilities: Vec::new(),
         profile: lease.spec.pool_ref.clone(),
         cluster_name: status.cluster_name,
         expires_at: status.expires_at,
@@ -5430,10 +5650,9 @@ mod tests {
             State(state),
             test_identity(),
             Json(CreateLeaseRequest {
-                profile: "e2e-basic".to_string(),
-                ttl: None,
-                alias: None,
+                profile: Some("e2e-basic".to_string()),
                 metadata: Some(serde_json::json!(["not", "an", "object"])),
+                ..CreateLeaseRequest::default()
             }),
         )
         .await;
@@ -5450,6 +5669,7 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let (state, server) = preflight_state().await;
+        mount_missing_sandbox_pool(&server, "e2e-basic").await;
 
         // count_active_leases: the requester has no active leases.
         Mock::given(method("GET"))
@@ -5486,10 +5706,8 @@ mod tests {
             State(state),
             test_identity(),
             Json(CreateLeaseRequest {
-                profile: "e2e-basic".to_string(),
-                ttl: None,
-                alias: None,
-                metadata: None,
+                profile: Some("e2e-basic".to_string()),
+                ..CreateLeaseRequest::default()
             }),
         )
         .await;
@@ -5522,6 +5740,7 @@ mod tests {
         use wiremock::{Mock, ResponseTemplate};
 
         let (state, server) = preflight_state().await;
+        mount_missing_sandbox_pool(&server, "e2e-basic").await;
 
         // Both the count and the post-create re-list see no active leases.
         Mock::given(method("GET"))
@@ -5570,10 +5789,9 @@ mod tests {
             State(state),
             test_identity(),
             Json(CreateLeaseRequest {
-                profile: "e2e-basic".to_string(),
-                ttl: None,
-                alias: None,
+                profile: Some("e2e-basic".to_string()),
                 metadata: Some(metadata.clone()),
+                ..CreateLeaseRequest::default()
             }),
         )
         .await;
@@ -5655,6 +5873,21 @@ mod tests {
         })
     }
 
+    async fn mount_missing_sandbox_pool(server: &wiremock::MockServer, name: &str) {
+        use wiremock::matchers::{method, path};
+        use wiremock::{Mock, ResponseTemplate};
+        Mock::given(method("GET"))
+            .and(path(format!(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/{name}"
+            )))
+            .respond_with(
+                ResponseTemplate::new(404)
+                    .set_body_json(k8s_not_found(&format!("sandboxpools \"{name}\" not found"))),
+            )
+            .mount(server)
+            .await;
+    }
+
     async fn mount_empty_cluster_leases(server: &wiremock::MockServer) {
         use wiremock::matchers::{method, path_regex};
         use wiremock::{Mock, ResponseTemplate};
@@ -5670,7 +5903,7 @@ mod tests {
     }
 
     #[tokio::test]
-    async fn create_lease_rejects_a_sandbox_pool_name_instead_of_queuing() {
+    async fn create_lease_dispatches_a_sandbox_pool_without_creating_a_cluster_lease() {
         use wiremock::matchers::{method, path};
         use wiremock::{Mock, ResponseTemplate};
 
@@ -5699,23 +5932,21 @@ mod tests {
             State(state),
             test_identity(),
             Json(CreateLeaseRequest {
-                profile: "e2e-agent".to_string(),
-                ttl: None,
-                alias: None,
-                metadata: None,
+                profile: Some("e2e-agent".to_string()),
+                ..CreateLeaseRequest::default()
             }),
         )
         .await;
 
-        assert_eq!(response.status(), StatusCode::CONFLICT);
-        let body = response_json(response).await;
-        assert_eq!(body["reason"], "wrong_resource_kind");
-        assert!(
-            body["error"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("Sandbox pool"),
-            "error should name the kind: {body}"
+        assert_ne!(
+            response.status(),
+            StatusCode::CONFLICT,
+            "a Sandbox pool name must not 409 on POST /v1/leases"
+        );
+        assert_ne!(
+            response.status(),
+            StatusCode::NOT_FOUND,
+            "a Sandbox pool that exists must not 404 on POST /v1/leases"
         );
         let posts = server
             .received_requests()
@@ -5760,10 +5991,8 @@ mod tests {
             State(state),
             test_identity(),
             Json(CreateLeaseRequest {
-                profile: "e2e-missing".to_string(),
-                ttl: None,
-                alias: None,
-                metadata: None,
+                profile: Some("e2e-missing".to_string()),
+                ..CreateLeaseRequest::default()
             }),
         )
         .await;

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -27,10 +27,9 @@ use super::routes::AppState;
 use super::sandbox_rate_limit::RateLimitDecision;
 use crate::backend::ClusterBackend;
 use crate::crd::{
-    ClusterPool, ResolvedSandboxPlacement, SandboxCondition, SandboxLease, SandboxLeasePhase,
-    SandboxLeaseSpec, SandboxPlacement, SandboxPlacementAuthority, SandboxPool,
-    SandboxPoolReference, SandboxPrincipal, SandboxReleaseCause, SandboxTargetProvenance,
-    SandboxVerb,
+    ResolvedSandboxPlacement, SandboxCondition, SandboxLease, SandboxLeasePhase, SandboxLeaseSpec,
+    SandboxPlacement, SandboxPlacementAuthority, SandboxPool, SandboxPoolReference,
+    SandboxPrincipal, SandboxReleaseCause, SandboxTargetProvenance, SandboxVerb,
 };
 use crate::pool::{is_valid_k8s_name, parse_duration};
 use crate::sandbox::{SANDBOX_LEASE_FINALIZER, aggregate_resource_limits, resource_ceiling_allows};
@@ -112,6 +111,28 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
         )
         .route(
             "/v1/sandbox-leases/{id}/executions/{execution}/logs",
+            get(get_sandbox_execution_logs::<B>),
+        )
+        // Canonical lease tree. `/v1/sandbox-leases` above stays as an alias
+        // so older clients keep working; create/list/get/release/extend for
+        // mixed kinds are served from `/v1/leases` in `routes.rs`.
+        .route("/v1/leases/{id}/logs", get(sandbox_logs::<B>))
+        .route("/v1/leases/{id}/exec", post(sandbox_exec::<B>))
+        .route("/v1/leases/{id}/attach", get(sandbox_attach::<B>))
+        .route(
+            "/v1/leases/{id}/port-forward",
+            get(sandbox_port_forward::<B>),
+        )
+        .route(
+            "/v1/leases/{id}/executions",
+            post(create_sandbox_execution::<B>),
+        )
+        .route(
+            "/v1/leases/{id}/executions/{execution}",
+            get(get_sandbox_execution::<B>).delete(cancel_sandbox_execution::<B>),
+        )
+        .route(
+            "/v1/leases/{id}/executions/{execution}/logs",
             get(get_sandbox_execution_logs::<B>),
         )
 }
@@ -2896,17 +2917,17 @@ fn access_denied(
 /// upstream Pod/Sandbox spec through a future-tolerant JSON object.
 #[derive(Debug, Deserialize)]
 #[serde(deny_unknown_fields)]
-struct CreateSandboxLeaseRequest {
-    pool: String,
+pub(crate) struct CreateSandboxLeaseRequest {
+    pub(crate) pool: String,
     #[serde(default)]
-    ttl: Option<String>,
+    pub(crate) ttl: Option<String>,
     #[serde(default)]
-    alias: Option<String>,
+    pub(crate) alias: Option<String>,
     /// Optional for compatibility with older API clients. Current clients send
     /// one key per deliberate create and reuse it only to recover an ambiguous
     /// response. The server never treats a missing key as retryable.
     #[serde(default, rename = "idempotencyKey")]
-    idempotency_key: Option<String>,
+    pub(crate) idempotency_key: Option<String>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -2967,6 +2988,8 @@ fn sha256_hex<'a>(components: impl IntoIterator<Item = &'a [u8]>) -> String {
 #[derive(Debug, Serialize)]
 struct SandboxLeaseResponse {
     id: String,
+    #[serde(rename = "resourceKind")]
+    resource_kind: &'static str,
     phase: String,
     pool: String,
     ttl: String,
@@ -2993,14 +3016,16 @@ struct SandboxLeaseResponse {
 }
 
 #[derive(Debug, Serialize)]
-struct SandboxLeaseSummary {
-    id: String,
-    phase: String,
-    pool: String,
+pub(crate) struct SandboxLeaseSummary {
+    pub id: String,
+    #[serde(rename = "resourceKind")]
+    resource_kind: &'static str,
+    pub phase: String,
+    pub pool: String,
     #[serde(skip_serializing_if = "Option::is_none")]
-    alias: Option<String>,
+    pub alias: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
-    expires_at: Option<String>,
+    pub expires_at: Option<String>,
 }
 
 /// Error body for every Sandbox route denial.
@@ -3249,6 +3274,7 @@ fn pending_sandbox_lease_response(
 ) -> SandboxLeaseResponse {
     SandboxLeaseResponse {
         id: lease_id,
+        resource_kind: "Sandbox",
         phase: SandboxLeasePhase::Pending.to_string(),
         pool,
         ttl: effective_ttl.clone(),
@@ -3287,7 +3313,7 @@ fn sandbox_throttled(error: String, retry_after: std::time::Duration) -> Respons
 }
 
 #[tracing::instrument(skip_all)]
-async fn create_sandbox_lease<B: ClusterBackend>(
+pub(crate) async fn create_sandbox_lease<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
     Json(request): Json<CreateSandboxLeaseRequest>,
@@ -3340,6 +3366,49 @@ async fn create_sandbox_lease_until_inner<B: ClusterBackend>(
             );
         }
     };
+    if !is_valid_k8s_name(&request.pool) {
+        return sandbox_error(
+            StatusCode::BAD_REQUEST,
+            "Invalid SandboxPool name",
+            Some(
+                "Pool must be a DNS label (lowercase alphanumeric and hyphens, 1-63 characters)"
+                    .into(),
+            ),
+        );
+    }
+    match crate::api::routes::resolve_create_pool_kind(&state, &request.pool).await {
+        Err(error) => return sandbox_infra_error("Unable to read pool", error),
+        Ok(crate::api::routes::CreatePoolKind::Cluster) => {
+            return crate::api::routes::create_lease(
+                State(state),
+                identity,
+                Json(crate::api::routes::CreateLeaseRequest {
+                    profile: Some(request.pool),
+                    pool: None,
+                    ttl: request.ttl,
+                    alias: request.alias,
+                    metadata: None,
+                    idempotency_key: None,
+                }),
+            )
+            .await;
+        }
+        Ok(crate::api::routes::CreatePoolKind::Ambiguous) => {
+            return sandbox_error_with_reason(
+                StatusCode::CONFLICT,
+                format!(
+                    "Pool name '{}' is ambiguous across Cluster and Sandbox resources",
+                    request.pool
+                ),
+                Some("Pool names must be unique across resource kinds".into()),
+                "wrong_resource_kind",
+            );
+        }
+        Ok(
+            crate::api::routes::CreatePoolKind::Sandbox
+            | crate::api::routes::CreatePoolKind::Missing,
+        ) => {}
+    }
     // FIRST operation that touches shared state, deliberately. Once admitted
     // by this limiter, the attempt spends its token even if a later pool,
     // policy, quota, or Kubernetes check refuses it: downstream failure must
@@ -3460,18 +3529,6 @@ async fn create_sandbox_lease_until_inner<B: ClusterBackend>(
     {
         Ok(Ok(pool)) => pool,
         Ok(Err(kube::Error::Api(error))) if error.code == 404 => {
-            let clusters: Api<ClusterPool> =
-                Api::namespaced(state.client.clone(), &state.namespace);
-            if matches!(clusters.get_opt(&request.pool).await, Ok(Some(_))) {
-                return sandbox_error_with_reason(
-                    StatusCode::CONFLICT,
-                    format!("Pool '{}' is a Cluster pool", request.pool),
-                    Some(
-                        "POST /v1/sandbox-leases creates Sandbox leases. Use POST /v1/leases; `kobe lease` selects the route from the pool kind.".into(),
-                    ),
-                    "wrong_resource_kind",
-                );
-            }
             return sandbox_error(StatusCode::NOT_FOUND, "SandboxPool not found", None);
         }
         Ok(Err(err)) => return sandbox_infra_error("Unable to load SandboxPool", err),
@@ -4201,8 +4258,50 @@ async fn create_sandbox_lease_until_inner<B: ClusterBackend>(
     )
 }
 
+/// Caller's Sandbox leases for the unified `GET /v1/leases` inventory.
+///
+/// Missing CRDs or a missing Sandbox grant return an empty list rather than
+/// failing the mixed inventory. The kind-specific `/v1/sandbox-leases` list
+/// still 403s when the grant is absent.
+pub(crate) async fn caller_sandbox_summaries<B: ClusterBackend>(
+    state: &AppState<B>,
+    identity: &AuthIdentity,
+) -> Result<Vec<SandboxLeaseSummary>, kube::Error> {
+    let policy = policy_for(identity);
+    let Some(grant) = policy.sandbox.as_ref() else {
+        return Ok(Vec::new());
+    };
+    if !grant.verbs.contains(&SandboxVerb::Lease) {
+        return Ok(Vec::new());
+    }
+    if require_sandbox_crds(&state.client, &[SANDBOX_LEASE_CRD])
+        .await
+        .is_err()
+    {
+        return Ok(Vec::new());
+    }
+    let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
+    let items = leases.list(&requester_list_params(identity)).await?;
+    Ok(items
+        .iter()
+        .filter(|lease| principal_matches(&lease.spec.requester, identity))
+        .filter(|lease| is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy))
+        .map(|lease| {
+            let status = lease.status.clone().unwrap_or_default();
+            SandboxLeaseSummary {
+                id: lease.name_any(),
+                resource_kind: "Sandbox",
+                phase: status.phase.to_string(),
+                pool: lease.spec.pool_ref.name.clone(),
+                alias: lease.spec.alias.clone(),
+                expires_at: status.expires_at.clone(),
+            }
+        })
+        .collect())
+}
+
 #[tracing::instrument(skip_all)]
-async fn list_sandbox_leases<B: ClusterBackend>(
+pub(crate) async fn list_sandbox_leases<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
 ) -> Response {
@@ -4239,6 +4338,7 @@ async fn list_sandbox_leases<B: ClusterBackend>(
                     let status = lease.status.clone().unwrap_or_default();
                     SandboxLeaseSummary {
                         id: lease.name_any(),
+                        resource_kind: "Sandbox",
                         phase: status.phase.to_string(),
                         pool: lease.spec.pool_ref.name.clone(),
                         alias: lease.spec.alias.clone(),
@@ -4253,7 +4353,7 @@ async fn list_sandbox_leases<B: ClusterBackend>(
 }
 
 #[tracing::instrument(skip_all)]
-async fn get_sandbox_lease<B: ClusterBackend>(
+pub(crate) async fn get_sandbox_lease<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
     Path(id): Path<String>,
@@ -4286,9 +4386,9 @@ async fn get_sandbox_lease<B: ClusterBackend>(
 /// and the older cluster-lease endpoint.
 #[derive(Debug, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
-struct ExtendSandboxLeaseRequest {
+pub(crate) struct ExtendSandboxLeaseRequest {
     #[serde(alias = "extend_ttl")]
-    extend_ttl: String,
+    pub(crate) extend_ttl: String,
 }
 
 #[derive(Debug, Serialize)]
@@ -4314,7 +4414,7 @@ struct ExtendSandboxLeaseResponse {
 /// taken at admission: a grant that has since been narrowed, or removed
 /// entirely, must bind immediately rather than let an old allowance coast.
 #[tracing::instrument(skip_all)]
-async fn extend_sandbox_lease<B: ClusterBackend>(
+pub(crate) async fn extend_sandbox_lease<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
     Path(id): Path<String>,
@@ -4549,7 +4649,7 @@ fn parse_lease_timestamp(value: &str) -> Option<chrono::DateTime<chrono::Utc>> {
 }
 
 #[tracing::instrument(skip_all)]
-async fn release_sandbox_lease<B: ClusterBackend>(
+pub(crate) async fn release_sandbox_lease<B: ClusterBackend>(
     State(state): State<AppState<B>>,
     identity: AuthIdentity,
     Path(id): Path<String>,
@@ -4910,6 +5010,7 @@ fn sandbox_lease_response(
     let status = lease.status.unwrap_or_default();
     SandboxLeaseResponse {
         id,
+        resource_kind: "Sandbox",
         phase: status.phase.to_string(),
         pool: lease.spec.pool_ref.name,
         ttl: lease.spec.ttl,
@@ -8240,6 +8341,20 @@ mod tests {
         let lease_state = Arc::new(Mutex::new(None::<serde_json::Value>));
         Mock::given(method("GET"))
             .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/clusterpools/agent-small",
+            ))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "kind": "Status",
+                "apiVersion": "v1",
+                "status": "Failure",
+                "reason": "NotFound",
+                "code": 404,
+                "message": "clusterpools \"agent-small\" not found"
+            })))
+            .mount(server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(
                 "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
             ))
             .respond_with(ResponseTemplate::new(200).set_body_json(pool_json()))
@@ -9365,10 +9480,38 @@ mod tests {
             "the id this endpoint issues ({id:?}) is not recognised as a lease id, \
              so every operation addressed by it is resolved as an alias and 404s"
         );
+        assert_eq!(body["resourceKind"], "Sandbox");
     }
 
     #[tokio::test]
-    async fn create_sandbox_lease_rejects_a_cluster_pool_name() {
+    async fn post_v1_leases_admits_a_sandbox_pool() {
+        let server = MockServer::start().await;
+        mount_create_api(&server, true, false).await;
+
+        let response = crate::api::routes::create_lease::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Json(crate::api::routes::CreateLeaseRequest {
+                profile: Some("agent-small".into()),
+                ..crate::api::routes::CreateLeaseRequest::default()
+            }),
+        )
+        .await;
+        let status = response.status();
+        let body = response_json(response).await;
+        assert_eq!(status, StatusCode::ACCEPTED, "response: {body}");
+        assert_eq!(body["resourceKind"], "Sandbox");
+        assert!(
+            body["id"]
+                .as_str()
+                .unwrap_or_default()
+                .starts_with("sandbox-"),
+            "id: {body}"
+        );
+    }
+
+    #[tokio::test]
+    async fn create_sandbox_lease_dispatches_a_cluster_pool_name() {
         let server = MockServer::start().await;
         mount_sandbox_crds(&server).await;
         Mock::given(method("GET"))
@@ -9410,15 +9553,10 @@ mod tests {
             }),
         )
         .await;
-        assert_eq!(response.status(), StatusCode::CONFLICT);
-        let body = response_json(response).await;
-        assert_eq!(body["reason"], "wrong_resource_kind");
-        assert!(
-            body["error"]
-                .as_str()
-                .unwrap_or_default()
-                .contains("Cluster pool"),
-            "error should name the kind: {body}"
+        assert_eq!(
+            response.status(),
+            StatusCode::FORBIDDEN,
+            "dispatch to Cluster create uses Cluster pool policy, not a kind 409"
         );
     }
 


### PR DESCRIPTION
## Summary

`POST /v1/leases` is the only create a client needs. The server looks up the pool and admits the matching CRD. Kind is a field on the lease, not a second URL the caller has to pick.

This is the adversarial fix for the hang: CLI 0.40.0 always POSTs `/v1/leases`. After this lands, that request creates a Sandbox lease when the pool is a Sandbox pool. It does not queue a fake ClusterLease.

Stacked on #177. #177's 409-on-wrong-door is replaced here by one door.

## API

- `POST /v1/leases` accepts `profile` or `pool`. Sandbox metadata is rejected. `idempotencyKey` is honoured for Sandbox creates.
- Same-name Cluster+Sandbox pools still 409 (`wrong_resource_kind`).
- `GET /v1/leases` returns both kinds with `resourceKind` and `capabilities`.
- `GET` / `DELETE` / `PATCH /v1/leases/:id` dispatch on the id (`sandbox-` vs `lease-`).
- Exec/logs/attach/port-forward/executions are also served under `/v1/leases/:id/...`.
- `/v1/sandbox-leases` stays as a compatibility alias. A Cluster pool name on that path is admitted as a Cluster lease.

## CLI

`GET /v1/leases` is treated as the mixed inventory when any item is Sandbox. Old operators that only list Cluster leases still get the extra `GET /v1/sandbox-leases` merge.

## Tested locally

- `cargo test -p kobectl --offline` (112 unit + 27 CLI)
- `cargo test --offline --bin kobe-operator -- api::sandbox::tests::create_ api::routes::tests::create_lease api::routes::tests::test_create_lease` (17 passed)
- `post_v1_leases_admits_a_sandbox_pool`, `create_sandbox_lease_dispatches_a_cluster_pool_name`