### PR TITLE
fix(cli): fail sandbox create immediately with the server error

### DIFF
--- a/crates/kobectl/src/commands/sandbox.rs
+++ b/crates/kobectl/src/commands/sandbox.rs
@@ -32,21 +32,22 @@ use sha2::{Digest, Sha256};
 
 use super::config::{CliConfig, ResolvedConfig};
 use super::{
-    OutputFormat, authed_client, get_auth_header, get_auth_header_noninteractive, print_json,
-    with_auth,
+    OutputFormat, authed_client, get_auth_header_for_output, get_auth_header_noninteractive,
+    print_json, with_auth,
 };
 
 async fn sandbox_auth_header(
     config: &ResolvedConfig,
     method: &str,
     path: &str,
-    body: &[u8],
+    _body: &[u8],
     output: OutputFormat,
 ) -> Result<Option<String>> {
-    match output {
-        OutputFormat::Text => get_auth_header(config, method, path, body).await,
-        OutputFormat::Json => get_auth_header_noninteractive(config, method, path, body).await,
-    }
+    // The server extracts AuthIdentity from request parts and verifies SSH
+    // signatures against an empty body (`validate_ssh(..., None)`). Signing the
+    // JSON payload here 401s every sandbox POST. Same workaround as
+    // `lease_create` / `extend_lease`.
+    get_auth_header_for_output(config, method, path, b"", output).await
 }
 
 /// Exit code for Kobe's own failures.
@@ -540,6 +541,26 @@ const CREATE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(9 * 6
 /// until this fresh window (measured from the transport failure) has elapsed.
 const CREATE_SETTLE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(9 * 60);
 const CREATE_RECOVERY_POLL: std::time::Duration = std::time::Duration::from_millis(500);
+
+fn format_create_http_detail(status: reqwest::StatusCode, raw: &str) -> String {
+    if raw.is_empty() {
+        return if status == reqwest::StatusCode::UNAUTHORIZED {
+            "empty body; SSH signature or Authorization was rejected".into()
+        } else {
+            "empty body".into()
+        };
+    }
+    serde_json::from_str::<serde_json::Value>(raw)
+        .ok()
+        .and_then(|value| {
+            let error = value["error"].as_str()?.to_string();
+            Some(match value["detail"].as_str() {
+                Some(detail) if !detail.is_empty() => format!("{error} — {detail}"),
+                _ => error,
+            })
+        })
+        .unwrap_or_else(|| raw.to_string())
+}
 const READY_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(5 * 60);
 const READY_POLL: std::time::Duration = std::time::Duration::from_secs(2);
 const RELEASE_TIMEOUT: std::time::Duration = std::time::Duration::from_secs(30);
@@ -1204,12 +1225,17 @@ async fn create_sandbox_lease(
         .map(|value| value.to_str().map(str::to_owned));
     let payload = tokio::time::timeout_at(deadline, response.bytes()).await;
     if !status.is_success() {
-        let detail = match payload {
+        let raw = match payload {
             Ok(Ok(bytes)) => String::from_utf8_lossy(&bytes).trim().to_string(),
             Ok(Err(error)) => format!("response body failed: {error}"),
             Err(_) => "response body exceeded the create deadline".to_string(),
         };
+        let detail = format_create_http_detail(status, &raw);
         let error = anyhow::anyhow!("could not create a sandbox (HTTP {status}): {detail}");
+        // Recover only when the POST itself may still be committing. A finished
+        // 401/403/503 with a body is the server's last word (pool not ready,
+        // bad SSH signature) and must print immediately — not poll 404s for
+        // nine minutes.
         if ambiguous_send.is_some() {
             return recover_expected_lease(
                 config,
@@ -1219,25 +1245,6 @@ async fn create_sandbox_lease(
                 format!("{error:#}"),
             )
             .await;
-        }
-        if status.is_server_error() {
-            // A server-side failure can be returned while a Kubernetes CREATE
-            // whose response was uncertain is still becoming observable. Do
-            // not let cleanup turn an immediate 404 into false absence proof:
-            // settle the deterministic handle first, then report the original
-            // create failure so `run` releases that exact object.
-            return match recover_expected_lease(
-                config,
-                expected_lease,
-                tokio::time::Instant::now() + CREATE_SETTLE_TIMEOUT,
-                output,
-                format!("{error:#}"),
-            )
-            .await
-            {
-                Ok(_) => Err(CreateFailure::ambiguous(error)),
-                Err(failure) => Err(failure),
-            };
         }
         return Err(CreateFailure::definite(error));
     }
@@ -1983,6 +1990,23 @@ pub async fn cancel(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn create_error_detail_prints_json_error_immediately() {
+        let raw = r#"{"error":"SandboxPool is not ready for new leases","detail":"Ready is False (CleanupBlocked)"}"#;
+        assert_eq!(
+            format_create_http_detail(reqwest::StatusCode::SERVICE_UNAVAILABLE, raw),
+            "SandboxPool is not ready for new leases — Ready is False (CleanupBlocked)"
+        );
+    }
+
+    #[test]
+    fn create_error_detail_explains_empty_401() {
+        assert_eq!(
+            format_create_http_detail(reqwest::StatusCode::UNAUTHORIZED, ""),
+            "empty body; SSH signature or Authorization was rejected"
+        );
+    }
 
     fn response(state: &str, exit_code: Option<i32>) -> ExecutionResponse {
         ExecutionResponse {

--- a/crates/kobectl/tests/sandbox_cli.rs
+++ b/crates/kobectl/tests/sandbox_cli.rs
@@ -916,46 +916,17 @@ fn lost_create_body_recovers_location_without_reposting_and_cleans_up() {
 }
 
 #[test]
-fn create_server_failure_settles_a_late_parent_before_cleanup() {
-    let lease = Arc::new(Mutex::new(String::new()));
-    let visible = Arc::new(AtomicBool::new(false));
-    let deleted = Arc::new(AtomicBool::new(false));
-    let gets = Arc::new(Mutex::new(0usize));
-    let known = Arc::clone(&lease);
-    let parent_visible = Arc::clone(&visible);
-    let released = Arc::clone(&deleted);
-    let recovery_gets = Arc::clone(&gets);
+fn create_finished_503_fails_immediately_without_settle() {
     let server = Server::start(move |request, stream| {
         if request.method == "POST" && request.path == "/v1/sandbox-leases" {
-            let (_, id) = keyed_lease(&request.body);
-            *known.lock().unwrap() = id;
-            // The handler reports failure before its uncertain Kubernetes
-            // CREATE is observable to a subsequent GET.
-            reply(stream, 503, &[], "checkpoint failed");
-        } else if request.method == "DELETE" {
-            assert!(
-                parent_visible.load(Ordering::SeqCst),
-                "cleanup must not accept 404 before the uncertain parent settles"
+            reply(
+                stream,
+                503,
+                &[],
+                r#"{"error":"SandboxPool is not ready for new leases","detail":"Ready is False (CleanupBlocked)"}"#,
             );
-            released.store(true, Ordering::SeqCst);
-            reply(stream, 204, &[], "");
-        } else if request.method == "GET" {
-            let mut count = recovery_gets.lock().unwrap();
-            *count += 1;
-            if *count == 1 {
-                reply(stream, 404, &[], "");
-                return;
-            }
-            parent_visible.store(true, Ordering::SeqCst);
-            let id = known.lock().unwrap().clone();
-            let phase = if released.load(Ordering::SeqCst) {
-                "Releasing"
-            } else {
-                "Pending"
-            };
-            reply(stream, 200, &[], &lease_body(&id, phase));
         } else {
-            panic!("create failure must skip execution: {request:?}");
+            panic!("finished 503 must not recover or execute: {request:?}");
         }
     });
     let (_directory, child) = spawn_child(
@@ -969,11 +940,14 @@ fn create_server_failure_settles_a_late_parent_before_cleanup() {
     assert!(output.stderr.is_empty());
     let json: Value = serde_json::from_slice(&output.stdout).unwrap();
     assert_eq!(json["outcome"], "createError");
-    assert_eq!(json["cleanup"]["released"], true);
-    assert!(json["lease"].as_str().unwrap().starts_with("sandbox-"));
-    assert!(*gets.lock().unwrap() >= 3);
-    assert!(visible.load(Ordering::SeqCst));
-    assert!(deleted.load(Ordering::SeqCst));
+    assert!(json["cleanup"].is_null());
+    assert!(json["lease"].is_null());
+    let error = json["error"].as_str().expect("createError carries error");
+    assert!(error.contains("503"), "{error}");
+    assert!(
+        error.contains("SandboxPool is not ready for new leases"),
+        "{error}"
+    );
 }
 
 #[test]

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ build-cli:
 # Build and install the CLI into ~/.cargo/bin (honors $CARGO_INSTALL_ROOT)
 [group('build')]
 install:
-    cargo install --path crates/kobectl --bin kobe --force
+    cargo install --path crates/kobectl --bin kobe --force --locked
 
 # Run the CLI (pass args after --)
 [group('dev')]

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -2,11 +2,11 @@ use std::collections::HashMap;
 use std::sync::Arc;
 use std::time::Duration;
 
-use axum::extract::FromRequestParts;
-use axum::http::request::Parts;
-use axum::http::StatusCode;
-use axum::response::{IntoResponse, Response};
 use axum::Json;
+use axum::extract::FromRequestParts;
+use axum::http::StatusCode;
+use axum::http::request::Parts;
+use axum::response::{IntoResponse, Response};
 use jsonwebtoken::Algorithm;
 use kunobi_auth::server::ssh::{CompiledSshProvider, NonceTracker, ParsedAuthorizedKey};
 use kunobi_auth::server::{

--- a/src/api/auth.rs
+++ b/src/api/auth.rs
@@ -4,6 +4,9 @@ use std::time::Duration;
 
 use axum::extract::FromRequestParts;
 use axum::http::request::Parts;
+use axum::http::StatusCode;
+use axum::response::{IntoResponse, Response};
+use axum::Json;
 use jsonwebtoken::Algorithm;
 use kunobi_auth::server::ssh::{CompiledSshProvider, NonceTracker, ParsedAuthorizedKey};
 use kunobi_auth::server::{
@@ -801,12 +804,40 @@ pub enum AuthError {
 impl AuthError {
     /// HTTP status for this error: credential rejections are `401`, server-side
     /// faults are `500`.
-    fn status_code(&self) -> axum::http::StatusCode {
+    fn status_code(&self) -> StatusCode {
         match self {
-            AuthError::InvalidToken(_) => axum::http::StatusCode::UNAUTHORIZED,
-            AuthError::Internal(_) => axum::http::StatusCode::INTERNAL_SERVER_ERROR,
+            AuthError::InvalidToken(_) => StatusCode::UNAUTHORIZED,
+            AuthError::Internal(_) => StatusCode::INTERNAL_SERVER_ERROR,
         }
     }
+
+    fn into_response(self) -> Response {
+        let status = self.status_code();
+        let error = if status == StatusCode::UNAUTHORIZED {
+            "Unauthorized"
+        } else {
+            "Internal auth error"
+        };
+        (
+            status,
+            Json(serde_json::json!({
+                "error": error,
+                "detail": self.to_string(),
+            })),
+        )
+            .into_response()
+    }
+}
+
+fn missing_authorization() -> Response {
+    (
+        StatusCode::UNAUTHORIZED,
+        Json(serde_json::json!({
+            "error": "Unauthorized",
+            "detail": "missing Authorization header",
+        })),
+    )
+        .into_response()
 }
 
 /// Map a kunobi-auth error to kobe's, preserving the 4xx/5xx distinction: kunobi
@@ -827,7 +858,7 @@ fn map_kunobi_auth_error(e: kunobi_auth::AuthError) -> AuthError {
 impl<B: crate::backend::ClusterBackend> FromRequestParts<crate::api::routes::AppState<B>>
     for AuthIdentity
 {
-    type Rejection = axum::http::StatusCode;
+    type Rejection = Response;
 
     async fn from_request_parts(
         parts: &mut Parts,
@@ -837,7 +868,7 @@ impl<B: crate::backend::ClusterBackend> FromRequestParts<crate::api::routes::App
             .headers
             .get("Authorization")
             .and_then(|v| v.to_str().ok())
-            .ok_or(axum::http::StatusCode::UNAUTHORIZED)?;
+            .ok_or_else(missing_authorization)?;
 
         // SSH-Signature path
         if let Some(ssh_header) = auth_header.strip_prefix("SSH-Signature ") {
@@ -859,14 +890,21 @@ impl<B: crate::backend::ClusterBackend> FromRequestParts<crate::api::routes::App
                         error = %e,
                         "SSH authentication failed"
                     );
-                    e.status_code()
+                    e.into_response()
                 });
         }
 
         // Bearer token path (existing OIDC/JWT)
-        let token = auth_header
-            .strip_prefix("Bearer ")
-            .ok_or(axum::http::StatusCode::UNAUTHORIZED)?;
+        let token = auth_header.strip_prefix("Bearer ").ok_or_else(|| {
+            (
+                StatusCode::UNAUTHORIZED,
+                Json(serde_json::json!({
+                    "error": "Unauthorized",
+                    "detail": "Authorization must be Bearer or SSH-Signature",
+                })),
+            )
+                .into_response()
+        })?;
 
         let method = parts.method.as_str();
         let path_with_query = parts
@@ -883,7 +921,7 @@ impl<B: crate::backend::ClusterBackend> FromRequestParts<crate::api::routes::App
                 status = e.status_code().as_u16(),
                 "Bearer authentication failed"
             );
-            e.status_code()
+            e.into_response()
         })
     }
 }

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -3548,7 +3548,7 @@ async fn create_sandbox_lease_until_inner<B: ClusterBackend>(
         return sandbox_error(
             StatusCode::SERVICE_UNAVAILABLE,
             "SandboxPool is not ready for new leases",
-            None,
+            Some(err.to_string()),
         );
     }
     let pool_reference = match sandbox_pool_reference(&pool) {
@@ -9408,6 +9408,18 @@ mod tests {
                 .unwrap();
             let response = app.clone().oneshot(request).await.unwrap();
             assert_eq!(response.status(), StatusCode::UNAUTHORIZED, "{verb} {uri}");
+            let body = axum::body::to_bytes(response.into_body(), usize::MAX)
+                .await
+                .unwrap();
+            let value: serde_json::Value = serde_json::from_slice(&body).unwrap_or_default();
+            assert_eq!(
+                value["error"], "Unauthorized",
+                "{verb} {uri} must name the failure: {value}"
+            );
+            assert_eq!(
+                value["detail"], "missing Authorization header",
+                "{verb} {uri} must say why: {value}"
+            );
         }
     }
 


### PR DESCRIPTION
## What

`kobe lease agent-trusted` 401ed with an empty body, then a later 503 sat for nine minutes polling a lease that was never created.

## Why

- Sandbox POSTs signed the JSON body; the operator verifies SSH against an empty body (`FromRequestParts` cannot read it). Cluster create already signed empty.
- A finished 503 was treated as an in-flight CREATE and entered `CREATE_SETTLE_TIMEOUT` (9m).
- `just install` omitted `--locked`, so cargo re-resolved the lock.

## Changes

- Sign sandbox POST/auth like `lease_create` (empty body).
- Print the server `error`/`detail` immediately; recover only if the POST itself may still be committing.
- 401 from the auth extractor returns JSON so the CLI can show why.
- Admission 503 includes the readiness error as `detail`.
- `just install` uses `--locked`.

Operator image on int-pro does not need this for the current lease path: the CLI is already installed from this tree, and `agent-trusted` is certified again.