### PR TITLE
fix(cli): shrink kobe status to a glance

### DIFF
--- a/crates/kobectl/src/commands/leases.rs
+++ b/crates/kobectl/src/commands/leases.rs
@@ -271,3 +271,128 @@ pub(crate) fn lease_when_label(lease: &LeaseSummary) -> String {
         lease_phase_label(lease)
     }
 }
+
+/// Released and expired records stay on the server for audit retention.
+/// Text `kobe status` hides them unless `--all`. Recycling still occupies
+/// capacity, so it stays visible.
+pub(crate) fn is_status_hidden_phase(phase: &str) -> bool {
+    matches!(phase.to_ascii_lowercase().as_str(), "released" | "expired")
+}
+
+/// Shorten a lease id for text columns. `sandbox-68c264e7eac6158b20edc7c9`
+/// becomes `sandbox-68c264e7…7c9`. JSON keeps the full id.
+pub(crate) fn short_lease_id(id: &str) -> String {
+    const HEAD: usize = 8;
+    const TAIL: usize = 3;
+    let Some(split) = id.find('-') else {
+        return id.to_string();
+    };
+    let (prefix, rest) = id.split_at(split + 1);
+    if rest.len() <= HEAD + TAIL + 1 {
+        return id.to_string();
+    }
+    format!("{prefix}{}…{}", &rest[..HEAD], &rest[rest.len() - TAIL..])
+}
+
+/// One status cell: phase, plus TTL or queue when that is not the same word.
+pub(crate) fn lease_glance_label(lease: &LeaseSummary) -> String {
+    let phase = lease_phase_label(lease);
+    if is_status_hidden_phase(&lease.phase) {
+        return phase;
+    }
+    if lease.phase.eq_ignore_ascii_case("pending") && lease.queue_position > 0 {
+        return format!("{phase}  queue #{}", lease.queue_position);
+    }
+    let Some(expires_at) = lease.expires_at.as_deref() else {
+        return phase;
+    };
+    let when = format_relative_time(expires_at);
+    if when == "expired" || when == phase {
+        return phase;
+    }
+    let remaining = when.strip_suffix(" left").unwrap_or(&when);
+    format!("{phase}  {remaining}")
+}
+
+/// One text `kobe status` lease row: short id, optional alias, pool, glance.
+pub(crate) fn format_lease_status_line(lease: &LeaseSummary) -> String {
+    let id = short_lease_id(&lease.id);
+    let glance = lease_glance_label(lease);
+    match lease.alias.as_deref().filter(|alias| !alias.is_empty()) {
+        Some(alias) => format!("{id}  {alias}  {}  {glance}", lease.profile),
+        None => format!("{id}  {}  {glance}", lease.profile),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn lease(id: &str, phase: &str, expires_at: Option<&str>, queue: u32) -> LeaseSummary {
+        LeaseSummary {
+            id: id.into(),
+            phase: phase.into(),
+            resource_kind: "Sandbox".into(),
+            capabilities: Vec::new(),
+            profile: "agent-trusted".into(),
+            cluster_name: None,
+            expires_at: expires_at.map(str::to_string),
+            queue_position: queue,
+            requester: None,
+            kubeconfig_path: None,
+            alias: None,
+            metadata: None,
+        }
+    }
+
+    #[test]
+    fn short_lease_id_keeps_prefix_and_tail() {
+        assert_eq!(
+            short_lease_id("sandbox-68c264e7eac6158b20edc7c9"),
+            "sandbox-68c264e7…7c9"
+        );
+        assert_eq!(short_lease_id("lease-abc"), "lease-abc");
+        assert_eq!(short_lease_id("lease-a1b2c3d4e5f6"), "lease-a1b2c3d4e5f6");
+        assert_eq!(short_lease_id("nohyphen"), "nohyphen");
+    }
+
+    #[test]
+    fn status_line_includes_alias_when_set() {
+        let mut named = lease("sandbox-68c264e7eac6158b20edc7c9", "Ready", None, 0);
+        named.alias = Some("pr-106".into());
+        assert_eq!(
+            format_lease_status_line(&named),
+            "sandbox-68c264e7…7c9  pr-106  agent-trusted  ready"
+        );
+        let unnamed = lease("sandbox-68c264e7eac6158b20edc7c9", "Released", None, 0);
+        assert_eq!(
+            format_lease_status_line(&unnamed),
+            "sandbox-68c264e7…7c9  agent-trusted  released"
+        );
+    }
+
+    #[test]
+    fn glance_label_does_not_repeat_expired() {
+        let expired = lease("sandbox-x", "Expired", Some("2020-01-01T00:00:00Z"), 0);
+        assert_eq!(lease_glance_label(&expired), "expired");
+        let released = lease("sandbox-x", "Released", Some("2020-01-01T00:00:00Z"), 0);
+        assert_eq!(lease_glance_label(&released), "released");
+    }
+
+    #[test]
+    fn glance_label_ready_shows_remaining_ttl() {
+        let expires = (chrono::Utc::now() + chrono::Duration::minutes(95)).to_rfc3339();
+        let ready = lease("sandbox-x", "Ready", Some(&expires), 0);
+        let label = lease_glance_label(&ready);
+        assert!(
+            label.starts_with("ready  1h "),
+            "expected remaining hours, got {label}"
+        );
+    }
+
+    #[test]
+    fn glance_label_pending_queue() {
+        let pending = lease("sandbox-x", "Pending", None, 3);
+        assert_eq!(lease_glance_label(&pending), "pending  queue #3");
+    }
+}

--- a/crates/kobectl/src/commands/pools.rs
+++ b/crates/kobectl/src/commands/pools.rs
@@ -122,6 +122,24 @@ pub(crate) async fn fetch_pool_for_config_with_output(
     Ok(response.json().await?)
 }
 
+/// Ready is always shown. Other counters only when non-zero.
+pub(crate) fn format_pool_counts(pool: &PoolSummary) -> String {
+    let mut parts = vec![format!("ready {}", pool.ready)];
+    for (label, value) in [
+        ("leased", pool.leased),
+        ("creating", pool.creating),
+        ("recycling", pool.recycling),
+        ("quarantined", pool.quarantined),
+        ("unhealthy", pool.unhealthy),
+        ("queue", pool.queue_depth),
+    ] {
+        if value > 0 {
+            parts.push(format!("{label} {value}"));
+        }
+    }
+    parts.join("  ")
+}
+
 pub(crate) fn format_policy(pool: &PoolSummary) -> Option<String> {
     let Some(policy) = &pool.policy else {
         return None;
@@ -169,15 +187,7 @@ pub(crate) fn print_pool_table(pools: &[PoolSummary], leases: &[LeaseSummary], i
 
         let phase = pool.phase.as_deref().unwrap_or("Unknown");
         println!("{indent}{}  {}  {phase}", pool.name, pool.resource_kind);
-        println!(
-            "{indent}  ready {}  leased {}  creating {}  recycling {}  quarantined {}  queue {}",
-            pool.ready,
-            pool.leased,
-            pool.creating,
-            pool.recycling,
-            pool.quarantined,
-            pool.queue_depth
-        );
+        println!("{indent}  {}", format_pool_counts(pool));
         if let Some(policy) = format_policy(pool) {
             println!("{indent}  {policy}");
         }
@@ -197,7 +207,7 @@ pub(crate) fn print_pool_table(pools: &[PoolSummary], leases: &[LeaseSummary], i
 
 #[cfg(test)]
 mod tests {
-    use super::{PoolSummary, format_policy, recycling_leases_by_pool};
+    use super::{PoolSummary, format_policy, format_pool_counts, recycling_leases_by_pool};
     use crate::commands::leases::LeaseSummary;
 
     #[test]
@@ -232,6 +242,31 @@ mod tests {
         assert!(pool.is_sandbox());
         assert!(pool.supports("exec"));
         assert!(!pool.supports("kubeconfig"));
+    }
+
+    #[test]
+    fn format_pool_counts_hides_zeros() {
+        let pool: PoolSummary = serde_json::from_value(serde_json::json!({
+            "name": "agent-trusted",
+            "resourceKind": "Sandbox",
+            "ready": 4,
+            "leased": 0,
+            "creating": 0,
+            "recycling": 0,
+            "quarantined": 0,
+            "queueDepth": 0
+        }))
+        .unwrap();
+        assert_eq!(format_pool_counts(&pool), "ready 4");
+
+        let busy: PoolSummary = serde_json::from_value(serde_json::json!({
+            "name": "ci-k3s-kunobi",
+            "ready": 4,
+            "leased": 5,
+            "creating": 2
+        }))
+        .unwrap();
+        assert_eq!(format_pool_counts(&busy), "ready 4  leased 5  creating 2");
     }
 
     #[test]

--- a/crates/kobectl/src/commands/status.rs
+++ b/crates/kobectl/src/commands/status.rs
@@ -3,8 +3,8 @@ use serde::Serialize;
 
 use super::config::{AuthMode, CliConfig};
 use super::leases::{
-    LeaseSummary, fetch_all_leases, fetch_lease, lease_cluster_label, lease_phase_label,
-    lease_when_label,
+    LeaseSummary, fetch_all_leases, fetch_lease, format_lease_status_line, is_status_hidden_phase,
+    lease_cluster_label,
 };
 use super::pools::{PoolSummary, fetch_pools_for_config, print_pool_table};
 use super::purge::live_lease_ids;
@@ -48,6 +48,13 @@ struct StatusOutput {
     orphan_kubeconfigs: Vec<String>,
 }
 
+fn format_status_header(endpoint: &str, endpoint_version: &str, auth_summary: &str) -> String {
+    format!(
+        "{endpoint}  cli {}  api {endpoint_version}  {auth_summary}",
+        cli_version()
+    )
+}
+
 fn auth_error_hint(error: &str) -> Option<&'static str> {
     if error.contains("found in SSH agent") {
         Some("check SSH_AUTH_SOCK and ssh-add -l")
@@ -56,10 +63,35 @@ fn auth_error_hint(error: &str) -> Option<&'static str> {
     }
 }
 
+fn hidden_lease_counts(leases: &[LeaseSummary]) -> (usize, usize) {
+    let mut released = 0;
+    let mut expired = 0;
+    for lease in leases {
+        match lease.phase.to_ascii_lowercase().as_str() {
+            "released" => released += 1,
+            "expired" => expired += 1,
+            _ => {}
+        }
+    }
+    (released, expired)
+}
+
+fn format_hidden_lease_parts(released: usize, expired: usize) -> String {
+    let mut parts = Vec::new();
+    if expired > 0 {
+        parts.push(format!("{expired} expired"));
+    }
+    if released > 0 {
+        parts.push(format!("{released} released"));
+    }
+    parts.join(", ")
+}
+
 pub async fn status(
     target_override: Option<&str>,
     endpoint_override: Option<&str>,
     output: OutputFormat,
+    show_all: bool,
 ) -> Result<()> {
     let config = CliConfig::load()?;
     let config = config.resolve(target_override, endpoint_override)?;
@@ -156,48 +188,61 @@ pub async fn status(
         });
     }
 
-    println!();
-    println!("\x1b[1mkobe\x1b[0m");
-    println!("  cli version: {}", cli_version());
-    if let Some(target) = &config.target {
-        println!("  target: {target}");
-    }
-    println!("  endpoint: {endpoint}");
-    println!("  endpoint version: {endpoint_version}");
+    println!(
+        "{}",
+        format_status_header(endpoint, endpoint_version, &auth_summary)
+    );
     super::version::warn_if_cli_behind_endpoint(endpoint_version);
-    println!();
 
-    println!("\x1b[1mAuth\x1b[0m");
-    println!("  {auth_summary}");
     if let Some(err) = &auth_error {
-        println!("  failed: {err}");
+        println!("auth failed: {err}");
         if let Some(hint) = auth_error_hint(err) {
-            println!("  hint: {hint}");
+            println!("hint: {hint}");
         }
         println!();
         return Ok(());
     }
     println!();
 
-    println!("\x1b[1mLeases\x1b[0m");
-    if leases.is_empty() {
-        println!("  none");
+    let (hidden_released, hidden_expired) = hidden_lease_counts(&leases);
+    let hidden = hidden_released + hidden_expired;
+    let mut visible: Vec<&LeaseSummary> = if show_all {
+        leases.iter().collect()
     } else {
-        for lease in &leases {
+        leases
+            .iter()
+            .filter(|lease| !is_status_hidden_phase(&lease.phase))
+            .collect()
+    };
+    if show_all {
+        visible.sort_by_key(|lease| is_status_hidden_phase(&lease.phase));
+    }
+
+    println!("\x1b[1mLeases\x1b[0m");
+    if visible.is_empty() {
+        if hidden == 0 {
+            println!("  none");
+        } else {
             println!(
-                "  {:<32}  {:<12}  {:<9}  {:<12}  {}",
-                lease.id,
-                lease.profile,
-                lease.resource_kind,
-                lease_phase_label(lease),
-                lease_when_label(lease)
+                "  none live  ({}; `kobe status --all` to list)",
+                format_hidden_lease_parts(hidden_released, hidden_expired)
             );
+        }
+    } else {
+        for lease in visible {
+            println!("  {}", format_lease_status_line(lease));
             if !lease.is_sandbox() {
                 println!("    cluster: {}", lease_cluster_label(lease));
             }
             if let Some(kubeconfig_path) = lease.kubeconfig_path.as_deref() {
                 println!("    config:  {kubeconfig_path}");
             }
+        }
+        if !show_all && hidden > 0 {
+            println!(
+                "  ({} hidden; `kobe status --all`)",
+                format_hidden_lease_parts(hidden_released, hidden_expired)
+            );
         }
     }
     if !orphan_kubeconfigs.is_empty() {
@@ -277,6 +322,71 @@ mod tests {
     /// `ssh-add -l`), not something they typed wrong. Attaching that hint to
     /// unrelated auth failures would send people chasing their agent when the
     /// real problem is an expired token or a bad issuer.
+    #[test]
+    fn status_header_is_one_line() {
+        let line = format_status_header("https://kobe.example", "main", "ssh SHA256:DpBgx...hSK8");
+        assert!(
+            !line.contains('\n'),
+            "header must be a single glance line, got {line:?}"
+        );
+        assert!(line.contains("https://kobe.example"));
+        assert!(line.contains("cli "));
+        assert!(line.contains("api main"));
+        assert!(line.contains("ssh "));
+    }
+
+    #[test]
+    fn hidden_lease_parts_name_released_and_expired() {
+        let leases = vec![
+            LeaseSummary {
+                id: "sandbox-a".into(),
+                phase: "Expired".into(),
+                resource_kind: "Sandbox".into(),
+                capabilities: Vec::new(),
+                profile: "agent-trusted".into(),
+                cluster_name: None,
+                expires_at: None,
+                queue_position: 0,
+                requester: None,
+                kubeconfig_path: None,
+                alias: None,
+                metadata: None,
+            },
+            LeaseSummary {
+                id: "sandbox-b".into(),
+                phase: "Released".into(),
+                resource_kind: "Sandbox".into(),
+                capabilities: Vec::new(),
+                profile: "agent-trusted".into(),
+                cluster_name: None,
+                expires_at: None,
+                queue_position: 0,
+                requester: None,
+                kubeconfig_path: None,
+                alias: None,
+                metadata: None,
+            },
+            LeaseSummary {
+                id: "sandbox-c".into(),
+                phase: "Ready".into(),
+                resource_kind: "Sandbox".into(),
+                capabilities: Vec::new(),
+                profile: "agent-trusted".into(),
+                cluster_name: None,
+                expires_at: None,
+                queue_position: 0,
+                requester: None,
+                kubeconfig_path: None,
+                alias: None,
+                metadata: None,
+            },
+        ];
+        assert_eq!(hidden_lease_counts(&leases), (1, 1));
+        assert_eq!(format_hidden_lease_parts(1, 2), "2 expired, 1 released");
+        assert_eq!(format_hidden_lease_parts(0, 3), "3 expired");
+        assert_eq!(format_hidden_lease_parts(1, 0), "1 released");
+    }
+
     #[test]
     fn the_ssh_hint_is_offered_only_for_the_failure_it_explains() {
         assert!(

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -29,7 +29,12 @@ struct Cli {
 #[derive(Subcommand)]
 enum Commands {
     /// Show status overview
-    Status,
+    Status {
+        /// Include released and expired leases in text output. JSON always
+        /// includes the full inventory.
+        #[arg(long)]
+        all: bool,
+    },
     /// Show CLI and endpoint versions
     Version,
     /// Authenticate with the Kobe service.
@@ -380,7 +385,7 @@ async fn main() -> anyhow::Result<()> {
     let output = cli.output;
 
     match cli.command {
-        Commands::Status => commands::status(target, endpoint, output).await,
+        Commands::Status { all } => commands::status(target, endpoint, output, all).await,
         Commands::Version => commands::version(target, endpoint, output).await,
         Commands::Login { device } => commands::login(target, endpoint, device).await,
         Commands::Logout => commands::logout(target, endpoint).await,

--- a/docs/kobe-docs/commands/reference.mdx
+++ b/docs/kobe-docs/commands/reference.mdx
@@ -34,11 +34,12 @@ description: All kobe CLI commands with flags and examples.
 
 ```sh
 kobe status
+kobe status --all
 ```
 
-Queries `GET /v1/status` on the configured endpoint. Shows the operator version, available auth methods, active sessions, and pool summary. Does not require authentication.
+Queries `GET /v1/status` on the configured endpoint. Shows the operator version, available auth methods, your leases, and pool summary. `GET /v1/status` itself does not require authentication; lease and pool rows do.
 
-Useful for verifying connectivity and checking which auth methods the endpoint accepts before logging in.
+Text output hides released and expired leases (they stay on the server for retention). Pass `--all` to list them. JSON (`-o json`) always includes the full inventory.
 
 Authenticated pool rows include the pool phase and a `quarantined` count. A
 non-zero count means cleanup evidence is incomplete and that capacity remains
@@ -132,7 +133,7 @@ When `--ensure` reuses an existing named lease, that lease keeps its original me
 kobe status
 ```
 
-The current CLI does not expose a standalone `kobe leases` command anymore. Use `kobe status` for an endpoint summary plus your active leases, or query `GET /v1/leases` directly.
+The current CLI does not expose a standalone `kobe leases` command anymore. Use `kobe status` for an endpoint summary plus your live leases. Released and expired records are omitted from text unless you pass `--all`. Query `GET /v1/leases` or `kobe status -o json` for the full inventory.
 
 ---
 

--- a/docs/kobe-docs/getting-started/quick-start.mdx
+++ b/docs/kobe-docs/getting-started/quick-start.mdx
@@ -97,7 +97,7 @@ description: Configure the kobe CLI, lease your first cluster, and release it wh
 kobe status
 ```
 
-Shows your active leases together with pool availability. For raw lease data, call `GET /v1/leases`.
+Shows your live leases together with pool availability. Released and expired records are omitted from text; pass `--all` or use `-o json` / `GET /v1/leases` for the full inventory.
 
 ## What happens when a lease expires
 

--- a/justfile
+++ b/justfile
@@ -54,7 +54,7 @@ build-cli:
 # Build and install the CLI into ~/.cargo/bin (honors $CARGO_INSTALL_ROOT)
 [group('build')]
 install:
-    cargo install --path crates/kobectl --bin kobe --force
+    cargo install --path crates/kobectl --bin kobe --force --locked
 
 # Run the CLI (pass args after --)
 [group('dev')]


### PR DESCRIPTION
## What

`kobe status` dumped a six-line header, padded full lease ids, duplicate phase/when cells, and all-zero pool counters. Released and expired records (kept ~7d for retention) dominated the list.

## Why

The command is a glance: what is live, and can I lease. Retention records belong behind `--all` or JSON.

## Changes

- One header line: endpoint, CLI version, API version, auth.
- Text lists live leases (pending/ready/recycling/quarantined). Released and expired are hidden unless `--all`.
- Short ids (`sandbox-68c264e7…7c9`), alias when set, phase + remaining TTL (or queue) in one cell.
- Pool counters omit zeros. Ready is always shown.
- JSON (`-o json`) still returns the full inventory.

Not merging.