### PR TITLE
chore: bump version to 0.41.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -2764,11 +2764,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.40.2"
+version = "0.41.0"
 
 [[package]]
 name = "kobectl"
-version = "0.40.2"
+version = "0.41.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.40.2"
+version = "0.41.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.40.2
-appVersion: "0.40.2"
+version: 0.41.0
+appVersion: "0.41.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.40.2
+      image: docker.io/zondax/kobe-operator:v0.41.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.40.2
+      image: docker.io/zondax/kobe-sync:v0.41.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
## Summary

- bump workspace packages to 0.41.0 (operator, CLI, runner, state-machine)
- bump Helm chart `version`, `appVersion`, and first-party image pins
- prepare the minor release of what is on `main` since `v0.40.2`

## Why minor

- #175 certify managed child runtime
- #176 pin Agent Sandbox to v1.0.0
- #168 opaque lease metadata
- #177 fail closed on pool-kind mismatch
- #174 teardown authority boundary
- #172 unified resource CLI tests
- #178 reqwest/jsonwebtoken

## Not in this tag unless they merge first

- #180 sandbox lease SSH / 503 handling, `just install --locked`
- #181 compact `kobe status`

Does not tag, publish, or merge. After this lands, cut `v0.41.0` from `main` with `just release` (or equivalent) as a separate step.

## Validation

- `just bump 0.41.0` → version consistency OK
- `git diff --check`