### PR TITLE
fix(vcluster): leave out snapshot RBAC the operator cannot delegate

### DIFF
--- a/docs/kobe-docs/pools/backends.mdx
+++ b/docs/kobe-docs/pools/backends.mdx
@@ -95,6 +95,8 @@ Values that do not name a real tag fail visibly, as an `ImagePullBackOff` on the
 
 > **Changed behaviour.** Earlier releases ignored `cluster.version` on this backend entirely, so every vcluster pool silently ran the chart default regardless of what its manifest said. If your pool carries a version that was never taking effect, check it names a real tag before upgrading — it now will.
 
+**Volume snapshot RBAC.** The operator installs each release under its own service account, and Kubernetes refuses to let it grant permissions it does not hold. Chart 0.34.0 renders `snapshot.storage.k8s.io` rules by default, so the operator sets `rbac.enableVolumeSnapshotRules.enabled: false`. Kobe pools do not sync volume snapshots. If a pool needs them, set the key back in `values` and grant the operator the matching rules.
+
 **When to use:** High density and low per-cluster overhead without maintaining an in-house syncer. Note that fidelity boundaries (cloud identity such as IRSA, syncer coverage, version skew) are inherited from vcluster — route tenants who need full cluster semantics to a real-cluster backend.
 
 ## vkobe (on hold)

--- a/src/backend/vcluster.rs
+++ b/src/backend/vcluster.rs
@@ -353,6 +353,24 @@ impl VclusterBackend {
         );
         root.insert(Value::from("controlPlane"), Value::Mapping(control_plane));
 
+        // Chart 0.34.0 defaults `rbac.enableVolumeSnapshotRules.enabled` to
+        // `auto`, which renders snapshot.storage.k8s.io rules into the
+        // vcluster Role and ClusterRole whenever private nodes are off. The
+        // operator installs the release under its own service account, and
+        // RBAC escalation prevention refuses to grant what the grantor does
+        // not hold, so every install fails before a pod exists. Kobe pools
+        // never sync volume snapshots; leave those rules out rather than
+        // widen the operator's grant. A pool that needs them can set the key
+        // back through `VclusterConfig.values`, which is merged last.
+        let mut volume_snapshot_rules = Mapping::new();
+        volume_snapshot_rules.insert(Value::from("enabled"), Value::from(false));
+        let mut rbac = Mapping::new();
+        rbac.insert(
+            Value::from("enableVolumeSnapshotRules"),
+            Value::Mapping(volume_snapshot_rules),
+        );
+        root.insert(Value::from("rbac"), Value::Mapping(rbac));
+
         let body = serde_yaml_ng::to_string(&Value::Mapping(root))
             // Serializing a mapping of plain scalars cannot fail; fall back to
             // an empty document rather than panicking in a reconcile.
@@ -887,6 +905,29 @@ mod tests {
             v["controlPlane"]["distro"]["k8s"]["version"].as_str(),
             Some("v1.32.3"),
             "a missing `v` must be added, got: {yaml}"
+        );
+    }
+
+    /// Chart 0.34.0 renders snapshot.storage.k8s.io rules by default, and the
+    /// operator's service account does not hold them. Kubernetes refuses to
+    /// let a grantor hand out permissions it lacks, so with the chart default
+    /// every vcluster install died at the ClusterRole and no instance ever
+    /// reached Ready. Kobe pools never sync volume snapshots, so the defaults
+    /// have to switch the rules off explicitly.
+    #[tokio::test]
+    async fn default_values_leave_out_snapshot_rbac_the_operator_cannot_delegate() {
+        let b = offline_backend(None);
+        let cfg = ClusterConfig {
+            version: "v1.32.3".to_string(),
+            servers: 1,
+            ..Default::default()
+        };
+        let yaml = b.default_values_yaml("foo", &cfg);
+        let v: serde_yaml_ng::Value = serde_yaml_ng::from_str(&yaml).unwrap();
+        assert_eq!(
+            v["rbac"]["enableVolumeSnapshotRules"]["enabled"].as_bool(),
+            Some(false),
+            "snapshot RBAC must be disabled, not left to the chart's `auto`, got: {yaml}"
         );
     }
 


### PR DESCRIPTION
## What

The nightly `conformance (vcluster)` leg has failed every night since at least 2026-08-14. Every `helm install` of the vcluster release dies at the ClusterRole:

```
clusterroles.rbac.authorization.k8s.io "vc-pool-e2e-vcluster-5-..." is forbidden:
user "system:serviceaccount:kobe-system:kobe" is attempting to grant RBAC permissions not currently held:
{APIGroups:["snapshot.storage.k8s.io"], Resources:["volumesnapshotclasses"], Verbs:["get" "list"]}
{APIGroups:["snapshot.storage.k8s.io"], Resources:["volumesnapshotcontents"], Verbs:["create" "delete" "patch" "update" "get" "list"]}
```

Chart 0.34.0 defaults `rbac.enableVolumeSnapshotRules.enabled` to `auto`, which renders those rules whenever private nodes are off. The operator installs under its own service account and does not hold them, so escalation prevention rejects the grant and no instance ever reaches Ready. The leg is `continue-on-error`, which is why main stayed green while it failed.

## Fix

Set `rbac.enableVolumeSnapshotRules.enabled: false` in the operator's default values. Kobe pools never sync volume snapshots, so this is the least-privilege answer rather than widening the operator's ClusterRole. A pool that needs the rules can set the key back through `VclusterConfig.values`, which is merged last, and grant the operator the matching rules.

Docs: a short note on the vcluster backend page.

## Verification

Rendering chart 0.34.0 with and without the new default:

```
$ helm template pool-x ./vcluster -n vcluster-pool-x | grep -c snapshot.storage.k8s.io
3
$ helm template pool-x ./vcluster -n vcluster-pool-x --set rbac.enableVolumeSnapshotRules.enabled=false | grep -c snapshot.storage.k8s.io
0
```

Unit test `default_values_leave_out_snapshot_rbac_the_operator_cannot_delegate` pins the key in the rendered defaults. The vcluster conformance leg only runs on the nightly schedule; the runner pool is a single Linux runner, so the on-branch matrix dispatch was cancelled in favour of the render above. Tonight's nightly confirms it end to end after merge.
