### PR TITLE
feat(cli): make attach the way into a sandbox

### DIFF
--- a/crates/kobectl/src/commands/mod.rs
+++ b/crates/kobectl/src/commands/mod.rs
@@ -59,6 +59,22 @@ pub async fn require_pool_capability(
 
 /// Resolve an exact ID, alias, or unique pool selector and reject an
 /// incompatible operation before it reaches a kind-specific route.
+/// Resolve a lease for a capability when the caller named none.
+///
+/// `kobe attach` with no argument: one attachable lease is taken, several open
+/// the picker, none is an error naming the verb. Kept beside
+/// [`require_lease_capability`] so a named lease and an unnamed one answer the
+/// same question about what the lease can serve.
+pub async fn pick_lease_with_capability(
+    capability: &str,
+    target_override: Option<&str>,
+    endpoint_override: Option<&str>,
+    output: OutputFormat,
+) -> anyhow::Result<String> {
+    let config = config::CliConfig::load()?.resolve(target_override, endpoint_override)?;
+    select::resolve_lease_for_capability(&config, capability, output).await
+}
+
 pub async fn require_lease_capability(
     selector: &str,
     capability: &str,

--- a/crates/kobectl/src/commands/sandbox_transport.rs
+++ b/crates/kobectl/src/commands/sandbox_transport.rs
@@ -272,7 +272,116 @@ async fn open_stream(config: &ResolvedConfig, path: &str, output: OutputFormat) 
 }
 
 /// Copy between this terminal and the stream until one of them ends.
+/// Write one server frame to the local terminal.
+///
+/// Returns the end reason once the session is over, so both input paths share
+/// one definition of "the stream said we are done".
+fn apply_server_frame(message: &Message) -> Option<String> {
+    match parse_server_frame(message) {
+        Some(ServerFrame::Stdout(bytes)) => {
+            let mut out = std::io::stdout();
+            out.write_all(&bytes).ok();
+            out.flush().ok();
+            None
+        }
+        Some(ServerFrame::Stderr(bytes)) => {
+            let mut err = std::io::stderr();
+            err.write_all(&bytes).ok();
+            err.flush().ok();
+            None
+        }
+        Some(ServerFrame::Ended { reason }) => Some(reason),
+        // A channel this client does not know. Ignored so a server that adds
+        // one does not break a client that never needed it.
+        Some(ServerFrame::Unknown) | None => None,
+    }
+}
+
 async fn pump_terminal(socket: &mut Socket, tty: bool) -> Result<String> {
+    #[cfg(unix)]
+    if tty {
+        return pump_raw(socket).await;
+    }
+    pump_key_events(socket, tty).await
+}
+
+/// Forward stdin byte for byte, interpreting nothing.
+///
+/// A full-screen program on the far side — zellij, tmux, vim — negotiates its
+/// own input modes by writing escape sequences that reach the real terminal,
+/// which then answers on stdin. Mouse reporting, bracketed paste, focus events
+/// and the kitty keyboard protocol all work that way. A client that decodes
+/// keystrokes and re-encodes them cannot participate: it drops every sequence
+/// its own key table has no name for, so the remote program enables a mode and
+/// then never hears from it. Copying the bytes through is both simpler and
+/// strictly more capable.
+///
+/// The cost is that resizes no longer arrive as decoded events, because
+/// nothing is decoding. `SIGWINCH` carries them instead.
+#[cfg(unix)]
+async fn pump_raw(socket: &mut Socket) -> Result<String> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    // A dedicated thread rather than `tokio::io::stdin()`: a read cancelled by
+    // `select!` can lose whatever it had already taken from the fd, and the
+    // bytes it would lose are the user's keystrokes. Handing them to a channel
+    // makes the branch cancel-safe, because a receive that loses the race
+    // leaves the message queued.
+    let (sender, mut receiver) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut stdin = std::io::stdin().lock();
+        let mut buffer = [0u8; 4096];
+        loop {
+            match stdin.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(read) => {
+                    if sender.blocking_send(buffer[..read].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut resized =
+        signal(SignalKind::window_change()).context("could not watch for terminal resizes")?;
+
+    loop {
+        tokio::select! {
+            inbound = socket.next() => {
+                let Some(message) = inbound else {
+                    return Ok("closed".to_string());
+                };
+                let message = message.context("stream failed")?;
+                if let Some(reason) = apply_server_frame(&message) {
+                    return Ok(reason);
+                }
+            }
+            outbound = receiver.recv() => {
+                // stdin at EOF is not the end of the session: the workload may
+                // still be writing. Stop forwarding and keep rendering.
+                let Some(bytes) = outbound else { continue };
+                socket.send(client_frame(CHANNEL_STDIN, &bytes)).await?;
+            }
+            _ = resized.recv() => {
+                if let Ok((width, height)) = crossterm::terminal::size()
+                    && let Some(frame) = resize_frame(width, height) {
+                    socket.send(frame).await?;
+                }
+            }
+        }
+    }
+}
+
+/// Decode key events and re-encode them as bytes.
+///
+/// The fallback where no `SIGWINCH` exists. Lossy by construction — see
+/// [`key_to_bytes`] — so it is only reached off Unix, or when there is no tty
+/// to put in raw mode.
+async fn pump_key_events(socket: &mut Socket, tty: bool) -> Result<String> {
     use crossterm::event::{Event, EventStream};
 
     let mut events = EventStream::new();
@@ -283,22 +392,8 @@ async fn pump_terminal(socket: &mut Socket, tty: bool) -> Result<String> {
                     return Ok("closed".to_string());
                 };
                 let message = message.context("stream failed")?;
-                match parse_server_frame(&message) {
-                    Some(ServerFrame::Stdout(bytes)) => {
-                        let mut out = std::io::stdout();
-                        out.write_all(&bytes).ok();
-                        out.flush().ok();
-                    }
-                    Some(ServerFrame::Stderr(bytes)) => {
-                        let mut err = std::io::stderr();
-                        err.write_all(&bytes).ok();
-                        err.flush().ok();
-                    }
-                    Some(ServerFrame::Ended { reason }) => return Ok(reason),
-                    // A channel this client does not know. Ignored so a server
-                    // that adds one does not break a client that never needed
-                    // it.
-                    Some(ServerFrame::Unknown) | None => {}
+                if let Some(reason) = apply_server_frame(&message) {
+                    return Ok(reason);
                 }
             }
             event = events.next(), if tty => {
@@ -651,6 +746,48 @@ mod tests {
 
         assert!(websocket_url("ftp://example", "/v1/x").is_err());
         assert!(websocket_url("not a url", "/v1/x").is_err());
+    }
+
+    /// Both input paths end the session on the same frame.
+    ///
+    /// The raw and key-event loops used to carry their own copy of this match;
+    /// a reason recognised by one and not the other would have left a caller
+    /// attached to a session the server considered finished.
+    #[test]
+    fn only_an_end_frame_ends_the_session() {
+        // A malformed error payload still ends the session, carrying the raw
+        // text: a reason this client cannot parse is more useful to whoever
+        // reads it than silently staying attached to a finished session.
+        assert_eq!(
+            apply_server_frame(&Message::Binary(vec![CHANNEL_ERROR, b'{'].into())),
+            Some("{".to_string())
+        );
+        assert_eq!(
+            apply_server_frame(&Message::Close(None)),
+            Some("closed".to_string())
+        );
+        assert_eq!(
+            apply_server_frame(&Message::Binary(
+                [&[CHANNEL_ERROR][..], br#"{"reason":"completed"}"#]
+                    .concat()
+                    .into()
+            )),
+            Some("completed".to_string())
+        );
+        // Output is written through, never treated as terminal.
+        assert_eq!(
+            apply_server_frame(&Message::Binary(vec![CHANNEL_STDOUT, b'h'].into())),
+            None
+        );
+        assert_eq!(
+            apply_server_frame(&Message::Binary(vec![CHANNEL_STDERR, b'h'].into())),
+            None
+        );
+        // A channel this client has never heard of must not end the session.
+        assert_eq!(
+            apply_server_frame(&Message::Binary(vec![99, b'x'].into())),
+            None
+        );
     }
 
     /// Ctrl-C reaches the workload rather than killing the CLI.

--- a/crates/kobectl/src/commands/select.rs
+++ b/crates/kobectl/src/commands/select.rs
@@ -97,6 +97,80 @@ fn select(
     }
 }
 
+/// Render lease candidates for the interactive picker.
+///
+/// Shared so every picker describes a lease the same way: whichever command
+/// opened it, the caller is choosing between the same rows.
+fn picker_items(candidates: &[LeaseSummary]) -> Vec<PickerItem> {
+    candidates
+        .iter()
+        .map(|lease| PickerItem {
+            primary: format!(
+                "{}  {}  {}",
+                lease.id,
+                lease.profile,
+                lease_when_label(lease)
+            ),
+            secondary: format!(
+                "kind: {}   phase: {}   resource: {}",
+                lease.resource_kind,
+                lease_phase_label(lease),
+                lease_cluster_label(lease)
+            ),
+        })
+        .collect()
+}
+
+/// Active leases that advertise `capability`.
+///
+/// Both halves matter. A released lease is gone, and a lease that never
+/// advertised the verb cannot serve it: cluster leases carry `kubeconfig`, not
+/// `attach`, so offering one in an attach picker would be offering a choice
+/// that can only fail.
+fn serving(leases: Vec<LeaseSummary>, capability: &str) -> Vec<LeaseSummary> {
+    leases
+        .into_iter()
+        .filter(is_active)
+        .filter(|lease| {
+            lease
+                .capabilities
+                .iter()
+                .any(|advertised| advertised == capability)
+        })
+        .collect()
+}
+
+/// Resolve a lease that advertises `capability`, with no target given.
+///
+/// `kobe attach` with no argument is the case where the caller knows they want
+/// a session but not which lease. Only leases that actually serve the verb are
+/// offered: a cluster lease never advertises `attach`, and listing one would
+/// be offering a choice that can only fail.
+pub(crate) async fn resolve_lease_for_capability(
+    config: &ResolvedConfig,
+    capability: &str,
+    output: OutputFormat,
+) -> Result<String> {
+    let capable = serving(fetch_all_leases(config).await?, capability);
+
+    if capable.is_empty() {
+        anyhow::bail!("No active lease supports `{capability}`. `kobe ls` shows what you hold.");
+    }
+
+    match select(capable, None, output, OnAmbiguous::Reject)? {
+        Selection::Resolved(id) => Ok(id),
+        Selection::NeedsPicker(candidates) => {
+            let items = picker_items(&candidates);
+            let selected = run_picker(
+                &format!("Select a lease to {capability}"),
+                "↑/↓ to move · Enter to select · q to cancel",
+                &items,
+            )?;
+            Ok(candidates[selected].id.clone())
+        }
+    }
+}
+
 /// Resolve a user-supplied selector to a concrete lease id.
 ///
 /// Precedence:
@@ -120,23 +194,7 @@ pub(crate) async fn resolve_lease_id(
     match select(active, target, output, on_ambiguous)? {
         Selection::Resolved(id) => Ok(id),
         Selection::NeedsPicker(candidates) => {
-            let items: Vec<PickerItem> = candidates
-                .iter()
-                .map(|lease| PickerItem {
-                    primary: format!(
-                        "{}  {}  {}",
-                        lease.id,
-                        lease.profile,
-                        lease_when_label(lease)
-                    ),
-                    secondary: format!(
-                        "kind: {}   phase: {}   resource: {}",
-                        lease.resource_kind,
-                        lease_phase_label(lease),
-                        lease_cluster_label(lease)
-                    ),
-                })
-                .collect();
+            let items = picker_items(&candidates);
             let selected = run_picker(
                 "Select a lease",
                 "↑/↓ to move · Enter to select · q to cancel",
@@ -177,6 +235,38 @@ mod tests {
             alias: None,
             metadata: None,
         }
+    }
+
+    /// An attach picker must only offer leases that can actually attach.
+    ///
+    /// Cluster leases advertise `kubeconfig` and never `attach`, so listing
+    /// one would be offering a choice that fails after the user commits to
+    /// it. Released leases are gone regardless of what they once advertised.
+    #[test]
+    fn only_active_leases_advertising_the_verb_are_offered() {
+        let attachable = |id: &str, phase: &str| {
+            let mut lease = lease(id, "agent-small", phase);
+            lease.resource_kind = "Sandbox".to_string();
+            lease.capabilities = vec!["lease".to_string(), "attach".to_string()];
+            lease
+        };
+
+        let offered = serving(
+            vec![
+                attachable("sbx-ready", "Ready"),
+                // Right verb, but the lease is over.
+                attachable("sbx-released", "Released"),
+                // Active, but a cluster lease cannot serve attach.
+                lease("cluster-1", "e2e-k3s", "Bound"),
+            ],
+            "attach",
+        );
+
+        let ids: Vec<&str> = offered.iter().map(|lease| lease.id.as_str()).collect();
+        assert_eq!(ids, vec!["sbx-ready"]);
+
+        // A verb nothing advertises yields nothing rather than everything.
+        assert!(serving(vec![attachable("sbx-ready", "Ready")], "port-forward").is_empty());
     }
 
     fn resolved(sel: Selection) -> String {

--- a/crates/kobectl/src/commands/select.rs
+++ b/crates/kobectl/src/commands/select.rs
@@ -154,7 +154,9 @@ pub(crate) async fn resolve_lease_for_capability(
     let capable = serving(fetch_all_leases(config).await?, capability);
 
     if capable.is_empty() {
-        anyhow::bail!("No active lease supports `{capability}`. `kobe ls` shows what you hold.");
+        anyhow::bail!(
+            "No active lease supports `{capability}`. `kobe status` lists what you hold."
+        );
     }
 
     match select(capable, None, output, OnAmbiguous::Reject)? {

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -89,8 +89,10 @@ enum Commands {
         execution: String,
     },
     /// Attach to a lease that supports `attach`.
+    ///
+    /// With no lease, picks the only attachable one or opens a picker.
     Attach {
-        lease: String,
+        lease: Option<String>,
         #[arg(long)]
         container: Option<String>,
         #[arg(long)]
@@ -267,7 +269,7 @@ enum SandboxAction {
     ///
     /// With no command, attaches to the container's existing process.
     Attach {
-        lease: String,
+        lease: Option<String>,
         #[arg(long)]
         container: Option<String>,
         /// Run without allocating a terminal.
@@ -527,10 +529,6 @@ async fn main() -> anyhow::Result<()> {
             no_tty,
             command,
         } => {
-            let lease =
-                commands::require_lease_capability(&lease, "attach", target, endpoint, output)
-                    .await
-                    .unwrap_or_else(|error| exit_resource_error(error, output));
             dispatch_resource_action(
                 SandboxAction::Attach {
                     lease,
@@ -688,6 +686,19 @@ async fn dispatch_resource_action(
             no_tty,
             command,
         } => {
+            // One resolution point for both spellings: a named lease must
+            // advertise `attach`, and an unnamed one opens the picker over
+            // the leases that do.
+            let lease = match lease {
+                Some(lease) => {
+                    commands::require_lease_capability(&lease, "attach", target, endpoint, output)
+                        .await
+                }
+                None => {
+                    commands::pick_lease_with_capability("attach", target, endpoint, output).await
+                }
+            }
+            .unwrap_or_else(|error| exit_resource_error(error, output));
             commands::sandbox_transport::attach(
                 &lease,
                 &command,

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -208,10 +208,15 @@ is yours.
 An interactive session inside the sandbox.
 
 ```bash
+kobe attach                          # pick from your attachable leases
 kobe attach dev                      # attach to the running process
 kobe attach dev -- /bin/bash         # start a shell instead
 kobe attach dev --no-tty -- command  # run without allocating a terminal
 ```
+
+With no lease, `kobe attach` takes the only attachable lease you hold, or opens
+a picker when there are several. Leases that cannot serve `attach` — a cluster
+lease, for one — are not offered.
 
 The terminal goes into raw mode, so **Ctrl-C reaches your workload** rather
 than killing `kobe`. Resizing the window is forwarded, so a shell inside keeps

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -217,6 +217,22 @@ The terminal goes into raw mode, so **Ctrl-C reaches your workload** rather
 than killing `kobe`. Resizing the window is forwarded, so a shell inside keeps
 rendering to the size you can actually see.
 
+Input is forwarded **byte for byte**, so a full-screen program on the far side
+works as it would locally: function keys, alt combinations, mouse reporting,
+bracketed paste and the kitty keyboard protocol all reach it. That is what
+lets you run a multiplexer or an editor inside a sandbox:
+
+```bash
+kobe attach dev -- zellij attach --create kobe
+```
+
+Running the multiplexer inside the sandbox also means your session survives a
+disconnect: reattaching resumes it rather than starting over.
+
+<Callout type="info">
+Byte transparency needs a Unix client and a terminal. Elsewhere `kobe` falls back to decoding keystrokes and re-encoding them, which carries ordinary typing, arrows and control keys but not mouse or paste.
+</Callout>
+
 The terminal is restored on every exit path, including a panic — a process
 that dies in raw mode leaves you with a terminal that does not echo.
 


### PR DESCRIPTION
Two changes that together make `kobe attach` the way into a sandbox, rather than a command you can only use once you already know a lease id and are willing to lose half your keyboard.

## 1. Input is forwarded byte for byte

`attach` decoded keystrokes into `crossterm` key events and re-encoded them from a small hand-written table. Anything the table had no name for was silently dropped: function keys, alt combinations, mouse reporting, bracketed paste, focus events, the kitty keyboard protocol.

That is most of what a full-screen program needs. A multiplexer or an editor inside a sandbox enables its input modes by writing escape sequences meant to reach the real terminal, which then answers on stdin. A client that decodes in the middle cannot participate: the remote program turns a mode on and never hears back.

Copy stdin through untouched on Unix with a tty instead.

- Resizes no longer arrive as decoded events, because nothing is decoding. `SIGWINCH` carries them.
- stdin is read on a dedicated thread and handed over a channel. A read cancelled by `select!` can lose bytes it already took from the fd, and those bytes are the caller's keystrokes; a receive that loses the race leaves the message queued.
- The key-event path stays for non-Unix clients and for `--no-tty`. `key_to_bytes` and its tests are unchanged.
- Server-frame handling is factored into one function both loops call, so the paths cannot disagree about what ends a session.

## 2. The lease argument is optional

A caller who wants a session does not necessarily have a lease id to hand. `kobe attach` with no argument takes the only attachable lease, opens the existing picker when there are several, and errors naming the verb when there are none.

Only leases advertising `attach` are offered. A cluster lease carries `kubeconfig` and never `attach`, so listing one would be offering a choice that fails after the user commits to it.

Resolution moves into the action arm, so `kobe attach` and the older `kobe sandbox attach` spelling now answer the same question about what a lease can serve. The latter previously skipped the capability check entirely. Picker row rendering is shared with the existing resolver rather than copied.

## Why both

Together they are what lets a multiplexer live in the sandbox:

```bash
kobe attach                                    # pick a sandbox
kobe attach dev -- zellij attach --create kobe # land in a session that survives disconnects
```

## Tests

- `only_an_end_frame_ends_the_session` pins the shared frame contract: output frames pass through, an unknown channel is ignored, an error frame ends the session, and a malformed error payload still ends it carrying raw text rather than leaving the caller attached to a finished session.
- `only_active_leases_advertising_the_verb_are_offered` pins the picker filter across a released sandbox lease and an active cluster lease.
- Full `kobectl` suite passes, 124 tests. Clippy clean.

The raw input path needs a real pty, so it is not unit tested. The existing `attach-pty` conformance scenario drives `kobe attach` under a pty end to end.
