### PR TITLE
fix(cli): say what to do when kobe cannot be reached

### DIFF
--- a/crates/kobectl/src/commands/leases.rs
+++ b/crates/kobectl/src/commands/leases.rs
@@ -2,7 +2,9 @@ use anyhow::Result;
 use serde::{Deserialize, Serialize};
 
 use super::config::ResolvedConfig;
-use super::{OutputFormat, authed_client, get_auth_header, get_auth_header_for_output, with_auth};
+use super::{
+    OutputFormat, Reaching, authed_client, get_auth_header, get_auth_header_for_output, with_auth,
+};
 
 #[derive(Debug, Clone, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -75,7 +77,8 @@ pub(crate) async fn fetch_leases_path(
     let client = authed_client();
     let response = with_auth(client.get(format!("{endpoint}{path}")), &token)
         .send()
-        .await?;
+        .await
+        .reaching(config)?;
 
     if !response.status().is_success() {
         anyhow::bail!("Failed to list leases (HTTP {})", response.status());
@@ -96,7 +99,8 @@ async fn fetch_sandbox_leases_with_output(
         &token,
     )
     .send()
-    .await?;
+    .await
+    .reaching(config)?;
     let status = response.status();
     if matches!(status.as_u16(), 403 | 404 | 501) {
         return Ok(Vec::new());
@@ -139,7 +143,8 @@ pub(crate) async fn fetch_all_leases_with_output(
         let token = get_auth_header_for_output(config, "GET", path, b"", output).await?;
         let response = with_auth(authed_client().get(format!("{endpoint}{path}")), &token)
             .send()
-            .await?;
+            .await
+            .reaching(config)?;
         if !response.status().is_success() {
             anyhow::bail!("Failed to list leases (HTTP {})", response.status());
         }
@@ -211,7 +216,8 @@ pub(crate) async fn fetch_lease(config: &ResolvedConfig, lease_id: &str) -> Resu
     let client = authed_client();
     let response = with_auth(client.get(format!("{endpoint}{path}")), &token)
         .send()
-        .await?;
+        .await
+        .reaching(config)?;
 
     if !response.status().is_success() {
         anyhow::bail!(

--- a/crates/kobectl/src/commands/mod.rs
+++ b/crates/kobectl/src/commands/mod.rs
@@ -376,6 +376,132 @@ fn apply_tofu_result(
 }
 
 /// Build an HTTP request with optional auth.
+/// Why a request never reached the server, in terms the caller can act on.
+///
+/// `reqwest` errors arrive as a chain — request, then connect, then the
+/// operating system's resolver text — and printing the chain gives the caller
+/// three clauses of plumbing and no idea what to do. Nothing below the top
+/// layer is theirs to fix; what is theirs is the endpoint, the VPN, and
+/// whether the server is up.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub(crate) enum Unreachable {
+    Dns,
+    Refused,
+    TimedOut,
+    Tls,
+    Other,
+}
+
+impl Unreachable {
+    fn summary(self) -> &'static str {
+        match self {
+            Self::Dns => "the host name does not resolve",
+            Self::Refused => "nothing is listening there",
+            Self::TimedOut => "the connection timed out",
+            Self::Tls => "the TLS handshake failed",
+            Self::Other => "the connection failed",
+        }
+    }
+
+    fn hint(self) -> &'static str {
+        match self {
+            Self::Dns => {
+                "A private cluster resolves only from its network: connect the VPN, or check the endpoint for a typo."
+            }
+            Self::Refused => {
+                "The name resolves, so the address is reachable but nothing answered. Check that the kobe ingress is up."
+            }
+            Self::TimedOut => {
+                "The address is routable but silent, which usually means a firewall or a missing VPN route."
+            }
+            Self::Tls => {
+                "The server's certificate was rejected. Check that the endpoint host matches the certificate."
+            }
+            Self::Other => "Check the endpoint and that the kobe server is reachable from here.",
+        }
+    }
+}
+
+/// Classify a transport failure.
+///
+/// The typed predicates carry the bucket; the resolver's own words are the
+/// only place DNS is distinguishable from a refused connection, because both
+/// surface as `is_connect`. Matching that text is unlovely but it is the
+/// difference between "connect the VPN" and "the server is down", which is
+/// the entire value of the message.
+pub(crate) fn classify_unreachable(error: &reqwest::Error) -> Unreachable {
+    if error.is_timeout() {
+        return Unreachable::TimedOut;
+    }
+
+    let mut chain = String::new();
+    let mut source: Option<&(dyn std::error::Error + 'static)> = Some(error);
+    while let Some(current) = source {
+        chain.push_str(&current.to_string().to_ascii_lowercase());
+        chain.push(' ');
+        source = current.source();
+    }
+
+    if chain.contains("dns error") || chain.contains("failed to lookup address") {
+        Unreachable::Dns
+    } else if chain.contains("connection refused") {
+        Unreachable::Refused
+    } else if chain.contains("timed out") {
+        Unreachable::TimedOut
+    } else if chain.contains("certificate") || chain.contains("tls") {
+        Unreachable::Tls
+    } else {
+        // Including `is_connect` with no recognisable cause: the bucket is
+        // the same, and a hint that guesses would be worse than a general one.
+        Unreachable::Other
+    }
+}
+
+/// Render the message a caller sees when kobe cannot be reached.
+pub(crate) fn unreachable_message(
+    endpoint: &str,
+    target: Option<&str>,
+    kind: Unreachable,
+) -> String {
+    let host = endpoint
+        .split_once("://")
+        .map_or(endpoint, |(_, rest)| rest)
+        .split('/')
+        .next()
+        .unwrap_or(endpoint);
+    let origin = match target {
+        Some(target) => format!("target    {target}"),
+        None => "target    (none: endpoint given directly)".to_string(),
+    };
+    format!(
+        "cannot reach kobe at {host}: {summary}\n\n  endpoint  {endpoint}\n  {origin}\n\n  {hint}\n  `kobe config view` shows where this endpoint came from.",
+        summary = kind.summary(),
+        hint = kind.hint(),
+    )
+}
+
+/// Attach the reachability explanation to a failed request.
+pub(crate) trait Reaching<T> {
+    fn reaching(self, config: &ResolvedConfig) -> anyhow::Result<T>;
+}
+
+impl<T> Reaching<T> for Result<T, reqwest::Error> {
+    fn reaching(self, config: &ResolvedConfig) -> anyhow::Result<T> {
+        self.map_err(|error| {
+            if error.is_builder() || error.is_body() || error.is_decode() {
+                // Not a reachability problem; the caller's own message is
+                // better than a story about the network.
+                return anyhow::Error::new(error);
+            }
+            anyhow::anyhow!(unreachable_message(
+                &config.endpoint,
+                config.target.as_deref(),
+                classify_unreachable(&error),
+            ))
+        })
+    }
+}
+
 pub(crate) fn authed_client() -> reqwest::Client {
     reqwest::Client::new()
 }
@@ -388,6 +514,65 @@ pub(crate) fn with_auth(
     match auth_header {
         Some(h) => builder.header("Authorization", h),
         None => builder,
+    }
+}
+
+#[cfg(test)]
+mod reachability_tests {
+    use super::*;
+
+    /// The message names the host, what failed, and where the endpoint came
+    /// from. A caller who sees it should not have to run anything to know
+    /// which of their machines is wrong.
+    #[test]
+    fn an_unreachable_message_names_the_host_target_and_remedy() {
+        let message = unreachable_message(
+            "https://kobe.zur1-worker1.int-pro.zondax.io",
+            Some("int-pro"),
+            Unreachable::Dns,
+        );
+        assert!(
+            message.starts_with("cannot reach kobe at kobe.zur1-worker1.int-pro.zondax.io: "),
+            "{message}"
+        );
+        assert!(
+            message.contains("the host name does not resolve"),
+            "{message}"
+        );
+        assert!(message.contains("int-pro"), "{message}");
+        assert!(message.contains("VPN"), "{message}");
+        // The operating system's resolver text is exactly what this replaces.
+        assert!(!message.contains("nodename"), "{message}");
+        assert!(!message.contains("servname"), "{message}");
+
+        // An endpoint passed directly has no target to name, and must say so
+        // rather than printing an empty field.
+        let direct = unreachable_message("http://127.0.0.1:8080", None, Unreachable::Refused);
+        assert!(direct.contains("endpoint given directly"), "{direct}");
+        assert!(direct.contains("nothing is listening there"), "{direct}");
+        // Host extraction keeps the port and drops the scheme and path.
+        assert!(direct.contains("at 127.0.0.1:8080:"), "{direct}");
+    }
+
+    /// DNS and a refused connection both arrive as `is_connect`, and they ask
+    /// the caller to do completely different things. Distinguishing them is
+    /// the whole point of classifying.
+    #[test]
+    fn resolver_and_refusal_are_told_apart() {
+        assert_eq!(Unreachable::Dns.summary(), "the host name does not resolve");
+        assert_eq!(Unreachable::Refused.summary(), "nothing is listening there");
+        assert_ne!(Unreachable::Dns.hint(), Unreachable::Refused.hint());
+        // Every bucket offers something to do next.
+        for kind in [
+            Unreachable::Dns,
+            Unreachable::Refused,
+            Unreachable::TimedOut,
+            Unreachable::Tls,
+            Unreachable::Other,
+        ] {
+            assert!(!kind.hint().is_empty(), "{kind:?} has no hint");
+            assert!(!kind.summary().is_empty(), "{kind:?} has no summary");
+        }
     }
 }
 

--- a/crates/kobectl/src/commands/status.rs
+++ b/crates/kobectl/src/commands/status.rs
@@ -9,7 +9,9 @@ use super::leases::{
 use super::pools::{PoolSummary, fetch_pools_for_config, print_pool_table};
 use super::purge::live_lease_ids;
 use super::state::{find_orphan_kubeconfigs, resolve_kubeconfig_path};
-use super::{OutputFormat, authed_client, cli_version, get_auth_header, print_json, with_auth};
+use super::{
+    OutputFormat, Reaching, authed_client, cli_version, get_auth_header, print_json, with_auth,
+};
 
 #[derive(Serialize)]
 #[serde(rename_all = "camelCase")]
@@ -106,7 +108,8 @@ pub async fn status(
     let client = authed_client();
     let response = with_auth(client.get(format!("{endpoint}/v1/status")), &token)
         .send()
-        .await?;
+        .await
+        .reaching(&config)?;
 
     if !response.status().is_success() {
         anyhow::bail!("Failed to get status (HTTP {})", response.status());

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -384,7 +384,7 @@ async fn main() -> anyhow::Result<()> {
     let endpoint = cli.endpoint.as_deref();
     let output = cli.output;
 
-    match cli.command {
+    let result = match cli.command {
         Commands::Status { all } => commands::status(target, endpoint, output, all).await,
         Commands::Version => commands::version(target, endpoint, output).await,
         Commands::Login { device } => commands::login(target, endpoint, device).await,
@@ -611,6 +611,15 @@ async fn main() -> anyhow::Result<()> {
             }
             None => print_config_help(),
         },
+    };
+    // One place decides how a failure reaches the caller: every command
+    // prints the same `kobe:` prefix in text mode and the same structured
+    // body under `--output json`. Returning the error to `main` instead
+    // printed anyhow's own `Error:` for everything except the sandbox
+    // actions, which routed through here already.
+    match result {
+        Ok(()) => Ok(()),
+        Err(error) => exit_resource_error(error, output),
     }
 }
 


### PR DESCRIPTION
## The message today

```
kobe: error sending request for url (https://kobe.zur1-worker1.int-pro.zondax.io/v1/status): client error (Connect): dns error: failed to lookup address information: nodename nor servname provided, or not known
```

Three clauses of plumbing, ending in `getaddrinfo`'s own words. None of it is the caller's to fix, and it answers none of the questions they actually have: which endpoint was tried, where that endpoint came from, and what to do next.

## The message now

```
kobe: cannot reach kobe at kobe.zur1-worker1.int-pro.zondax.io: the host name does not resolve

  endpoint  https://kobe.zur1-worker1.int-pro.zondax.io
  target    default

  A private cluster resolves only from its network: connect the VPN, or check the endpoint for a typo.
  `kobe config view` shows where this endpoint came from.
```

That is real output from the reproduction, not a mock-up.

## How

Transport failures are classified into five buckets, each with its own summary and remedy: unresolved host, nothing listening, timed out, TLS rejected, and a general fallback.

DNS and a refused connection both arrive as `is_connect`, and they ask the caller to do completely different things — connect the VPN, versus the server is down. The only place they are distinguishable is the resolver's own text, so the classifier walks the source chain and matches on it. Matching error text is unlovely and the comment says so, but that distinction is the entire value of the message.

Applied at the request sites a caller hits first: `status` and the four lease-listing paths. Builder, body, and decode errors are passed through untouched, since those are not reachability problems and their own messages are better.

## Also

Every command's failure now goes through one printer. Previously only the sandbox actions carried the `kobe:` prefix and the structured `--output json` body; everything else fell through to anyhow's default `Error:`. Verified in both modes, and `status` against an unresolvable host exits `125`.

## Tests

- `an_unreachable_message_names_the_host_target_and_remedy` pins the shape: host, summary, target, remedy, and the absence of the resolver's `nodename`/`servname` text. Covers an endpoint passed directly, which has no target to name and must say so rather than print an empty field.
- `resolver_and_refusal_are_told_apart` pins that DNS and refusal give different remedies, and that every bucket offers something to do next.
- Full `kobectl` suite passes, 124 tests. Clippy clean.
