### PR TITLE
fix(ci): stop a merge from cancelling the nightly

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,8 +56,20 @@ on:
     - cron: "0 3 * * *"
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # A scheduled or dispatched run is the only thing that exercises the full
+  # matrix, and it takes hours. Sharing one group with pushes to the same ref
+  # meant any merge to main killed the nightly mid-flight: it happened twice in
+  # two days, and each time the vcluster and vkobe-etcd legs died before
+  # reporting, so a conformance fix landed with no end-to-end proof at all.
+  #
+  # Give the slow runs a group of their own and never cancel them. Push and PR
+  # runs keep superseding each other, which is right — a newer commit makes an
+  # older run irrelevant — but nothing they do can now interrupt the matrix.
+  group: >-
+    ${{ github.workflow }}-${{ github.ref }}-${{
+    (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
+    && 'full' || 'fast' }}
+  cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
 
 jobs:
   checks:


### PR DESCRIPTION
## The bug

The nightly and a push to main share one concurrency group, and that group cancels in progress. So merging anything to main kills a running nightly.

It happened twice in two days:

- **2026-09-02**: two merges eight seconds apart (#183 and #184) cancelled each other. Neither fix got a run on main.
- **2026-09-03**: the nightly started at 04:26 UTC, ran for 99 minutes, and was cancelled at 06:05:51 UTC — 27 seconds after #185 merged. The `vcluster` and `vkobe-etcd` legs died before reporting.

## Why it matters more than it looks

The scheduled run is the only one that exercises the full matrix and the full sandbox conformance suite. A push to main runs the k3s leg with `test-sandbox-conformance-pr`, the smaller subset. So main going green after a merge says considerably less than it appears to, and both conformance fixes landed this week with no end-to-end proof.

The 09-03 nightly did get far enough to report `conformance (k3s)` as failed before it was cancelled, which is how the remaining quarantine bug was found at all. Had the merge landed twenty minutes earlier, that signal would have been lost too.

## The fix

Scheduled and dispatched runs get a concurrency group of their own and are never cancelled. Push and PR runs keep superseding each other, which is the behaviour you want: a newer commit makes an older run irrelevant.

```yaml
group: >-
  ${{ github.workflow }}-${{ github.ref }}-${{
  (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
  && 'full' || 'fast' }}
cancel-in-progress: ${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}
```

`workflow_dispatch` is included because a manually dispatched full matrix has the same cost and the same reason not to be interrupted.

## Verification

The folded scalar collapses to a single-line expression, confirmed by parsing the workflow and printing the resolved values:

```
group:  "${{ github.workflow }}-${{ github.ref }}-${{ (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch') && 'full' || 'fast' }}"
cancel: "${{ github.event_name != 'schedule' && github.event_name != 'workflow_dispatch' }}"
```

`actionlint` reports nothing new: the only findings are nine pre-existing `runner-label` warnings for the self-hosted `kunobi-runners` label, which are present on main.
