### PR TITLE
fix(sandbox): prove absence for a cancel that beat every create

### DIFF
--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -247,6 +247,7 @@ spec:
                 description: Durable management-Claim deletion fence understood by this controller.
                 enum:
                 - AdmissionOnlyV1
+                - PreCreateV1
                 - FinalizerV1
                 nullable: true
                 type: string

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -1889,6 +1889,50 @@ fn admitted_pending_is_allocation_free(
         && crate::api::sandbox::admitted_reservation_provenance_is_valid(lease)
 }
 
+/// Whether a release can still prove that no create was ever authorised.
+///
+/// [`admitted_pending_is_allocation_free`] answers the same question but only
+/// for the exact admission shape, which survives until the controller's first
+/// status write — an interval of well under a second. That was the entire
+/// window in which an early cancel could be proven harmless, and a caller who
+/// lost it was quarantined for having been slow, holding pool capacity for a
+/// Sandbox that never existed.
+///
+/// This covers the rest of the pre-create window. `observedGeneration` and
+/// `phase = Provisioning` are expected here: they are the controller saying it
+/// has started, not that it has built anything. What must still hold is that
+/// nothing was ever *named*. `target` is written in the same fenced patch that
+/// records a child handle, and `sandbox_lease_authorizes_allocation` refuses
+/// every create once a release reason or an allocation fence is present, so an
+/// unnamed target plus a drained fence is the durable statement that no POST
+/// was issued and none can be.
+///
+/// A recorded `ChildCluster` placement is excluded: it is only ever written
+/// together with the handle reference, so it means a `ClusterLease` was
+/// created and the child path owns that teardown.
+fn pre_create_is_allocation_free(
+    lease: &SandboxLease,
+    status: &crate::crd::SandboxLeaseStatus,
+) -> bool {
+    matches!(
+        status.phase,
+        crate::crd::SandboxLeasePhase::Pending | crate::crd::SandboxLeasePhase::Provisioning
+    ) && status.ready_at.is_none()
+        && status.expires_at.is_none()
+        && status.release_cause.is_none()
+        && status.target.is_none()
+        && !matches!(
+            status.placement,
+            Some(crate::crd::ResolvedSandboxPlacement::ChildCluster { .. })
+        )
+        && status.claim_cleanup_fence.is_none()
+        && status.sandbox_claim_tombstone.is_none()
+        && status.allocation_fence.is_none()
+        && status.conditions.is_empty()
+        && sandbox_finalizer_present(lease)
+        && crate::api::sandbox::admitted_reservation_provenance_is_valid(lease)
+}
+
 fn claim_reference_has_expected_shape(
     reference: &crate::crd::SandboxObjectReference,
     namespace: &str,
@@ -4346,6 +4390,112 @@ async fn admission_only_management_footprint_absent(
         .await
 }
 
+/// Prove nothing was created for a lease cancelled before any create.
+///
+/// The obligation is deliberately heavier than the admission-only proof. That
+/// one can lean on the exact admission shape; this one cannot, because the
+/// controller has already written to the lease. So it asks for two absences
+/// rather than one: the management Claim family, and the deterministic child
+/// handle. Either placement could have been chosen by the time the release
+/// landed, and until a `target` names one, neither can be ruled out by shape
+/// alone.
+///
+/// The 404s are only meaningful because the caller waited. The allocation
+/// fence has drained by the time this runs, and `sandbox_lease_authorizes_allocation`
+/// refuses every create once that fence exists, so nothing can appear behind
+/// the check. Without the drain these would be the "a 404 cannot distinguish
+/// never-created from GC'd-before-checkpoint" mistake this whole protocol
+/// exists to avoid.
+async fn pre_create_footprint_absent(
+    lease: &SandboxLease,
+    ctx: &SandboxContext,
+    tombstone: &SandboxObjectReference,
+    prior_claim_uid: Option<&str>,
+) -> TargetFootprintCheck {
+    let status = lease.status.clone().unwrap_or_default();
+    if status.claim_cleanup_fence != Some(crate::crd::SandboxClaimCleanupFence::PreCreateV1)
+        || status.ready_at.is_some()
+        || status.expires_at.is_some()
+        || status.target.is_some()
+        || matches!(
+            status.placement,
+            Some(crate::crd::ResolvedSandboxPlacement::ChildCluster { .. })
+        )
+        || prior_claim_uid.is_some()
+        || status.sandbox_claim_tombstone.as_ref() != Some(tombstone)
+        || !recorded_reference_is_exact(
+            tombstone,
+            AGENT_SANDBOX_API_VERSION,
+            SANDBOX_CLAIM_KIND,
+            &ctx.namespace,
+        )
+        || tombstone.name != claim_name(&lease.name_any())
+    {
+        return TargetFootprintCheck::Quarantine("pre_create_provenance_invalid");
+    }
+
+    // The child handle carries a whole nested cluster. Its deterministic name
+    // is the only thing that could exist without a `target` to point at it, so
+    // an unreadable answer here withholds capacity rather than guessing.
+    let internal: Api<crate::crd::ClusterLease> =
+        Api::namespaced(ctx.client.clone(), &ctx.namespace);
+    let handle = crate::controllers::sandbox_child::internal_lease_name(&lease.name_any());
+    match internal.get(&handle).await {
+        Ok(_) => return TargetFootprintCheck::Quarantine("pre_create_child_handle_present"),
+        Err(kube::Error::Api(error)) if error.code == 404 => {}
+        Err(_) => return TargetFootprintCheck::Retry("pre_create_child_handle_unreadable"),
+    }
+
+    // Same management-side scans the admission-only proof performs: the
+    // tombstone occupies the deterministic Claim name, and nothing claims
+    // descent from it.
+    let sandboxes: Api<DynamicObject> =
+        Api::namespaced_with(ctx.client.clone(), &ctx.namespace, &sandbox_resource());
+    let check = claim_labelled_sandboxes_absent(&sandboxes, &tombstone.uid, None).await;
+    if check != TargetFootprintCheck::Verified {
+        return check;
+    }
+
+    for (api, present, unverifiable, transient) in [
+        (
+            Api::namespaced_with(
+                ctx.client.clone(),
+                &ctx.namespace,
+                &core_resource("Pod", "pods"),
+            ),
+            "pre_create_sandbox_owned_pod_present",
+            "pod_owner_chain_unverifiable",
+            "pod_owner_chain_transient",
+        ),
+        (
+            Api::namespaced_with(
+                ctx.client.clone(),
+                &ctx.namespace,
+                &core_resource("Service", "services"),
+            ),
+            "pre_create_sandbox_owned_service_present",
+            "service_owner_chain_unverifiable",
+            "service_owner_chain_transient",
+        ),
+    ] {
+        let check = unresolved_sandbox_children_absent(
+            &api,
+            &sandboxes,
+            tombstone,
+            present,
+            unverifiable,
+            transient,
+        )
+        .await;
+        if check != TargetFootprintCheck::Verified {
+            return check;
+        }
+    }
+
+    exact_owned_storage_is_absent(&ctx.client, &ctx.namespace, &[tombstone.uid.as_str()], None)
+        .await
+}
+
 /// Record the exact tombstone as the sole management Claim identity when the
 /// pre-POST cleanup protocol proves no active Claim could have disappeared.
 ///
@@ -4375,6 +4525,16 @@ async fn checkpoint_never_started_management_claim(
             TargetFootprintCheck::Verified => finish_release(lease, ctx, reason).await,
             TargetFootprintCheck::Retry(check) => {
                 debug!(lease = %lease.name_any(), check, "admission-only footprint proof will retry");
+                Ok(Action::requeue(std::time::Duration::from_secs(10)))
+            }
+            TargetFootprintCheck::Quarantine(check) => quarantine_lease(lease, ctx, check).await,
+        };
+    }
+    if next.claim_cleanup_fence == Some(crate::crd::SandboxClaimCleanupFence::PreCreateV1) {
+        return match pre_create_footprint_absent(lease, ctx, tombstone, prior_claim_uid).await {
+            TargetFootprintCheck::Verified => finish_release(lease, ctx, reason).await,
+            TargetFootprintCheck::Retry(check) => {
+                debug!(lease = %lease.name_any(), check, "pre-create footprint proof will retry");
                 Ok(Action::requeue(std::time::Duration::from_secs(10)))
             }
             TargetFootprintCheck::Quarantine(check) => quarantine_lease(lease, ctx, check).await,
@@ -4450,6 +4610,8 @@ async fn drive_release(
         next.release_cause = proposed_cause;
         if admitted_pending_is_allocation_free(lease, &status) {
             next.claim_cleanup_fence = Some(crate::crd::SandboxClaimCleanupFence::AdmissionOnlyV1);
+        } else if pre_create_is_allocation_free(lease, &status) {
+            next.claim_cleanup_fence = Some(crate::crd::SandboxClaimCleanupFence::PreCreateV1);
         }
         if patch_lease_status_fenced(ctx, lease, &next).await? {
             info!(lease = %name, reason = reason.as_str(), "releasing Sandbox lease");
@@ -13193,6 +13355,221 @@ pub(crate) mod tests {
             )
             .await,
             1
+        );
+    }
+
+    /// Cancelling one controller pass later must still release capacity.
+    ///
+    /// The admission-only proof expires the instant the controller writes
+    /// `phase = Provisioning` and `observedGeneration`, which it does to every
+    /// admitted lease within a second. A caller who cancelled just after that
+    /// had nothing left to prove absence with and was quarantined for it,
+    /// holding a pool slot for a Sandbox that was never built. That is the
+    /// nightly `cancelling_while_provisioning_leaves_nothing_behind` failure.
+    #[tokio::test]
+    async fn cancel_after_the_provisioning_checkpoint_still_releases_capacity() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+
+        // No child handle was ever created; the pre-create proof must confirm
+        // that itself rather than assume it.
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "kind": "Status", "status": "Failure", "code": 404, "reason": "NotFound"
+            })))
+            .mount(&server)
+            .await;
+
+        let tombstone = tombstone_claim_json("pre-create-tombstone-uid", None);
+        Mock::given(method("GET"))
+            .and(path(CLAIM_PATH))
+            .respond_with(ResponseTemplate::new(404).set_body_json(serde_json::json!({
+                "kind": "Status", "status": "Failure", "code": 404, "reason": "NotFound"
+            })))
+            .up_to_n_times(2)
+            .with_priority(1)
+            .mount(&server)
+            .await;
+        Mock::given(method("POST"))
+            .and(path(CLAIMS_PATH))
+            .respond_with(ResponseTemplate::new(201).set_body_json(&tombstone))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(CLAIM_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(&tombstone))
+            .with_priority(2)
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(SANDBOXES_PATH))
+            .and(query_param(
+                "labelSelector",
+                format!("{UPSTREAM_CLAIM_UID_LABEL}=pre-create-tombstone-uid"),
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": crate::controllers::sandbox_canary::SANDBOX_API_VERSION,
+                "kind": "SandboxList", "metadata": { "resourceVersion": "1" }, "items": []
+            })))
+            .with_priority(1)
+            .mount(&server)
+            .await;
+
+        let mut lease = freshly_admitted_lease();
+        {
+            let status = lease.status.as_mut().unwrap();
+            status.phase = crate::crd::SandboxLeasePhase::Provisioning;
+            status.observed_generation = Some(1);
+            status.placement = Some(crate::crd::ResolvedSandboxPlacement::Management {});
+        }
+        // The window this fix is about: past the admission shape, before any
+        // create.
+        assert!(!admitted_pending_is_allocation_free(
+            &lease,
+            lease.status.as_ref().unwrap()
+        ));
+        assert!(pre_create_is_allocation_free(
+            &lease,
+            lease.status.as_ref().unwrap()
+        ));
+        lease.metadata.annotations.as_mut().unwrap().insert(
+            SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION.to_string(),
+            chrono::Utc::now().to_rfc3339(),
+        );
+
+        let mut phases = Vec::new();
+        for pass in 0..16 {
+            let before = server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PATCH" && request.url.path() == LEASE_STATUS_PATH
+                })
+                .count();
+            let _ = reconcile_lease(Arc::new(lease.clone()), ctx.clone())
+                .await
+                .expect("pre-create cancellation must converge");
+            let statuses: Vec<_> = server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PATCH" && request.url.path() == LEASE_STATUS_PATH
+                })
+                .filter_map(status_value_of)
+                .collect();
+            if let Some(latest) = statuses.get(before).cloned() {
+                lease.status =
+                    Some(serde_json::from_value(latest).expect("typed pre-create checkpoint"));
+                lease.metadata.resource_version = Some(format!("pre-create-rv-{pass}"));
+            }
+            let phase = lease.status.as_ref().unwrap().phase;
+            phases.push(phase);
+            if phase == crate::crd::SandboxLeasePhase::Released {
+                break;
+            }
+        }
+
+        let status = lease.status.as_ref().unwrap();
+        assert_eq!(
+            status.phase,
+            crate::crd::SandboxLeasePhase::Released,
+            "cancelling before any create must release, phases: {phases:?}"
+        );
+        assert_eq!(
+            status.release_cause,
+            Some(crate::crd::SandboxReleaseCause::Requested),
+            "a caller-requested cancel is not an expiry"
+        );
+        assert!(
+            !phases.contains(&crate::crd::SandboxLeasePhase::Quarantined),
+            "capacity must never be withheld for a Sandbox that was never built: {phases:?}"
+        );
+        assert_eq!(
+            status.claim_cleanup_fence,
+            Some(crate::crd::SandboxClaimCleanupFence::PreCreateV1)
+        );
+    }
+
+    /// The proof must fail closed when the child handle actually exists.
+    ///
+    /// A child handle is a whole nested cluster. If one was created before the
+    /// cancel landed, "nothing was built" is false, and releasing the slot
+    /// would hand a tenant's capacity to the next caller while the cluster is
+    /// still running. This is the property that separates proving absence from
+    /// assuming it.
+    #[tokio::test]
+    async fn a_live_child_handle_refuses_the_pre_create_proof() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(serde_json::json!({
+                "apiVersion": "kobe.kunobi.ninja/v1alpha1",
+                "kind": "ClusterLease",
+                "metadata": {
+                    "name": "kobe-sbx-sbx-1",
+                    "namespace": NS,
+                    "uid": "live-child-handle-uid",
+                    "resourceVersion": "7"
+                },
+                "spec": { "profile": "child-pool" }
+            })))
+            .mount(&server)
+            .await;
+
+        let mut lease = freshly_admitted_lease();
+        {
+            let status = lease.status.as_mut().unwrap();
+            status.phase = crate::crd::SandboxLeasePhase::Provisioning;
+            status.observed_generation = Some(1);
+        }
+        lease.metadata.annotations.as_mut().unwrap().insert(
+            SANDBOX_RELEASE_REQUESTED_AT_ANNOTATION.to_string(),
+            chrono::Utc::now().to_rfc3339(),
+        );
+
+        let mut released = false;
+        for pass in 0..16 {
+            let before = server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PATCH" && request.url.path() == LEASE_STATUS_PATH
+                })
+                .count();
+            let _ = reconcile_lease(Arc::new(lease.clone()), ctx.clone()).await;
+            let statuses: Vec<_> = server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PATCH" && request.url.path() == LEASE_STATUS_PATH
+                })
+                .filter_map(status_value_of)
+                .collect();
+            if let Some(latest) = statuses.get(before).cloned() {
+                lease.status =
+                    Some(serde_json::from_value(latest).expect("typed child-handle checkpoint"));
+                lease.metadata.resource_version = Some(format!("child-handle-rv-{pass}"));
+            }
+            if lease.status.as_ref().unwrap().phase == crate::crd::SandboxLeasePhase::Released {
+                released = true;
+                break;
+            }
+        }
+
+        assert!(
+            !released,
+            "a lease whose child handle exists must not release its slot"
         );
     }
 

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -887,6 +887,24 @@ pub enum SandboxClaimCleanupFence {
     /// inert tombstone plus empty descendant scans without inventing target
     /// provenance for workload that never started.
     AdmissionOnlyV1,
+    /// Release won after the controller had checkpointed provisioning but
+    /// before any create was authorised: no target was ever named, so no
+    /// Claim and no child `ClusterLease` POST can have been issued.
+    ///
+    /// Weaker than [`Self::AdmissionOnlyV1`], which requires the exact
+    /// admission shape and is only reachable in the moment between admission
+    /// and the controller's first status write. That interval is far too
+    /// narrow to be the only pre-create proof: the first write sets
+    /// `phase = Provisioning` and `observedGeneration`, and a caller who
+    /// cancels immediately after it lands had, until this variant existed,
+    /// nothing to prove absence with and was quarantined for it.
+    ///
+    /// The obligation is correspondingly stronger. Verification waits for the
+    /// allocation fence to drain, then requires BOTH the inert Claim tombstone
+    /// with empty descendant scans AND a verified 404 on the deterministic
+    /// child handle name. The drain is what makes those 404s mean "nothing was
+    /// created and nothing can be" rather than "I did not find it".
+    PreCreateV1,
     /// A management Claim cleanup finalizer was durable before the first POST,
     /// or an exact non-deleting legacy Claim was atomically migrated to that
     /// ownerless/finalized shape before this checkpoint was written.


### PR DESCRIPTION
## The failure

The nightly's hard gate, `cancelling_while_provisioning_leaves_nothing_behind`, on both placements:

```
[child] a sandbox cancelled while provisioning quarantined:
  "Teardown could not be verified; capacity is withheld"
```

A Sandbox cancelled before it ever ran ends up `Quarantined`, so its pool slot is withheld for a Sandbox that was never built. The test's own comment states the property: *uncertain teardown holds capacity on purpose, but a lease cancelled before it ever ran should have nothing to be uncertain about*.

## Cause

The absence proof exists; it was armed too narrowly.

`admitted_pending_is_allocation_free` requires the exact admission shape, including `phase == Pending` and `observedGeneration == None`. Both are falsified by `begin_sandbox_provisioning`, the first thing the controller does to any admitted lease, of either placement. So the proof was only available in the sub-second interval between admission's HTTP response and the controller's first write.

Cancel after that and no fence is stamped. `checkpoint_never_started_management_claim` recognises exactly two fence values, finds neither, and quarantines. That is correct behaviour given what it was told, and the wrong thing to have told it.

**#183 made this reachable rather than causing it.** Before that fix, a release racing the controller lost its resourceVersion fence and returned 503, so the lease survived and the test failed earlier with a different message. Now the release lands, and it lands in exactly the window the proof did not cover.

## Fix

A third fence value, `PreCreateV1`, stamped when nothing was ever *named*:

- `phase` still `Pending` or `Provisioning`
- no `target`, no recorded `ChildCluster` placement, no tombstone, no conditions, no allocation fence
- finalizer present and admission reservation provenance valid

`observedGeneration` and `Provisioning` are expected here. They are the controller saying it has started, not that it has built anything.

**The obligation is heavier than the admission-only proof, not lighter.** Verification waits for the allocation fence to drain, then requires *both*:

1. the inert Claim tombstone with empty UID-scoped descendant scans, exactly as the admission-only proof does, and
2. a verified 404 on the deterministic child handle name.

Either placement was still possible when the release landed, so neither can be ruled out by shape alone. A recorded `ChildCluster` placement is excluded from the predicate entirely, since it is only ever written together with the handle reference.

The drain is what makes those 404s mean "nothing was created and nothing can be" rather than "I did not find it": `sandbox_lease_authorizes_allocation` already refuses every create once a release reason or an allocation fence is present. An unreadable handle retries rather than concluding absence.

## Safety

Quarantine remains the default. Nothing here turns a missing name into evidence — the rule that a 404 cannot distinguish "never created" from "GC'd before its UID checkpoint" is untouched. This adds a positive proof that has to be established first.

All 35 quarantine tests pass unchanged, including `child_placement_with_missing_handle_quarantines_and_keeps_capacity`, which is the statement of the safety property. If any of them had started passing for the wrong reason, the fix would have crossed from proving absence into assuming it.

## Tests

- `cancel_after_the_provisioning_checkpoint_still_releases_capacity` drives the exact failing window: past the admission shape, before any create. Asserts `Released` with cause `Requested`, the `PreCreateV1` fence, and that `Quarantined` never appears in any observed phase.
- `a_live_child_handle_refuses_the_pre_create_proof` is the negative twin: the handle GET returns a live object, and the lease must not release its slot. A child handle is a whole nested cluster, and releasing the slot would hand a tenant's capacity to the next caller while it is still running.

Full operator suite passes, 1437 tests. Clippy clean. Lease CRD regenerated for the new enum value.

## Note on validation

This needs a real nightly to confirm end to end, and merges have been cancelling the nightly (see #187). Land #187 first so the next scheduled run actually survives.
