### PR TITLE
test(sandbox): prove attach forwards a terminal's own bytes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,6 +11,11 @@ on:
     paths:
       - "src/**"
       - "crates/**"
+      # The conformance suite lives here. Without it a PR that only touches
+      # `tests/` triggers no run at all, so its required check never reports
+      # and the PR is blocked forever — and a change that broke the suite
+      # would reach main unexamined.
+      - "tests/**"
       - "charts/**"
       - "Cargo.toml"
       - "Cargo.lock"

--- a/tests/sandbox_conformance.rs
+++ b/tests/sandbox_conformance.rs
@@ -706,6 +706,60 @@ impl Drop for LeasedSandbox {
 // ---------------------------------------------------------------------------
 
 both_placements!(
+    /// Bytes the caller's terminal emits arrive at the workload unchanged.
+    ///
+    /// `attach` used to decode keystrokes into key events and re-encode them
+    /// from a small table, so anything the table had no name for was dropped
+    /// on the floor: function keys, alt combinations, mouse reporting,
+    /// bracketed paste. A full-screen program negotiates those modes by
+    /// writing escape sequences that reach the real terminal, and then waits
+    /// for replies that could never arrive.
+    ///
+    /// The three sequences here are chosen because the old encoder produced
+    /// none of them. `crossterm` parses F5 and alt-x into key codes the table
+    /// returned `None` for, and never modelled an SGR mouse report at all.
+    /// Asserting on their exact hex is what distinguishes "forwarded" from
+    /// "re-encoded into something plausible".
+    a_terminals_own_bytes_reach_the_workload_unchanged,
+    |placement| async move {
+        let mut sandbox = LeasedSandbox::create(placement, "20m").await?;
+        sandbox.wait_ready(Duration::from_secs(600)).await?;
+
+        // F5, then alt-x, then an SGR mouse press at column 10 row 5.
+        let sent = "\\x1b[15~\\x1bx\\x1b[<0;10;5M";
+        let expected = "1b5b31357e1b781b5b3c303b31303b354d";
+
+        // Raw mode on the remote too: in cooked mode `head` would wait for a
+        // line terminator that a mouse report never contains. Hexdumping is
+        // what makes an assertion possible at all — a transcript carrying the
+        // literal bytes would be indistinguishable from one that lost them.
+        let script = "stty raw -echo; head -c 17 | od -An -tx1 | tr -d ' \\n'";
+        let transcript = harness(&[
+            "attach-pty",
+            "--lease",
+            &sandbox.id,
+            "--send",
+            sent,
+            "--expect",
+            expected,
+            "--timeout",
+            "120",
+            "--",
+            "/bin/sh",
+            "-c",
+            script,
+        ])
+        .await?;
+        anyhow::ensure!(
+            transcript.contains(expected),
+            "the workload did not receive the exact bytes typed: {transcript}"
+        );
+
+        sandbox.release().await
+    }
+);
+
+both_placements!(
     a_lease_becomes_ready_and_reports_the_same_shape,
     |placement| async move {
         let mut sandbox = LeasedSandbox::create(placement, "10m").await?;


### PR DESCRIPTION
Two things, because the second is why the first could not report.

## 1. Prove attach forwards a terminal's own bytes

Byte transparency landed in #185 as an assertion in a commit message with nothing enforcing it. A regression would be silent in exactly the way the original bug was: ordinary typing keeps working, and only the sequences a full-screen program depends on quietly stop arriving.

A `both_placements!` conformance scenario types three sequences through a real pty and hexdumps what the workload received:

| Sequence | Bytes |
|---|---|
| F5 | `1b 5b 31 35 7e` |
| alt-x | `1b 78` |
| SGR mouse press at column 10, row 5 | `1b 5b 3c 30 3b 31 30 3b 35 4d` |

All three are chosen because the old encoder produced **none** of them. `crossterm` parses F5 and alt-x into key codes that `key_to_bytes` returned `None` for, and it never modelled an SGR mouse report at all. The scenario therefore fails on the pre-#185 client and passes after it.

Asserting on exact hex rather than the rendered transcript is deliberate: a transcript carrying literal escape bytes looks much the same whether they arrived intact or were re-encoded into something plausible.

The remote side runs `stty raw -echo` first, because a mouse report contains no line terminator and cooked-mode `head` would wait for one that never comes.

## 2. Run CI when the conformance suite changes

The `pull_request` path filter listed `src`, `crates`, `charts`, `hack` and the workflow files, but not `tests`. The conformance suite lives in `tests/`, so a PR touching only it triggered no run at all — its required check never reported and the PR sat `BLOCKED` with nothing to wait for.

That is exactly what happened here: this PR had zero checks for several hours. Adding `tests/**` made them appear within a minute.

The quieter half is worse than the blocked PR. A change that broke the conformance suite could reach main without CI ever looking at it.

## Note

The scenario itself runs in the nightly, not on PRs, since it needs a real leased sandbox. #187 has landed, so the nightly is no longer cancelled by merges and this will actually report.
