### PR TITLE
chore: bump version to 0.42.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -2764,11 +2764,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.41.0"
+version = "0.42.0"
 
 [[package]]
 name = "kobectl"
-version = "0.41.0"
+version = "0.42.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.41.0"
+version = "0.42.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.41.0
-appVersion: "0.41.0"
+version: 0.42.0
+appVersion: "0.42.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.41.0
+      image: docker.io/zondax/kobe-operator:v0.42.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.41.0
+      image: docker.io/zondax/kobe-sync:v0.42.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Version bump for the v0.42.0 release. Minor rather than patch because two of the eight changes are features.

## What is in it, since v0.41.0

**Fixes**

- #183 release re-reads a Sandbox lease when its fence loses, instead of answering 503 to a caller cancelling during provisioning.
- #189 a Sandbox cancelled before anything was built now proves absence and releases its pool slot, rather than quarantining and withholding capacity. This is the fix for the nightly `cancelling_while_provisioning_leaves_nothing_behind` failure.
- #184 the operator no longer asks the vcluster chart to render snapshot RBAC it cannot delegate, which had left the vcluster conformance leg failing since mid-August.
- #186 an unreachable endpoint now names the host, the target, and what to do, instead of printing three layers of reqwest and the resolver's own words.

**Features**

- #185 `kobe attach` forwards input byte for byte, so a full-screen program inside a sandbox behaves as it would locally. The lease argument is now optional and picks from the leases that can actually attach.
- #188 a pool can declare `template.attachCommand`, so a bare attach lands in a multiplexer session that survives a dropped connection rather than the container's idle process.

**CI**

- #187 a merge no longer cancels the running nightly.
- #190 CI runs when the conformance suite changes, which it previously did not, and a new scenario proves attach's byte transparency with a real pty.

## Note on validation

Every conformance signal for these changes came from the PR path, which runs the smaller subset and only the k3s leg. The first full-matrix run covering #189 and #184 end to end is the nightly, which has not completed since they landed. Cutting the tag before that nightly reports is a deliberate choice, not an oversight.
