### PR TITLE
fix(sandbox): a terminating child handle is not somebody else's

### DIFF
--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -5828,15 +5828,42 @@ async fn release_child_composition(
         Api::namespaced(ctx.client.clone(), &ctx.namespace);
     match internal.get(&recorded.name).await {
         Ok(current) if current.uid().as_deref() == Some(recorded.uid.as_str()) => {
-            match ensure_internal_lease_fenced(&internal, &current, lease).await? {
-                InternalHandleFence::Ready => {}
-                InternalHandleFence::Patched => {
-                    info!(lease = %name, "fenced exact child handle before release");
-                    return Ok(Action::requeue(std::time::Duration::from_secs(5)));
-                }
-                InternalHandleFence::Foreign => {
+            // A handle that is already terminating is not somebody else's.
+            //
+            // `internal_lease_ownership` reports Foreign for any handle
+            // carrying a deletionTimestamp, which is right where it gates
+            // ADOPTION — placement must never adopt a dying handle. Here it is
+            // wrong: the uid was pinned one line above, so this is provably the
+            // handle this lease recorded, and the retention finalizer is what
+            // keeps a deleted handle readable and patchable precisely so
+            // teardown can still consume its proof.
+            //
+            // Without this the release quarantines its own composition and
+            // withholds the pool slot forever, which is the nightly
+            // `cancelling_while_provisioning_leaves_nothing_behind` failure.
+            // The post-proof path already gets this right; only the pre-proof
+            // path was missing it.
+            if current.metadata.deletion_timestamp.is_some() {
+                if !internal_handle_retention_fence_matches(
+                    &current,
+                    lease,
+                    chrono::Utc::now(),
+                    true,
+                ) {
                     return quarantine_lease(lease, ctx, "child_composition_identity_changed")
                         .await;
+                }
+            } else {
+                match ensure_internal_lease_fenced(&internal, &current, lease).await? {
+                    InternalHandleFence::Ready => {}
+                    InternalHandleFence::Patched => {
+                        info!(lease = %name, "fenced exact child handle before release");
+                        return Ok(Action::requeue(std::time::Duration::from_secs(5)));
+                    }
+                    InternalHandleFence::Foreign => {
+                        return quarantine_lease(lease, ctx, "child_composition_identity_changed")
+                            .await;
+                    }
                 }
             }
             let recorded_pool = recorded_child_pool(&status, &ctx.namespace);
@@ -17060,6 +17087,145 @@ current-context: child
             checkpoint["placement"]["clusterPool"]["uid"],
             "cluster-pool-uid"
         );
+    }
+
+    /// A handle that is already terminating is not somebody else's.
+    ///
+    /// `internal_lease_ownership` calls any handle carrying a
+    /// deletionTimestamp Foreign, which is correct where it gates adoption —
+    /// placement must never adopt a dying handle. On the release path it was
+    /// wrong: the uid is pinned from the recorded reference first, so the
+    /// object is provably this lease's own composition, and the retention
+    /// finalizer exists precisely to keep a deleted handle readable so
+    /// teardown can still consume its proof.
+    ///
+    /// The nightly caught this as
+    /// `cancelling_while_provisioning_leaves_nothing_behind` quarantining with
+    /// `child_composition_identity_changed`, holding the pool slot forever.
+    /// The post-proof path had always handled it; only the pre-proof path had
+    /// not.
+    #[tokio::test]
+    async fn a_terminating_child_handle_is_still_this_leases_own_composition() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+
+        let attempt = "terminating-attempt-1";
+        let proof = "2026-09-04T00:00:00Z";
+        let mut proven = child_cluster_lease("child-lease-uid", "Released", None);
+        proven["status"]["teardownAttemptId"] = attempt.into();
+        proven["status"]["unboundReleaseVerifiedAt"] = proof.into();
+        proven["status"]["conditions"] = serde_json::json!([{
+            "type": "AllocationAbsent",
+            "status": "True",
+            "reason": "NeverBound",
+            "message": format!("release attempt {attempt} proved no reciprocal allocation existed"),
+            "lastTransitionTime": proof,
+        }]);
+        proven["metadata"]["annotations"]
+            [crate::crd::UNBOUND_RELEASE_PROOF_ACKNOWLEDGED_ANNOTATION] =
+            format!("{attempt}:{proof}").into();
+        // The condition under test: deleted, but retained by its finalizer and
+        // with its tombstone identity intact.
+        proven["metadata"]["deletionTimestamp"] = "2026-09-04T00:10:00Z".into();
+
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(proven))
+            .mount(&server)
+            .await;
+
+        let mut lease = child_placed_lease("child-lease-uid");
+        {
+            let status = lease.status.as_mut().unwrap();
+            status.phase = crate::crd::SandboxLeasePhase::Releasing;
+            status.release_cause = Some(crate::crd::SandboxReleaseCause::Requested);
+            // Cancelled while provisioning: the handle was created but never
+            // bound, so no instance was ever recorded.
+            if let Some(target) = status.target.as_mut() {
+                target.child_cluster_instance = None;
+            }
+        }
+
+        let mut phases = Vec::new();
+        for pass in 0..12 {
+            let before = server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PATCH" && request.url.path() == LEASE_STATUS_PATH
+                })
+                .count();
+            let _ = reconcile_lease(Arc::new(lease.clone()), ctx.clone()).await;
+            let statuses: Vec<_> = server
+                .received_requests()
+                .await
+                .unwrap_or_default()
+                .iter()
+                .filter(|request| {
+                    request.method.as_str() == "PATCH" && request.url.path() == LEASE_STATUS_PATH
+                })
+                .filter_map(status_value_of)
+                .collect();
+            if let Some(latest) = statuses.get(before).cloned() {
+                lease.status = Some(serde_json::from_value(latest).unwrap());
+                lease.metadata.resource_version = Some(format!("terminating-rv-{pass}"));
+            }
+            let phase = lease.status.as_ref().unwrap().phase;
+            phases.push(phase);
+            if phase == crate::crd::SandboxLeasePhase::Released {
+                break;
+            }
+        }
+
+        assert!(
+            !phases.contains(&crate::crd::SandboxLeasePhase::Quarantined),
+            "a lease must not quarantine its own terminating handle: {phases:?}"
+        );
+    }
+
+    /// The relaxation is bounded by the tombstone, not by the uid alone.
+    ///
+    /// Pinning the uid proves the object is the one recorded; it does not
+    /// prove the object is still intact. A terminating handle whose retention
+    /// identity has been stripped cannot be reasoned about, so it must still
+    /// withhold capacity.
+    #[tokio::test]
+    async fn a_terminating_child_handle_with_a_broken_tombstone_still_quarantines() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+
+        let mut corrupted = child_cluster_lease("child-lease-uid", "Pending", None);
+        corrupted["metadata"]["deletionTimestamp"] = "2026-09-04T00:10:00Z".into();
+        // The retention finalizer is what keeps a deleted handle readable.
+        // Without it the tombstone shape is not satisfied.
+        corrupted["metadata"]["finalizers"] = serde_json::json!([]);
+
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(ResponseTemplate::new(200).set_body_json(corrupted))
+            .mount(&server)
+            .await;
+
+        let mut lease = child_placed_lease("child-lease-uid");
+        {
+            let status = lease.status.as_mut().unwrap();
+            status.phase = crate::crd::SandboxLeasePhase::Releasing;
+            status.release_cause = Some(crate::crd::SandboxReleaseCause::Requested);
+        }
+
+        for _ in 0..6 {
+            let _ = reconcile_lease(Arc::new(lease.clone()), ctx.clone()).await;
+            if recorded_phases(&server)
+                .await
+                .iter()
+                .any(|phase| phase == "Quarantined")
+            {
+                return;
+            }
+        }
+        panic!("a terminating handle with no retention identity must withhold capacity");
     }
 
     /// An uncheckpointed Pending handle is real provenance but not an


### PR DESCRIPTION
## The failure

Last night's nightly (run 33832346740, on `5c7aa78` = v0.42.0) still failed `cancelling_while_provisioning_leaves_nothing_behind` on the child leg — but with a **different reason** than before:

```json
{"reason":"child_composition_identity_changed",
 "message":"Teardown could not be verified; capacity is withheld",
 "phase":"Quarantined","placement":{"type":"childCluster"}}
```

The same WARN re-fired every ~18ms for 24 minutes and survived an operator restart, so this is a durable fact about etcd, not a race.

## Cause

`internal_lease_ownership` (`sandbox_child.rs:587-591`) returns `Foreign` for any handle carrying a `deletionTimestamp`. That is correct where it gates **adoption** — placement must never adopt a dying handle, and the same function backs `internal_lease_is_for_sandbox` and `internal_lease_matches_composition_identity` at allocation time.

On the release path it is wrong. `release_child_composition` compares the recorded uid against the live object one line earlier (`sandbox.rs:5830`), so by the time it calls the ownership check the object is *provably* this lease's own composition. And `CHILD_HANDLE_RETENTION_FINALIZER` exists precisely so a deleted handle stays readable and patchable while teardown consumes its proof.

So the release quarantined its own composition and withheld the slot forever.

**The post-proof path already gets this right.** `finish_child_release_after_proof` (`sandbox.rs:6783`) checks `deletion_timestamp` and validates the retention tombstone with `allow_deleting = true`. `release_child_composition` simply never learned it. Note the asymmetry is invisible in normal operation, because reaching the post-proof path requires the absence proof the pre-proof path was refusing to produce.

## Fix

Give the pre-proof path the same check the post-proof path has. When the handle is terminating, validate the full retention tombstone rather than asking the ownership predicate.

**What bounds the relaxation.** The uid, and the tombstone, and both are required:

- The uid comparison at `:5830` already rejects a name-reuser, so a genuinely foreign same-named handle never reaches this arm.
- Pinning the uid proves the object is the one recorded; it does not prove it is intact. A terminating handle whose retention identity has been stripped still quarantines.

Deliberately **not** applied to the unrecorded branch (`:5578`), where no uid is pinned and `Foreign` must stay fatal. Deliberately **not** fixed by adding a `Terminating` variant to `InternalLeaseOwnership`, which would let placement adopt a dying handle.

## Tests

- `a_terminating_child_handle_is_still_this_leases_own_composition` — recorded handle, no `FootprintAbsent`, handle terminating with an intact tombstone and a NeverBound proof. Must converge without ever quarantining.
- `a_terminating_child_handle_with_a_broken_tombstone_still_quarantines` — same, with the retention finalizer stripped. Must still withhold capacity.

Full suite 1440 passes, clippy clean. All six foreign-handle safety tests unchanged and passing, including `a_name_reused_by_a_later_composition_is_not_this_leases_cluster` and `unrecorded_child_with_foreign_identity_quarantines`.

## Context

Third failure in the same scenario. #183 fixed the 503 on release, #189 proved absence for a cancel that beat every create, this covers a cancel landing after the handle exists and after its deletion has begun. Each fix moved the failure to the next window, which is why the reason string changed each time.

**This one needs a nightly to confirm.** The PR path runs `test-sandbox-conformance-pr`, which does not include this scenario — that is exactly why the previous two fixes shipped looking green.

## Related, not fixed here

The diagnosis also found a plausible upstream producer of the premature delete: `close_stale_sandbox_composition` (`lease.rs:389-419`) writes the stale-rejected annotation in a patch fenced only on uid+resourceVersion, then flips the phase in a second patch that additionally tests `phase == Pending`. If the handle binds between the two, the annotation lands durably on a handle that *did* allocate, and `lease.rs:1863` then lets it self-retire without an outer ACK. Worth its own PR; this fix is insensitive to which producer set the deletionTimestamp.
