### PR TITLE
ci: run the light jobs on the small kunobi runner set

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ concurrency:
 jobs:
   checks:
     name: Rust Checks
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-small
     container:
       # Toolchain floor is driven by `kunobi-ha` (≥ 1.94 since kunobi-ha
       # repointed its MSRV in their #6). Bump together with that crate
@@ -223,7 +223,7 @@ jobs:
 
   lifecycle-state-machine:
     name: Lifecycle State Machine (Kani + mutations)
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-small
     # Bare ARC runners intentionally carry no compiler/linker. Use the same
     # build environment as the main Rust gate so installing Kani has `cc`.
     container:
@@ -273,7 +273,7 @@ jobs:
   # image, Helm release, or external Agent Sandbox runtime is involved.
   sandbox-apiserver-contract:
     name: Sandbox API-server Contract
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-small
     timeout-minutes: 15
     env:
       SANDBOX_CONTRACT_CLUSTER: sandbox-api-${{ github.run_id }}-${{ github.run_attempt }}
@@ -335,7 +335,7 @@ jobs:
   # refuses to reuse one.
   sandbox-runtime-contract:
     name: Agent Sandbox Runtime Contract
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-small
     timeout-minutes: 20
     env:
       SANDBOX_RUNTIME_CLUSTER: sandbox-runtime-${{ github.run_id }}-${{ github.run_attempt }}
@@ -674,7 +674,7 @@ jobs:
   publish-chart:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [version-consistency, publish]
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-small
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -696,7 +696,7 @@ jobs:
   # signed, or published to crates.io. Hermetic (manifest reads only).
   version-consistency:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-small
     container:
       image: rust:1.94-bookworm
     timeout-minutes: 5


### PR DESCRIPTION
## Why

Every job targeted `kunobi-runners`, which is **capped at `maxRunners: 1` on purpose**: it reserves one builder node to guarantee 128Gi of ephemeral storage and pins itself there by node affinity. So the whole workflow serialised behind a single slot shared with every other `kunobi-ninja` repo.

The cost today was concrete: PR checks arriving one at a time over hours, and a nightly that took four. The scale set was also holding an assignment that never completed — `gha_assigned_jobs` flat at `1.0` for three hours, while `kunobi-runners-small` cycled jobs normally throughout.

## What moves

| Job | Work |
|---|---|
| Rust Checks | cargo build, clippy, test |
| Lifecycle State Machine | Kani + mutations |
| Sandbox API-server Contract | cargo test |
| Agent Sandbox Runtime Contract | cargo test |
| publish-chart | helm push |
| version-consistency | manifest reads only |

`kunobi-runners-small` has three slots on the general builder nodes, reserving 60Gi each — well above what any of these need.

## What deliberately stays

`conformance` leases kind clusters running nested k3s and builds three images; `docker-dry-run` and `publish` build the same multi-arch images. Those are the workloads the 128Gi guarantee exists for, and I have no measurement showing they fit in 60Gi. Moving them is a capacity question that needs node data, not a guess.

## Effect

Six of nine jobs stop contending for the one heavy slot, and three parallel slots mean a PR's checks can now run concurrently instead of single-file. Conformance still serialises, which is correct — it is the job that needs the reserved node.
