### PR TITLE
chore: bump version to 0.42.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2687,7 +2687,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -2753,7 +2753,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -2764,11 +2764,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.42.0"
+version = "0.42.1"
 
 [[package]]
 name = "kobectl"
-version = "0.42.0"
+version = "0.42.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.42.0"
+version = "0.42.1"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.42.0
-appVersion: "0.42.0"
+version: 0.42.1
+appVersion: "0.42.1"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.42.0
+      image: docker.io/zondax/kobe-operator:v0.42.1
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.42.0
+      image: docker.io/zondax/kobe-sync:v0.42.1
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Patch release for the child-handle quarantine fix.

## What it ships

**#192** — a Sandbox cancelled while its child cluster was provisioning quarantined its own composition and withheld the pool slot permanently. The ownership check reports any handle carrying a `deletionTimestamp` as foreign, which is right where it gates adoption but wrong on the release path, where the recorded uid is compared first and the retention finalizer exists precisely to keep a deleted handle readable for teardown.

v0.42.0 was tagged before that merged, so the bug is live in int-pro today.

Also included, with no runtime effect: **#193** moved the light CI jobs to the small runner set.

## Verification

Unlike v0.42.0, this one has real evidence. A full-matrix dispatch on `72cce57` — the same commit this bumps — ran the complete sandbox suite rather than the PR subset:

```
test cancelling_while_provisioning_leaves_nothing_behind ... ok
test result: ok. 26 passed; 0 failed; 0 ignored; 0 measured; 3 filtered out
```

That test had failed for four days across three distinct causes: a 503 on release (#183), no way to prove absence for a cancel that beat every create (#189), and a lease quarantining its own terminating handle (#192). All three are now on main and verified together.

k3s, k0s, vkobe-etcd and vkobe-kine all passed on that run. vcluster failed, as it has since mid-August; it is non-gating and tracked separately.

## Note on the nightly

Last night's nightly shows `Sandbox API-server Contract` failing, which is **not** a regression: it ran on `72cce5746`, the identical commit that passed the same job at 15:30 UTC the previous afternoon. No code changed between the two runs. The assertion also reports an empty message (`control plane forged teardown proof or failed unexpectedly: `), which suggests the test swallows its own cause — worth its own fix, separately from this release.
