### PR TITLE
fix(harness): wait for the real condition, not for the write to return

### DIFF
--- a/hack/e2e.ts
+++ b/hack/e2e.ts
@@ -1724,12 +1724,55 @@ kubectl --context "$CTX" delete deployment -n ${namespace} ${DEMO_VKOBE_ETCD_BAC
       step: "failed to clean up existing local demo pool resources",
     },
   );
+  await waitForDemoPoolsGone(cluster, namespace);
   await runCommand(
     ["/bin/sh", "-lc", `cat <<'EOF' | kubectl --context ${kubeContext(cluster)} apply -f -
 ${bootstrapManifest(namespace, sandboxFixture)}EOF`],
     {
       step: "failed to apply local demo token/policy/pool",
     },
+  );
+}
+
+/// Prove the demo pools are actually gone before re-applying their names.
+///
+/// Every delete above is suffixed `|| true`, which swallows a delete that
+/// timed out waiting on a finalizer exactly as if it had succeeded. Re-applying
+/// the same names then adopts a terminating object instead of creating a fresh
+/// one, and the failure surfaces much later as a pool that never goes Ready.
+async function waitForDemoPoolsGone(
+  cluster: string,
+  namespace: string,
+): Promise<void> {
+  const deadline = Date.now() + 60_000;
+  let lastObservation = "objects were never listed";
+  while (Date.now() < deadline) {
+    const remaining = await runCommand(
+      [
+        "kubectl",
+        "--context",
+        kubeContext(cluster),
+        "get",
+        "clusterpools.kobe.kunobi.ninja,clusterinstances.kobe.kunobi.ninja",
+        "-n",
+        namespace,
+        "-o",
+        "name",
+      ],
+      { allowFailure: true },
+    );
+    const names = remaining.stdout
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0 && line.includes("demo"));
+    if (remaining.exitCode === 0 && names.length === 0) {
+      return;
+    }
+    lastObservation = names.join(", ") || remaining.stderr.trim();
+    await Bun.sleep(500);
+  }
+  throw new Error(
+    `demo pools did not finish deleting within 60s, refusing to re-apply over them: ${lastObservation}`,
   );
 }
 
@@ -2747,7 +2790,82 @@ async function injectRbacRevocation(args: Args): Promise<void> {
   await kubectl(args, ["patch", "clusterrole", name, "--type=merge", "-p", JSON.stringify({ rules })], {
     step: `failed to narrow ClusterRole '${name}'`,
   });
+  // The patch is in etcd; the authorizer may still be answering from a stale
+  // cache. Returning here lets the operator get one more successful read and
+  // verify a teardown the scenario needs to be unverifiable.
+  await waitForAuthorizerVerdict(args, await operatorSubject(args), UNVERIFIABLE_TEARDOWN_REVOCATIONS, "no");
   step(`Injected '${args.failure}' into ClusterRole '${name}'`);
+}
+
+/// Wait until the authorizer actually reflects a ClusterRole change.
+///
+/// `kubectl patch` returning proves the object is in etcd, not that the
+/// apiserver's RBAC authorizer has refreshed its cache. That gap inverts the
+/// meaning of the `teardown-unverifiable` scenario: if the operator's
+/// verification `get` runs inside the window it SUCCEEDS, teardown verifies,
+/// the lease reaches Released, and the assertion reports "an unverifiable
+/// teardown reported Released, releasing capacity it could not prove free" —
+/// a capacity-safety violation in the operator that never happened.
+///
+/// `auth can-i` is a SubjectAccessReview evaluated by the same authorizer
+/// instance the operator's own request will meet, so this waits on the exact
+/// condition rather than a proxy for it.
+async function waitForAuthorizerVerdict(
+  args: Args,
+  subject: string,
+  targets: ReadonlyArray<RevocationTarget>,
+  want: "yes" | "no",
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let lastObservation = "authorizer never answered";
+  while (Date.now() < deadline) {
+    const verdicts = await Promise.all(
+      targets.map((target) =>
+        kubectl(
+          args,
+          [
+            "auth",
+            "can-i",
+            target.verb,
+            `${target.resource}.${target.apiGroup}`,
+            `--as=${subject}`,
+            "-n",
+            args.namespace,
+          ],
+          { allowFailure: true },
+        ),
+      ),
+    );
+    const answers = verdicts.map((verdict) => verdict.stdout.trim());
+    if (answers.every((answer) => answer === want)) {
+      return;
+    }
+    lastObservation = answers.join(", ");
+    await Bun.sleep(500);
+  }
+  throw new Error(
+    `authorizer did not report '${want}' for ${subject} within 30s: ${lastObservation}`,
+  );
+}
+
+/// The identity the operator's own API calls carry.
+async function operatorSubject(args: Args): Promise<string> {
+  const account = await kubectl(
+    args,
+    [
+      "get",
+      "deployment",
+      "-n",
+      args.namespace,
+      "-l",
+      `app.kubernetes.io/name=kobe,app.kubernetes.io/instance=${args.release}`,
+      "-o",
+      "jsonpath={.items[0].spec.template.spec.serviceAccountName}",
+    ],
+    { step: "failed to resolve the operator ServiceAccount" },
+  );
+  const name = account.stdout.trim() || "kobe";
+  return `system:serviceaccount:${args.namespace}:${name}`;
 }
 
 type ServiceList = {
@@ -2813,8 +2931,48 @@ async function injectChildApiUnreachable(args: Args): Promise<void> {
       ],
       { step: `failed to sever Service '${service.namespace}/${service.name}'` },
     );
+    await waitForServiceDrained(args, service.namespace, service.name);
   }
   step(`Injected '${args.failure}' for ClusterInstance '${instance}'`);
+}
+
+/// Wait until a severed Service actually stops routing.
+///
+/// Patching the selector puts the change in etcd; the endpoints controller and
+/// kube-proxy have not yet converged, so the child API stays reachable for a
+/// window. Returning inside it means "the operator cannot reach the child" is
+/// asserted while it still can.
+async function waitForServiceDrained(
+  args: Args,
+  namespace: string,
+  name: string,
+): Promise<void> {
+  const deadline = Date.now() + 30_000;
+  let lastObservation = "endpoints were never read";
+  while (Date.now() < deadline) {
+    const slices = await kubectl(
+      args,
+      [
+        "get",
+        "endpointslices",
+        "-n",
+        namespace,
+        "-l",
+        `kubernetes.io/service-name=${name}`,
+        "-o",
+        "jsonpath={.items[*].endpoints[*].addresses[*]}",
+      ],
+      { allowFailure: true },
+    );
+    lastObservation = slices.stdout.trim();
+    if (slices.exitCode === 0 && lastObservation === "") {
+      return;
+    }
+    await Bun.sleep(500);
+  }
+  throw new Error(
+    `Service ${namespace}/${name} still had endpoints after 30s: ${lastObservation}`,
+  );
 }
 
 /// Resolve the child cluster behind a lease, by reading the CR.
@@ -2889,6 +3047,14 @@ async function clearFailure(args: Args): Promise<void> {
         JSON.stringify({ rules: state.clusterRole.rules }),
       ],
       { step: `failed to restore ClusterRole '${state.clusterRole.name}'` },
+    );
+    // Mirror of the injection wait: the restore is only meaningful once the
+    // authorizer grants again, or the next step races the recovery.
+    await waitForAuthorizerVerdict(
+      args,
+      await operatorSubject(args),
+      UNVERIFIABLE_TEARDOWN_REVOCATIONS,
+      "yes",
     );
   }
 

--- a/hack/test-sandbox-apiserver.ts
+++ b/hack/test-sandbox-apiserver.ts
@@ -166,14 +166,48 @@ async function waitForTeardownFencePolicy(): Promise<void> {
 			policy.status?.observedGeneration === policy.metadata?.generation &&
 			policy.status?.typeChecking !== undefined
 		) {
-			const probe = await kubectl(
-				["create", "-f", "-", "--validate=false", "--dry-run=server"],
+			// Probe with the identity the assertions use, not as admin.
+			// The same apply installed tenant's Role and RoleBinding, and
+			// authorization runs before validating admission: an unpropagated
+			// binding answers `is forbidden` instead of the fence message, so
+			// the deny assertion reads the fence as wrong and — worse — the
+			// allow assertion reads a plain RBAC 403 as the fence being
+			// over-broad. Require BOTH outcomes in one iteration, which is
+			// exactly the conjunction the assertions depend on.
+			const denied = await kubectl(
+				[
+					"create",
+					"-f",
+					"-",
+					"--validate=false",
+					"--dry-run=server",
+					`--as=${tenantUsername}`,
+				],
 				{
 					stdin: ownedPod("blocked-descendant", blockedOwnerUid),
 					allowFailure: true,
 				},
 			);
-			if (probe.stderr.includes(teardownFenceMessage)) return;
+			const allowed = await kubectl(
+				[
+					"create",
+					"-f",
+					"-",
+					"--validate=false",
+					"--dry-run=server",
+					`--as=${tenantUsername}`,
+				],
+				{
+					stdin: ownedPod("unrelated-descendant", "22222222-2222-2222-2222-222222222222"),
+					allowFailure: true,
+				},
+			);
+			if (
+				denied.stderr.includes(teardownFenceMessage) &&
+				allowed.exitCode === 0
+			) {
+				return;
+			}
 		}
 		await Bun.sleep(500);
 	}
@@ -412,9 +446,38 @@ async function waitForAdmissionLedgerControls(): Promise<void> {
 				],
 				{ stdin: configMap(quotaCanaryName), allowFailure: true },
 			);
+			// Both probes above run as the operator, so they prove the
+			// operator's path only. Two later assertions read the tenant's
+			// RBAC and the operator's SelfSubjectAccessReview grant, both
+			// applied in the same manifest — and an unpropagated binding
+			// answers `is forbidden` before admission ever runs, which reads
+			// as the ledger policy misbehaving. Require those too.
+			const tenantProbe = await kubectl(
+				[
+					"create",
+					"-f",
+					"-",
+					"--validate=false",
+					"--dry-run=server",
+					`--as=${tenantUsername}`,
+				],
+				{ stdin: coordinationLease("ledger-readiness-probe"), allowFailure: true },
+			);
+			const reviewGrant = await kubectl(
+				[
+					"auth",
+					"can-i",
+					"create",
+					"selfsubjectaccessreviews.authorization.k8s.io",
+					`--as=${operatorUsername}`,
+				],
+				{ allowFailure: true },
+			);
 			if (
 				policyProbe.stderr.includes(policyCanaryMessage) &&
-				quotaProbe.stderr.toLowerCase().includes("exceeded quota")
+				quotaProbe.stderr.toLowerCase().includes("exceeded quota") &&
+				tenantProbe.stderr.includes("only the operator may mutate the Sandbox ledger") &&
+				reviewGrant.stdout.trim() === "yes"
 			) {
 				return;
 			}


### PR DESCRIPTION
Follow-up to #195. An audit of every fixed-duration wait in the harness found the same bug in five more places. Each one waits for a *proxy* for the thing the next step depends on.

**None of these adds a longer sleep.** The fix is always to wait for the real condition.

## What was found

Thirty-odd `Bun.sleep` calls were classified. Most are correct backoff inside bounded poll loops. Five were not.

### `inject-failure` returned before the revocation was enforceable — worst of the set

`kubectl patch` returning proves the ClusterRole is in etcd, not that the RBAC authorizer has refreshed. If the operator's verification `get` lands in that window it **succeeds**, teardown verifies, the lease reaches `Released`, and the scenario reports:

> an unverifiable teardown reported Released, releasing capacity it could not prove free

A capacity-safety violation in the operator that never happened. The failure is silent and inverted — the harness accuses the code.

Now polls `auth can-i` until the authorizer answers `no`, and mirrors it on restore so the next step is not racing the recovery. `auth can-i` is a SubjectAccessReview through the same authorizer instance the operator's own request meets.

### Readiness probed as admin, assertions run as tenant

`waitForTeardownFencePolicy` probed with no `--as`, proving the policy enforces for `kubernetes-admin`. The same apply installed tenant's Role and RoleBinding, and **authorization runs before validating admission**, so an unpropagated binding answers `is forbidden` rather than the fence message.

The deny assertion then reports the fence as wrong. Worse, the allow assertion requires `exitCode === 0` for an unrelated owner — an RBAC 403 there reports the fence as **over-broad**. Same shape as the bug in #195: a propagation delay reads as a security defect.

Now probes as the tenant and requires both the deny and the allow in one iteration.

### Ledger readiness proved only the operator's path

`waitForAdmissionLedgerControls` probed twice as the operator. Three later assertions read the tenant's binding and the operator's `SelfSubjectAccessReview` grant, both applied in the same manifest. The SSAR assertion is literally a read of the authorizer's current view of a Role applied three lines earlier.

Now additionally requires a tenant-identity denial carrying the ledger message, and `auth can-i` for the review grant.

### `child-api-unreachable` returned before the Service drained

Patching the selector does not mean the endpoints controller and kube-proxy have converged, so the child API stays reachable while the test asserts it is not. Now polls EndpointSlice addresses until empty. Latent today (no conformance caller), fixed before it bites.

### Demo pools re-applied over terminating objects

Every delete is suffixed `|| true`, which swallows a delete that timed out on a finalizer exactly as if it had succeeded, then re-applies the same names. Now polls until they are gone and fails loudly with the lingering names.

## Verified

`bun build` parses and bundles all three modified files. The real proof is the gate staying green across both afternoon and small-hours runs, which is where these diverged before.

## Not changed

`waitForReadyInstance` in `test-e2e-k3s.ts` polls pod readiness as a proxy for guest-API readiness. Benign today because its only consumers exec into the host-side pod, but it becomes a live wrong-signal wait the moment anything talks to the guest API through the published kubeconfig. `test-smoke.ts` already shows the right pattern.
