### PR TITLE
ci: name the reserved node explicitly for the jobs that need it

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,7 @@ jobs:
   docker-dry-run:
     if: github.event_name == 'pull_request'
     needs: checks
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-large
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
@@ -463,7 +463,7 @@ jobs:
           || (github.event_name == 'push'
               && (github.ref == 'refs/heads/main' || startsWith(github.ref, 'refs/tags/v'))) }}
     needs: [checks]
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-large
     timeout-minutes: 180
     # The vkobe backend is ON HOLD (see docs/kobe-docs/how-it-works/
     # runtime-strategy.mdx) and its legs currently fail on a real behavior
@@ -629,7 +629,7 @@ jobs:
           && needs.checks.result == 'success'
           && needs['lifecycle-state-machine'].result == 'success'
           && (!startsWith(github.ref, 'refs/tags/v') || needs['version-consistency'].result == 'success') }}
-    runs-on: kunobi-runners
+    runs-on: kunobi-runners-large
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Why

`kunobi-runners` is the unmarked, default-looking name, and today it is the **exception**: one runner pinned to a builder node reserved for a 128Gi ephemeral-storage guarantee. So every repo that reaches for the obvious name lands on the scarcest resource in the organisation.

The fix is to make the default safe: repoint `kunobi-runners` at the general pool. Then no repo needs to know anything, and the reserved node is requested explicitly by the few jobs that need it.

**This PR is the prerequisite.** These three jobs genuinely need the reservation, so they must name it before the default flips underneath them — otherwise they land on the general pool without the storage guarantee and fail on disk pressure, which is a slow and confusing failure.

## What

| Job | Why it stays on the reserved node |
|---|---|
| `conformance` | leases kind clusters running nested k3s, builds three images |
| `publish` | builds three Rust images, multi-arch |
| `docker-dry-run` | same three images with `--set '*.cache-from='`, so a cold workspace compile |

Everything else already sits on `kunobi-runners-small` and is untouched. The diff is three `runs-on` lines.

## Sequence

1. Zondax/tenant-int-dev#108 — added `kunobi-runners-large`. Merged, and the listener is live in the cluster.
2. **This PR** — kobe's heavy jobs name it.
3. tenant-int-dev — repoint `kunobi-runners` at the general pool.
4. Retire the redundant name once nothing depends on the old meaning.

## Note

`docker-dry-run` is on the reserved node by caution rather than measurement. It builds three Rust images cold, so it is plausibly heavy, but I have not measured its actual ephemeral-storage use. Worth checking later and moving it to the general pool if it fits, since it is the most frequently run of the three.
