### PR TITLE
chore(ci): use the default runner name for the light jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,7 @@ concurrency:
 jobs:
   checks:
     name: Rust Checks
-    runs-on: kunobi-runners-small
+    runs-on: kunobi-runners
     container:
       # Toolchain floor is driven by `kunobi-ha` (≥ 1.94 since kunobi-ha
       # repointed its MSRV in their #6). Bump together with that crate
@@ -223,7 +223,7 @@ jobs:
 
   lifecycle-state-machine:
     name: Lifecycle State Machine (Kani + mutations)
-    runs-on: kunobi-runners-small
+    runs-on: kunobi-runners
     # Bare ARC runners intentionally carry no compiler/linker. Use the same
     # build environment as the main Rust gate so installing Kani has `cc`.
     container:
@@ -273,7 +273,7 @@ jobs:
   # image, Helm release, or external Agent Sandbox runtime is involved.
   sandbox-apiserver-contract:
     name: Sandbox API-server Contract
-    runs-on: kunobi-runners-small
+    runs-on: kunobi-runners
     timeout-minutes: 15
     env:
       SANDBOX_CONTRACT_CLUSTER: sandbox-api-${{ github.run_id }}-${{ github.run_attempt }}
@@ -335,7 +335,7 @@ jobs:
   # refuses to reuse one.
   sandbox-runtime-contract:
     name: Agent Sandbox Runtime Contract
-    runs-on: kunobi-runners-small
+    runs-on: kunobi-runners
     timeout-minutes: 20
     env:
       SANDBOX_RUNTIME_CLUSTER: sandbox-runtime-${{ github.run_id }}-${{ github.run_attempt }}
@@ -674,7 +674,7 @@ jobs:
   publish-chart:
     if: startsWith(github.ref, 'refs/tags/v')
     needs: [version-consistency, publish]
-    runs-on: kunobi-runners-small
+    runs-on: kunobi-runners
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@v7
@@ -696,7 +696,7 @@ jobs:
   # signed, or published to crates.io. Hermetic (manifest reads only).
   version-consistency:
     if: startsWith(github.ref, 'refs/tags/v')
-    runs-on: kunobi-runners-small
+    runs-on: kunobi-runners
     container:
       image: rust:1.94-bookworm
     timeout-minutes: 5


### PR DESCRIPTION
`kunobi-runners-small` and `kunobi-runners` are separate ARC scale sets with identical configuration and separate budgets, three slots and six. Two names for one pool split work between them based on nothing but which string a workflow happened to use.

Six light jobs move to the default name. `conformance`, `publish` and `docker-dry-run` keep `kunobi-runners-large`, the reserved node.

| job | before | after |
|---|---|---|
| checks | `kunobi-runners-small` | `kunobi-runners` |
| lifecycle-state-machine | `kunobi-runners-small` | `kunobi-runners` |
| sandbox-apiserver-contract | `kunobi-runners-small` | `kunobi-runners` |
| sandbox-runtime-contract | `kunobi-runners-small` | `kunobi-runners` |
| publish-chart | `kunobi-runners-small` | `kunobi-runners` |
| version-consistency | `kunobi-runners-small` | `kunobi-runners` |
| docker-dry-run | `kunobi-runners-large` | unchanged |
| conformance | `kunobi-runners-large` | unchanged |
| publish | `kunobi-runners-large` | unchanged |

The two pools differ only in name, `maxRunners`, and one extra label. Same node affinity, same priority class, same image.

Part of retiring `-small`. shin and kache move in parallel, then the scale set is deleted in Zondax/tenant-int-dev. Order matters only in that the set cannot be deleted while a workflow still names it, or those jobs queue forever.