### PR TITLE
ci: move docker-dry-run off the reserved node

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -386,7 +386,11 @@ jobs:
   docker-dry-run:
     if: github.event_name == 'pull_request'
     needs: checks
-    runs-on: kunobi-runners-large
+    # The general pool. `bake` builds inside the dind sidecar, and dind is
+    # configured identically on both pools (2 cpu, 4Gi, 20Gi ephemeral), so the
+    # reserved node's larger runner container buys this job nothing. It only
+    # checks out the tree and drives buildx.
+    runs-on: kunobi-runners
     timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7


### PR DESCRIPTION
## Measurement

`docker-dry-run` went to `kunobi-runners-large` in #198 out of caution, without anyone checking what it needs. It does not need the reservation.

`docker buildx bake` builds inside the dind sidecar, and dind is configured identically on both pools:

| container | `kunobi-runners` | `kunobi-runners-large` |
|---|---|---|
| **dind** | 2 cpu, 4Gi, 20Gi ephemeral | **identical** |
| runner | 6 cpu, 16Gi, 80Gi ephemeral | 6 cpu, 32Gi, 160Gi ephemeral |

The pools differ only in the runner container, and this job does nothing there but check out the tree and drive buildx. Every layer it writes lands in dind, which is the same box either way.

Recent runs, all on reserved-class hardware:

| result | duration |
|---|---|
| success | 4m54s |
| success | 4m58s |
| success | 4m51s |
| success | 4m22s |
| success | 5m01s |

Five minutes, comfortably inside dind's 20Gi.

## Why now

`kunobi-runners-large` is a single slot. kache's nine heavy bench arms moved onto it in kunobi-ninja/kache#956 and total roughly 46 hours of worst-case serialized runtime against a nightly schedule. Leaving a five-minute PR check there means every kobe pull request can queue behind a Firefox build.

## Staying put

- **conformance** — 30 to 34 minutes of nested kind clusters. Genuinely heavier, and worth measuring separately rather than assuming.
- **publish** — same dind-bound shape as this job, so the same argument probably applies, but it only runs on release tags. Rare enough that the queue does not hurt, and the release path is the wrong place to take a risk for no gain.

## Related

Follows Zondax/tenant-int-dev#110 and #111, which fixed the general pool's anti-affinity and retired `kunobi-runners-small`.