### PR TITLE
feat(sandbox): optional iroh transport for attach and port-forward

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3455,6 +3455,7 @@ dependencies = [
  "crossterm",
  "dirs",
  "futures-util",
+ "iroh",
  "kunobi-auth",
  "libc",
  "ratatui",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,41 @@
 version = 4
 
 [[package]]
+name = "aead"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d122413f284cf2d62fb1b7db97e02edb8cda96d769b16e443a4f6195e35662b0"
+dependencies = [
+ "crypto-common 0.1.6",
+ "generic-array",
+]
+
+[[package]]
+name = "aes"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b169f7a6d4742236a0a00c541b845991d0ac43e546831af1249753ab4c3aa3a0"
+dependencies = [
+ "cfg-if",
+ "cipher",
+ "cpufeatures 0.2.17",
+]
+
+[[package]]
+name = "aes-gcm"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "831010a0f742e1209b3bcea8fab6a8e149051ba6099432c8cb2cc117dec3ead1"
+dependencies = [
+ "aead",
+ "aes",
+ "cipher",
+ "ctr",
+ "ghash",
+ "subtle",
+]
+
+[[package]]
 name = "ahash"
 version = "0.8.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -105,6 +140,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3fb67a6e08acf24fdeccbac2cb6ac4305825bd1f117462e0e6f2f193345ad56"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -199,6 +240,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "async_io_stream"
+version = "0.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d7b9decdf35d8908a7e3ef02f64c5e9b1695e230154c0e8de3969142d9b94c"
+dependencies = [
+ "futures",
+ "pharos",
+ "rustc_version",
+]
+
+[[package]]
 name = "atoi"
 version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -212,6 +264,18 @@ name = "atomic-waker"
 version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1505bd5d3d116872e7271a6d4e16d81d0c8570876c8de68093a09ac269d8aac0"
+
+[[package]]
+name = "attohttpc"
+version = "0.30.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "16e2cdb6d5ed835199484bb92bb8b3edd526effe995c61732580439c1a67e2e9"
+dependencies = [
+ "base64 0.22.1",
+ "http 1.5.0",
+ "log",
+ "url",
+]
 
 [[package]]
 name = "autocfg"
@@ -766,6 +830,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
 
 [[package]]
+name = "base16ct"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd307490d624467aa6f74b0eabb77633d1f758a7b25f12bceb0b22e08d9726f6"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -809,6 +879,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "blake3"
+version = "1.8.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d9e454fc11f76977dc803893aff6304ed33d6a26efae8696573bea74baa27ae"
+dependencies = [
+ "arrayvec",
+ "cc",
+ "cfg-if",
+ "constant_time_eq",
+ "cpufeatures 0.3.1",
+]
+
+[[package]]
 name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -824,6 +907,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2f6c7dbe95a6ed67ad9f18e57daf93a2f034c524b99fd2b76d18fdfeb6660aa"
 dependencies = [
  "hybrid-array",
+]
+
+[[package]]
+name = "block2"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
+dependencies = [
+ "objc2",
 ]
 
 [[package]]
@@ -889,6 +981,12 @@ dependencies = [
  "libc",
  "shlex",
 ]
+
+[[package]]
+name = "cesu8"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6d43a04d8753f35258c91f8ec639f792891f748a1edbd759cf1dcea3382ad83c"
 
 [[package]]
 name = "cfg-if"
@@ -993,6 +1091,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ea0ac24bc397ab3c98583a3c9ba74fa56b09a4449bbe172b9b1ddb016027a"
 
 [[package]]
+name = "cobs"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0fa961b519f0b462e3a3b4a34b64d119eeaca1d59af726fe450bbba07a9fc0a1"
+dependencies = [
+ "thiserror 2.0.20",
+]
+
+[[package]]
 name = "colorchoice"
 version = "1.0.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1033,6 +1140,41 @@ name = "const-oid"
 version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a6ef517f0926dd24a1582492c791b6a4818a4d94e789a334894aa15b0d12f55c"
+
+[[package]]
+name = "constant_time_eq"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3d52eff69cd5e647efe296129160853a42795992097e8af39800e1060caeea9b"
+
+[[package]]
+name = "convert_case"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "633458d4ef8c78b72454de2d54fd6ab2e60f9e02be22f3c6104cdc8a4e0fceb9"
+dependencies = [
+ "unicode-segmentation",
+]
+
+[[package]]
+name = "cordyceps"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b9ab7e0ca1d179628fa0172b2b97203c7fa0cd81be2448bd446fb9559ca9261"
+dependencies = [
+ "loom",
+ "tracing",
+]
+
+[[package]]
+name = "core-foundation"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91e195e091a93c46f7102ec7818a2aa394e1e1771c3ab4825963fa03e45afb8f"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
 
 [[package]]
 name = "core-foundation"
@@ -1100,6 +1242,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8498c871161e1742aaa9d52551b2d6ebdd4c3d45a3be423e3728f33b955be550"
 dependencies = [
  "cfg-if",
+]
+
+[[package]]
+name = "critical-section"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "790eea4361631c5e7d22598ecd5723ff611904e3344ce8720784c93e3d83d40b"
+
+[[package]]
+name = "crossbeam-channel"
+version = "0.5.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d85363c37faeca707aef026efa9f3b34d077bce547e48f770770625c6013679e"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
+name = "crossbeam-epoch"
+version = "0.9.20"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6914041f254d6e9176c01941b21115dcfb7089e55135a35411081bd106ef3f"
+dependencies = [
+ "crossbeam-utils",
 ]
 
 [[package]]
@@ -1172,6 +1338,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ce6e4c961d6cd6c9a86db418387425e8bdeaf05b3c8bc1411e6dca4c252f1453"
 dependencies = [
  "hybrid-array",
+ "rand_core 0.10.1",
+]
+
+[[package]]
+name = "ctr"
+version = "0.9.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0369ee1ad671834580515889b80f2ea915f23b8be8d0daa4bbaf2ac5c7590835"
+dependencies = [
+ "cipher",
 ]
 
 [[package]]
@@ -1193,8 +1369,26 @@ dependencies = [
  "cpufeatures 0.2.17",
  "curve25519-dalek-derive",
  "digest 0.10.7",
- "fiat-crypto",
+ "fiat-crypto 0.2.9",
  "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "5.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5eed333089e2e1c1ac8c6c0398e5e2497b4c9926ca6d0365ed1e099afa5bc23"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.3.1",
+ "curve25519-dalek-derive",
+ "digest 0.11.3",
+ "fiat-crypto 0.3.0",
+ "rand_core 0.10.1",
+ "rustc_version",
+ "serde",
  "subtle",
  "zeroize",
 ]
@@ -1285,6 +1479,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4583a4551df46e2792f82ceeac45e850d2e2d5debba0b91f102385cda5b11f06"
 
 [[package]]
+name = "data-encoding-macro"
+version = "0.1.21"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6a127ecbb3c4632e1525380e04c0c3fcf8dcb44d32a79ea290d8a36906edcd8"
+dependencies = [
+ "data-encoding",
+ "data-encoding-macro-internal",
+]
+
+[[package]]
+name = "data-encoding-macro-internal"
+version = "0.1.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c54e03a951783e8b327515db3f2a2fd0e3bed362a96b066f341ce66ed49b4ead"
+dependencies = [
+ "data-encoding",
+ "syn 3.0.4",
+]
+
+[[package]]
 name = "deadpool"
 version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1340,7 +1554,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
 dependencies = [
  "const-oid 0.9.6",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
+ "zeroize",
+]
+
+[[package]]
+name = "der"
+version = "0.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a69dedd701da44b0536442edf09c81a64b0ab97a7a4a5e3d1971f00027cbc63d"
+dependencies = [
+ "const-oid 0.10.2",
+ "pem-rfc7468 1.0.0",
  "zeroize",
 ]
 
@@ -1382,11 +1607,19 @@ version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "799a97264921d8623a957f6c3b9011f3b5492f557bbb7a5a19b7fa6d06ba8dcb"
 dependencies = [
+ "convert_case",
  "proc-macro2",
  "quote",
  "rustc_version",
  "syn 2.0.119",
+ "unicode-xid",
 ]
+
+[[package]]
+name = "diatomic-waker"
+version = "0.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab03c107fafeb3ee9f5925686dbb7a73bc76e3932abb0d2b365cb64b169cf04c"
 
 [[package]]
 name = "digest"
@@ -1434,6 +1667,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "dispatch2"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e0e367e4e7da84520dedcac1901e4da967309406d1e51017ae1abfb97adbd38"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
 name = "displaydoc"
 version = "0.2.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1442,6 +1687,17 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 3.0.4",
+]
+
+[[package]]
+name = "dlopen2"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5e2c5bd4158e66d1e215c49b837e11d62f3267b30c92f1d171c4d3105e3dc4d4"
+dependencies = [
+ "libc",
+ "once_cell",
+ "winapi",
 ]
 
 [[package]]
@@ -1474,12 +1730,12 @@ version = "0.16.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
 dependencies = [
- "der",
+ "der 0.7.10",
  "digest 0.10.7",
  "elliptic-curve",
  "rfc6979",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -1488,8 +1744,19 @@ version = "2.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
 dependencies = [
- "pkcs8",
- "signature",
+ "pkcs8 0.10.2",
+ "signature 2.2.0",
+]
+
+[[package]]
+name = "ed25519"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "29fcf32e6c73d1079f83ab4d782de2d81620346a5f38c6237a86a22f8368980a"
+dependencies = [
+ "pkcs8 0.11.0",
+ "serdect",
+ "signature 3.0.0",
 ]
 
 [[package]]
@@ -1498,10 +1765,26 @@ version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
 dependencies = [
- "curve25519-dalek",
- "ed25519",
+ "curve25519-dalek 4.1.3",
+ "ed25519 2.2.3",
  "serde",
  "sha2 0.10.9",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ebaa1a2bf1290ab3bfe5a7b771d050ebffab2711c19a81691c683a5144a25de"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "ed25519 3.0.0",
+ "rand_core 0.10.1",
+ "serde",
+ "sha2 0.11.0",
+ "signature 3.0.0",
  "subtle",
  "zeroize",
 ]
@@ -1533,19 +1816,42 @@ version = "0.13.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "crypto-bigint",
  "digest 0.10.7",
  "ff",
  "generic-array",
  "group",
  "hkdf",
- "pem-rfc7468",
- "pkcs8",
+ "pem-rfc7468 0.7.0",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sec1",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "embedded-io"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef1a6892d9eef45c8fa6b9e0086428a2cca8491aca8f787c534a3d6d0bcb3ced"
+
+[[package]]
+name = "embedded-io"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "edd0f118536f44f5ccd48bcb8b111bdc3de888b58c74639dfb034a357d0f206d"
+
+[[package]]
+name = "enum-assoc"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0590c4a94da3372e83493b956755a6e2266830b6e4e3b101afe66e3f39477b91"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 3.0.4",
 ]
 
 [[package]]
@@ -1638,6 +1944,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
+name = "fiat-crypto"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64cd1e32ddd350061ae6edb1b082d7c54915b5c672c389143b9a63403a109f24"
+
+[[package]]
 name = "find-msvc-tools"
 version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1712,6 +2024,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "futures-buffered"
+version = "0.2.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4421cb78ee172b6b06080093479d3c50f058e7c81b7d577bbb8d118d551d4cd5"
+dependencies = [
+ "cordyceps",
+ "diatomic-waker",
+ "futures-core",
+ "pin-project-lite",
+ "spin 0.10.1",
+]
+
+[[package]]
 name = "futures-channel"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1756,6 +2081,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "53c0fa8157de1303bfffdaa1cc2a673bfffb60102f76b0ef4441659124373fed"
 
 [[package]]
+name = "futures-lite"
+version = "2.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
+dependencies = [
+ "fastrand",
+ "futures-core",
+ "futures-io",
+ "parking",
+ "pin-project-lite",
+]
+
+[[package]]
 name = "futures-macro"
 version = "0.3.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1793,6 +2131,21 @@ dependencies = [
  "memchr",
  "pin-project-lite",
  "slab",
+]
+
+[[package]]
+name = "generator"
+version = "0.8.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b3b854b0e584ead1a33f18b2fcad7cf7be18b3875c78816b753639aa501513ae"
+dependencies = [
+ "cc",
+ "cfg-if",
+ "libc",
+ "log",
+ "rustversion",
+ "windows-link",
+ "windows-result",
 ]
 
 [[package]]
@@ -1843,6 +2196,16 @@ dependencies = [
  "r-efi 6.0.0",
  "rand_core 0.10.1",
  "wasm-bindgen",
+]
+
+[[package]]
+name = "ghash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0d8a4362ccb29cb0b265253fb0a2728f592895ee6854fd9bc13f2ffda266ff1"
+dependencies = [
+ "opaque-debug",
+ "polyval",
 ]
 
 [[package]]
@@ -1939,6 +2302,11 @@ name = "hashbrown"
 version = "0.17.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ed5909b6e89a2db4456e54cd5f673791d7eca6732202bbf2a9cc504fe2f9b84a"
+dependencies = [
+ "allocator-api2",
+ "equivalent",
+ "foldhash 0.2.0",
+]
 
 [[package]]
 name = "hashlink"
@@ -1966,6 +2334,83 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hickory-net"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084e7bd6a377435d568f652153e571b50970d7ccc1d1eeec0519f834632287e1"
+dependencies = [
+ "async-trait",
+ "bytes",
+ "cfg-if",
+ "data-encoding",
+ "futures-channel",
+ "futures-io",
+ "futures-util",
+ "h2 0.4.19",
+ "hickory-proto",
+ "http 1.5.0",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "rand 0.10.2",
+ "rustls 0.23.43",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-proto"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7e2da0694c15b44c6f68a6b05e0233617008c54080e31d6eb848d858a9c5b38d"
+dependencies = [
+ "data-encoding",
+ "idna",
+ "ipnet",
+ "jni 0.22.4",
+ "once_cell",
+ "prefix-trie",
+ "rand 0.10.2",
+ "ring",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "hickory-resolver"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e4f9f4603319422d482738f3f6fe5aac03157fdbfed1cd85a3ff45adb09072f"
+dependencies = [
+ "cfg-if",
+ "futures-util",
+ "hickory-net",
+ "hickory-proto",
+ "ipconfig",
+ "ipnet",
+ "jni 0.22.4",
+ "moka",
+ "ndk-context",
+ "once_cell",
+ "parking_lot",
+ "rand 0.10.2",
+ "resolv-conf",
+ "rustls 0.23.43",
+ "smallvec",
+ "system-configuration",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tracing",
+]
 
 [[package]]
 name = "hkdf"
@@ -2319,6 +2764,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
+name = "identity-hash"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dfdd7caa900436d8f13b2346fe10257e0c05c1f1f9e351f4f5d57c03bd5f45da"
+
+[[package]]
 name = "idna"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2337,6 +2788,26 @@ checksum = "cb68373c0d6620ef8105e855e7745e18b0d00d3bdb07fb532e434244cdb9a714"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
+]
+
+[[package]]
+name = "igd-next"
+version = "0.17.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "de7238d487a9aff61f81b5ab41c0a841532a115a398b5fa92a2fadd0885e2581"
+dependencies = [
+ "attohttpc",
+ "bytes",
+ "futures",
+ "http 1.5.0",
+ "http-body-util",
+ "hyper 1.11.1",
+ "hyper-util",
+ "log",
+ "rand 0.10.2",
+ "tokio",
+ "url",
+ "xmltree",
 ]
 
 [[package]]
@@ -2427,10 +2898,192 @@ dependencies = [
 ]
 
 [[package]]
+name = "ipconfig"
+version = "0.3.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4d40460c0ce33d6ce4b0630ad68ff63d6661961c48b6dba35e5a4d81cfb48222"
+dependencies = [
+ "socket2 0.6.5",
+ "widestring",
+ "windows-registry",
+ "windows-result",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
 name = "ipnet"
 version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a756c3fac73139e83f14c2d742155dd2b78d3ee56597b419a0579b7bdd6dd78"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "iroh"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "329552fad4e46b5ccb4439d5635216f6289eec2c46f3fde4bc732d762694b9e5"
+dependencies = [
+ "backon",
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "ctutils",
+ "data-encoding",
+ "derive_more",
+ "ed25519-dalek 3.0.0",
+ "futures-util",
+ "getrandom 0.4.3",
+ "hickory-resolver",
+ "http 1.5.0",
+ "ipnet",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "iroh-relay",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netwatch",
+ "noq",
+ "noq-proto",
+ "noq-udp",
+ "papaya",
+ "pin-project",
+ "portable-atomic",
+ "portmapper",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rustc-hash",
+ "rustls 0.23.43",
+ "rustls-pki-types",
+ "serde",
+ "smallvec",
+ "strum 0.28.0",
+ "time",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
+ "tracing",
+ "url",
+ "wasm-bindgen-futures",
+]
+
+[[package]]
+name = "iroh-base"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3ccf4cde68a02ef03c0095ab2c031c6adfe508f3bc8e7c258558a027ebe64a8e"
+dependencies = [
+ "curve25519-dalek 5.0.0",
+ "data-encoding",
+ "data-encoding-macro",
+ "derive_more",
+ "ed25519-dalek 3.0.0",
+ "getrandom 0.4.3",
+ "n0-error",
+ "rand 0.10.2",
+ "serde",
+ "url",
+ "zeroize",
+]
+
+[[package]]
+name = "iroh-dns"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a41224eb0140a5c519935d4073fc6b236d174080be401f9bf7da126b2ee3aa4"
+dependencies = [
+ "arc-swap",
+ "cfg_aliases",
+ "derive_more",
+ "hickory-resolver",
+ "iroh-base",
+ "n0-error",
+ "n0-future",
+ "ndk-context",
+ "portable-atomic",
+ "rand 0.10.2",
+ "rustls 0.23.43",
+ "simple-dns",
+ "strum 0.28.0",
+ "tokio",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "iroh-metrics"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "291065721ad7c477b972e581bbc528df031dc8eb5e39fe1ff3300ae5dfb157ef"
+dependencies = [
+ "iroh-metrics-derive",
+ "itoa",
+ "n0-error",
+ "portable-atomic",
+ "ryu",
+ "serde",
+ "tracing",
+]
+
+[[package]]
+name = "iroh-metrics-derive"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ae5f0c4405d1fbc9fb16ff422ca40620e93dc36c30ecaba0c2aee3992b7bd48"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "iroh-relay"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5f6f07e2c9b0c4bc82e2864be09f4aea4320165d5316e668616dbc822f428a"
+dependencies = [
+ "blake3",
+ "bytes",
+ "cfg_aliases",
+ "data-encoding",
+ "derive_more",
+ "getrandom 0.4.3",
+ "hickory-resolver",
+ "http 1.5.0",
+ "http-body-util",
+ "hyper 1.11.1",
+ "hyper-util",
+ "iroh-base",
+ "iroh-dns",
+ "iroh-metrics",
+ "lru 0.18.4",
+ "n0-error",
+ "n0-future",
+ "noq",
+ "noq-proto",
+ "num_enum",
+ "pin-project",
+ "postcard",
+ "rand 0.10.2",
+ "reqwest 0.13.4",
+ "rustls 0.23.43",
+ "rustls-pki-types",
+ "serde",
+ "serde_bytes",
+ "strum 0.28.0",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
+ "tokio-websockets",
+ "tracing",
+ "url",
+ "webpki-roots 1.0.9",
+ "ws_stream_wasm",
+]
 
 [[package]]
 name = "is-docker"
@@ -2545,6 +3198,22 @@ dependencies = [
 
 [[package]]
 name = "jni"
+version = "0.21.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a87aa2bb7d2af34197c04845522473242e1aa17c12f4935d5856491a7fb8c97"
+dependencies = [
+ "cesu8",
+ "cfg-if",
+ "combine",
+ "jni-sys 0.3.1",
+ "log",
+ "thiserror 1.0.69",
+ "walkdir",
+ "windows-sys 0.45.0",
+]
+
+[[package]]
+name = "jni"
 version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5efd9a482cf3a427f00d6b35f14332adc7902ce91efb778580e180ff90fa3498"
@@ -2552,7 +3221,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-macros",
- "jni-sys",
+ "jni-sys 0.4.1",
  "log",
  "simd_cesu8",
  "thiserror 2.0.20",
@@ -2571,6 +3240,15 @@ dependencies = [
  "rustc_version",
  "simd_cesu8",
  "syn 2.0.119",
+]
+
+[[package]]
+name = "jni-sys"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41a652e1f9b6e0275df1f15b32661cf0d4b78d4d87ddec5e0c3c20f097433258"
+dependencies = [
+ "jni-sys 0.4.1",
 ]
 
 [[package]]
@@ -2655,7 +3333,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
 dependencies = [
  "base64 0.22.1",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "getrandom 0.2.17",
  "hmac 0.12.1",
  "js-sys",
@@ -2667,7 +3345,7 @@ dependencies = [
  "serde",
  "serde_json",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "simple_asn1",
  "zeroize",
 ]
@@ -2706,6 +3384,7 @@ dependencies = [
  "http-body-util",
  "hyper 1.11.1",
  "hyper-util",
+ "iroh",
  "json-patch",
  "jsonwebtoken",
  "k8s-openapi",
@@ -3057,6 +3736,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9f8bd3e56ce4dfc153cf470fffbfa98c7620958b312ca5c3a4b8d5181fd13c6"
 
 [[package]]
+name = "loom"
+version = "0.7.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "419e0dc8046cb947daa77eb95ae174acfbddb7673b4151f56d1eed8e93fbfaca"
+dependencies = [
+ "cfg-if",
+ "generator",
+ "scoped-tls",
+ "tracing",
+ "tracing-subscriber",
+]
+
+[[package]]
 name = "lru"
 version = "0.12.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3075,10 +3767,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "lru"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff9840bcc50b71349309900da0ce7279aa336ae71d73250b07998932c7d97c25"
+dependencies = [
+ "hashbrown 0.17.1",
+]
+
+[[package]]
 name = "lru-slab"
 version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
+
+[[package]]
+name = "mac-addr"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3d25b0e0b648a86960ac23b7ad4abb9717601dec6f66c165f5b037f3f03065f"
 
 [[package]]
 name = "matchers"
@@ -3146,6 +3853,250 @@ dependencies = [
 ]
 
 [[package]]
+name = "moka"
+version = "0.12.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4293f18e7567a1caf3c584855554377025c65e0aa445344d04171f5ad63d19b9"
+dependencies = [
+ "crossbeam-channel",
+ "crossbeam-epoch",
+ "crossbeam-utils",
+ "equivalent",
+ "parking_lot",
+ "portable-atomic",
+ "smallvec",
+ "tagptr",
+ "uuid",
+]
+
+[[package]]
+name = "n0-error"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26c59ea174675ce6bc196878851e5049e11b8b1f9af3ba87e4d6df8d828bb001"
+dependencies = [
+ "n0-error-macros",
+ "spez",
+]
+
+[[package]]
+name = "n0-error-macros"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4412346410d6616f3668c40e53c298e5320c7b856f7a960e5914e442601be79f"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "n0-future"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2ab99dfb861450e68853d34ae665243a88b8c493d01ba957321a1e9b2312bbe"
+dependencies = [
+ "cfg_aliases",
+ "derive_more",
+ "futures-buffered",
+ "futures-lite",
+ "futures-util",
+ "js-sys",
+ "pin-project",
+ "send_wrapper",
+ "tokio",
+ "tokio-util",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-time",
+]
+
+[[package]]
+name = "n0-watcher"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbc618745ad0b7414b149d0517ad8b5573b2fb4d4e2717add3d2446ce1fdd826"
+dependencies = [
+ "derive_more",
+ "n0-error",
+ "n0-future",
+]
+
+[[package]]
+name = "ndk-context"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
+
+[[package]]
+name = "netdev"
+version = "0.45.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "096c44b66a9b09b99b4dd36b1c295ff3a492039ccecaf55466bd6ddcdba59968"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "jni 0.21.1",
+ "libc",
+ "mac-addr",
+ "ndk-context",
+ "netlink-packet-core 0.8.2",
+ "netlink-packet-route 0.31.0",
+ "netlink-sys 0.8.8",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-core-wlan",
+ "objc2-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netdev"
+version = "0.46.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4db4135b187ddae3b6813c4f9d9ac9d5181859fa6a08b4e006c63a130974ed62"
+dependencies = [
+ "block2",
+ "dispatch2",
+ "dlopen2",
+ "ipnet",
+ "jni 0.21.1",
+ "libc",
+ "mac-addr",
+ "ndk-context",
+ "netlink-packet-core 0.9.0",
+ "netlink-packet-route 0.33.0",
+ "netlink-sys 0.9.0",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "once_cell",
+ "plist",
+ "windows-sys 0.61.2",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.8.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b897d7bd4f0af82e68d40d0344cf37e97f9c97ddf74a098de3e4da05e96ca395"
+dependencies = [
+ "paste",
+]
+
+[[package]]
+name = "netlink-packet-core"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d6e2daf9a8c2e21302714706860a0e6be02e03d17294ecc66b354ea7d4059dd"
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e2288fcb784eb3defd5fb16f4c4160d5f477de192eac730f43e1d11c24d9a007"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core 0.8.2",
+]
+
+[[package]]
+name = "netlink-packet-route"
+version = "0.33.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "59d48ffc8b73a506e1ff0878528c72668f2bfbc3d875b6be890a96be5d0d5576"
+dependencies = [
+ "bitflags 2.13.1",
+ "libc",
+ "log",
+ "netlink-packet-core 0.9.0",
+ "zerocopy",
+]
+
+[[package]]
+name = "netlink-proto"
+version = "0.12.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93af8261786086024cd5e96e0a991dd65ced07bbf7c233a487bbc96b971d5539"
+dependencies = [
+ "bytes",
+ "futures-channel",
+ "futures-util",
+ "log",
+ "netlink-packet-core 0.8.2",
+ "netlink-sys 0.8.8",
+ "thiserror 2.0.20",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.8.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd6c30ed10fa69cc491d491b85cc971f6bdeb8e7367b7cde2ee6cc878d583fae"
+dependencies = [
+ "bytes",
+ "futures-util",
+ "libc",
+ "log",
+ "tokio",
+]
+
+[[package]]
+name = "netlink-sys"
+version = "0.9.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c99d38e00b420df49e940fe0826e667c3dad82ac68eb4c2bbf754c1c14a83a10"
+dependencies = [
+ "bytes",
+ "libc",
+ "log",
+]
+
+[[package]]
+name = "netwatch"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "39da9cad5f23aa43401f09497d3b280e51b5feba115d9ffbf38ca35d6ff95e96"
+dependencies = [
+ "atomic-waker",
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "ipnet",
+ "js-sys",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "n0-watcher",
+ "netdev 0.45.1",
+ "netdev 0.46.2",
+ "netlink-packet-core 0.8.2",
+ "netlink-packet-route 0.31.0",
+ "netlink-proto",
+ "netlink-sys 0.8.8",
+ "noq-udp",
+ "objc2-core-foundation",
+ "objc2-system-configuration",
+ "pin-project-lite",
+ "serde",
+ "socket2 0.6.5",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tracing",
+ "web-sys",
+ "windows",
+ "windows-result",
+ "wmi",
+]
+
+[[package]]
 name = "nom"
 version = "7.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +4104,68 @@ checksum = "d273983c5a657a70a3e8f2a01329822f3b8c8172b73826411a55751e404a0a4a"
 dependencies = [
  "memchr",
  "minimal-lexical",
+]
+
+[[package]]
+name = "noq"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1e6c57353d26be91a242f0ec96073066c4481a03f6be874daafb18902394515"
+dependencies = [
+ "bytes",
+ "cfg_aliases",
+ "derive_more",
+ "noq-proto",
+ "noq-udp",
+ "pin-project-lite",
+ "rustc-hash",
+ "rustls 0.23.43",
+ "socket2 0.6.5",
+ "thiserror 2.0.20",
+ "tokio",
+ "tokio-stream",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-proto"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9a46813e306c29c4f86357b6ffa39a8e1c97bb274b9a296a19a56d62e4111225"
+dependencies = [
+ "aes-gcm",
+ "bytes",
+ "derive_more",
+ "enum-assoc",
+ "getrandom 0.4.3",
+ "identity-hash",
+ "lru-slab",
+ "rand 0.10.2",
+ "rand_pcg",
+ "ring",
+ "rustc-hash",
+ "rustls 0.23.43",
+ "rustls-pki-types",
+ "slab",
+ "sorted-index-buffer",
+ "thiserror 2.0.20",
+ "tinyvec",
+ "tracing",
+ "web-time",
+]
+
+[[package]]
+name = "noq-udp"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b56d621ed2c1773b5356ab39cc68c819f8d0103f7493d8661c4a5f5f8ea55f40"
+dependencies = [
+ "cfg_aliases",
+ "libc",
+ "socket2 0.6.5",
+ "tracing",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -3272,6 +4285,28 @@ dependencies = [
 ]
 
 [[package]]
+name = "num_enum"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d0bca838442ec211fa11de3a8b0e0e8f3a4522575b5c4c06ed722e005036f26"
+dependencies = [
+ "num_enum_derive",
+ "rustversion",
+]
+
+[[package]]
+name = "num_enum_derive"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "680998035259dcfcafe653688bf2aa6d3e2dc05e98be6ab46afb089dc84f1df8"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "oauth2"
 version = "5.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3292,12 +4327,58 @@ dependencies = [
 ]
 
 [[package]]
+name = "objc2"
+version = "0.6.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3a12a8ed07aefc768292f076dc3ac8c48f3781c8f2d5851dd3d98950e8c5a89f"
+dependencies = [
+ "objc2-encode",
+]
+
+[[package]]
 name = "objc2-core-foundation"
 version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
  "bitflags 2.13.1",
+ "block2",
+ "dispatch2",
+ "libc",
+ "objc2",
+]
+
+[[package]]
+name = "objc2-core-wlan"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c71e34919aba0d701380d911702455038a8a3587467fe0141d6a71501e7ffe48"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-foundation",
+ "objc2-security",
+ "objc2-security-foundation",
+]
+
+[[package]]
+name = "objc2-encode"
+version = "4.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef25abbcd74fb2609453eb695bd2f860d389e457f67dc17cafc8b8cbc89d0c33"
+
+[[package]]
+name = "objc2-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
+dependencies = [
+ "bitflags 2.13.1",
+ "block2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
 ]
 
 [[package]]
@@ -3308,6 +4389,41 @@ checksum = "33fafba39597d6dc1fb709123dfa8289d39406734be322956a69f0931c73bb15"
 dependencies = [
  "libc",
  "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "709fe137109bd1e8b5a99390f77a7d8b2961dafc1a1c5db8f2e60329ad6d895a"
+dependencies = [
+ "bitflags 2.13.1",
+ "objc2",
+ "objc2-core-foundation",
+]
+
+[[package]]
+name = "objc2-security-foundation"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ef76382e9cedd18123099f17638715cc3d81dba3637d4c0d39ab69df2ef345a5"
+dependencies = [
+ "objc2",
+ "objc2-foundation",
+]
+
+[[package]]
+name = "objc2-system-configuration"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7216bd11cbda54ccabcab84d523dc93b858ec75ecfb3a7d89513fa22464da396"
+dependencies = [
+ "bitflags 2.13.1",
+ "dispatch2",
+ "libc",
+ "objc2",
+ "objc2-core-foundation",
+ "objc2-security",
 ]
 
 [[package]]
@@ -3324,12 +4440,22 @@ name = "once_cell"
 version = "1.21.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f7c3e4beb33f85d45ae3e3a1792185706c8e16d043238c593331cc7cd313b50"
+dependencies = [
+ "critical-section",
+ "portable-atomic",
+]
 
 [[package]]
 name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "opaque-debug"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "open"
@@ -3350,7 +4476,7 @@ dependencies = [
  "base64 0.21.7",
  "chrono",
  "dyn-clone",
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "hmac 0.12.1",
  "http 1.5.0",
  "itertools 0.10.5",
@@ -3505,12 +4631,22 @@ version = "0.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fc9e2161f1f215afdfce23677034ae137bbd45016a880c2eb3ba8eb95f085b2"
 dependencies = [
- "base16ct",
+ "base16ct 0.2.0",
  "ecdsa",
  "elliptic-curve",
  "primeorder",
  "rand_core 0.6.4",
  "sha2 0.10.9",
+]
+
+[[package]]
+name = "papaya"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da2442474a9404698c42509b8967f437249dbc7b50493e83020333d3943ec0ae"
+dependencies = [
+ "equivalent",
+ "seize",
 ]
 
 [[package]]
@@ -3568,6 +4704,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "pem-rfc7468"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a6305423e0e7738146434843d1694d621cce767262b2a86910beab705e4493d9"
+dependencies = [
+ "base64ct",
+]
+
+[[package]]
 name = "percent-encoding"
 version = "2.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3616,6 +4761,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "pharos"
+version = "0.5.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e9567389417feee6ce15dd6527a8a1ecac205ef62c2932bcf3d9f6fc5b78b414"
+dependencies = [
+ "futures",
+ "rustc_version",
+]
+
+[[package]]
 name = "pin-project"
 version = "1.1.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3653,9 +4808,9 @@ version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
 dependencies = [
- "der",
- "pkcs8",
- "spki",
+ "der 0.7.10",
+ "pkcs8 0.10.2",
+ "spki 0.7.3",
 ]
 
 [[package]]
@@ -3664,8 +4819,18 @@ version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
 dependencies = [
- "der",
- "spki",
+ "der 0.7.10",
+ "spki 0.7.3",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "451913da69c775a56034ea8d9003d27ee8948e12443eae7c038ba100a4f21cb7"
+dependencies = [
+ "der 0.8.1",
+ "spki 0.8.0",
 ]
 
 [[package]]
@@ -3681,10 +4846,38 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b4596b6d070b27117e987119b4dac604f3c58cfb0b191112e24771b2faeac1a6"
 
 [[package]]
+name = "plist"
+version = "1.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da1d65da6dd5d1e44199ac0f58712d241c0f439f80adea8924d832384087f85"
+dependencies = [
+ "base64 0.22.1",
+ "indexmap 2.14.1",
+ "quick-xml",
+ "serde",
+ "time",
+]
+
+[[package]]
+name = "polyval"
+version = "0.6.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9d1fe60d06143b2430aa532c94cfe9e29783047f06c0d7fd359a9a51b729fa25"
+dependencies = [
+ "cfg-if",
+ "cpufeatures 0.2.17",
+ "opaque-debug",
+ "universal-hash",
+]
+
+[[package]]
 name = "portable-atomic"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05c8b63e8d9609db387f0324918f81d68fe27748f084ef092fb35954d0539a85"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "portable-atomic-util"
@@ -3693,6 +4886,59 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a106d1259c23fac8e543272398ae0e3c0b8d33c88ed73d0cc71b0f1d902618"
 dependencies = [
  "portable-atomic",
+]
+
+[[package]]
+name = "portmapper"
+version = "0.19.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca97242f016e090a25330613bc2382aab65eb22f9149dbe84d8f8e711d49a530"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "derive_more",
+ "hyper-util",
+ "igd-next",
+ "iroh-metrics",
+ "libc",
+ "n0-error",
+ "n0-future",
+ "netwatch",
+ "num_enum",
+ "rand 0.10.2",
+ "serde",
+ "smallvec",
+ "socket2 0.6.5",
+ "time",
+ "tokio",
+ "tokio-util",
+ "tower-layer",
+ "tracing",
+ "url",
+]
+
+[[package]]
+name = "postcard"
+version = "1.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6764c3b5dd454e283a30e6dfe78e9b31096d9e32036b5d1eaac7a6119ccb9a24"
+dependencies = [
+ "cobs",
+ "embedded-io 0.4.0",
+ "embedded-io 0.6.1",
+ "postcard-derive",
+ "serde",
+]
+
+[[package]]
+name = "postcard-derive"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0232bd009a197ceec9cc881ba46f727fcd8060a2d8d6a9dde7a69030a6fe2bb"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
 ]
 
 [[package]]
@@ -3720,12 +4966,32 @@ dependencies = [
 ]
 
 [[package]]
+name = "prefix-trie"
+version = "0.8.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cf6e3177f0684016a5c209b00882e15f8bdd3f3bb48f0491df10cd102d0c6e7"
+dependencies = [
+ "either",
+ "ipnet",
+ "num-traits",
+]
+
+[[package]]
 name = "primeorder"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
 dependencies = [
  "elliptic-curve",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e67ba7e9b2b56446f1d419b1d807906278ffa1a658a8a5d8a39dcb1f5a78614f"
+dependencies = [
+ "toml_edit 0.25.13+spec-1.1.0",
 ]
 
 [[package]]
@@ -3793,6 +5059,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3e36c2f31e0a47f9280fb347ef5e461ffcd2c52dd520d8e216b52f93b0b0d7d6"
 dependencies = [
  "thiserror 1.0.69",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.41.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e660451e55124f798a69a5af3f49ccfbefbd41910eefd25caf2393e1f3473ec1"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]
@@ -3973,7 +5248,7 @@ dependencies = [
  "itertools 0.13.0",
  "lru 0.12.5",
  "paste",
- "strum",
+ "strum 0.26.3",
  "unicode-segmentation",
  "unicode-truncate",
  "unicode-width 0.2.0",
@@ -4166,6 +5441,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "resolv-conf"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e061d1b48cb8d38042de4ae0a7a6401009d6143dc80d2e2d6f31f0bdd6470c7"
+
+[[package]]
 name = "rfc6979"
 version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4201,11 +5482,11 @@ dependencies = [
  "num-integer",
  "num-traits",
  "pkcs1",
- "pkcs8",
+ "pkcs8 0.10.2",
  "rand_core 0.6.4",
  "sha2 0.10.9",
- "signature",
- "spki",
+ "signature 2.2.0",
+ "spki 0.7.3",
  "subtle",
  "zeroize",
 ]
@@ -4325,9 +5606,9 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26d1e2536ce4f35f4846aa13bff16bd0ff40157cdb14cc056c7b14ba41233ba0"
 dependencies = [
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
- "jni",
+ "jni 0.22.4",
  "log",
  "once_cell",
  "rustls 0.23.43",
@@ -4436,6 +5717,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "scoped-tls"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1cf6437eb19a8f4a6cc0f7dca544973b0b78843adbfeb3683d1a94a0024a294"
+
+[[package]]
 name = "scopeguard"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4457,10 +5744,10 @@ version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
 dependencies = [
- "base16ct",
- "der",
+ "base16ct 0.2.0",
+ "der 0.7.10",
  "generic-array",
- "pkcs8",
+ "pkcs8 0.10.2",
  "subtle",
  "zeroize",
 ]
@@ -4481,7 +5768,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b7f4bc775c73d9a02cde8bf7b2ec4c9d12743edf609006c7facc23998404cd1d"
 dependencies = [
  "bitflags 2.13.1",
- "core-foundation",
+ "core-foundation 0.10.1",
  "core-foundation-sys",
  "libc",
  "security-framework-sys",
@@ -4498,10 +5785,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "seize"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b55fb86dfd3a2f5f76ea78310a88f96c4ea21a3031f8d212443d56123fd0521"
+
+[[package]]
 name = "semver"
 version = "1.0.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a7852d02fc848982e0c167ef163aaff9cd91dc640ba85e263cb1ce46fae51cd"
+
+[[package]]
+name = "send_wrapper"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd0b0ec5f1c1ca621c432a25813d8d60c88abe6d3e08a3eb9cf37d97a0fe3d73"
 
 [[package]]
 name = "serde"
@@ -4521,6 +5820,16 @@ checksum = "f3a1a3341211875ef120e117ea7fd5228530ae7e7036a779fdc9117be6b3282c"
 dependencies = [
  "ordered-float",
  "serde",
+]
+
+[[package]]
+name = "serde_bytes"
+version = "0.11.19"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+dependencies = [
+ "serde",
+ "serde_core",
 ]
 
 [[package]]
@@ -4668,6 +5977,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "serdect"
+version = "0.4.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "66cf8fedced2fcf12406bcb34223dffb92eaf34908ede12fed414c82b7f00b3e"
+dependencies = [
+ "base16ct 1.0.0",
+ "serde",
+]
+
+[[package]]
 name = "sha1"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4688,6 +6007,12 @@ dependencies = [
  "cpufeatures 0.3.1",
  "digest 0.11.3",
 ]
+
+[[package]]
+name = "sha1_smol"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bbfa15b3dddfee50a0fff136974b3e1bde555604ba463834a7eb7deb6417705d"
 
 [[package]]
 name = "sha2"
@@ -4768,6 +6093,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "3.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28d567dcbaf0049cb8ac2608a76cd95ff9e4412e1899d389ee400918ca7537f5"
+dependencies = [
+ "rand_core 0.10.1",
+]
+
+[[package]]
 name = "simd_cesu8"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4782,6 +6116,15 @@ name = "simdutf8"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3a9fe34e3e7a50316060351f37187a3f546bce95496156754b601a5fa71b76e"
+
+[[package]]
+name = "simple-dns"
+version = "0.12.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b6f884fa9a8d48101774bfbd3aeb81e968dd22cffd19a372da69f183db22c1a"
+dependencies = [
+ "bitflags 2.13.1",
+]
 
 [[package]]
 name = "simple_asn1"
@@ -4831,6 +6174,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "sorted-index-buffer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ea06cc588e43c632923a55450401b8f25e628131571d4e1baea1bdfdb2b5ed06"
+
+[[package]]
+name = "spez"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c87e960f4dca2788eeb86bbdde8dd246be8948790b7618d656e68f9b720a86e8"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.119",
+]
+
+[[package]]
 name = "spin"
 version = "0.9.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4852,7 +6212,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
 dependencies = [
  "base64ct",
- "der",
+ "der 0.7.10",
+]
+
+[[package]]
+name = "spki"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d9efca8738c78ee9484207732f728b1ef517bbb1833d6fc0879ca898a522f6f"
+dependencies = [
+ "base64ct",
+ "der 0.8.1",
 ]
 
 [[package]]
@@ -5053,7 +6423,7 @@ checksum = "d0eca9f3c8984d0deb4e773ab3bb8aab0c9c0276b63b72d82c090fe58a620cf9"
 dependencies = [
  "bytes",
  "interprocess",
- "signature",
+ "signature 2.2.0",
  "ssh-encoding",
  "ssh-key",
  "thiserror 2.0.20",
@@ -5076,7 +6446,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb9242b9ef4108a78e8cd1a2c98e193ef372437f8c22be363075233321dd4a15"
 dependencies = [
  "base64ct",
- "pem-rfc7468",
+ "pem-rfc7468 0.7.0",
  "sha2 0.10.9",
 ]
 
@@ -5086,7 +6456,7 @@ version = "0.6.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3b86f5297f0f04d08cabaa0f6bff7cb6aec4d9c3b49d87990d63da9d9156a8c3"
 dependencies = [
- "ed25519-dalek",
+ "ed25519-dalek 2.2.0",
  "num-bigint-dig",
  "p256",
  "p384",
@@ -5095,7 +6465,7 @@ dependencies = [
  "rsa",
  "sec1",
  "sha2 0.10.9",
- "signature",
+ "signature 2.2.0",
  "ssh-cipher",
  "ssh-encoding",
  "subtle",
@@ -5137,7 +6507,16 @@ version = "0.26.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8fec0f0aef304996cf250b31b5a10dee7980c85da9d759361292b8bca5a18f06"
 dependencies = [
- "strum_macros",
+ "strum_macros 0.26.4",
+]
+
+[[package]]
+name = "strum"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9628de9b8791db39ceda2b119bbe13134770b56c138ec1d3af810d045c04f9bd"
+dependencies = [
+ "strum_macros 0.28.0",
 ]
 
 [[package]]
@@ -5150,6 +6529,18 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
+ "syn 2.0.119",
+]
+
+[[package]]
+name = "strum_macros"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab85eea0270ee17587ed4156089e10b9e6880ee688791d45a905f5b1ca36f664"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
  "syn 2.0.119",
 ]
 
@@ -5214,6 +6605,33 @@ dependencies = [
  "objc2-io-kit",
  "windows",
 ]
+
+[[package]]
+name = "system-configuration"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a13f3d0daba03132c0aa9767f98351b3488edc2c100cda2d2ec2b04f3d8d3c8b"
+dependencies = [
+ "bitflags 2.13.1",
+ "core-foundation 0.9.4",
+ "system-configuration-sys",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "tagptr"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b2093cf4c8eb1e67749a6762251bc9cd836b6fc171623bd0a9d324d37af2417"
 
 [[package]]
 name = "tempfile"
@@ -5284,6 +6702,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdb87b95ec50ddfa440816d227a17b2ccbdda963a316a727fda0fc4334f7d134"
 dependencies = [
  "deranged",
+ "js-sys",
  "num-conv",
  "powerfmt",
  "serde_core",
@@ -5389,6 +6808,7 @@ dependencies = [
  "futures-core",
  "pin-project-lite",
  "tokio",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5439,10 +6859,34 @@ dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
+ "futures-util",
  "libc",
  "pin-project-lite",
  "slab",
  "tokio",
+]
+
+[[package]]
+name = "tokio-websockets"
+version = "0.13.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d52efb639344a7c6adb8e62c6f3d2c19c001ff1b79a5041ba1c6ed42e19c6aa5"
+dependencies = [
+ "base64 0.22.1",
+ "bytes",
+ "futures-core",
+ "futures-sink",
+ "getrandom 0.4.3",
+ "http 1.5.0",
+ "httparse",
+ "rand 0.10.2",
+ "ring",
+ "rustls-pki-types",
+ "sha1_smol",
+ "simdutf8",
+ "tokio",
+ "tokio-rustls 0.26.4",
+ "tokio-util",
 ]
 
 [[package]]
@@ -5453,8 +6897,8 @@ checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
 dependencies = [
  "serde",
  "serde_spanned",
- "toml_datetime",
- "toml_edit",
+ "toml_datetime 0.6.11",
+ "toml_edit 0.22.27",
 ]
 
 [[package]]
@@ -5467,6 +6911,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "1.1.1+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3165f65f62e28e0115a00b2ebdd37eb6f3b641855f9d636d3cd4103767159ad7"
+dependencies = [
+ "serde_core",
+]
+
+[[package]]
 name = "toml_edit"
 version = "0.22.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5475,9 +6928,30 @@ dependencies = [
  "indexmap 2.14.1",
  "serde",
  "serde_spanned",
- "toml_datetime",
+ "toml_datetime 0.6.11",
  "toml_write",
- "winnow",
+ "winnow 0.7.15",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.25.13+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6975367e4d2ef766d86af01ffad14b622fecc8d4357a998fbc4deb6e9bacaf9b"
+dependencies = [
+ "indexmap 2.14.1",
+ "toml_datetime 1.1.1+spec-1.1.0",
+ "toml_parser",
+ "winnow 1.0.4",
+]
+
+[[package]]
+name = "toml_parser"
+version = "1.1.3+spec-1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1d38ac1cf9b95face32296c0a3ede1fdc270627c9d9c02a7274dd6d960dc4d56"
+dependencies = [
+ "winnow 1.0.4",
 ]
 
 [[package]]
@@ -5774,6 +7248,22 @@ name = "unicode-width"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1fc81956842c57dac11422a97c3b8195a1ff727f06e85c84ed2e8aa277c9a0fd"
+
+[[package]]
+name = "unicode-xid"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "universal-hash"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fc1de2c688dc15305988b563c3854064043356019f97a4b46276fe734c4f07ea"
+dependencies = [
+ "crypto-common 0.1.6",
+ "subtle",
+]
 
 [[package]]
 name = "unsafe-libyaml"
@@ -6145,6 +7635,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "windows-registry"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "02752bf7fbdcce7f2a27a742f798510f3e5ad88dbe84871e5168e2120c3d5720"
+dependencies = [
+ "windows-link",
+ "windows-result",
+ "windows-strings",
+]
+
+[[package]]
 name = "windows-result"
 version = "0.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6160,6 +7661,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-sys"
+version = "0.45.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "75283be5efb2831d37ea142365f009c02ec203cd29a3ebecbc093d52315b66d0"
+dependencies = [
+ "windows-targets 0.42.2",
 ]
 
 [[package]]
@@ -6205,6 +7715,21 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "windows-targets"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e5180c00cd44c9b1c88adb3693291f1cd93605ded80c250a75d472756b4d071"
+dependencies = [
+ "windows_aarch64_gnullvm 0.42.2",
+ "windows_aarch64_msvc 0.42.2",
+ "windows_i686_gnu 0.42.2",
+ "windows_i686_msvc 0.42.2",
+ "windows_x86_64_gnu 0.42.2",
+ "windows_x86_64_gnullvm 0.42.2",
+ "windows_x86_64_msvc 0.42.2",
 ]
 
 [[package]]
@@ -6266,6 +7791,12 @@ dependencies = [
 
 [[package]]
 name = "windows_aarch64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "597a5118570b68bc08d8d59125332c54f1ba9d9adeedeef5b99b02ba2b0698f8"
+
+[[package]]
+name = "windows_aarch64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b38e32f0abccf9987a4e3079dfb67dcd799fb61361e53e2882c3cbaf0d905d8"
@@ -6284,6 +7815,12 @@ checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
 
 [[package]]
 name = "windows_aarch64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e08e8864a60f06ef0d0ff4ba04124db8b0fb3be5776a5cd47641e942e58c4d43"
+
+[[package]]
+name = "windows_aarch64_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dc35310971f3b2dbbf3f0690a219f40e2d9afcf64f9ab7cc1be722937c26b4bc"
@@ -6299,6 +7836,12 @@ name = "windows_aarch64_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+
+[[package]]
+name = "windows_i686_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c61d927d8da41da96a81f029489353e68739737d3beca43145c8afec9a31a84f"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -6332,6 +7875,12 @@ checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44d840b6ec649f480a41c8d80f9c65108b92d89345dd94027bfe06ac444d1060"
+
+[[package]]
+name = "windows_i686_msvc"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8f55c233f70c4b27f66c523580f78f1004e8b5a8b659e05a4eb49d4166cca406"
@@ -6347,6 +7896,12 @@ name = "windows_i686_msvc"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+
+[[package]]
+name = "windows_x86_64_gnu"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8de912b8b8feb55c064867cf047dda097f92d51efad5b491dfb98f6bbb70cb36"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -6368,6 +7923,12 @@ checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "26d41b46a36d453748aedef1486d5c7a85db22e56aff34643984ea85514e94a3"
+
+[[package]]
+name = "windows_x86_64_gnullvm"
 version = "0.48.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b7b52767868a23d5bab768e390dc5f5c55825b6d30b86c844ff2dc7414044cc"
@@ -6383,6 +7944,12 @@ name = "windows_x86_64_gnullvm"
 version = "0.53.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+
+[[package]]
+name = "windows_x86_64_msvc"
+version = "0.42.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9aec5da331524158c6d1a4ac0ab1541149c0b9505fde06423b02f5ef0106b9f0"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -6407,6 +7974,15 @@ name = "winnow"
 version = "0.7.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "winnow"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "23b97319f7b8343df12cc98938e5c3eb436064524c8d2b4e30a1d3a36eecdf81"
 dependencies = [
  "memchr",
 ]
@@ -6441,10 +8017,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
+name = "wmi"
+version = "0.18.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c81b85c57a57500e56669586496bf2abd5cf082b9d32995251185d105208b64"
+dependencies = [
+ "chrono",
+ "futures",
+ "log",
+ "serde",
+ "thiserror 2.0.20",
+ "windows",
+ "windows-core",
+]
+
+[[package]]
 name = "writeable"
 version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3ad82d2a33cdc9674dc7465672f271e096168fcdbe0f799d9e6db8c5892679dc"
+
+[[package]]
+name = "ws_stream_wasm"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c173014acad22e83f16403ee360115b38846fe754e735c5d9d3803fe70c6abc"
+dependencies = [
+ "async_io_stream",
+ "futures",
+ "js-sys",
+ "log",
+ "pharos",
+ "rustc_version",
+ "send_wrapper",
+ "thiserror 2.0.20",
+ "wasm-bindgen",
+ "wasm-bindgen-futures",
+ "web-sys",
+]
 
 [[package]]
 name = "x509-parser"
@@ -6465,10 +8075,25 @@ dependencies = [
 ]
 
 [[package]]
+name = "xml-rs"
+version = "0.8.29"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e450f9b2ed1dff33c94c12589a87338689467b9c4f5d8a5710bd09a847d2c8a7"
+
+[[package]]
 name = "xmlparser"
 version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "66fee0b777b0f5ac1c69bb06d361268faafa61cd4682ae064a171c16c433e9e4"
+
+[[package]]
+name = "xmltree"
+version = "0.10.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d7d8a75eaf6557bb84a65ace8609883db44a29951042ada9b393151532e41fcb"
+dependencies = [
+ "xml-rs",
+]
 
 [[package]]
 name = "yasna"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -156,6 +156,11 @@ http = "1"
 libc = "0.2"
 regex = "1"
 
+# P2P data-plane transport for Sandbox attach/exec/port-forward (#197).
+# Compiled into the binary unconditionally; activated per-pool at runtime via
+# `SandboxPool.spec.transport`. Public relay by default, overridable.
+iroh = "1"
+
 # The wire contract with the in-container Sandbox runner (#82). A path
 # dependency on the runner crate rather than a second copy of the types: two
 # hand-maintained definitions of a wire format drift, and the drift shows up as

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -312,6 +312,18 @@ spec:
                   rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)'
                 - message: exposed port names must contain a letter and cannot contain consecutive hyphens
                   rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches(''.*[a-z].*'') && !p.name.contains(''--''))'
+              transport:
+                default: direct
+                description: |-
+                  Data-plane transport for attach/exec/port-forward sessions (#197).
+                  `direct` (default) is the current WebSocket path terminated at the API
+                  server; `iroh` opts the pool into the P2P QUIC transport. Admission
+                  rejects `iroh` where the operator has not enabled it — never silently
+                  downgrades to `direct`.
+                enum:
+                - direct
+                - iroh
+                type: string
               warmCapacity:
                 description: Desired number of unclaimed upstream Sandboxes kept warm.
                 format: uint32

--- a/charts/kobe/templates/deployment-teardown-authority.yaml
+++ b/charts/kobe/templates/deployment-teardown-authority.yaml
@@ -44,6 +44,10 @@ spec:
               value: "teardown-authority"
             - name: AGENT_SANDBOX_MODE
               value: "disabled"
+            # The authority never serves sessions; it must not hold relay
+            # connections open.
+            - name: KOBE_IROH_RELAY
+              value: "disabled"
             - name: OPERATOR_NAMESPACE
               value: {{ .Values.operatorNamespace | quote }}
             - name: POD_NAMESPACE

--- a/charts/kobe/templates/deployment.yaml
+++ b/charts/kobe/templates/deployment.yaml
@@ -99,6 +99,11 @@ spec:
             # operator-installed Agent Sandbox v1.0.0 runtime.
             - name: AGENT_SANDBOX_MODE
               value: {{ .Values.agentSandbox.mode | default "disabled" | quote }}
+            # Iroh P2P data-plane relay selection (#197): public | disabled |
+            # comma-separated relay URLs. Always set so the operator never
+            # inherits a relay choice from a compiled-in default silently.
+            - name: KOBE_IROH_RELAY
+              value: {{ .Values.agentSandbox.irohRelay | default "public" | quote }}
             {{- if eq .Values.agentSandbox.mode "managed" }}
             - name: KOBE_AGENT_SANDBOX_OWNER
               value: {{ include "kobe.agentSandboxOwner" . | quote }}

--- a/charts/kobe/values.schema.json
+++ b/charts/kobe/values.schema.json
@@ -93,6 +93,11 @@
           "type": "integer",
           "minimum": 4,
           "maximum": 1000000
+        },
+        "irohRelay": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Iroh relay selection: public, disabled, or comma-separated relay URLs."
         }
       },
       "required": [

--- a/charts/kobe/values.yaml
+++ b/charts/kobe/values.yaml
@@ -127,6 +127,17 @@ containerSecurityContext:
 #             the release owner and pinned digest before using either runtime.
 agentSandbox:
   mode: disabled
+  # Iroh P2P data-plane relay selection (#197). The binary always ships iroh;
+  # this only decides which relays the operator endpoint uses.
+  #
+  #   public    (default) Public n0 relays. Session bytes are end-to-end
+  #             encrypted QUIC, so a relay observes metadata only (addresses,
+  #             timing), never session content — but it is an external
+  #             dependency without an SLA.
+  #   disabled  No endpoint is bound. Pools requesting `iroh` transport are
+  #             refused at admission, never silently served over WebSocket.
+  #   <urls>    Comma-separated relay URLs for a self-hosted relay map.
+  irohRelay: public
   # Aggregate object ceiling across every caller. This namespace contains only
   # admission tokens plus distributed operation gates/principal ledgers, so
   # the quota cannot starve unrelated leader elections. Each live Sandbox can

--- a/crates/kobectl/Cargo.toml
+++ b/crates/kobectl/Cargo.toml
@@ -45,6 +45,10 @@ tokio-tungstenite = { version = "0.28", features = [
   "connect",
   "rustls-tls-webpki-roots",
 ], default-features = false }
+# P2P data-plane for `attach` / `port-forward` when the lease's pool selected
+# iroh (#197). tls-ring matches reqwest/tungstenite so rustls does not panic
+# on two providers. Metrics/portmapper stay off to keep the Windows tree slim.
+iroh = { version = "1", default-features = false, features = ["tls-ring"] }
 futures-util = { version = "0.3", default-features = false, features = ["sink"] }
 # A direct dependency ONLY so the CLI can choose its crypto provider. reqwest
 # selects ring; tokio-tungstenite's rustls feature pulls aws-lc-rs. With two

--- a/crates/kobectl/src/commands/lease_create.rs
+++ b/crates/kobectl/src/commands/lease_create.rs
@@ -161,6 +161,8 @@ pub async fn lease_create(command: LeaseCreateCommand<'_>) -> Result<()> {
                 alias: command.name,
                 expires_at: detail.expires_at.as_deref(),
                 capabilities: &actions,
+                transport: detail.transport.as_deref(),
+                iroh: detail.iroh.as_ref(),
             },
             command.output,
         )?;
@@ -681,6 +683,8 @@ mod tests {
             queue_position: 0,
             metadata: None,
             kubeconfig: Some("apiVersion: v1".to_string()),
+            transport: None,
+            iroh: None,
         };
 
         assert!(lease_is_usable(&detail));

--- a/crates/kobectl/src/commands/leases.rs
+++ b/crates/kobectl/src/commands/leases.rs
@@ -6,7 +6,7 @@ use super::{
     OutputFormat, Reaching, authed_client, get_auth_header, get_auth_header_for_output, with_auth,
 };
 
-#[derive(Debug, Clone, Deserialize, Serialize)]
+#[derive(Debug, Clone, Default, Deserialize, Serialize)]
 #[serde(rename_all = "camelCase")]
 pub(crate) struct LeaseSummary {
     pub id: String,
@@ -33,6 +33,20 @@ pub(crate) struct LeaseSummary {
     /// Caller-supplied descriptive JSON metadata.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub metadata: Option<serde_json::Value>,
+    /// Sandbox data-plane. Absent or `direct` means WebSocket.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub transport: Option<String>,
+    /// How to reach the operator over iroh when `transport` is `iroh`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub iroh: Option<IrohDial>,
+}
+
+#[derive(Debug, Clone, Deserialize, Serialize, Default)]
+#[serde(rename_all = "camelCase")]
+pub(crate) struct IrohDial {
+    pub node_id: String,
+    #[serde(default)]
+    pub relay: String,
 }
 
 #[derive(Debug, Clone, Deserialize)]
@@ -55,6 +69,10 @@ pub(crate) struct LeaseDetail {
     pub metadata: Option<serde_json::Value>,
     #[serde(default)]
     pub kubeconfig: Option<String>,
+    #[serde(default)]
+    pub transport: Option<String>,
+    #[serde(default)]
+    pub iroh: Option<IrohDial>,
 }
 
 fn default_resource_kind() -> String {
@@ -324,9 +342,25 @@ pub(crate) fn lease_glance_label(lease: &LeaseSummary) -> String {
 pub(crate) fn format_lease_status_line(lease: &LeaseSummary) -> String {
     let id = short_lease_id(&lease.id);
     let glance = lease_glance_label(lease);
-    match lease.alias.as_deref().filter(|alias| !alias.is_empty()) {
+    let mut line = match lease.alias.as_deref().filter(|alias| !alias.is_empty()) {
         Some(alias) => format!("{id}  {alias}  {}  {glance}", lease.profile),
         None => format!("{id}  {}  {glance}", lease.profile),
+    };
+    if lease.transport.as_deref() == Some("iroh") {
+        match lease.iroh.as_ref() {
+            Some(iroh) if !iroh.node_id.is_empty() => {
+                line.push_str(&format!("  iroh {}", short_iroh_node(&iroh.node_id)));
+            }
+            _ => line.push_str("  iroh"),
+        }
+    }
+    line
+}
+
+fn short_iroh_node(node_id: &str) -> String {
+    match node_id.char_indices().nth(8) {
+        Some((idx, _)) => format!("{}…", &node_id[..idx]),
+        None => node_id.to_string(),
     }
 }
 
@@ -348,7 +382,24 @@ mod tests {
             kubeconfig_path: None,
             alias: None,
             metadata: None,
+            transport: None,
+            iroh: None,
         }
+    }
+
+    #[test]
+    fn iroh_leases_show_transport_and_short_node_id() {
+        let mut lease = lease("sandbox-1", "Ready", None, 0);
+        lease.transport = Some("iroh".into());
+        lease.iroh = Some(IrohDial {
+            node_id: "abcdef0123456789deadbeef".into(),
+            relay: "public".into(),
+        });
+        let line = format_lease_status_line(&lease);
+        assert!(line.contains("iroh abcdef01…"), "{line}");
+        lease.iroh = None;
+        let line = format_lease_status_line(&lease);
+        assert!(line.ends_with("iroh"), "{line}");
     }
 
     #[test]

--- a/crates/kobectl/src/commands/purge.rs
+++ b/crates/kobectl/src/commands/purge.rs
@@ -396,6 +396,8 @@ mod tests {
             kubeconfig_path: None,
             alias: None,
             metadata: None,
+            transport: None,
+            iroh: None,
         };
 
         assert!(is_active_lease(&base));
@@ -428,6 +430,8 @@ mod tests {
             kubeconfig_path: None,
             alias: None,
             metadata: None,
+            transport: None,
+            iroh: None,
         };
         let sandbox = LeaseSummary {
             id: "sandbox-agent".to_string(),
@@ -457,6 +461,8 @@ mod tests {
             kubeconfig_path: None,
             alias: None,
             metadata: None,
+            transport: None,
+            iroh: None,
         };
         let leases = vec![
             LeaseSummary {

--- a/crates/kobectl/src/commands/sandbox.rs
+++ b/crates/kobectl/src/commands/sandbox.rs
@@ -405,6 +405,10 @@ struct SandboxLeaseResponse {
     alias: Option<String>,
     #[serde(default)]
     expires_at: Option<String>,
+    #[serde(default)]
+    transport: Option<String>,
+    #[serde(default)]
+    iroh: Option<super::leases::IrohDial>,
 }
 
 #[derive(Debug, Serialize)]
@@ -419,6 +423,10 @@ struct LeaseOutput<'a> {
     ttl: Option<&'a str>,
     alias: Option<&'a str>,
     expires_at: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    transport: Option<&'a str>,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iroh: Option<&'a super::leases::IrohDial>,
 }
 
 const SANDBOX_CAPABILITIES: &[&str] = &[
@@ -782,6 +790,8 @@ pub(crate) async fn lease(config: &ResolvedConfig, command: LeaseCommand<'_>) ->
                 alias: command.alias,
                 expires_at: None,
                 capabilities: &actions,
+                transport: None,
+                iroh: None,
             },
             command.output,
         );
@@ -822,6 +832,8 @@ pub(crate) async fn lease(config: &ResolvedConfig, command: LeaseCommand<'_>) ->
             alias: ready.alias.as_deref().or(command.alias),
             expires_at: ready.expires_at.as_deref(),
             capabilities: &actions,
+            transport: ready.transport.as_deref(),
+            iroh: ready.iroh.as_ref(),
         },
         command.output,
     )?;
@@ -854,6 +866,8 @@ pub(crate) struct LeasePrint<'a> {
     pub alias: Option<&'a str>,
     pub expires_at: Option<&'a str>,
     pub capabilities: &'a [String],
+    pub transport: Option<&'a str>,
+    pub iroh: Option<&'a super::leases::IrohDial>,
 }
 
 pub(crate) fn emit_lease_output(lease: &LeasePrint<'_>, output: OutputFormat) -> Result<()> {
@@ -867,6 +881,12 @@ pub(crate) fn emit_lease_output(lease: &LeasePrint<'_>, output: OutputFormat) ->
                 println!("Expires: {expires_at}");
             }
             println!("Actions: {}", lease.capabilities.join(", "));
+            if let Some(transport) = lease.transport {
+                println!("Transport: {transport}");
+            }
+            if let Some(iroh) = lease.iroh {
+                println!("Iroh:     {}  ({})", iroh.node_id, iroh.relay);
+            }
             if let Some(next) = next_sandbox_hint(lease.id, lease.phase, lease.capabilities) {
                 println!("Next:    {next}");
             }
@@ -882,6 +902,8 @@ pub(crate) fn emit_lease_output(lease: &LeasePrint<'_>, output: OutputFormat) ->
             ttl: lease.ttl,
             alias: lease.alias,
             expires_at: lease.expires_at,
+            transport: lease.transport,
+            iroh: lease.iroh,
         }),
     }
 }

--- a/crates/kobectl/src/commands/sandbox_transport.rs
+++ b/crates/kobectl/src/commands/sandbox_transport.rs
@@ -32,7 +32,10 @@ use futures_util::{SinkExt, StreamExt};
 use tokio_tungstenite::tungstenite::Message;
 
 use super::config::{CliConfig, ResolvedConfig};
-use super::{OutputFormat, get_auth_header, get_auth_header_noninteractive};
+use super::{
+    OutputFormat, Reaching, authed_client, get_auth_header, get_auth_header_for_output,
+    get_auth_header_noninteractive, with_auth,
+};
 
 pub const CHANNEL_STDIN: u8 = 0;
 pub const CHANNEL_STDOUT: u8 = 1;
@@ -94,6 +97,10 @@ pub fn parse_server_frame(message: &Message) -> Option<ServerFrame> {
         }
         _ => return None,
     };
+    parse_server_payload(payload)
+}
+
+fn parse_server_payload(payload: &[u8]) -> Option<ServerFrame> {
     let (&channel, body) = payload.split_first()?;
     Some(match channel {
         CHANNEL_STDOUT => ServerFrame::Stdout(body.to_vec()),
@@ -202,6 +209,10 @@ pub async fn attach(
     }
     let config = CliConfig::load()?;
     let config = config.resolve(target_override, endpoint_override)?;
+
+    if lease_uses_iroh(&config, lease, output).await {
+        return attach_iroh(&config, lease, command, container, tty).await;
+    }
 
     let mut path = format!("/v1/sandbox-leases/{lease}/attach?tty={tty}");
     if let Some(container) = container {
@@ -511,6 +522,7 @@ pub async fn port_forward(
         "/v1/sandbox-leases/{lease}/port-forward?port={}",
         urlencoding_minimal(remote)
     );
+    let iroh = lease_uses_iroh(&config, lease, output).await;
 
     // One connection at a time, on purpose. Concurrency here would need one
     // upstream stream per local connection, and each of those counts against
@@ -518,14 +530,28 @@ pub async fn port_forward(
     // exhaust it and the failures would look like the sandbox misbehaving.
     loop {
         let (mut local, peer) = listener.accept().await.context("accept failed")?;
-        let mut socket = match open_stream(&config, &path, output).await {
-            Ok(socket) => socket,
-            Err(error) => {
-                report_port_forward_error(output, lease, peer, &format!("{error:#}"))?;
-                continue;
+        let result = if iroh {
+            match dial_iroh_session(
+                &config,
+                lease,
+                output,
+                serde_json::json!({
+                    "operation": "port-forward",
+                    "port": remote,
+                }),
+            )
+            .await
+            {
+                Ok(mut link) => pump_connection_iroh(&mut local, &mut link).await,
+                Err(error) => Err(error),
+            }
+        } else {
+            match open_stream(&config, &path, output).await {
+                Ok(mut socket) => pump_connection(&mut local, &mut socket).await,
+                Err(error) => Err(error),
             }
         };
-        if let Err(error) = pump_connection(&mut local, &mut socket).await {
+        if let Err(error) = result {
             report_port_forward_error(output, lease, peer, &format!("{error:#}"))?;
         }
     }
@@ -583,6 +609,387 @@ async fn pump_connection(local: &mut tokio::net::TcpStream, socket: &mut Socket)
             inbound = socket.next() => {
                 let Some(message) = inbound else { return Ok(()) };
                 match parse_server_frame(&message?) {
+                    Some(ServerFrame::Stdout(bytes)) | Some(ServerFrame::Stderr(bytes)) => {
+                        local.write_all(&bytes).await?;
+                    }
+                    Some(ServerFrame::Ended { reason }) => {
+                        if end_is_failure(&reason) {
+                            anyhow::bail!("forward ended: {reason}");
+                        }
+                        return Ok(());
+                    }
+                    Some(ServerFrame::Unknown) | None => {}
+                }
+            }
+        }
+    }
+}
+
+/// ALPN must match the operator's `kobe-sandbox/1`. Duplicated rather than
+/// shared: this crate cannot depend on the operator binary.
+const KOBE_SANDBOX_ALPN: &[u8] = b"kobe-sandbox/1";
+const MAX_BLOB_BYTES: usize = 1024 * 1024;
+
+#[derive(Debug, serde::Deserialize)]
+#[serde(rename_all = "camelCase")]
+struct IrohSessionOffer {
+    node_id: String,
+    ticket: String,
+    #[serde(default)]
+    relay: String,
+}
+
+#[derive(Debug, serde::Deserialize)]
+struct LeaseTransportView {
+    #[serde(default)]
+    transport: Option<String>,
+}
+
+async fn lease_uses_iroh(config: &ResolvedConfig, lease: &str, output: OutputFormat) -> bool {
+    let path = format!("/v1/sandbox-leases/{lease}");
+    let token = match get_auth_header_for_output(config, "GET", &path, b"", output).await {
+        Ok(token) => token,
+        Err(_) => return false,
+    };
+    let response = match with_auth(
+        authed_client().get(format!("{}{path}", config.endpoint.as_str())),
+        &token,
+    )
+    .send()
+    .await
+    {
+        Ok(response) => response,
+        Err(_) => return false,
+    };
+    if !response.status().is_success() {
+        return false;
+    }
+    match response.json::<LeaseTransportView>().await {
+        Ok(body) => body.transport.as_deref() == Some("iroh"),
+        Err(_) => false,
+    }
+}
+
+async fn request_iroh_session(
+    config: &ResolvedConfig,
+    lease: &str,
+    output: OutputFormat,
+    body: serde_json::Value,
+) -> Result<IrohSessionOffer> {
+    let path = format!("/v1/sandbox-leases/{lease}/session");
+    let encoded = serde_json::to_vec(&body).context("session body")?;
+    // SSH signatures are verified against an empty body on this API.
+    let token = get_auth_header_for_output(config, "POST", &path, b"", output).await?;
+    let response = with_auth(
+        authed_client()
+            .post(format!("{}{path}", config.endpoint.as_str()))
+            .header("content-type", "application/json")
+            .body(encoded),
+        &token,
+    )
+    .send()
+    .await
+    .reaching(config)?;
+    if !response.status().is_success() {
+        anyhow::bail!("iroh session was refused (HTTP {})", response.status());
+    }
+    Ok(response.json().await.context("iroh session offer")?)
+}
+
+async fn write_blob<W: tokio::io::AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    data: &[u8],
+) -> std::io::Result<()> {
+    if data.len() > MAX_BLOB_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "iroh blob exceeds MAX_BLOB_BYTES",
+        ));
+    }
+    let len = u32::try_from(data.len()).expect("len fits u32");
+    writer.write_all(&len.to_be_bytes()).await?;
+    writer.write_all(data).await?;
+    writer.flush().await
+}
+
+async fn read_blob<R: tokio::io::AsyncReadExt + Unpin>(
+    reader: &mut R,
+) -> std::io::Result<Option<Vec<u8>>> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len == 0 || len > MAX_BLOB_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "iroh blob length is not a usable frame",
+        ));
+    }
+    let mut data = vec![0u8; len];
+    reader.read_exact(&mut data).await?;
+    Ok(Some(data))
+}
+
+fn decode_hex(input: &str) -> Result<Vec<u8>> {
+    if !input.len().is_multiple_of(2) {
+        anyhow::bail!("ticket is not hex");
+    }
+    (0..input.len())
+        .step_by(2)
+        .map(|i| u8::from_str_radix(&input[i..i + 2], 16).context("ticket is not hex"))
+        .collect()
+}
+
+fn relay_mode(configured: &str) -> Result<iroh::RelayMode> {
+    match configured.trim().to_ascii_lowercase().as_str() {
+        "" | "public" => Ok(iroh::RelayMode::Default),
+        "disabled" => Ok(iroh::RelayMode::Disabled),
+        urls => {
+            let map = iroh::RelayMap::empty();
+            for url in urls
+                .split(',')
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+            {
+                let parsed: iroh::RelayUrl = url
+                    .parse()
+                    .with_context(|| format!("invalid iroh relay URL: {url}"))?;
+                let cfg = std::sync::Arc::new(iroh::RelayConfig::new(parsed.clone(), None));
+                map.insert(parsed, cfg);
+            }
+            Ok(iroh::RelayMode::Custom(map))
+        }
+    }
+}
+
+struct IrohLink {
+    send: iroh::endpoint::SendStream,
+    recv: iroh::endpoint::RecvStream,
+    _conn: iroh::endpoint::Connection,
+    _endpoint: iroh::Endpoint,
+}
+
+async fn dial_iroh_session(
+    config: &ResolvedConfig,
+    lease: &str,
+    output: OutputFormat,
+    body: serde_json::Value,
+) -> Result<IrohLink> {
+    let offer = request_iroh_session(config, lease, output, body).await?;
+    let node: iroh::EndpointId = offer
+        .node_id
+        .parse()
+        .context("iroh node id from the session offer is not valid")?;
+    let endpoint = iroh::Endpoint::builder(iroh::endpoint::presets::N0)
+        .relay_mode(relay_mode(&offer.relay)?)
+        .bind()
+        .await
+        .context("bind local iroh endpoint")?;
+    if offer.relay != "disabled" {
+        tokio::time::timeout(std::time::Duration::from_secs(30), endpoint.online())
+            .await
+            .context("local iroh endpoint did not come online")?;
+    }
+    let conn = endpoint
+        .connect(node, KOBE_SANDBOX_ALPN)
+        .await
+        .context("dial operator iroh endpoint")?;
+    let (mut send, recv) = conn.open_bi().await.context("open iroh stream")?;
+    let ticket = decode_hex(&offer.ticket)?;
+    write_blob(&mut send, &ticket)
+        .await
+        .context("send iroh session ticket")?;
+    Ok(IrohLink {
+        send,
+        recv,
+        _conn: conn,
+        _endpoint: endpoint,
+    })
+}
+
+async fn attach_iroh(
+    config: &ResolvedConfig,
+    lease: &str,
+    command: &[String],
+    container: Option<&str>,
+    tty: bool,
+) -> Result<i32> {
+    let mut body = serde_json::json!({
+        "operation": "attach",
+        "tty": tty,
+    });
+    if !command.is_empty() {
+        body["command"] = serde_json::json!(command);
+    }
+    if let Some(container) = container {
+        body["container"] = serde_json::json!(container);
+    }
+    let mut link = dial_iroh_session(config, lease, OutputFormat::Text, body).await?;
+    let _raw = if tty {
+        Some(RawModeGuard::enter()?)
+    } else {
+        None
+    };
+    if tty
+        && let Ok((width, height)) = crossterm::terminal::size()
+        && width > 0
+        && height > 0
+    {
+        let payload = format!(r#"{{"width":{width},"height":{height}}}"#);
+        let mut frame = Vec::with_capacity(payload.len() + 1);
+        frame.push(CHANNEL_RESIZE);
+        frame.extend_from_slice(payload.as_bytes());
+        write_blob(&mut link.send, &frame).await.ok();
+    }
+    let reason = pump_terminal_iroh(&mut link, tty).await?;
+    if end_is_failure(&reason) {
+        eprintln!("kobe: session ended: {reason}");
+        return Ok(super::sandbox::CLI_FAILURE_EXIT);
+    }
+    Ok(0)
+}
+
+fn apply_server_blob(payload: &[u8]) -> Option<String> {
+    match parse_server_payload(payload) {
+        Some(ServerFrame::Stdout(bytes)) => {
+            let mut out = std::io::stdout();
+            out.write_all(&bytes).ok();
+            out.flush().ok();
+            None
+        }
+        Some(ServerFrame::Stderr(bytes)) => {
+            let mut err = std::io::stderr();
+            err.write_all(&bytes).ok();
+            err.flush().ok();
+            None
+        }
+        Some(ServerFrame::Ended { reason }) => Some(reason),
+        Some(ServerFrame::Unknown) | None => None,
+    }
+}
+
+async fn pump_terminal_iroh(link: &mut IrohLink, tty: bool) -> Result<String> {
+    #[cfg(unix)]
+    if tty {
+        return pump_raw_iroh(link).await;
+    }
+    pump_key_events_iroh(link).await
+}
+
+#[cfg(unix)]
+async fn pump_raw_iroh(link: &mut IrohLink) -> Result<String> {
+    use tokio::signal::unix::{SignalKind, signal};
+
+    let (sender, mut receiver) = tokio::sync::mpsc::channel::<Vec<u8>>(64);
+    std::thread::spawn(move || {
+        use std::io::Read;
+        let mut stdin = std::io::stdin().lock();
+        let mut buffer = [0u8; 4096];
+        loop {
+            match stdin.read(&mut buffer) {
+                Ok(0) => break,
+                Ok(read) => {
+                    if sender.blocking_send(buffer[..read].to_vec()).is_err() {
+                        break;
+                    }
+                }
+                Err(error) if error.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(_) => break,
+            }
+        }
+    });
+
+    let mut resized =
+        signal(SignalKind::window_change()).context("could not watch for terminal resizes")?;
+
+    loop {
+        tokio::select! {
+            inbound = read_blob(&mut link.recv) => {
+                let Some(payload) = inbound.context("iroh stream failed")? else {
+                    return Ok("closed".to_string());
+                };
+                if let Some(reason) = apply_server_blob(&payload) {
+                    return Ok(reason);
+                }
+            }
+            outbound = receiver.recv() => {
+                let Some(bytes) = outbound else { continue };
+                let mut frame = Vec::with_capacity(bytes.len() + 1);
+                frame.push(CHANNEL_STDIN);
+                frame.extend_from_slice(&bytes);
+                write_blob(&mut link.send, &frame).await?;
+            }
+            _ = resized.recv() => {
+                if let Ok((width, height)) = crossterm::terminal::size()
+                    && width > 0
+                    && height > 0
+                {
+                    let payload = format!(r#"{{"width":{width},"height":{height}}}"#);
+                    let mut frame = Vec::with_capacity(payload.len() + 1);
+                    frame.push(CHANNEL_RESIZE);
+                    frame.extend_from_slice(payload.as_bytes());
+                    write_blob(&mut link.send, &frame).await?;
+                }
+            }
+        }
+    }
+}
+
+async fn pump_key_events_iroh(link: &mut IrohLink) -> Result<String> {
+    use crossterm::event::{Event, EventStream};
+    use futures_util::StreamExt;
+
+    let mut events = EventStream::new();
+    loop {
+        tokio::select! {
+            inbound = read_blob(&mut link.recv) => {
+                let Some(payload) = inbound.context("iroh stream failed")? else {
+                    return Ok("closed".to_string());
+                };
+                if let Some(reason) = apply_server_blob(&payload) {
+                    return Ok(reason);
+                }
+            }
+            event = events.next() => {
+                let Some(event) = event else { continue };
+                let Event::Key(key) = event.context("keyboard")? else { continue };
+                if let Some(bytes) = key_to_bytes(&key) {
+                    let mut frame = Vec::with_capacity(bytes.len() + 1);
+                    frame.push(CHANNEL_STDIN);
+                    frame.extend_from_slice(&bytes);
+                    write_blob(&mut link.send, &frame).await?;
+                }
+            }
+        }
+    }
+}
+
+async fn pump_connection_iroh(
+    local: &mut tokio::net::TcpStream,
+    link: &mut IrohLink,
+) -> Result<()> {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+
+    let mut buffer = vec![0u8; 32 * 1024];
+    loop {
+        tokio::select! {
+            read = local.read(&mut buffer) => {
+                match read? {
+                    0 => return Ok(()),
+                    count => {
+                        let mut frame = Vec::with_capacity(count + 1);
+                        frame.push(CHANNEL_STDIN);
+                        frame.extend_from_slice(&buffer[..count]);
+                        write_blob(&mut link.send, &frame).await?;
+                    }
+                }
+            }
+            inbound = read_blob(&mut link.recv) => {
+                let Some(payload) = inbound? else { return Ok(()) };
+                match parse_server_payload(&payload) {
                     Some(ServerFrame::Stdout(bytes)) | Some(ServerFrame::Stderr(bytes)) => {
                         local.write_all(&bytes).await?;
                     }

--- a/crates/kobectl/src/commands/sandbox_transport.rs
+++ b/crates/kobectl/src/commands/sandbox_transport.rs
@@ -693,7 +693,7 @@ async fn request_iroh_session(
     if !response.status().is_success() {
         anyhow::bail!("iroh session was refused (HTTP {})", response.status());
     }
-    Ok(response.json().await.context("iroh session offer")?)
+    response.json().await.context("iroh session offer")
 }
 
 async fn write_blob<W: tokio::io::AsyncWriteExt + Unpin>(

--- a/crates/kobectl/src/commands/select.rs
+++ b/crates/kobectl/src/commands/select.rs
@@ -236,6 +236,8 @@ mod tests {
             kubeconfig_path: None,
             alias: None,
             metadata: None,
+            transport: None,
+            iroh: None,
         }
     }
 

--- a/crates/kobectl/src/commands/status.rs
+++ b/crates/kobectl/src/commands/status.rs
@@ -302,6 +302,8 @@ async fn enrich_leases(
                 kubeconfig_path,
                 alias: lease.alias,
                 metadata: detail.metadata.or(lease.metadata),
+                transport: detail.transport.or(lease.transport),
+                iroh: detail.iroh.or(lease.iroh),
             }),
             Err(_) => enriched.push(LeaseSummary {
                 kubeconfig_path,
@@ -354,6 +356,8 @@ mod tests {
                 kubeconfig_path: None,
                 alias: None,
                 metadata: None,
+                transport: None,
+                iroh: None,
             },
             LeaseSummary {
                 id: "sandbox-b".into(),
@@ -368,6 +372,8 @@ mod tests {
                 kubeconfig_path: None,
                 alias: None,
                 metadata: None,
+                transport: None,
+                iroh: None,
             },
             LeaseSummary {
                 id: "sandbox-c".into(),
@@ -382,6 +388,8 @@ mod tests {
                 kubeconfig_path: None,
                 alias: None,
                 metadata: None,
+                transport: None,
+                iroh: None,
             },
         ];
         assert_eq!(hidden_lease_counts(&leases), (1, 1));

--- a/crates/kobectl/tests/sandbox_cli.rs
+++ b/crates/kobectl/tests/sandbox_cli.rs
@@ -985,6 +985,12 @@ fn json_attach_is_refused_and_port_forward_errors_are_machine_events() {
         match (request.method.as_str(), request.path.as_str()) {
             ("GET", "/v1/leases") => reply(stream, 200, &[], "[]"),
             ("GET", "/v1/sandbox-leases") => reply(stream, 200, &[], &sandbox_inventory()),
+            ("GET", "/v1/sandbox-leases/sandbox-test") => reply(
+                stream,
+                200,
+                &[],
+                &json!({"id":"sandbox-test","phase":"Ready","pool":"agents"}).to_string(),
+            ),
             _ => {
                 *observed.lock().unwrap() += 1;
                 reply(stream, 403, &[], "forward denied");

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -27,7 +27,7 @@ use crate::controllers::lease::extend_lease_ttl;
 use crate::crd::{
     CIDRClaim, CIDRClaimPhase, ClusterInstance, ClusterInstancePhase, ClusterLease,
     ClusterLeaseCondition, ClusterLeaseSpec, ClusterPool, LeaseBinding, LeasePhase, Requester,
-    SandboxPool, SandboxVerb,
+    SandboxPool, SandboxTransport, SandboxVerb,
 };
 use crate::lease_binding::{BindingResolutionError, BindingResolveMode, resolve_lease_binding};
 use crate::metrics;
@@ -611,6 +611,17 @@ struct LeaseSummary {
     /// and `alias` when a shared-pool listing contains another tenant's lease.
     #[serde(skip_serializing_if = "Option::is_none")]
     metadata: Option<serde_json::Value>,
+    /// Sandbox data-plane. Omitted for cluster leases and for `direct`.
+    #[serde(skip_serializing_if = "is_direct_or_absent")]
+    transport: Option<SandboxTransport>,
+    /// How to reach this replica over iroh. Omitted unless `transport` is iroh
+    /// and this process has an endpoint bound.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iroh: Option<crate::iroh_transport::IrohDial>,
+}
+
+fn is_direct_or_absent(transport: &Option<SandboxTransport>) -> bool {
+    !matches!(transport, Some(SandboxTransport::Iroh))
 }
 
 /// Query parameters for `GET /v1/leases` (#107 P2).
@@ -1672,6 +1683,8 @@ async fn list_leases<B: ClusterBackend>(
                         requester: None,
                         alias,
                         metadata: c.spec.metadata.as_deref().cloned(),
+                        transport: None,
+                        iroh: None,
                     }
                 })
                 .collect();
@@ -1700,6 +1713,8 @@ async fn list_leases<B: ClusterBackend>(
                                 requester: None,
                                 alias: lease.alias,
                                 metadata: None,
+                                transport: Some(lease.transport),
+                                iroh: lease.iroh,
                             })
                         }));
                     }
@@ -2950,6 +2965,8 @@ async fn list_pool_leases<B: ClusterBackend>(
                         requester: None,
                         alias: lease.alias,
                         metadata: None,
+                        transport: Some(lease.transport),
+                        iroh: lease.iroh,
                     })
                     .collect();
                 return (StatusCode::OK, Json(summaries)).into_response();
@@ -3012,6 +3029,8 @@ fn pool_lease_summary(lease: &ClusterLease, caller_identity: &str) -> LeaseSumma
         metadata: own
             .then(|| lease.spec.metadata.as_deref().cloned())
             .flatten(),
+        transport: None,
+        iroh: None,
     }
 }
 

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -83,6 +83,11 @@ pub struct AppState<B: ClusterBackend> {
     /// validated at startup. Disabled deployments do not mount Sandbox HTTP
     /// routes, so they cannot admit leases that no controller will reconcile.
     pub sandbox_enabled: bool,
+    /// Operator-side iroh endpoint for P2P session bytes (#197). `None` when
+    /// the operator disabled iroh (`KOBE_IROH_RELAY=disabled`); pools that
+    /// request `iroh` transport are then rejected at admission, never silently
+    /// served over WebSocket.
+    pub iroh_endpoint: Option<iroh::Endpoint>,
 }
 
 /// Per-lease connect-proxy context cache. Newtype over a shared, mutex-guarded
@@ -3998,6 +4003,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled,
+            iroh_endpoint: None,
         };
 
         (build_router(state), server)
@@ -4031,6 +4037,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         use wiremock::matchers::{method, path};
@@ -4123,6 +4130,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         use wiremock::matchers::{method, path};
@@ -4660,6 +4668,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         use wiremock::matchers::{method, path_regex};
@@ -4756,6 +4765,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         use wiremock::matchers::{header, method, path, path_regex};
@@ -4854,6 +4864,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         use wiremock::matchers::{header, method, path, path_regex};
@@ -4962,6 +4973,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         use wiremock::matchers::{method, path_regex};
@@ -5045,6 +5057,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         let response = connect_proxy::<crate::testutil::MockBackend>(
@@ -5156,6 +5169,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
 
         Mock::given(method("GET"))
@@ -5625,6 +5639,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         };
         (state, server)
     }

--- a/src/api/routes.rs
+++ b/src/api/routes.rs
@@ -88,6 +88,10 @@ pub struct AppState<B: ClusterBackend> {
     /// request `iroh` transport are then rejected at admission, never silently
     /// served over WebSocket.
     pub iroh_endpoint: Option<iroh::Endpoint>,
+    /// Replica-local one-shot tickets for iroh sessions. Empty when the
+    /// endpoint is `None`; still present so tests can exercise mint/claim
+    /// without binding UDP.
+    pub iroh_sessions: crate::iroh_transport::IrohSessionHub,
 }
 
 /// Per-lease connect-proxy context cache. Newtype over a shared, mutex-guarded
@@ -4004,6 +4008,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         (build_router(state), server)
@@ -4038,6 +4043,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         use wiremock::matchers::{method, path};
@@ -4131,6 +4137,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         use wiremock::matchers::{method, path};
@@ -4669,6 +4676,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         use wiremock::matchers::{method, path_regex};
@@ -4766,6 +4774,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         use wiremock::matchers::{header, method, path, path_regex};
@@ -4865,6 +4874,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         use wiremock::matchers::{header, method, path, path_regex};
@@ -4974,6 +4984,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         use wiremock::matchers::{method, path_regex};
@@ -5058,6 +5069,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         let response = connect_proxy::<crate::testutil::MockBackend>(
@@ -5170,6 +5182,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
 
         Mock::given(method("GET"))
@@ -5640,6 +5653,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         };
         (state, server)
     }

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -3354,10 +3354,73 @@ struct SandboxLeaseResponse {
     /// pool selected the P2P path.
     #[serde(default, skip_serializing_if = "is_direct_transport")]
     transport: SandboxTransport,
+    /// How to reach this replica over iroh. Omitted for `direct` pools and
+    /// when this process has no endpoint bound.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    iroh: Option<crate::iroh_transport::IrohDial>,
 }
 
 fn is_direct_transport(transport: &SandboxTransport) -> bool {
     *transport == SandboxTransport::Direct
+}
+
+fn iroh_dial_for<B: ClusterBackend>(
+    state: &AppState<B>,
+    transport: SandboxTransport,
+) -> Option<crate::iroh_transport::IrohDial> {
+    if transport != SandboxTransport::Iroh {
+        return None;
+    }
+    let endpoint = state.iroh_endpoint.as_ref()?;
+    let relay = crate::iroh_transport::operator_config_from_env()
+        .map(|cfg| cfg.as_offer_string())
+        .unwrap_or_else(|_| "public".into());
+    Some(crate::iroh_transport::IrohDial::from_endpoint(
+        endpoint, relay,
+    ))
+}
+
+/// Map pool UID → transport for list responses. A missing or unreadable
+/// pool list is treated as every lease being `direct` rather than failing
+/// the caller's inventory.
+async fn pool_uid_transports(
+    client: &kube::Client,
+    namespace: &str,
+) -> std::collections::HashMap<String, SandboxTransport> {
+    let pools: Api<SandboxPool> = Api::namespaced(client.clone(), namespace);
+    match pools.list(&ListParams::default()).await {
+        Ok(listed) => listed
+            .iter()
+            .filter_map(|pool| Some((pool.uid()?.to_string(), pool.spec.transport)))
+            .collect(),
+        Err(_) => std::collections::HashMap::new(),
+    }
+}
+
+fn sandbox_lease_summary(
+    lease: &SandboxLease,
+    transports: &std::collections::HashMap<String, SandboxTransport>,
+    iroh: Option<&crate::iroh_transport::IrohDial>,
+) -> SandboxLeaseSummary {
+    let status = lease.status.clone().unwrap_or_default();
+    let transport = transports
+        .get(&lease.spec.pool_ref.uid)
+        .copied()
+        .unwrap_or(SandboxTransport::Direct);
+    SandboxLeaseSummary {
+        id: lease.name_any(),
+        resource_kind: "Sandbox",
+        phase: status.phase.to_string(),
+        pool: lease.spec.pool_ref.name.clone(),
+        alias: lease.spec.alias.clone(),
+        expires_at: status.expires_at.clone(),
+        transport,
+        iroh: if transport == SandboxTransport::Iroh {
+            iroh.cloned()
+        } else {
+            None
+        },
+    }
 }
 
 #[derive(Debug, Serialize)]
@@ -3371,6 +3434,10 @@ pub(crate) struct SandboxLeaseSummary {
     pub alias: Option<String>,
     #[serde(skip_serializing_if = "Option::is_none")]
     pub expires_at: Option<String>,
+    #[serde(default, skip_serializing_if = "is_direct_transport")]
+    pub transport: SandboxTransport,
+    #[serde(skip_serializing_if = "Option::is_none")]
+    pub iroh: Option<crate::iroh_transport::IrohDial>,
 }
 
 /// Error body for every Sandbox route denial.
@@ -3634,6 +3701,7 @@ fn pending_sandbox_lease_response(
         target: None,
         conditions: Vec::new(),
         transport: SandboxTransport::Direct,
+        iroh: None,
     }
 }
 
@@ -4645,21 +4713,13 @@ pub(crate) async fn caller_sandbox_summaries<B: ClusterBackend>(
     }
     let leases: Api<SandboxLease> = Api::namespaced(state.client.clone(), &state.namespace);
     let items = leases.list(&requester_list_params(identity)).await?;
+    let transports = pool_uid_transports(&state.client, &state.namespace).await;
+    let iroh = iroh_dial_for(state, SandboxTransport::Iroh);
     Ok(items
         .iter()
         .filter(|lease| principal_matches(&lease.spec.requester, identity))
         .filter(|lease| is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy))
-        .map(|lease| {
-            let status = lease.status.clone().unwrap_or_default();
-            SandboxLeaseSummary {
-                id: lease.name_any(),
-                resource_kind: "Sandbox",
-                phase: status.phase.to_string(),
-                pool: lease.spec.pool_ref.name.clone(),
-                alias: lease.spec.alias.clone(),
-                expires_at: status.expires_at.clone(),
-            }
-        })
+        .map(|lease| sandbox_lease_summary(lease, &transports, iroh.as_ref()))
         .collect())
 }
 
@@ -4698,23 +4758,15 @@ pub(crate) async fn list_sandbox_leases<B: ClusterBackend>(
     let params = requester_list_params(&identity);
     match leases.list(&params).await {
         Ok(items) => {
+            let transports = pool_uid_transports(&state.client, &state.namespace).await;
+            let iroh = iroh_dial_for(&state, SandboxTransport::Iroh);
             let response: Vec<_> = items
                 .iter()
                 .filter(|lease| principal_matches(&lease.spec.requester, &identity))
                 .filter(|lease| {
                     is_sandbox_allowed(&lease.spec.pool_ref.name, SandboxVerb::Lease, &policy)
                 })
-                .map(|lease| {
-                    let status = lease.status.clone().unwrap_or_default();
-                    SandboxLeaseSummary {
-                        id: lease.name_any(),
-                        resource_kind: "Sandbox",
-                        phase: status.phase.to_string(),
-                        pool: lease.spec.pool_ref.name.clone(),
-                        alias: lease.spec.alias.clone(),
-                        expires_at: status.expires_at,
-                    }
-                })
+                .map(|lease| sandbox_lease_summary(lease, &transports, iroh.as_ref()))
                 .collect();
             (StatusCode::OK, Json(response)).into_response()
         }
@@ -4755,6 +4807,7 @@ pub(crate) async fn get_sandbox_lease<B: ClusterBackend>(
     {
         body.transport = pool.spec.transport;
     }
+    body.iroh = iroh_dial_for(&state, body.transport);
 
     (StatusCode::OK, Json(body)).into_response()
 }
@@ -5451,6 +5504,7 @@ fn sandbox_lease_response(
         target: status.target.map(caller_visible_provenance),
         conditions: status.conditions,
         transport: SandboxTransport::Direct,
+        iroh: None,
     }
 }
 
@@ -8288,6 +8342,26 @@ mod tests {
         assert_eq!(denied.status(), StatusCode::CONFLICT);
         let body = response_json(denied).await;
         assert_eq!(body["reason"], "iroh_transport");
+    }
+
+    #[test]
+    fn list_summaries_surface_iroh_dial_only_for_iroh_pools() {
+        let lease: SandboxLease =
+            serde_json::from_value(lease_json("sandbox-list", "alice@example.com", "Ready"))
+                .unwrap();
+        let dial = crate::iroh_transport::IrohDial {
+            node_id: "abcdef0123456789".into(),
+            relay: "public".into(),
+        };
+        let mut transports = std::collections::HashMap::new();
+        let direct = sandbox_lease_summary(&lease, &transports, Some(&dial));
+        assert_eq!(direct.transport, SandboxTransport::Direct);
+        assert!(direct.iroh.is_none());
+
+        transports.insert(lease.spec.pool_ref.uid.clone(), SandboxTransport::Iroh);
+        let iroh = sandbox_lease_summary(&lease, &transports, Some(&dial));
+        assert_eq!(iroh.transport, SandboxTransport::Iroh);
+        assert_eq!(iroh.iroh.as_ref().unwrap().node_id, "abcdef0123456789");
     }
 
     /// A pool that ships a multiplexer decides what a bare attach lands in.

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -29,7 +29,7 @@ use crate::backend::ClusterBackend;
 use crate::crd::{
     ResolvedSandboxPlacement, SandboxCondition, SandboxLease, SandboxLeasePhase, SandboxLeaseSpec,
     SandboxPlacement, SandboxPlacementAuthority, SandboxPool, SandboxPoolReference,
-    SandboxPrincipal, SandboxReleaseCause, SandboxTargetProvenance, SandboxVerb,
+    SandboxPrincipal, SandboxReleaseCause, SandboxTargetProvenance, SandboxTransport, SandboxVerb,
 };
 use crate::pool::{is_valid_k8s_name, parse_duration};
 use crate::sandbox::{SANDBOX_LEASE_FINALIZER, aggregate_resource_limits, resource_ceiling_allows};
@@ -102,6 +102,10 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
             get(sandbox_port_forward::<B>),
         )
         .route(
+            "/v1/sandbox-leases/{id}/session",
+            post(sandbox_session::<B>),
+        )
+        .route(
             "/v1/sandbox-leases/{id}/executions",
             post(create_sandbox_execution::<B>),
         )
@@ -123,6 +127,7 @@ pub fn routes<B: ClusterBackend + Clone + 'static>() -> Router<AppState<B>> {
             "/v1/leases/{id}/port-forward",
             get(sandbox_port_forward::<B>),
         )
+        .route("/v1/leases/{id}/session", post(sandbox_session::<B>))
         .route(
             "/v1/leases/{id}/executions",
             post(create_sandbox_execution::<B>),
@@ -2467,6 +2472,10 @@ async fn sandbox_attach<B: ClusterBackend>(
         );
     }
 
+    if let Err(response) = refuse_websocket_on_iroh_pool(&state, &identity, &id, "attach").await {
+        return response;
+    }
+
     // Which subresource this calls — `pods/exec` with a command, `pods/attach`
     // without — decides which credential to mint, and the pool may supply the
     // command, so both are settled inside `prepare_upgrade` once the pool is
@@ -2574,6 +2583,12 @@ async fn sandbox_port_forward<B: ClusterBackend>(
 ) -> Response {
     use crate::api::sandbox_transport as transport;
 
+    if let Err(response) =
+        refuse_websocket_on_iroh_pool(&state, &identity, &id, "port-forward").await
+    {
+        return response;
+    }
+
     let context =
         match prepare_upgrade(&state, &identity, &id, UpgradeIntent::PortForward, None).await {
             Ok(context) => context,
@@ -2651,6 +2666,268 @@ async fn sandbox_port_forward<B: ClusterBackend>(
             "Sandbox stream"
         );
     })
+}
+
+/// WebSocket attach/port-forward on an `iroh` pool would be a silent
+/// downgrade of the transport the administrator chose. Refuse with a
+/// bounded reason the CLI can branch on.
+async fn refuse_websocket_on_iroh_pool<B: ClusterBackend>(
+    state: &AppState<B>,
+    identity: &AuthIdentity,
+    id: &str,
+    operation: &'static str,
+) -> Result<(), Response> {
+    match crate::api::sandbox_access::resolve_sandbox_target(
+        &state.client,
+        &state.namespace,
+        id,
+        identity,
+    )
+    .await
+    {
+        Ok((_, target)) if target.transport == SandboxTransport::Iroh => {
+            Err(sandbox_error_with_reason(
+                StatusCode::CONFLICT,
+                "SandboxPool uses iroh transport",
+                Some(format!(
+                    "POST /v1/sandbox-leases/{id}/session for a dial ticket"
+                )),
+                "iroh_transport",
+            ))
+        }
+        Ok(_) => Ok(()),
+        Err(denied) => Err(access_denied(identity, id, operation, denied)),
+    }
+}
+
+#[derive(Debug, Deserialize)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+struct SandboxSessionRequest {
+    /// `attach` or `port-forward`.
+    operation: String,
+    #[serde(default)]
+    command: Option<Vec<String>>,
+    #[serde(default)]
+    container: Option<String>,
+    #[serde(default)]
+    tty: bool,
+    #[serde(default)]
+    port: Option<String>,
+}
+
+/// Mint a one-shot iroh ticket after the same authorization as the WebSocket
+/// upgrade. Direct pools are refused: they keep the existing WS URL.
+#[tracing::instrument(skip_all, fields(lease = %id))]
+async fn sandbox_session<B: ClusterBackend>(
+    State(state): State<AppState<B>>,
+    identity: AuthIdentity,
+    Path(id): Path<String>,
+    Json(request): Json<SandboxSessionRequest>,
+) -> Response {
+    let (intent, tty, port) = match request.operation.as_str() {
+        "attach" => {
+            if let Some(command) = request.command.as_ref()
+                && (command.is_empty() || command.iter().any(String::is_empty))
+            {
+                return sandbox_error(
+                    StatusCode::BAD_REQUEST,
+                    "command must be non-empty argv",
+                    None,
+                );
+            }
+            (
+                UpgradeIntent::Attach(request.command.clone()),
+                request.tty,
+                None,
+            )
+        }
+        "port-forward" => {
+            let Some(port) = request.port.clone() else {
+                return sandbox_error(
+                    StatusCode::BAD_REQUEST,
+                    "port-forward session requires port",
+                    None,
+                );
+            };
+            (UpgradeIntent::PortForward, false, Some(port))
+        }
+        other => {
+            return sandbox_error(
+                StatusCode::BAD_REQUEST,
+                format!("unknown session operation: {other}"),
+                None,
+            );
+        }
+    };
+
+    let target = match crate::api::sandbox_access::resolve_sandbox_target(
+        &state.client,
+        &state.namespace,
+        &id,
+        &identity,
+    )
+    .await
+    {
+        Ok((_, target)) => target,
+        Err(denied) => return access_denied(&identity, &id, intent.label(), denied),
+    };
+    if target.transport != SandboxTransport::Iroh {
+        return sandbox_error_with_reason(
+            StatusCode::CONFLICT,
+            "SandboxPool uses direct transport",
+            Some("open the WebSocket attach or port-forward URL".into()),
+            "direct_transport",
+        );
+    }
+    let Some(endpoint) = state.iroh_endpoint.clone() else {
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "SandboxPool requests iroh transport but the operator has it disabled",
+            None,
+        );
+    };
+
+    let context =
+        match prepare_upgrade(&state, &identity, &id, intent, request.container.as_deref()).await {
+            Ok(context) => context,
+            Err(response) => return response,
+        };
+
+    let resolved_port = if let Some(port) = port.as_deref() {
+        match context.target.resolve_port(port) {
+            Ok(port) => Some(port),
+            Err(denied) => return access_denied(&identity, &id, "port-forward", denied),
+        }
+    } else {
+        None
+    };
+
+    let (ticket, rx) = state.iroh_sessions.mint();
+    let relay = crate::iroh_transport::operator_config_from_env()
+        .map(|cfg| cfg.as_offer_string())
+        .unwrap_or_else(|_| "public".into());
+    let offer = crate::iroh_transport::IrohSessionOffer::new(&endpoint, ticket, relay);
+    let principal = identity.identity.clone();
+    let lease_id = id.clone();
+
+    tokio::spawn(async move {
+        serve_iroh_session(rx, context, tty, resolved_port, principal, lease_id).await;
+    });
+
+    (StatusCode::OK, Json(offer)).into_response()
+}
+
+async fn serve_iroh_session(
+    rx: tokio::sync::oneshot::Receiver<crate::iroh_transport::IrohLink>,
+    context: UpgradeContext,
+    tty: bool,
+    port: Option<u16>,
+    principal: String,
+    id: String,
+) {
+    use crate::api::sandbox_transport as transport;
+
+    let mut link = match tokio::time::timeout(transport::STREAM_SETUP_TIMEOUT, rx).await {
+        Ok(Ok(link)) => link,
+        _ => return,
+    };
+
+    let guard = context.guard;
+    let revoked = guard.cancelled();
+    let pods: kube::Api<k8s_openapi::api::core::v1::Pod> =
+        kube::Api::namespaced(context.scoped.clone(), &context.target.namespace);
+
+    match transport::bounded_setup(pod_identity_holds(&pods, &context.target), &revoked).await {
+        Ok(true) => {}
+        Ok(false) | Err(transport::StreamEnd::TargetError) => {
+            transport::close_with_iroh(&mut link, transport::StreamEnd::TargetError).await;
+            return;
+        }
+        Err(end) => {
+            transport::close_with_iroh(&mut link, end).await;
+            return;
+        }
+    }
+
+    let operation = if let Some(port) = port {
+        let mut forwarder = match transport::bounded_setup(
+            pods.portforward(&context.target.pod_name, &[port]),
+            &revoked,
+        )
+        .await
+        {
+            Ok(Ok(forwarder)) => forwarder,
+            Ok(Err(_)) | Err(transport::StreamEnd::TargetError) => {
+                transport::close_with_iroh(&mut link, transport::StreamEnd::TargetError).await;
+                return;
+            }
+            Err(end) => {
+                transport::close_with_iroh(&mut link, end).await;
+                return;
+            }
+        };
+        let Some(mut stream) = forwarder.take_stream(port) else {
+            transport::close_with_iroh(&mut link, transport::StreamEnd::TargetError).await;
+            return;
+        };
+        let mut limits = transport::StreamLimits::new(
+            transport::IDLE_TIMEOUT,
+            transport::MAX_STREAM_DURATION,
+            transport::MAX_STREAM_BYTES,
+        );
+        let end = transport::pump_duplex_iroh(&mut link, &mut stream, &mut limits, revoked).await;
+        transport::close_with_iroh(&mut link, end).await;
+        ("port-forward", end)
+    } else {
+        let params = kube::api::AttachParams::default()
+            .container(&context.container)
+            .stdin(true)
+            .stdout(true)
+            .stderr(!tty)
+            .tty(tty);
+        let attached = transport::bounded_setup(
+            async {
+                match context.command.as_ref() {
+                    Some(command) => pods.exec(&context.target.pod_name, command, &params).await,
+                    None => pods.attach(&context.target.pod_name, &params).await,
+                }
+            },
+            &revoked,
+        )
+        .await;
+        let mut attached = match attached {
+            Ok(Ok(attached)) => attached,
+            Ok(Err(_)) | Err(transport::StreamEnd::TargetError) => {
+                transport::close_with_iroh(&mut link, transport::StreamEnd::TargetError).await;
+                return;
+            }
+            Err(end) => {
+                transport::close_with_iroh(&mut link, end).await;
+                return;
+            }
+        };
+        let mut limits = transport::StreamLimits::new(
+            transport::IDLE_TIMEOUT,
+            transport::MAX_STREAM_DURATION,
+            transport::MAX_STREAM_BYTES,
+        );
+        let end =
+            transport::pump_attached_iroh(&mut link, &mut attached, &mut limits, revoked).await;
+        attached.abort();
+        transport::close_with_iroh(&mut link, end).await;
+        ("attach", end)
+    };
+
+    info!(
+        principal = %principal,
+        lease = %id,
+        pod_uid = %context.target.pod_uid,
+        operation = operation.0,
+        outcome = "closed",
+        reason = operation.1.code(),
+        caller_fault = operation.1.is_caller_fault(),
+        "Sandbox iroh stream"
+    );
 }
 
 /// How long one exec may run before it is abandoned.
@@ -3072,6 +3349,15 @@ struct SandboxLeaseResponse {
     target: Option<SandboxTargetProvenance>,
     #[serde(skip_serializing_if = "Vec::is_empty")]
     conditions: Vec<SandboxCondition>,
+    /// Data-plane transport for attach/port-forward. Omitted when `direct` so
+    /// existing clients keep parsing. Present as `iroh` when the admitting
+    /// pool selected the P2P path.
+    #[serde(default, skip_serializing_if = "is_direct_transport")]
+    transport: SandboxTransport,
+}
+
+fn is_direct_transport(transport: &SandboxTransport) -> bool {
+    *transport == SandboxTransport::Direct
 }
 
 #[derive(Debug, Serialize)]
@@ -3347,6 +3633,7 @@ fn pending_sandbox_lease_response(
         placement: None,
         target: None,
         conditions: Vec::new(),
+        transport: SandboxTransport::Direct,
     }
 }
 
@@ -4459,7 +4746,17 @@ pub(crate) async fn get_sandbox_lease<B: ClusterBackend>(
         );
     }
 
-    (StatusCode::OK, Json(sandbox_lease_response(lease, None))).into_response()
+    let pool_name = lease.spec.pool_ref.name.clone();
+    let pool_uid = lease.spec.pool_ref.uid.clone();
+    let mut body = sandbox_lease_response(lease, None);
+    let pools: Api<SandboxPool> = Api::namespaced(state.client.clone(), &state.namespace);
+    if let Ok(pool) = pools.get(&pool_name).await
+        && pool.uid().as_deref() == Some(pool_uid.as_str())
+    {
+        body.transport = pool.spec.transport;
+    }
+
+    (StatusCode::OK, Json(body)).into_response()
 }
 
 /// Request body for [`extend_sandbox_lease`].
@@ -5153,6 +5450,7 @@ fn sandbox_lease_response(
         placement: status.placement,
         target: status.target.map(caller_visible_provenance),
         conditions: status.conditions,
+        transport: SandboxTransport::Direct,
     }
 }
 
@@ -7886,6 +8184,7 @@ mod tests {
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
             iroh_endpoint: None,
+            iroh_sessions: Default::default(),
         }
     }
 
@@ -7934,6 +8233,61 @@ mod tests {
             parse_attach_query(Some("tty=true&tty=false")).unwrap_err(),
             AttachQueryError::DuplicateParameter("tty")
         );
+    }
+
+    #[tokio::test]
+    async fn a_direct_pool_refuses_an_iroh_session_ticket() {
+        let server = MockServer::start().await;
+        mount_extendable(&server, extendable_lease_json("sandbox-direct", 0)).await;
+        let response = sandbox_session::<crate::testutil::MockBackend>(
+            State(test_state(&server)),
+            identity(),
+            Path("sandbox-direct".into()),
+            Json(SandboxSessionRequest {
+                operation: "attach".into(),
+                command: None,
+                container: None,
+                tty: false,
+                port: None,
+            }),
+        )
+        .await;
+        assert_eq!(response.status(), StatusCode::CONFLICT);
+        let body = response_json(response).await;
+        assert_eq!(body["reason"], "direct_transport");
+    }
+
+    #[tokio::test]
+    async fn an_iroh_pool_refuses_the_websocket_attach_url() {
+        let server = MockServer::start().await;
+        let mut pool = pool_json();
+        pool["spec"]["transport"] = serde_json::json!("iroh");
+        Mock::given(method("GET"))
+            .and(path(
+                "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/test-ns/sandboxpools/agent-small",
+            ))
+            .respond_with(ResponseTemplate::new(200).set_body_json(pool))
+            .mount(&server)
+            .await;
+        Mock::given(method("GET"))
+            .and(path(sandbox_lease_path("sandbox-iroh")))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(extendable_lease_json("sandbox-iroh", 0)),
+            )
+            .mount(&server)
+            .await;
+
+        let denied = refuse_websocket_on_iroh_pool(
+            &test_state(&server),
+            &identity(),
+            "sandbox-iroh",
+            "attach",
+        )
+        .await
+        .expect_err("iroh pools must not upgrade WebSocket");
+        assert_eq!(denied.status(), StatusCode::CONFLICT);
+        let body = response_json(denied).await;
+        assert_eq!(body["reason"], "iroh_transport");
     }
 
     /// A pool that ships a multiplexer decides what a bare attach lands in.

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -3599,6 +3599,20 @@ async fn create_sandbox_lease_until_inner<B: ClusterBackend>(
     if let Err(err) = pool.spec.validate() {
         return sandbox_infra_error("SandboxPool configuration is invalid", err);
     }
+    // Iroh pools need a bound operator endpoint (#197). Refuse explicitly:
+    // serving them over WebSocket instead would be a silent downgrade of the
+    // transport the pool administrator chose.
+    if let Err(detail) = crate::iroh_transport::require_iroh_available(
+        pool.spec.transport,
+        state.iroh_endpoint.is_some(),
+    ) {
+        warn!(pool = %request.pool, "Sandbox admission refused an iroh pool with no operator endpoint");
+        return sandbox_error(
+            StatusCode::SERVICE_UNAVAILABLE,
+            "SandboxPool requests iroh transport but the operator has it disabled",
+            Some(detail.to_string()),
+        );
+    }
     let child_composition_eligible = child_pool_allocation_is_certified(&pool);
     if let Err(err) = crate::sandbox::require_current_sandbox_pool_ready(&pool)
         && !child_composition_eligible
@@ -7871,6 +7885,7 @@ mod tests {
             sandbox_admission_limiter: Default::default(),
             shutdown: tokio_util::sync::CancellationToken::new(),
             sandbox_enabled: true,
+            iroh_endpoint: None,
         }
     }
 

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -35,7 +35,9 @@
 use kube::ResourceExt;
 use kube::api::Api;
 
-use crate::crd::{ResolvedSandboxPlacement, SandboxLease, SandboxLeasePhase, SandboxPool};
+use crate::crd::{
+    ResolvedSandboxPlacement, SandboxLease, SandboxLeasePhase, SandboxPool, SandboxTransport,
+};
 
 /// One exact, fully identified Sandbox target.
 ///
@@ -69,6 +71,10 @@ pub struct SandboxTarget {
     /// attach joins the container's own process, which is the behaviour of a
     /// pool that has said nothing about multiplexers.
     pub attach_command: Option<Vec<String>>,
+    /// Data-plane transport the admitting pool selected. Copied here so attach
+    /// and port-forward do not re-read the pool after resolution, and so a
+    /// later pool edit cannot silently change a live lease's transport.
+    pub transport: SandboxTransport,
 }
 
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -323,6 +329,7 @@ pub fn target_from_provenance(
         // Same provenance as `runner_path`: the pool that admitted the lease,
         // never the caller. It becomes an exec argv under Kobe's credential.
         attach_command: pool.spec.template.attach_command.clone(),
+        transport: pool.spec.transport,
     })
 }
 

--- a/src/api/sandbox_credentials.rs
+++ b/src/api/sandbox_credentials.rs
@@ -1012,6 +1012,7 @@ mod tests {
             ports: vec![],
             runner_path: None,
             attach_command: None,
+            transport: crate::crd::SandboxTransport::Direct,
         }
     }
 

--- a/src/api/sandbox_executions.rs
+++ b/src/api/sandbox_executions.rs
@@ -1378,6 +1378,7 @@ fn cleanup_target(
         attach_command: None,
         // An execution replays a recorded target; attach never runs through
         // this path, so there is nothing for a pool default to fill in.
+        transport: crate::crd::SandboxTransport::Direct,
     })
 }
 
@@ -1976,6 +1977,7 @@ mod tests {
             ports: vec![],
             runner_path: Some("/kobe-runner".into()),
             attach_command: None,
+            transport: crate::crd::SandboxTransport::Direct,
         }
     }
 
@@ -2461,6 +2463,7 @@ mod tests {
             ports: vec![],
             runner_path: Some("/kobe-runner".into()),
             attach_command: None,
+            transport: crate::crd::SandboxTransport::Direct,
         };
         let mut running = build_execution_record(
             "test-ns",

--- a/src/api/sandbox_transport.rs
+++ b/src/api/sandbox_transport.rs
@@ -179,7 +179,12 @@ pub fn parse_caller_frame(message: &Message) -> Result<CallerFrame, StreamEnd> {
         // silently-mangled bytes to a shell.
         Message::Text(_) => return Err(StreamEnd::ProtocolViolation),
     };
+    parse_caller_payload(payload)
+}
 
+/// Parse one channel-framed payload, shared by WebSocket messages and iroh
+/// blobs after the ticket handshake.
+pub fn parse_caller_payload(payload: &[u8]) -> Result<CallerFrame, StreamEnd> {
     let Some((&channel, body)) = payload.split_first() else {
         // An empty frame has no channel, so there is no way to know what the
         // caller meant by it.
@@ -607,6 +612,265 @@ pub async fn pump_attached(
                         }
                     }
                     Some(Err(_)) => return StreamEnd::TargetError,
+                }
+            }
+        }
+    }
+}
+
+async fn send_iroh_channel(
+    send: &mut iroh::endpoint::SendStream,
+    channel: u8,
+    payload: &[u8],
+) -> Result<(), StreamEnd> {
+    let mut frame = Vec::with_capacity(payload.len() + 1);
+    frame.push(channel);
+    frame.extend_from_slice(payload);
+    crate::iroh_transport::write_blob(send, &frame)
+        .await
+        .map_err(|_| StreamEnd::Completed)
+}
+
+async fn next_iroh_frame(recv: &mut iroh::endpoint::RecvStream) -> Result<CallerFrame, StreamEnd> {
+    match crate::iroh_transport::read_blob(recv).await {
+        Ok(None) => Ok(CallerFrame::Close),
+        Ok(Some(blob)) => parse_caller_payload(&blob),
+        Err(_) => Err(StreamEnd::Completed),
+    }
+}
+
+/// Tell an iroh caller why their stream ended, then finish the send side.
+pub async fn close_with_iroh(link: &mut crate::iroh_transport::IrohLink, end: StreamEnd) {
+    debug!(reason = end.code(), "closing Sandbox iroh stream");
+    let payload = format!(r#"{{"reason":"{}"}}"#, end.code());
+    let close = async {
+        let _ = send_iroh_channel(&mut link.send, CHANNEL_ERROR, payload.as_bytes()).await;
+        let _ = link.send.finish();
+    };
+    let _ = tokio::time::timeout(Duration::from_secs(1), close).await;
+}
+
+/// Same pump as [`pump_attached`], over an iroh stream instead of a WebSocket.
+pub async fn pump_attached_iroh(
+    link: &mut crate::iroh_transport::IrohLink,
+    attached: &mut kube::api::AttachedProcess,
+    limits: &mut StreamLimits,
+    revoked: CancellationToken,
+) -> StreamEnd {
+    let mut stdin = attached.stdin();
+    let mut stdout = attached.stdout();
+    let mut stderr = attached.stderr();
+    let mut resize = attached.terminal_size();
+
+    let mut out_buffer = vec![0u8; 32 * 1024];
+    let mut err_buffer = vec![0u8; 32 * 1024];
+
+    loop {
+        let now = tokio::time::Instant::now();
+        if let Err(end) = limits.check(now) {
+            return end;
+        }
+        let deadline = limits.next_deadline(now);
+
+        let stdout_read = async {
+            match stdout.as_mut() {
+                Some(stream) => Some(stream.read(&mut out_buffer).await),
+                None => std::future::pending().await,
+            }
+        };
+        let stderr_read = async {
+            match stderr.as_mut() {
+                Some(stream) => Some(stream.read(&mut err_buffer).await),
+                None => std::future::pending().await,
+            }
+        };
+
+        tokio::select! {
+            _ = revoked.cancelled() => return StreamEnd::Revoked,
+            _ = tokio::time::sleep(deadline) => {
+                return limits
+                    .check(tokio::time::Instant::now())
+                    .err()
+                    .unwrap_or(StreamEnd::IdleTimeout);
+            }
+            inbound = next_iroh_frame(&mut link.recv) => {
+                let frame = match inbound {
+                    Ok(frame) => frame,
+                    Err(end) => return end,
+                };
+                match frame {
+                    CallerFrame::Close => return StreamEnd::Completed,
+                    CallerFrame::Stdin(bytes) => {
+                        if bytes.is_empty() {
+                            continue;
+                        }
+                        if let Err(end) =
+                            limits.record(bytes.len(), tokio::time::Instant::now())
+                        {
+                            return end;
+                        }
+                        let Some(stdin) = stdin.as_mut() else {
+                            return StreamEnd::ProtocolViolation;
+                        };
+                        if let Err(end) = bounded_io(
+                            stdin.write_all(&bytes),
+                            limits,
+                            &revoked,
+                            StreamEnd::TargetError,
+                        )
+                        .await
+                        {
+                            return end;
+                        }
+                    }
+                    CallerFrame::Resize { width, height } => {
+                        let Some(resize) = resize.as_mut() else {
+                            return StreamEnd::ProtocolViolation;
+                        };
+                        if let Err(end) = bounded_io(
+                            resize.send(kube::api::TerminalSize { width, height }),
+                            limits,
+                            &revoked,
+                            StreamEnd::TargetError,
+                        )
+                        .await
+                        {
+                            return end;
+                        }
+                    }
+                }
+            }
+            read = stdout_read => {
+                match read {
+                    Some(Ok(0)) | None => {
+                        stdout = None;
+                        if stderr.is_none() {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Some(Ok(count)) => {
+                        if let Err(end) = limits.record(count, tokio::time::Instant::now()) {
+                            return end;
+                        }
+                        if let Err(end) = bounded_io(
+                            send_iroh_channel(&mut link.send, CHANNEL_STDOUT, &out_buffer[..count]),
+                            limits,
+                            &revoked,
+                            StreamEnd::Completed,
+                        )
+                        .await
+                        {
+                            return end;
+                        }
+                    }
+                    Some(Err(_)) => return StreamEnd::TargetError,
+                }
+            }
+            read = stderr_read => {
+                match read {
+                    Some(Ok(0)) | None => {
+                        stderr = None;
+                        if stdout.is_none() {
+                            return StreamEnd::Completed;
+                        }
+                    }
+                    Some(Ok(count)) => {
+                        if let Err(end) = limits.record(count, tokio::time::Instant::now()) {
+                            return end;
+                        }
+                        if let Err(end) = bounded_io(
+                            send_iroh_channel(&mut link.send, CHANNEL_STDERR, &err_buffer[..count]),
+                            limits,
+                            &revoked,
+                            StreamEnd::Completed,
+                        )
+                        .await
+                        {
+                            return end;
+                        }
+                    }
+                    Some(Err(_)) => return StreamEnd::TargetError,
+                }
+            }
+        }
+    }
+}
+
+/// Same pump as [`pump_duplex`], over an iroh stream instead of a WebSocket.
+pub async fn pump_duplex_iroh<S>(
+    link: &mut crate::iroh_transport::IrohLink,
+    target: &mut S,
+    limits: &mut StreamLimits,
+    revoked: CancellationToken,
+) -> StreamEnd
+where
+    S: tokio::io::AsyncRead + tokio::io::AsyncWrite + Unpin,
+{
+    let mut buffer = vec![0u8; 32 * 1024];
+    loop {
+        let now = tokio::time::Instant::now();
+        if let Err(end) = limits.check(now) {
+            return end;
+        }
+        let deadline = limits.next_deadline(now);
+
+        tokio::select! {
+            _ = revoked.cancelled() => return StreamEnd::Revoked,
+            _ = tokio::time::sleep(deadline) => {
+                return limits
+                    .check(tokio::time::Instant::now())
+                    .err()
+                    .unwrap_or(StreamEnd::IdleTimeout);
+            }
+            inbound = next_iroh_frame(&mut link.recv) => {
+                let frame = match inbound {
+                    Ok(frame) => frame,
+                    Err(end) => return end,
+                };
+                match frame {
+                    CallerFrame::Close => return StreamEnd::Completed,
+                    CallerFrame::Resize { .. } => return StreamEnd::ProtocolViolation,
+                    CallerFrame::Stdin(bytes) => {
+                        if bytes.is_empty() {
+                            continue;
+                        }
+                        if let Err(end) =
+                            limits.record(bytes.len(), tokio::time::Instant::now())
+                        {
+                            return end;
+                        }
+                        if let Err(end) = bounded_io(
+                            target.write_all(&bytes),
+                            limits,
+                            &revoked,
+                            StreamEnd::TargetError,
+                        )
+                        .await
+                        {
+                            return end;
+                        }
+                    }
+                }
+            }
+            read = target.read(&mut buffer) => {
+                match read {
+                    Ok(0) => return StreamEnd::Completed,
+                    Ok(count) => {
+                        if let Err(end) = limits.record(count, tokio::time::Instant::now()) {
+                            return end;
+                        }
+                        if let Err(end) = bounded_io(
+                            send_iroh_channel(&mut link.send, CHANNEL_STDOUT, &buffer[..count]),
+                            limits,
+                            &revoked,
+                            StreamEnd::Completed,
+                        )
+                        .await
+                        {
+                            return end;
+                        }
+                    }
+                    Err(_) => return StreamEnd::TargetError,
                 }
             }
         }

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -9422,7 +9422,7 @@ pub(crate) mod tests {
         SandboxContainerResources, SandboxContainerSpec, SandboxExecutionCanary, SandboxIsolation,
         SandboxLeaseSpec, SandboxLeaseStatus, SandboxPoolReference, SandboxPoolSpec,
         SandboxPortSpec, SandboxPrincipal, SandboxReadinessRequirements, SandboxResourceQuantity,
-        SandboxTemplateSpec,
+        SandboxTemplateSpec, SandboxTransport,
     };
     use kube::api::ObjectMeta;
     use wiremock::matchers::{method, path, query_param};
@@ -9939,6 +9939,7 @@ pub(crate) mod tests {
                 max_ttl: "8h".into(),
                 provisioning_timeout: "10m".into(),
                 placement: SandboxPlacement::Management {},
+                transport: SandboxTransport::Direct,
                 template: SandboxTemplateSpec {
                     default_container: "agent".into(),
                     containers: vec![SandboxContainerSpec {

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -69,6 +69,14 @@ pub struct SandboxPoolSpec {
     /// placement mutually exclusive in both JSON and generated OpenAPI.
     pub placement: SandboxPlacement,
 
+    /// Data-plane transport for attach/exec/port-forward sessions (#197).
+    /// `direct` (default) is the current WebSocket path terminated at the API
+    /// server; `iroh` opts the pool into the P2P QUIC transport. Admission
+    /// rejects `iroh` where the operator has not enabled it — never silently
+    /// downgrades to `direct`.
+    #[serde(default)]
+    pub transport: SandboxTransport,
+
     /// Restricted template translated into the controller-owned upstream
     /// `SandboxTemplate`; this is intentionally not a `PodSpec` escape hatch.
     pub template: SandboxTemplateSpec,
@@ -211,6 +219,23 @@ impl SandboxPoolSpec {
 
         Ok(())
     }
+}
+
+/// Data-plane transport for a pool's attach/exec/port-forward sessions (#197).
+///
+/// The control plane (REST admission, scoped credentials) is unaffected: this
+/// only selects how session *bytes* move. `Direct` is the WebSocket path
+/// terminated at the API server; `Iroh` is P2P QUIC through the operator's
+/// iroh endpoint (public relay by default).
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, Default, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub enum SandboxTransport {
+    /// WebSocket sessions via the API server. The default.
+    #[default]
+    Direct,
+    /// P2P sessions via iroh. Requires the operator to have iroh enabled;
+    /// admission must reject this otherwise, never fall back to `Direct`.
+    Iroh,
 }
 
 /// Exactly one place in which a SandboxPool may be reconciled.
@@ -1188,6 +1213,7 @@ mod tests {
             max_ttl: "8h".into(),
             provisioning_timeout: "10m".into(),
             placement: SandboxPlacement::Management {},
+            transport: SandboxTransport::Direct,
             template: SandboxTemplateSpec {
                 default_container: "agent".into(),
                 containers: vec![SandboxContainerSpec {
@@ -1355,6 +1381,21 @@ mod tests {
             }))
             .is_err()
         );
+    }
+
+    #[test]
+    fn transport_defaults_to_direct_and_roundtrips() {
+        // Pre-#197 pools omit the field: they must keep working as `direct`.
+        assert_eq!(SandboxTransport::default(), SandboxTransport::Direct);
+        assert_eq!(
+            serde_json::from_value::<SandboxTransport>(serde_json::json!("direct")).unwrap(),
+            SandboxTransport::Direct
+        );
+        assert_eq!(
+            serde_json::from_value::<SandboxTransport>(serde_json::json!("iroh")).unwrap(),
+            SandboxTransport::Iroh
+        );
+        assert!(serde_json::from_value::<SandboxTransport>(serde_json::json!("quic")).is_err());
     }
 
     #[test]

--- a/src/iroh_transport.rs
+++ b/src/iroh_transport.rs
@@ -40,10 +40,11 @@ pub const KOBE_SANDBOX_ALPN: &[u8] = b"kobe-sandbox/1";
 
 /// Longest to wait for the endpoint to come online (home relay selected)
 /// before a session attempt fails explicitly rather than hanging.
+#[allow(dead_code)] // consumed by the session path (step 4, #197)
 pub const ENDPOINT_ONLINE_TIMEOUT: Duration = Duration::from_secs(30);
 
 /// How the operator endpoint reaches the relay network.
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq, Eq)]
 pub enum RelayConfig {
     /// Public n0 relays. The current default (#197: relay público por ahora).
     #[default]
@@ -51,6 +52,7 @@ pub enum RelayConfig {
     /// Operator-run relays, by URL.
     Custom(Vec<String>),
     /// No relays: direct UDP only. Fails behind NAT by construction.
+    #[allow(dead_code)] // constructed via KOBE_IROH_RELAY parsing follow-ups (step 4, #197)
     Disabled,
 }
 
@@ -84,6 +86,69 @@ pub struct IrohTransportConfig {
     pub secret_key: Option<SecretKey>,
 }
 
+/// Operator-side iroh enablement, parsed from `KOBE_IROH_RELAY`.
+///
+/// Fail-closed like [`crate::sandbox_runtime::parse_mode`]: an unrecognised
+/// value refuses startup rather than running an operator whose relays are not
+/// what the administrator wrote down.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IrohOperatorConfig {
+    /// No endpoint is bound. Pools requesting `iroh` transport are rejected
+    /// at admission — never silently served over WebSocket.
+    Disabled,
+    /// Bind the endpoint with these relays.
+    Enabled(RelayConfig),
+}
+
+/// Parse the configured relay selection without silently degrading bad input.
+///
+/// - `""` / `"public"` → public n0 relays (current default, #197).
+/// - `"disabled"` → no endpoint; `iroh` pools are refused.
+/// - anything else → comma-separated relay URLs for a self-hosted relay map.
+pub fn parse_operator_config(configured: &str) -> Result<IrohOperatorConfig, String> {
+    match configured.trim().to_ascii_lowercase().as_str() {
+        "" | "public" => Ok(IrohOperatorConfig::Enabled(RelayConfig::Public)),
+        "disabled" => Ok(IrohOperatorConfig::Disabled),
+        urls => {
+            let urls: Vec<String> = urls
+                .split(',')
+                .map(str::trim)
+                .filter(|part| !part.is_empty())
+                .map(str::to_string)
+                .collect();
+            if urls.is_empty() {
+                return Err(format!("invalid KOBE_IROH_RELAY value: {configured:?}"));
+            }
+            // Validate eagerly so a typo fails startup, not the first session.
+            for url in &urls {
+                url.parse::<iroh::RelayUrl>()
+                    .map_err(|_| format!("invalid iroh relay URL in KOBE_IROH_RELAY: {url:?}"))?;
+            }
+            Ok(IrohOperatorConfig::Enabled(RelayConfig::Custom(urls)))
+        }
+    }
+}
+
+/// Read the operator iroh configuration. Absence defaults to the public relay.
+pub fn operator_config_from_env() -> Result<IrohOperatorConfig, String> {
+    parse_operator_config(&std::env::var("KOBE_IROH_RELAY").unwrap_or_default())
+}
+
+/// Admission gate for `iroh` pools: the pool may only use the P2P transport
+/// when the operator actually bound an endpoint. Pure so both the HTTP path
+/// and tests share one decision.
+pub fn require_iroh_available(
+    transport: crate::crd::SandboxTransport,
+    endpoint_present: bool,
+) -> Result<(), &'static str> {
+    if transport == crate::crd::SandboxTransport::Iroh && !endpoint_present {
+        return Err(
+            "pool requests iroh transport but the operator has it disabled (KOBE_IROH_RELAY=disabled)",
+        );
+    }
+    Ok(())
+}
+
 /// Bind the operator endpoint: N0 preset, kobe ALPN, configured relays.
 ///
 /// Returns once bound; callers that need a home relay before accepting
@@ -102,6 +167,7 @@ pub async fn bind_endpoint(config: &IrohTransportConfig) -> Result<Endpoint> {
 ///
 /// An endpoint that never comes online must fail the session explicitly —
 /// the failure contract for admission (#101) has no room for a hang.
+#[allow(dead_code)] // consumed by the session path (step 4, #197)
 pub async fn wait_online(endpoint: &Endpoint) -> Result<()> {
     tokio::time::timeout(ENDPOINT_ONLINE_TIMEOUT, endpoint.online())
         .await
@@ -136,5 +202,42 @@ mod tests {
     #[test]
     fn alpn_is_versioned() {
         assert!(KOBE_SANDBOX_ALPN.ends_with(b"/1"));
+    }
+
+    #[test]
+    fn operator_config_defaults_to_public_relay() {
+        assert_eq!(
+            parse_operator_config("").unwrap(),
+            IrohOperatorConfig::Enabled(RelayConfig::Public)
+        );
+        assert_eq!(
+            parse_operator_config("public").unwrap(),
+            IrohOperatorConfig::Enabled(RelayConfig::Public)
+        );
+        assert_eq!(
+            parse_operator_config("disabled").unwrap(),
+            IrohOperatorConfig::Disabled
+        );
+    }
+
+    #[test]
+    fn operator_config_accepts_custom_relays_and_rejects_garbage() {
+        let parsed =
+            parse_operator_config("https://relay.example.com, https://relay2.example.com").unwrap();
+        assert!(matches!(
+            parsed,
+            IrohOperatorConfig::Enabled(RelayConfig::Custom(_))
+        ));
+        assert!(parse_operator_config("https://relay.example.com, !!!").is_err());
+        assert!(parse_operator_config(",,,").is_err());
+    }
+
+    #[test]
+    fn iroh_pool_requires_a_bound_endpoint() {
+        use crate::crd::SandboxTransport;
+        assert!(require_iroh_available(SandboxTransport::Direct, false).is_ok());
+        assert!(require_iroh_available(SandboxTransport::Direct, true).is_ok());
+        assert!(require_iroh_available(SandboxTransport::Iroh, true).is_ok());
+        assert!(require_iroh_available(SandboxTransport::Iroh, false).is_err());
     }
 }

--- a/src/iroh_transport.rs
+++ b/src/iroh_transport.rs
@@ -62,8 +62,9 @@ impl RelayConfig {
             RelayConfig::Custom(urls) => {
                 let map = iroh::RelayMap::empty();
                 for url in urls {
-                    let url: iroh::RelayUrl =
-                        url.parse().with_context(|| format!("invalid iroh relay URL: {url}"))?;
+                    let url: iroh::RelayUrl = url
+                        .parse()
+                        .with_context(|| format!("invalid iroh relay URL: {url}"))?;
                     let cfg = std::sync::Arc::new(iroh::RelayConfig::new(url.clone(), None));
                     map.insert(url, cfg);
                 }
@@ -94,10 +95,7 @@ pub async fn bind_endpoint(config: &IrohTransportConfig) -> Result<Endpoint> {
     if let Some(key) = &config.secret_key {
         builder = builder.secret_key(key.clone());
     }
-    builder
-        .bind()
-        .await
-        .context("bind iroh operator endpoint")
+    builder.bind().await.context("bind iroh operator endpoint")
 }
 
 /// Wait until the endpoint is online (usable for dial/accept), or time out.

--- a/src/iroh_transport.rs
+++ b/src/iroh_transport.rs
@@ -222,6 +222,27 @@ impl IrohOperatorConfig {
     }
 }
 
+/// How a caller reaches this replica's iroh endpoint.
+///
+/// Shown on lease list/get so `kobe status` can print the node ID without
+/// opening a session. The node ID is replica-local: another replica has a
+/// different one, and a restart currently mints a new key.
+#[derive(Debug, Clone, Serialize, PartialEq, Eq)]
+#[serde(rename_all = "camelCase")]
+pub struct IrohDial {
+    pub node_id: String,
+    pub relay: String,
+}
+
+impl IrohDial {
+    pub fn from_endpoint(endpoint: &Endpoint, relay: String) -> Self {
+        Self {
+            node_id: endpoint.id().to_string(),
+            relay,
+        }
+    }
+}
+
 /// What REST returns after minting a ticket. The client dials `node_id` with
 /// `alpn` and writes the decoded ticket as the first blob.
 #[derive(Debug, Clone, Serialize)]

--- a/src/iroh_transport.rs
+++ b/src/iroh_transport.rs
@@ -87,6 +87,9 @@ pub enum RelayConfig {
     /// Operator-run relays, by URL.
     Custom(Vec<String>),
     /// No relays: direct UDP only. Fails behind NAT by construction.
+    /// Constructed by tests and by a future `KOBE_IROH_RELAY` mapping; production
+    /// `"disabled"` currently means no endpoint at all (`IrohOperatorConfig`).
+    #[allow(dead_code)]
     Disabled,
 }
 
@@ -359,6 +362,7 @@ pub async fn read_blob<R: AsyncReadExt + Unpin>(
 }
 
 /// Write the raw ticket bytes as the first blob on a newly opened stream.
+#[cfg(test)]
 pub async fn write_ticket<W: AsyncWriteExt + Unpin>(
     writer: &mut W,
     ticket_hex: &str,

--- a/src/iroh_transport.rs
+++ b/src/iroh_transport.rs
@@ -2,7 +2,7 @@
 //!
 //! The control plane stays where it is: REST over axum, admission through the
 //! API server, scoped credentials through #81. Iroh only carries the *bytes*
-//! of attach/exec/port-forward sessions, and later the dial to child-cluster
+//! of attach/port-forward sessions, and later the dial to child-cluster
 //! apiservers, where direct L3 connectivity cannot reach (NATs).
 //!
 //! # Always compiled, activated per pool
@@ -11,6 +11,17 @@
 //! a session uses it is decided at runtime by `SandboxPool.spec.transport`
 //! (`direct` by default). Asking for `iroh` where the operator did not enable
 //! it is rejected at admission — never silently downgraded to WebSocket.
+//!
+//! # Session handshake
+//!
+//! A caller that wants bytes on an `iroh` pool first hits REST
+//! (`POST /v1/sandbox-leases/{id}/session`). That path does the same
+//! authorization and stream registration as the WebSocket upgrade, then
+//! returns a one-shot ticket plus this replica's node ID. The client dials
+//! iroh, writes the ticket as the first length-prefixed blob, and from then
+//! on the wire is the same channel-framed protocol as the WebSocket path.
+//! An unknown or reused ticket is dropped; it is never served over
+//! WebSocket instead.
 //!
 //! # Relay
 //!
@@ -23,14 +34,21 @@
 //!
 //! The operator endpoint keeps an ephemeral [`SecretKey`] for the spike. A
 //! stable identity persisted in a Secret is follow-up work: without it, every
-//! operator restart changes the node ID peers dial. Lease-scoped peer IDs are
-//! exchanged through the existing scoped-credential path (#81) and die with
-//! the lease TTL.
+//! operator restart changes the node ID peers dial. Session tickets are
+//! replica-local and die with [`TICKET_TTL`].
 
-use std::time::Duration;
+use std::collections::HashMap;
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
 
 use anyhow::{Context, Result};
+use iroh::endpoint::{Incoming, RecvStream, SendStream};
 use iroh::{Endpoint, RelayMode, SecretKey, endpoint::presets::N0};
+use rand::Rng;
+use serde::Serialize;
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::sync::oneshot;
+use tracing::warn;
 
 /// ALPN negotiated on every kobe↔sandbox iroh connection.
 ///
@@ -40,8 +58,25 @@ pub const KOBE_SANDBOX_ALPN: &[u8] = b"kobe-sandbox/1";
 
 /// Longest to wait for the endpoint to come online (home relay selected)
 /// before a session attempt fails explicitly rather than hanging.
-#[allow(dead_code)] // consumed by the session path (step 4, #197)
+#[allow(dead_code)] // used by callers that dial after bind (CLI, future session helpers)
 pub const ENDPOINT_ONLINE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How long a minted ticket is valid before the accept loop drops it.
+///
+/// Matches [`crate::api::sandbox_transport::STREAM_SETUP_TIMEOUT`]: a caller
+/// that cannot dial in that window has already lost the same race the
+/// WebSocket path would have lost opening the target stream.
+pub const TICKET_TTL: Duration = Duration::from_secs(30);
+
+/// Raw ticket size. The JSON offer hex-encodes these bytes.
+pub const TICKET_BYTES: usize = 32;
+
+/// Largest length-prefixed blob accepted on an iroh stream.
+///
+/// A WebSocket message is already bounded by the HTTP stack. QUIC is a byte
+/// stream, so this is the equivalent: a caller that announces a multi-megabyte
+/// frame is probing, not resizing a terminal.
+pub const MAX_BLOB_BYTES: usize = 1024 * 1024;
 
 /// How the operator endpoint reaches the relay network.
 #[derive(Debug, Clone, Default, PartialEq, Eq)]
@@ -52,7 +87,6 @@ pub enum RelayConfig {
     /// Operator-run relays, by URL.
     Custom(Vec<String>),
     /// No relays: direct UDP only. Fails behind NAT by construction.
-    #[allow(dead_code)] // constructed via KOBE_IROH_RELAY parsing follow-ups (step 4, #197)
     Disabled,
 }
 
@@ -167,11 +201,193 @@ pub async fn bind_endpoint(config: &IrohTransportConfig) -> Result<Endpoint> {
 ///
 /// An endpoint that never comes online must fail the session explicitly —
 /// the failure contract for admission (#101) has no room for a hang.
-#[allow(dead_code)] // consumed by the session path (step 4, #197)
+#[allow(dead_code)] // CLI dials wait on its own endpoint; operator accept does not.
 pub async fn wait_online(endpoint: &Endpoint) -> Result<()> {
     tokio::time::timeout(ENDPOINT_ONLINE_TIMEOUT, endpoint.online())
         .await
         .context("iroh endpoint did not come online in time")?;
+    Ok(())
+}
+
+impl IrohOperatorConfig {
+    /// Canonical relay string put in a session offer so the client builds the
+    /// same [`RelayMode`] the operator is using.
+    pub fn as_offer_string(&self) -> String {
+        match self {
+            Self::Disabled => "disabled".into(),
+            Self::Enabled(RelayConfig::Public) => "public".into(),
+            Self::Enabled(RelayConfig::Disabled) => "disabled".into(),
+            Self::Enabled(RelayConfig::Custom(urls)) => urls.join(","),
+        }
+    }
+}
+
+/// What REST returns after minting a ticket. The client dials `node_id` with
+/// `alpn` and writes the decoded ticket as the first blob.
+#[derive(Debug, Clone, Serialize)]
+#[serde(rename_all = "camelCase")]
+pub struct IrohSessionOffer {
+    pub transport: &'static str,
+    pub node_id: String,
+    pub ticket: String,
+    pub alpn: String,
+    pub relay: String,
+}
+
+impl IrohSessionOffer {
+    pub fn new(endpoint: &Endpoint, ticket: String, relay: String) -> Self {
+        Self {
+            transport: "iroh",
+            node_id: endpoint.id().to_string(),
+            ticket,
+            alpn: String::from_utf8_lossy(KOBE_SANDBOX_ALPN).into_owned(),
+            relay,
+        }
+    }
+}
+
+/// One accepted iroh stream, handed from the accept loop to the REST waiter.
+pub struct IrohLink {
+    pub send: SendStream,
+    pub recv: RecvStream,
+}
+
+struct PendingTicket {
+    tx: oneshot::Sender<IrohLink>,
+    inserted: Instant,
+}
+
+/// Replica-local ticket map. Tickets never leave this process: another replica
+/// has a different node ID, so a ticket minted here is useless there.
+#[derive(Clone, Default)]
+pub struct IrohSessionHub {
+    inner: Arc<Mutex<HashMap<String, PendingTicket>>>,
+}
+
+impl IrohSessionHub {
+    /// Mint a single-use ticket. The receiver completes when the accept loop
+    /// claims it, or when [`TICKET_TTL`] elapses and the sender is dropped.
+    pub fn mint(&self) -> (String, oneshot::Receiver<IrohLink>) {
+        let mut bytes = [0u8; TICKET_BYTES];
+        rand::rng().fill(&mut bytes);
+        let ticket = hex::encode(bytes);
+        let (tx, rx) = oneshot::channel();
+        let mut map = self.inner.lock().expect("iroh session hub lock");
+        Self::gc_locked(&mut map);
+        map.insert(
+            ticket.clone(),
+            PendingTicket {
+                tx,
+                inserted: Instant::now(),
+            },
+        );
+        (ticket, rx)
+    }
+
+    /// Take the waiter for `ticket`, if it is still pending and unexpired.
+    pub fn claim(&self, ticket: &str) -> Option<oneshot::Sender<IrohLink>> {
+        let mut map = self.inner.lock().expect("iroh session hub lock");
+        Self::gc_locked(&mut map);
+        map.remove(ticket).map(|pending| pending.tx)
+    }
+
+    fn gc_locked(map: &mut HashMap<String, PendingTicket>) {
+        let now = Instant::now();
+        map.retain(|_, pending| now.duration_since(pending.inserted) < TICKET_TTL);
+    }
+}
+
+/// Write one length-prefixed blob. First blob on a session is the raw ticket;
+/// later blobs are `[channel][payload]` matching the WebSocket frames.
+pub async fn write_blob<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    data: &[u8],
+) -> std::io::Result<()> {
+    if data.len() > MAX_BLOB_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidInput,
+            "iroh blob exceeds MAX_BLOB_BYTES",
+        ));
+    }
+    let len = u32::try_from(data.len()).expect("len fits u32");
+    writer.write_all(&len.to_be_bytes()).await?;
+    writer.write_all(data).await?;
+    writer.flush().await
+}
+
+/// Read one length-prefixed blob, or `None` on a clean EOF before any bytes.
+pub async fn read_blob<R: AsyncReadExt + Unpin>(
+    reader: &mut R,
+) -> Result<Option<Vec<u8>>, std::io::Error> {
+    let mut len_buf = [0u8; 4];
+    match reader.read_exact(&mut len_buf).await {
+        Ok(_) => {}
+        Err(err) if err.kind() == std::io::ErrorKind::UnexpectedEof => return Ok(None),
+        Err(err) => return Err(err),
+    }
+    let len = u32::from_be_bytes(len_buf) as usize;
+    if len == 0 || len > MAX_BLOB_BYTES {
+        return Err(std::io::Error::new(
+            std::io::ErrorKind::InvalidData,
+            "iroh blob length is not a usable frame",
+        ));
+    }
+    let mut data = vec![0u8; len];
+    reader.read_exact(&mut data).await?;
+    Ok(Some(data))
+}
+
+/// Write the raw ticket bytes as the first blob on a newly opened stream.
+pub async fn write_ticket<W: AsyncWriteExt + Unpin>(
+    writer: &mut W,
+    ticket_hex: &str,
+) -> Result<(), String> {
+    let bytes = hex::decode(ticket_hex).map_err(|_| "ticket is not hex".to_string())?;
+    if bytes.len() != TICKET_BYTES {
+        return Err("ticket has the wrong length".into());
+    }
+    write_blob(writer, &bytes)
+        .await
+        .map_err(|err| err.to_string())
+}
+
+/// Accept incoming iroh connections until the endpoint closes.
+///
+/// Each connection is expected to open one bi-stream and write a ticket as
+/// the first blob. Unknown tickets are dropped rather than mapped onto the
+/// WebSocket path.
+pub async fn accept_loop(endpoint: Endpoint, sessions: IrohSessionHub) {
+    loop {
+        let Some(incoming) = endpoint.accept().await else {
+            break;
+        };
+        let sessions = sessions.clone();
+        tokio::spawn(async move {
+            if let Err(err) = accept_one(incoming, &sessions).await {
+                warn!(error = %err, "iroh accept failed");
+            }
+        });
+    }
+}
+
+async fn accept_one(incoming: Incoming, sessions: &IrohSessionHub) -> Result<()> {
+    let conn = incoming.await.context("iroh handshake failed")?;
+    let (send, mut recv) = conn.accept_bi().await.context("iroh accept_bi failed")?;
+    let Some(blob) = read_blob(&mut recv).await.context("read iroh ticket")? else {
+        return Ok(());
+    };
+    if blob.len() != TICKET_BYTES {
+        anyhow::bail!("iroh ticket blob has the wrong length");
+    }
+    let ticket = hex::encode(&blob);
+    match sessions.claim(&ticket) {
+        Some(tx) => {
+            let _ = tx.send(IrohLink { send, recv });
+        }
+        None => {
+            warn!("iroh connection presented an unknown or expired ticket");
+        }
+    }
     Ok(())
 }
 
@@ -239,5 +455,65 @@ mod tests {
         assert!(require_iroh_available(SandboxTransport::Direct, true).is_ok());
         assert!(require_iroh_available(SandboxTransport::Iroh, true).is_ok());
         assert!(require_iroh_available(SandboxTransport::Iroh, false).is_err());
+    }
+
+    #[test]
+    fn a_ticket_is_claimed_once_and_unknown_tickets_are_dropped() {
+        let hub = IrohSessionHub::default();
+        let (ticket, mut rx) = hub.mint();
+        assert!(hub.claim("not-a-ticket").is_none());
+        let tx = hub.claim(&ticket).expect("fresh ticket is claimable");
+        assert!(hub.claim(&ticket).is_none(), "a ticket is single-use");
+        drop(tx);
+        assert!(rx.try_recv().is_err());
+    }
+
+    #[tokio::test]
+    async fn length_prefixed_blobs_round_trip() {
+        let (mut writer, mut reader) = tokio::io::duplex(128);
+        write_blob(&mut writer, b"hello").await.unwrap();
+        let got = read_blob(&mut reader).await.unwrap().unwrap();
+        assert_eq!(got, b"hello");
+    }
+
+    /// Two endpoints on this host, no relay: a minted ticket becomes a live
+    /// stream the waiter can read.
+    #[tokio::test]
+    async fn a_ticket_opens_an_iroh_stream_between_two_endpoints() {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let config = IrohTransportConfig {
+            relay: RelayConfig::Disabled,
+            secret_key: None,
+        };
+        let server = bind_endpoint(&config).await.expect("bind server");
+        let client = bind_endpoint(&config).await.expect("bind client");
+        let hub = IrohSessionHub::default();
+        let (ticket, rx) = hub.mint();
+
+        let accept = tokio::spawn(accept_loop(server.clone(), hub));
+        let conn = client
+            .connect(server.addr(), KOBE_SANDBOX_ALPN)
+            .await
+            .expect("dial");
+        let (mut send, _recv) = conn.open_bi().await.expect("open_bi");
+        write_ticket(&mut send, &ticket)
+            .await
+            .expect("write ticket");
+
+        let mut link = tokio::time::timeout(Duration::from_secs(5), rx)
+            .await
+            .expect("ticket claimed in time")
+            .expect("sender still live");
+        write_blob(&mut send, &[1, b'x']).await.expect("frame");
+        let got = tokio::time::timeout(Duration::from_secs(5), read_blob(&mut link.recv))
+            .await
+            .expect("frame arrived")
+            .expect("readable")
+            .expect("not eof");
+        assert_eq!(got, vec![1, b'x']);
+
+        client.close().await;
+        server.close().await;
+        let _ = accept.await;
     }
 }

--- a/src/iroh_transport.rs
+++ b/src/iroh_transport.rs
@@ -1,0 +1,142 @@
+//! Optional P2P data-plane transport for Sandbox operations (#197).
+//!
+//! The control plane stays where it is: REST over axum, admission through the
+//! API server, scoped credentials through #81. Iroh only carries the *bytes*
+//! of attach/exec/port-forward sessions, and later the dial to child-cluster
+//! apiservers, where direct L3 connectivity cannot reach (NATs).
+//!
+//! # Always compiled, activated per pool
+//!
+//! The binary always contains iroh (plain dependency, no Cargo feature). Whether
+//! a session uses it is decided at runtime by `SandboxPool.spec.transport`
+//! (`direct` by default). Asking for `iroh` where the operator did not enable
+//! it is rejected at admission — never silently downgraded to WebSocket.
+//!
+//! # Relay
+//!
+//! Default is the public n0 relay ([`RelayMode::Default`]); traffic is
+//! end-to-end encrypted QUIC, so a relay observes metadata only (addresses,
+//! timing), never session bytes. A self-hosted relay is a config change
+//! ([`RelayMode::Custom`]), not a protocol change.
+//!
+//! # Identity
+//!
+//! The operator endpoint keeps an ephemeral [`SecretKey`] for the spike. A
+//! stable identity persisted in a Secret is follow-up work: without it, every
+//! operator restart changes the node ID peers dial. Lease-scoped peer IDs are
+//! exchanged through the existing scoped-credential path (#81) and die with
+//! the lease TTL.
+
+use std::time::Duration;
+
+use anyhow::{Context, Result};
+use iroh::{Endpoint, RelayMode, SecretKey, endpoint::presets::N0};
+
+/// ALPN negotiated on every kobe↔sandbox iroh connection.
+///
+/// Versioned so a future wire change fails at the handshake instead of
+/// misreading a stream.
+pub const KOBE_SANDBOX_ALPN: &[u8] = b"kobe-sandbox/1";
+
+/// Longest to wait for the endpoint to come online (home relay selected)
+/// before a session attempt fails explicitly rather than hanging.
+pub const ENDPOINT_ONLINE_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// How the operator endpoint reaches the relay network.
+#[derive(Debug, Clone, Default)]
+pub enum RelayConfig {
+    /// Public n0 relays. The current default (#197: relay público por ahora).
+    #[default]
+    Public,
+    /// Operator-run relays, by URL.
+    Custom(Vec<String>),
+    /// No relays: direct UDP only. Fails behind NAT by construction.
+    Disabled,
+}
+
+impl RelayConfig {
+    fn relay_mode(&self) -> Result<RelayMode> {
+        match self {
+            RelayConfig::Public => Ok(RelayMode::Default),
+            RelayConfig::Disabled => Ok(RelayMode::Disabled),
+            RelayConfig::Custom(urls) => {
+                let map = iroh::RelayMap::empty();
+                for url in urls {
+                    let url: iroh::RelayUrl =
+                        url.parse().with_context(|| format!("invalid iroh relay URL: {url}"))?;
+                    let cfg = std::sync::Arc::new(iroh::RelayConfig::new(url.clone(), None));
+                    map.insert(url, cfg);
+                }
+                Ok(RelayMode::Custom(map))
+            }
+        }
+    }
+}
+
+/// Configuration for the operator-side iroh endpoint.
+#[derive(Debug, Clone, Default)]
+pub struct IrohTransportConfig {
+    /// Relay selection. Default is the public relay.
+    pub relay: RelayConfig,
+    /// Stable identity. `None` generates an ephemeral key (spike behavior);
+    /// production should load this from a Secret so restarts keep the node ID.
+    pub secret_key: Option<SecretKey>,
+}
+
+/// Bind the operator endpoint: N0 preset, kobe ALPN, configured relays.
+///
+/// Returns once bound; callers that need a home relay before accepting
+/// sessions should additionally await [`wait_online`].
+pub async fn bind_endpoint(config: &IrohTransportConfig) -> Result<Endpoint> {
+    let mut builder = Endpoint::builder(N0)
+        .alpns(vec![KOBE_SANDBOX_ALPN.to_vec()])
+        .relay_mode(config.relay.relay_mode()?);
+    if let Some(key) = &config.secret_key {
+        builder = builder.secret_key(key.clone());
+    }
+    builder
+        .bind()
+        .await
+        .context("bind iroh operator endpoint")
+}
+
+/// Wait until the endpoint is online (usable for dial/accept), or time out.
+///
+/// An endpoint that never comes online must fail the session explicitly —
+/// the failure contract for admission (#101) has no room for a hang.
+pub async fn wait_online(endpoint: &Endpoint) -> Result<()> {
+    tokio::time::timeout(ENDPOINT_ONLINE_TIMEOUT, endpoint.online())
+        .await
+        .context("iroh endpoint did not come online in time")?;
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn public_relay_is_default() {
+        assert!(matches!(
+            IrohTransportConfig::default().relay,
+            RelayConfig::Public
+        ));
+    }
+
+    #[test]
+    fn disabled_maps_to_disabled_mode() {
+        let mode = RelayConfig::Disabled.relay_mode().unwrap();
+        assert!(matches!(mode, RelayMode::Disabled));
+    }
+
+    #[test]
+    fn custom_relay_rejects_garbage_url() {
+        let cfg = RelayConfig::Custom(vec!["not a url at all !!!".to_string()]);
+        assert!(cfg.relay_mode().is_err());
+    }
+
+    #[test]
+    fn alpn_is_versioned() {
+        assert!(KOBE_SANDBOX_ALPN.ends_with(b"/1"));
+    }
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -371,6 +371,7 @@ async fn run() -> anyhow::Result<()> {
     };
 
     // ── Start HTTP server immediately (all replicas serve API + health) ──
+    let iroh_sessions = crate::iroh_transport::IrohSessionHub::default();
     let state = AppState {
         client: client.clone(),
         authenticator: authenticator.clone(),
@@ -385,11 +386,17 @@ async fn run() -> anyhow::Result<()> {
         shutdown: shutdown.clone(),
         sandbox_enabled: agent_sandbox_mode.enabled(),
         iroh_endpoint: iroh_endpoint.clone(),
+        iroh_sessions: iroh_sessions.clone(),
     };
 
     // Close the iroh endpoint once shutdown starts so P2P sessions drain with
-    // the HTTP server instead of outliving the process.
+    // the HTTP server instead of outliving the process. The accept loop
+    // returns when `close` makes `accept()` yield `None`.
     if let Some(endpoint) = iroh_endpoint {
+        tokio::spawn(crate::iroh_transport::accept_loop(
+            endpoint.clone(),
+            iroh_sessions,
+        ));
         let shutdown_signal = shutdown.clone();
         tokio::spawn(async move {
             shutdown_signal.cancelled().await;

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ mod backend;
 mod controllers;
 mod crd;
 mod diagnostics;
+mod iroh_transport;
 mod lease_binding;
 mod metrics;
 pub mod pki;

--- a/src/main.rs
+++ b/src/main.rs
@@ -209,6 +209,38 @@ async fn run() -> anyhow::Result<()> {
         );
         std::process::exit(1);
     }
+    // Iroh P2P data-plane endpoint (#197). Config is refused at STARTUP for the
+    // same reason as the Agent Sandbox mode above: a misconfigured relay must
+    // fail boot, not the first iroh session. Default is the public relay;
+    // `disabled` binds nothing and makes iroh pools inadmissible. A bind
+    // failure degrades to no-endpoint (direct pools keep working; iroh pools
+    // are refused explicitly at admission) rather than killing the operator.
+    let iroh_endpoint = match crate::iroh_transport::operator_config_from_env() {
+        Err(reason) => {
+            error!(reason = %reason, "invalid KOBE_IROH_RELAY");
+            std::process::exit(1);
+        }
+        Ok(crate::iroh_transport::IrohOperatorConfig::Disabled) => {
+            info!("iroh transport disabled; pools requesting iroh will be refused");
+            None
+        }
+        Ok(crate::iroh_transport::IrohOperatorConfig::Enabled(relay)) => {
+            let config = crate::iroh_transport::IrohTransportConfig {
+                relay,
+                secret_key: None,
+            };
+            match crate::iroh_transport::bind_endpoint(&config).await {
+                Ok(endpoint) => {
+                    info!(node_id = %endpoint.id(), "iroh operator endpoint bound");
+                    Some(endpoint)
+                }
+                Err(err) => {
+                    error!(error = %err, "iroh endpoint bind failed; iroh pools will be refused");
+                    None
+                }
+            }
+        }
+    };
     if agent_sandbox_mode.enabled() {
         let policy_name = match std::env::var("KOBE_SANDBOX_LEDGER_POLICY_NAME") {
             Ok(value) if crate::pool::is_valid_k8s_name(&value) => value,
@@ -352,7 +384,18 @@ async fn run() -> anyhow::Result<()> {
         sandbox_admission_limiter: Default::default(),
         shutdown: shutdown.clone(),
         sandbox_enabled: agent_sandbox_mode.enabled(),
+        iroh_endpoint: iroh_endpoint.clone(),
     };
+
+    // Close the iroh endpoint once shutdown starts so P2P sessions drain with
+    // the HTTP server instead of outliving the process.
+    if let Some(endpoint) = iroh_endpoint {
+        let shutdown_signal = shutdown.clone();
+        tokio::spawn(async move {
+            shutdown_signal.cancelled().await;
+            endpoint.close().await;
+        });
+    }
 
     let app = build_router(state);
     let bind_addr = std::env::var("BIND_ADDR").unwrap_or_else(|_| "0.0.0.0:8080".into());

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -1362,7 +1362,7 @@ mod tests {
     use crate::crd::{
         SandboxCondition, SandboxContainerResources, SandboxContainerSpec, SandboxExecutionCanary,
         SandboxIsolation, SandboxPlacement, SandboxPoolStatus, SandboxPortSpec,
-        SandboxReadinessRequirements, SandboxResourceQuantity,
+        SandboxReadinessRequirements, SandboxResourceQuantity, SandboxTransport,
     };
 
     fn quantity(cpu: &str, memory: &str, ephemeral_storage: &str) -> SandboxResourceQuantity {
@@ -1380,6 +1380,7 @@ mod tests {
             max_ttl: "8h".into(),
             provisioning_timeout: "10m".into(),
             placement: SandboxPlacement::Management {},
+            transport: SandboxTransport::Direct,
             template: SandboxTemplateSpec {
                 default_container: "agent".into(),
                 containers: vec![SandboxContainerSpec {


### PR DESCRIPTION
Towards #197 phase (a). Iroh is always in the binary; a pool opts in with `spec.transport: iroh`. Attach and port-forward then take a parallel path: REST mints a one-shot ticket, `kobe attach` / `port-forward` dial this replica, bytes use the same channel framing and limits as WebSocket. Direct pools are unchanged. Asking for iroh with no operator endpoint is a 503, not a silent WebSocket.

## What this does

- `SandboxPool.spec.transport: direct | iroh` (default `direct`)
- Operator endpoint from `KOBE_IROH_RELAY` (Helm `agentSandbox.irohRelay`, default public)
- `POST /v1/sandbox-leases/{id}/session` returns `{ nodeId, ticket, relay }`
- CLI dials iroh when list/get say `transport: iroh`
- List/get publish this replica's node ID so you can see the address without opening a session
- WebSocket against an iroh pool is 409 `iroh_transport`

`kobe exec` stays on HTTP.

## Not in this PR

Tracked on #197: stable operator identity (Secret), identity shared across replicas, snapshot of `transport` on the lease, a real attach behind NAT, conformance (#76), child-cluster link, connect-proxy.

## Test plan

- [x] `iroh_transport` unit tests, including two endpoints on this host with no relay
- [x] admission: iroh pool without endpoint is refused; WebSocket on iroh is 409
- [x] list summaries include node ID only for iroh pools
- [x] `sandbox_cli` attach/port-forward still pass on direct
- [ ] CI `Rust Checks`