### PR TITLE
fix(sandbox): a receipt with nothing recorded yet is not a mismatch

### DIFF
--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -5638,7 +5638,26 @@ async fn release_child_composition(
                             })
                         })
                         || unbound_child_release_is_proven(&unrecorded, recorded_instance);
-                if unrecorded_status.teardown_receipt.is_some() && !proof_is_exact {
+                // A receipt is only a mismatch once there is something to
+                // check it against. A handle that bound before the outer
+                // Sandbox checkpointed its pool and instance has no recorded
+                // identity yet, and cancelling while provisioning is how that
+                // window is reached: teardown produces a receipt, the
+                // checkpoint never happened.
+                //
+                // The recovery below is written for exactly that handle. It
+                // resolves the pool and instance from the reciprocal binding,
+                // never from the receipt, checkpoints them and returns, and
+                // the recorded path revalidates the receipt on the next pass
+                // with the exact identities in hand. Quarantining here makes
+                // that recovery unreachable and withholds capacity for a
+                // handle that was never in doubt.
+                let identity_is_recoverable = unrecorded_status.binding.is_some()
+                    && !(recorded_pool.is_some() && recorded_instance.is_some());
+                if unrecorded_status.teardown_receipt.is_some()
+                    && !proof_is_exact
+                    && !identity_is_recoverable
+                {
                     return quarantine_lease(lease, ctx, "child_receipt_does_not_match").await;
                 }
 
@@ -17075,6 +17094,77 @@ current-context: child
             .rev()
             .find_map(status_value_of)
             .expect("complete child recovery checkpoint");
+        assert_eq!(
+            checkpoint["target"]["childClusterLease"]["uid"],
+            "child-lease-uid"
+        );
+        assert_eq!(
+            checkpoint["target"]["childClusterInstance"]["uid"],
+            "child-instance-uid"
+        );
+        assert_eq!(
+            checkpoint["placement"]["clusterPool"]["uid"],
+            "cluster-pool-uid"
+        );
+    }
+
+    /// A receipt does not make the recovery above unreachable.
+    ///
+    /// Cancelling while provisioning reaches a window where the child bound
+    /// and tore down — leaving a receipt — before the outer Sandbox ever
+    /// checkpointed the pool and instance that receipt has to be validated
+    /// against. `validated_child_receipt_token` deliberately reconstructs no
+    /// expected field from the receipt itself, so with nothing recorded it
+    /// cannot match, and the pre-proof path quarantined on that alone.
+    ///
+    /// The identities are recoverable from the reciprocal binding, which is
+    /// what the recovery does, and the recorded path revalidates the receipt
+    /// on the next pass with them in hand. Quarantining first only withheld
+    /// the pool slot forever.
+    ///
+    /// The nightly caught this as
+    /// `cancelling_while_provisioning_leaves_nothing_behind` quarantining with
+    /// `child_receipt_does_not_match`.
+    #[tokio::test]
+    async fn an_unrecorded_child_receipt_recovers_identity_before_it_can_mismatch() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        Mock::given(method("GET"))
+            .and(path(CLUSTER_LEASE_PATH))
+            .respond_with(
+                ResponseTemplate::new(200).set_body_json(child_cluster_lease(
+                    "child-lease-uid",
+                    "Recycling",
+                    Some(verified_receipt("kobe-abc123", "child-instance-uid")),
+                )),
+            )
+            .mount(&server)
+            .await;
+
+        let mut lease = child_placed_lease("child-lease-uid");
+        let status = lease.status.as_mut().unwrap();
+        status.phase = crate::crd::SandboxLeasePhase::Releasing;
+        status.release_cause = Some(crate::crd::SandboxReleaseCause::Requested);
+        // The window this test exists for: torn down, never checkpointed.
+        status.placement = None;
+        status.target = None;
+
+        assert_eq!(
+            reconcile_lease(Arc::new(lease), ctx).await.unwrap(),
+            Action::await_change()
+        );
+        let checkpoint = server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .rev()
+            .find_map(status_value_of)
+            .expect("complete child recovery checkpoint");
+        assert_ne!(
+            checkpoint["phase"], "Quarantined",
+            "a receipt that has nothing recorded to match yet is not a mismatch"
+        );
         assert_eq!(
             checkpoint["target"]["childClusterLease"]["uid"],
             "child-lease-uid"


### PR DESCRIPTION
## The failure

The nightly has failed twice on `cancelling_while_provisioning_leaves_nothing_behind`, both times identically:

```
CleanupVerified=False  reason=child_receipt_does_not_match
phase: Quarantined     release_cause: Requested
```

This is the fourth distinct cause behind that one test, after the 503, the absence-proof gap, and the terminating-handle case fixed in #192.

It only appears on the nightly. The same commit passes the leg on push:

| commit | trigger | conformance (k3s) |
|---|---|---|
| `93ec1b0` | push | success |
| `93ec1b0` | schedule | **failure** |
| `93ec1b0` | tag `v0.42.1` | success |
| `72cce57` | dispatch | success |
| `72cce57` | schedule | **failure** |

## Why it happens

Cancelling while provisioning reaches a window where the child bound and tore down, leaving a receipt, before the outer Sandbox ever checkpointed the pool and instance that receipt must be validated against.

`validated_child_receipt_token` reconstructs no expected field from the receipt. That is deliberate and load-bearing — the outer Sandbox supplies the identities it checkpointed, so a forged receipt cannot self-certify. With nothing recorded, validation cannot succeed:

```rust
let proof_is_exact = unrecorded_status.teardown_receipt.as_ref().is_some_and(|receipt| {
    recorded_pool.is_some_and(|pool| { ... })   // recorded_pool is None here
}) || unbound_child_release_is_proven(&unrecorded, recorded_instance);  // it did bind

if unrecorded_status.teardown_receipt.is_some() && !proof_is_exact {
    return quarantine_lease(lease, ctx, "child_receipt_does_not_match").await;
}
```

The recovery immediately below is written for exactly this handle — *"A bound pre-checkpoint handle is not safe to describe from its display name. Recover the reciprocal lease, instance, and pool tuple first."* It resolves the identities via `resolve_lease_binding`, never from the receipt, checkpoints them, and returns `await_change()`. The next pass takes the recorded path and validates the receipt strictly.

The quarantine returned first, so that recovery was unreachable whenever a receipt existed. The slot was withheld forever for a handle that was never in doubt.

## The change

Quarantine only when the identities are already known, or when there is no binding to recover them from:

```rust
let identity_is_recoverable = unrecorded_status.binding.is_some()
    && !(recorded_pool.is_some() && recorded_instance.is_some());
if unrecorded_status.teardown_receipt.is_some() && !proof_is_exact && !identity_is_recoverable {
    return quarantine_lease(lease, ctx, "child_receipt_does_not_match").await;
}
```

## What is not weakened

- The recorded path (the second `child_receipt_does_not_match` site) is untouched. That is where enforcement belongs, and it has every identity in hand.
- Recovery derives identity from the reciprocal binding only. The receipt is never a source of expected values.
- The handle is already proven this lease's own before reaching here: `ensure_internal_lease_fenced` quarantines a Foreign handle, and the recovery quarantines on a generation change.
- Falling through delays validation by one reconcile; it does not skip it.

## Test

`an_unrecorded_child_receipt_recovers_identity_before_it_can_mismatch` drives the window directly, since the conformance test only reaches it under nightly timing.

Verified it fails without the fix — quarantine's 300s requeue instead of the recovery's `await_change()`:

```
left: Action { requeue_after: Some(300s) }
right: Action { requeue_after: None }
```

`cargo test --bin kobe-operator`: 1441 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` both clean.

## Note on v0.42.1

Already released and published. It carries #192's fix and not this one; this failure mode predates it and is conservative — a withheld slot, not lost data.