### PR TITLE
fix(vcluster): hold what the syncer Role grants, and show the denial

### DIFF
--- a/charts/kobe/templates/rbac.yaml
+++ b/charts/kobe/templates/rbac.yaml
@@ -119,15 +119,37 @@ rules:
   # boundary, including the readiness canary, which runs under this identity —
   # a failure no unit test can see, because RBAC and that gate only apply
   # against a real apiserver.
+  #
+  # The remaining verbs are held to be DELEGATED, not used. The vcluster chart
+  # creates a Role granting its syncer the full set on these subresources, and
+  # RBAC escalation prevention refuses any rule the installer does not itself
+  # hold. The operator installs that release under this identity, so a verb
+  # missing here fails the whole `helm install` — which is what left the
+  # vcluster conformance leg red. `delete`, `patch`, `update`, `list` and
+  # `watch` have no meaning the apiserver acts on for a connection
+  # subresource; `get` and `create` above are the capability.
   - apiGroups: [""]
     resources: ["pods/exec", "pods/attach", "pods/portforward"]
-    verbs: ["get", "create"]
+    verbs: ["get", "create", "delete", "patch", "update", "list", "watch"]
   # Sandbox log reads (#81). Separate from `pods` above because `pods/log` is
   # its own resource to RBAC — and worth stating explicitly: this is the verb
   # that lets the operator return a workload's own output to its lease holder.
+  # `list` and `watch` are delegation-only, for the same vcluster Role.
   - apiGroups: [""]
     resources: ["pods/log"]
-    verbs: ["get"]
+    verbs: ["get", "list", "watch"]
+  # Delegation-only, and the one grant here that is a real capability rather
+  # than a formality: `pods/ephemeralcontainers` permits attaching a debug
+  # container to a running Pod, and `pods/resize` permits in-place resource
+  # changes. The operator calls neither. Both are in the Role the vcluster
+  # chart creates, so it cannot install without holding them.
+  #
+  # They are namespaced to wherever this ClusterRole is bound, so the bound
+  # scope is the bound on this. Dropping `vcluster` from the supported
+  # backends is what it would take to drop these.
+  - apiGroups: [""]
+    resources: ["pods/ephemeralcontainers", "pods/resize"]
+    verbs: ["patch", "update"]
   # Per-lease scoped credentials (#81). Kobe mints a ServiceAccount whose Role
   # names exactly one Pod, then a short-lived token for it, and reaches the
   # tenant's Sandbox as THAT identity rather than as itself.
@@ -158,6 +180,22 @@ rules:
   - apiGroups: ["apps"]
     resources: ["deployments", "statefulsets"]
     verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  # The rest of what the vcluster syncer's Role names, held only so the
+  # operator can create that Role. RBAC escalation prevention refuses any rule
+  # the installer does not hold itself, and the check is per verb per resource,
+  # so one gap fails the entire `helm install`.
+  #
+  # `events.k8s.io` is a separate API group from the core `events` above, and
+  # holding one says nothing about the other.
+  - apiGroups: ["apps"]
+    resources: ["replicasets"]
+    verbs: ["get", "list", "watch", "patch", "update"]
+  - apiGroups: ["discovery.k8s.io"]
+    resources: ["endpointslices"]
+    verbs: ["get", "list", "watch", "create", "update", "patch", "delete"]
+  - apiGroups: ["events.k8s.io"]
+    resources: ["events"]
+    verbs: ["get", "list", "watch", "create"]
   # PodDisruptionBudgets — the k3s backend creates a PDB for HA control
   # planes (servers>1) and deletes it on every recycle. Without these verbs
   # the recycle loop's `delete()` fails with 403 Forbidden (RBAC is checked

--- a/src/backend/vcluster.rs
+++ b/src/backend/vcluster.rs
@@ -206,7 +206,14 @@ const HELM_REPO_ALIAS: &str = "kobe-loft-sh";
 /// reads helm's stderr in full before this applies. That is acceptable here
 /// because helm is a trusted local binary whose diagnostics are small; it is
 /// not a defence against a hostile subprocess.
-const HELM_STDERR_LIMIT: usize = 800;
+///
+/// 800 was too small for the errors that matter most. An RBAC escalation
+/// denial enumerates every rule the installer may not grant, one per line,
+/// and helm reports several such errors together — the vcluster conformance
+/// leg failed for three weeks on a message that was cut off partway through
+/// the first of two. Sizing this to hold that class of failure whole is the
+/// difference between a diagnosis and a rerun.
+const HELM_STDERR_LIMIT: usize = 4000;
 
 /// Describe how a process ended, without asserting an exit code it may not have.
 ///


### PR DESCRIPTION
## The failure

The vcluster leg has been red since mid-August. Every member fails, the pool sits in `Failing`, the lease queues forever:

```
No ready cluster, lease queued at position 1: no Ready cluster;
pool e2e-vcluster phase=Failing, consecutiveFailures=9,
lastFailureReason=9 instance(s) not reaching Ready
```

`helm install` fails before anything is created:

```
roles.rbac.authorization.k8s.io "vc-pool-e2e-vcluster-5" is forbidden:
user "system:serviceaccount:kobe-system:kobe" is attempting to grant
RBAC permissions not currently held:
{APIGroups:[""], Resources:["pods/attach"], Verbs:["delete" "patch" "update" "list" "watch"]}
{APIGroups:[""], Resources:["pods/ephemeralcontainers"], Verbs:["patch" "update"]}
...
```

RBAC escalation prevention refuses any rule the installer does not hold itself, checked per verb per resource. The operator installs the release under its own identity, so a single gap fails the whole install.

## The complete set

Templating chart `0.34.0` with the values the backend actually sets — snapshot rules off, as #184 left them — and diffing against the rendered kobe ClusterRole:

| group | resource | missing verbs |
|---|---|---|
| `""` | `pods/exec`, `pods/attach`, `pods/portforward` | delete, patch, update, list, watch |
| `""` | `pods/log` | list, watch |
| `""` | `pods/ephemeralcontainers`, `pods/resize` | patch, update |
| `apps` | `replicasets` | get, list, watch, patch, update |
| `discovery.k8s.io` | `endpointslices` | create, delete, get, list, patch, update, watch |
| `events.k8s.io` | `events` | create, get, list, watch |

`events.k8s.io` is a different API group from the core `events` already held; holding one says nothing about the other. That, and the `apps`/`discovery.k8s.io` rules, are almost certainly the second of the two errors helm reported — which no run has ever shown, see below.

## What is actually being granted

Most of it is formality. `delete`, `patch`, `update`, `list` and `watch` have no meaning the apiserver acts on for a connection subresource; `get` and `create` on exec/attach/portforward were already held and are the real capability.

**`pods/ephemeralcontainers: patch, update` is the exception and is a genuine capability increase** — it permits attaching a debug container to a running Pod. The operator calls it never; it holds it so it can create the Role. The grant is namespaced to wherever this ClusterRole is bound, so the bound scope bounds it. Dropping the `vcluster` backend is what it would take to drop it.

Flagging it rather than burying it: this widens the operator's authority to satisfy an upstream chart.

## Why it took three weeks

`HELM_STDERR_LIMIT` was 800 bytes. An escalation denial enumerates every offending rule on its own line, and helm reports several such errors together — the message cut off partway through the first of two. Every red run since mid-August carried the answer and truncated it.

Raised to 4000. The cap exists so `ClusterInstance.status.message` does not bloat; that message is rewritten on every attempt, so it does not accumulate.

## Verification

Coverage checked programmatically rather than by eye — every rule in the vcluster chart's Role and ClusterRole, cross-referenced against the rendered kobe ClusterRole:

```
STILL MISSING: none — every rule the vcluster chart grants is delegable
```

`helm template charts/kobe` renders. `cargo test --bin kobe-operator`: 1455 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

The real proof is the leg going green, which needs a full-matrix run after merge — it cannot be tested from unit tests, since RBAC only applies against a real apiserver.

## Not addressed

The pool's `lastFailureReason` still reads "N instance(s) not reaching Ready" and never cites the member's message, because `reconcile_profile` only quotes one when the instance controller stamped a `crash_message`, which a provisioning failure never sets. Worth fixing separately; this PR makes the message correct where it is already recorded.