### PR TITLE
chore: bump version to 0.43.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -3443,11 +3443,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.42.1"
+version = "0.43.0"
 
 [[package]]
 name = "kobectl"
-version = "0.42.1"
+version = "0.43.0"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.42.1"
+version = "0.43.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.42.1
-appVersion: "0.42.1"
+version: 0.43.0
+appVersion: "0.43.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.42.1
+      image: docker.io/zondax/kobe-operator:v0.43.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.42.1
+      image: docker.io/zondax/kobe-sync:v0.43.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Minor, not patch: #201 landed a `feat:` since v0.42.1 — optional iroh transport for attach and port-forward — and it adds API surface to `charts/kobe/crds/sandboxpools.yaml`.

Shipped since v0.42.1:

| commit | change |
|---|---|
| [#201](https://github.com/kunobi-ninja/kobe/pull/201) | `feat(sandbox)`: optional iroh transport for attach and port-forward |
| [#202](https://github.com/kunobi-ninja/kobe/pull/202) | `fix(sandbox)`: a receipt with nothing recorded yet is not a mismatch |
| [#203](https://github.com/kunobi-ninja/kobe/pull/203) | `fix(vcluster)`: hold what the syncer Role grants, and show the denial |

`just bump 0.43.0` moves the workspace, `Chart.yaml` `version` and `appVersion`, and the image pins in lockstep. `check-version-consistency.sh` passes.

Release evidence, since v0.42.1 was tagged without it: the full matrix on `76b49f5` has `vcluster`, `vkobe-etcd`, `vkobe-kine` and `k0s` green, with `vcluster` passing for the first time since mid-August. `k3s` is still running at the time of writing and gates the tag.