### PR TITLE
fix(sandbox): recover the child instance this lease never recorded

### DIFF
--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -5550,6 +5550,71 @@ async fn cleanup_child_executions_after_proof(
 /// The quota slot returns only once a receipt proves the exact recorded
 /// instance gone. The disappearance of a name is not evidence — a same-named
 /// replacement is fresh capacity, not proof that the original was destroyed.
+/// Checkpoint the child instance identity this lease never recorded.
+///
+/// A sandbox cancelled while provisioning records its child handle before the
+/// pool has bound an instance, so `child_cluster_instance` stays empty while a
+/// teardown receipt already exists. [`validated_child_receipt_token`] requires
+/// that reference and returns `None` without it, which reads as a mismatch on
+/// a receipt already proven authoritative — and no retry can change it.
+///
+/// The identity is resolved from the reciprocal binding, never from the
+/// receipt, so a receipt still cannot certify its own scope.
+async fn recover_child_instance_identity(
+    lease: &SandboxLease,
+    ctx: &SandboxContext,
+    status: &crate::crd::SandboxLeaseStatus,
+    recorded: &crate::crd::SandboxObjectReference,
+) -> Result<Action, SandboxPlacementError> {
+    let name = lease.name_any();
+    let resolution = {
+        let client = ctx.client.clone();
+        let namespace = ctx.namespace.clone();
+        let lease_name = recorded.name.clone();
+        let lease_uid = recorded.uid.clone();
+        tokio::spawn(async move {
+            crate::lease_binding::resolve_lease_binding(
+                &client,
+                &namespace,
+                &lease_name,
+                &lease_uid,
+                crate::lease_binding::BindingResolveMode::Lifecycle,
+            )
+            .await
+        })
+        .await
+    };
+    let resolved = match resolution {
+        Ok(Ok(resolved)) => resolved,
+        Ok(Err(error)) => {
+            warn!(lease = %name, reason = error.reason_code(), "recorded child binding is not reciprocally valid");
+            return quarantine_lease(lease, ctx, "child_binding_identity_unverifiable").await;
+        }
+        Err(error) => {
+            warn!(lease = %name, error = %error, "child binding resolver task did not complete");
+            return Ok(Action::requeue(std::time::Duration::from_secs(15)));
+        }
+    };
+    let mut next = status.clone();
+    let Some(target) = next.target.as_mut() else {
+        return quarantine_lease(lease, ctx, "child_composition_provenance_invalid").await;
+    };
+    target.child_cluster_instance = Some(crate::crd::SandboxObjectReference {
+        api_version: "kobe.kunobi.ninja/v1alpha1".into(),
+        kind: "ClusterInstance".into(),
+        namespace: Some(ctx.namespace.clone()),
+        name: resolved.binding.instance.name.clone(),
+        uid: resolved.binding.instance.uid.clone(),
+        generation: Some(resolved.binding.instance.observed_generation),
+    });
+    if patch_lease_status_fenced(ctx, lease, &next).await? {
+        info!(lease = %name, "recovered the child instance identity before teardown");
+    } else {
+        debug!(lease = %name, "child instance recovery checkpoint lost a status race");
+    }
+    Ok(Action::await_change())
+}
+
 async fn release_child_composition(
     lease: &SandboxLease,
     ctx: &SandboxContext,
@@ -5920,6 +5985,31 @@ async fn release_child_composition(
                         return Ok(Action::requeue(std::time::Duration::from_secs(15)));
                     }
                 };
+                // The instance identity can be missing here for the same
+                // reason the receipt exists. A sandbox cancelled while
+                // provisioning checkpoints its handle before the pool has
+                // bound an instance, so `child_cluster_instance` is never
+                // written. `validated_child_receipt_token` requires it and
+                // returns None without it — a mismatch verdict on a receipt
+                // this controller has just proven authoritative against the
+                // immutable evidence object. No retry can change that, so the
+                // release quarantines, the pool slot is withheld forever, and
+                // the lease re-enters this path on every reconcile.
+                //
+                // Recover it the way the pre-checkpoint path does: from the
+                // reciprocal binding, never from the receipt, so a receipt
+                // still cannot certify its own scope. Validation then runs on
+                // the next pass with the exact identity in hand, and a genuine
+                // mismatch still quarantines below.
+                if recorded_instance.is_none() {
+                    // Boxed for the same reason the evidence lookup above is:
+                    // this teardown future is already broad and runs on a
+                    // normal Tokio worker stack.
+                    return Box::pin(recover_child_instance_identity(
+                        lease, ctx, &status, recorded,
+                    ))
+                    .await;
+                }
                 let Some(token) = validated_child_receipt_token(
                     &current,
                     receipt,
@@ -17673,6 +17763,54 @@ current-context: child
             1,
             "the receipt handle is removed only after its proof is durable"
         );
+    }
+
+    /// An instance this lease never recorded is recoverable, not a mismatch.
+    ///
+    /// Cancelling while provisioning checkpoints the child handle before the
+    /// pool has bound an instance, so `child_cluster_instance` is never
+    /// written. `validated_child_receipt_token` requires it and returns None
+    /// without it — a mismatch verdict on a receipt already proven
+    /// authoritative against its immutable evidence object. Nothing about that
+    /// changes on a retry, so the lease quarantined, withheld the pool slot
+    /// forever, and re-entered the same path on every reconcile.
+    ///
+    /// The identity comes from the reciprocal binding, never from the receipt,
+    /// so a receipt still cannot certify its own scope.
+    ///
+    /// The nightly caught this as
+    /// `cancelling_while_provisioning_leaves_nothing_behind` quarantining with
+    /// `child_receipt_does_not_match`.
+    #[tokio::test]
+    async fn a_receipt_recovers_the_unrecorded_instance_instead_of_quarantining() {
+        let (ctx, server) = test_context().await;
+        mount_teardown_scaffolding(&server).await;
+        mount_child_handle_cleanup(
+            &server,
+            2,
+            Some(verified_receipt("kobe-abc123", "child-instance-uid")),
+        )
+        .await;
+
+        let mut lease = child_placed_lease("child-lease-uid");
+        // The window this test exists for: handle recorded, instance not.
+        lease
+            .status
+            .as_mut()
+            .unwrap()
+            .target
+            .as_mut()
+            .unwrap()
+            .child_cluster_instance = None;
+
+        reconcile_release_after_checkpoint(lease, ctx, &server).await;
+
+        let phases = recorded_phases(&server).await;
+        assert!(
+            !phases.iter().any(|phase| phase == "Quarantined"),
+            "an instance that was never recorded is recoverable, not a receipt mismatch: {phases:?}"
+        );
+        assert_eq!(phases.last().map(String::as_str), Some("Released"));
     }
 
     /// Receipt-backed fallback still retires the durable execution inventory


### PR DESCRIPTION
## What actually fails

A sandbox cancelled while provisioning checkpoints its child handle before the pool has bound an instance, so `child_cluster_instance` is never written while a teardown receipt already exists.

On the recorded release path the receipt passes `authoritative_child_receipt_matches` — it is provably this lease's own, cross-checked against the immutable evidence object — and then:

```rust
let Some(token) = validated_child_receipt_token(
    &current, receipt, recorded, recorded_instance, recorded_pool,
) else {
    return quarantine_lease(lease, ctx, "child_receipt_does_not_match").await;
};
```

`validated_child_receipt_token` begins with `let expected = recorded_instance?`. With no recorded instance it returns `None`, which reads as a mismatch on a receipt just proven authoritative. No retry changes that verdict, so the lease quarantines, the pool slot is withheld, and the release re-enters the same path forever:

```
INFO  releasing Sandbox lease      lease=sandbox-b3c67ce17a9c reason=ReleaseRequested
WARN  Sandbox lease quarantined    lease=sandbox-b3c67ce17a9c reason=child_receipt_does_not_match
```

4662 such pairs in 106 seconds.

## The fix

Resolve the instance from the reciprocal binding, exactly as the pre-checkpoint path already does, checkpoint it, and let validation run on the next pass with the identity in hand.

The receipt is never a source of expected values, so it still cannot certify its own scope. A genuine mismatch still quarantines. A binding that does not resolve reciprocally quarantines as `child_binding_identity_unverifiable`.

Boxed, like the evidence lookup beside it — inlining the resolver into this already broad teardown future overflowed the stack in `a_child_lease_is_never_released_by_deleting_a_management_claim`, which is what the comment above that lookup warns about.

## Correcting #202

#202 fixed a real ordering bug on the *pre-checkpoint* path and its unit test stands, but that path never runs in this failure. I reached it by reasoning from the inline `kubectl logs --tail 400` in CI, which covers about **four seconds** of this controller — the operator writes ~90 lines/second here, so the tail was almost entirely the post-failure quarantine loop.

The full history is in the `kind-logs` artifact, across three rotated files. There, `"never recorded"` — the warning that precedes the pre-checkpoint quarantine — appears **zero** times, which rules that path out. That evidence was available all along.

## Test

`a_receipt_recovers_the_unrecorded_instance_instead_of_quarantining` drives the window: a recorded handle with `child_cluster_instance` cleared, plus a verified receipt.

Without the fix it reproduces production exactly:

```
an instance that was never recorded is recoverable, not a receipt mismatch: ["Releasing", "Quarantined"]
```

With it, the release reaches `Released`.

`cargo test --bin kobe-operator`: 1456 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

The real verdict is the nightly, since this only reproduces there naturally.

## Worth doing separately

- `--tail 400` in the conformance diagnostics is actively misleading for this controller. Either raise it or point at the artifact.
- Both `child_receipt_does_not_match` call sites share one reason string, so logs cannot tell them apart. Distinct reasons would have made this a five-minute diagnosis.
- Quarantine does not stop the release path re-running, hence the ~46/second loop. That is a requeue storm independent of this bug.