### PR TITLE
fix: make the next teardown failure readable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -594,7 +594,13 @@ jobs:
             kubectl --context "$CTX" exec -n kobe-system "$POD" -c workspace -v=8 \
               --as "system:serviceaccount:kobe-system:${SA:-kobe}" -- /bin/true 2>&1 | tail -30 || true
           fi
-          kubectl --context "$CTX" logs -n kobe-system -l app.kubernetes.io/name=kobe --tail 400 --all-containers || true
+          # A quarantine loop writes ~90 lines a second, so 400 lines was about
+          # four seconds of this controller — enough to show the symptom and
+          # never the cause. The full history, including rotated files from
+          # before a restart, is in the kind-logs artifact below; say so here,
+          # because a truncated tail reads like a complete record.
+          echo "== operator log (tail; FULL history incl. rotated files is in the kind-logs artifact) =="
+          kubectl --context "$CTX" logs -n kobe-system -l app.kubernetes.io/name=kobe --tail 4000 --all-containers || true
           mkdir -p /tmp/kind-logs
           mise exec -- kind export logs /tmp/kind-logs --name "$E2E_CLUSTER" || true
 

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -5723,7 +5723,18 @@ async fn release_child_composition(
                     && !proof_is_exact
                     && !identity_is_recoverable
                 {
-                    return quarantine_lease(lease, ctx, "child_receipt_does_not_match").await;
+                    // Distinct from the recorded path's verdict below. Both
+                    // read "the receipt does not match", but they are reached
+                    // under opposite conditions — here nothing was
+                    // checkpointed, there everything was — and a shared string
+                    // cost a day of reading logs that could not tell them
+                    // apart.
+                    return quarantine_lease(
+                        lease,
+                        ctx,
+                        "child_receipt_does_not_match_precheckpoint",
+                    )
+                    .await;
                 }
 
                 let mut next = status.clone();
@@ -17215,7 +17226,10 @@ current-context: child
     ///
     /// The nightly caught this as
     /// `cancelling_while_provisioning_leaves_nothing_behind` quarantining with
-    /// `child_receipt_does_not_match`.
+    /// `child_receipt_does_not_match`, which this path now reports under its
+    /// own name, `child_receipt_does_not_match_precheckpoint` — the shared
+    /// string was why the failure was first read as this path when it was the
+    /// recorded one.
     #[tokio::test]
     async fn an_unrecorded_child_receipt_recovers_identity_before_it_can_mismatch() {
         let (ctx, server) = test_context().await;


### PR DESCRIPTION
Two things cost a day on the v0.43.0 quarantine bug, and neither was the bug.

## One reason string, two opposite conditions

Both `child_receipt_does_not_match` sites used the same string:

| site | reached when |
|---|---|
| pre-checkpoint path | nothing was recorded — no handle, no instance |
| recorded path | everything was recorded, and validation still failed |

The reason is what lands on `CleanupVerified` and in the quarantine log line, so neither the condition nor the logs could say which fired. I read the failure as the pre-checkpoint path, fixed that path in #202, and the nightly failed again identically — it was the recorded path all along, fixed in #205.

The pre-checkpoint site now reports `child_receipt_does_not_match_precheckpoint`. The recorded path keeps the original name, so anything already keyed on it still matches — and now means exactly one thing.

## A tail that reads like a record

```
kubectl logs -n kobe-system -l app.kubernetes.io/name=kobe --tail 400
```

A quarantine loop writes ~90 lines a second. 400 lines was about **four seconds** of this controller: the symptom, never the cause. Worse, the pre-checkpoint path's `"releasing a child composition that was allocated but never recorded"` warning had simply scrolled out — so its absence looked like proof that path never ran, which is the wrong turn that produced #202.

Raised to 4000 and captioned:

```
== operator log (tail; FULL history incl. rotated files is in the kind-logs artifact) ==
```

The full history was in the `kind-logs` artifact the whole time, across three rotated files. Reading it is what identified the real path. The caption exists because a truncated tail does not announce itself.

## Verification

`cargo test --bin kobe-operator`: 1456 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean. `ci.yml` parses.

No behaviour change beyond the reason string on one path.