### PR TITLE
fix(test): report how long the policy takes to enforce

### DIFF
--- a/hack/test-teardown-authority-apiserver.ts
+++ b/hack/test-teardown-authority-apiserver.ts
@@ -199,11 +199,24 @@ async function waitForEnforcingPolicy(
 	probe: () => Promise<CommandResult>,
 	expected: string,
 ): Promise<void> {
-	const deadline = Date.now() + 60_000;
+	// 60s was not enough on a loaded apiserver: kobe#204 failed here with the
+	// probe still ADMITTED, on a version-bump-only change that could not have
+	// caused it. The budget is not the interesting number though — how long
+	// this actually takes is, and nothing recorded it, so any replacement
+	// would be another guess. Report the elapsed time on success so the next
+	// person sizes this from observations instead.
+	const budgetMs = 180_000;
+	const started = Date.now();
+	const deadline = started + budgetMs;
+	let attempts = 0;
 	let lastObservation = "policy never rejected the probe write";
 	while (Date.now() < deadline) {
+		attempts += 1;
 		const result = await probe();
 		if (result.exitCode !== 0 && result.stderr.includes(expected)) {
+			console.log(
+				`    policy enforcing for ${username} after ${Date.now() - started}ms (${attempts} probes)`,
+			);
 			return;
 		}
 		lastObservation =
@@ -213,7 +226,8 @@ async function waitForEnforcingPolicy(
 		await Bun.sleep(500);
 	}
 	throw new Error(
-		`admission policy did not become enforcing for ${username}: ${lastObservation}`,
+		`admission policy did not become enforcing for ${username} within ${budgetMs}ms ` +
+			`(${attempts} probes): ${lastObservation}`,
 	);
 }
 


### PR DESCRIPTION
## The flake

[#204](https://github.com/kunobi-ninja/kobe/pull/204) failed on `Verify split teardown-authority isolation`:

```
admission policy did not become enforcing for
system:serviceaccount:kobe-authority-contract-mtqa5ogu:authority-contract-kobe:
probe write was ADMITTED (policy not yet enforcing)
```

That PR only bumped a version string, so it cannot have caused this. The rerun passed. The 60s budget is simply too small for a loaded apiserver.

## Why I did not just pick a bigger number

Nothing records how long this actually takes when it succeeds. Any replacement budget would be a guess sized from how long the last failure happened to take, and the next failure would look identical to this one — no way to tell "genuinely slow today" from "budget was always marginal".

So: log the elapsed time and probe count on success.

```
    policy enforcing for <user> after 2140ms (5 probes)
```

After a few runs the real distribution is visible in any conformance log, and the bound can be set from observations. Raised to 180s meanwhile, and the timeout message now names the budget and probe count instead of leaving both implicit.

## Unchanged

Probing with a write the policy must reject stays the signal. #195 established that the API server type-checking a policy is not the same as its binding being live on the admission path, and that the gap is real — this job passed at 15:30 UTC and failed at 03:12 UTC on an identical commit. That reasoning is untouched; only the budget and what it reports change.

## Notes

`bun build` bundles cleanly. `hack/*.ts` is not covered by any formatter in `just check` (`fmt` runs `cargo fmt` only) — prettier flags this file both before and after, so its opinion is not a signal here. New lines follow the file's existing tab indentation.