### PR TITLE
chore: bump version to 0.43.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -3443,11 +3443,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.43.0"
+version = "0.43.1"
 
 [[package]]
 name = "kobectl"
-version = "0.43.0"
+version = "0.43.1"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.43.0"
+version = "0.43.1"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.43.0
-appVersion: "0.43.0"
+version: 0.43.1
+appVersion: "0.43.1"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.43.0
+      image: docker.io/zondax/kobe-operator:v0.43.1
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.43.0
+      image: docker.io/zondax/kobe-sync:v0.43.1
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Patch: everything since v0.43.0 is a `fix:`, and only one touches shipped code.

| commit | ships |
|---|---|
| [#207](https://github.com/kunobi-ninja/kobe/pull/207) | `src/controllers/sandbox.rs` — the pre-checkpoint path now reports `child_receipt_does_not_match_precheckpoint` instead of sharing one reason string with the recorded path |
| [#208](https://github.com/kunobi-ninja/kobe/pull/208) | `hack/` only — the admission-policy wait reports its elapsed time |
| [#206](https://github.com/kunobi-ninja/kobe/pull/206) | CI only — release workflow pin |

The quarantine fix ([#205](https://github.com/kunobi-ninja/kobe/pull/205)) is **not** in this release; it merged before the v0.43.0 bump and shipped there, and is already live in int-pro.

So the user-visible change is one diagnostic reason string on one code path. `just bump 0.43.1` moved the workspace, `Chart.yaml` `version` and `appVersion` and the image pins in lockstep; `check-version-consistency.sh` passes.