### PR TITLE
fix(lease): teardown can resolve its own terminating handle

### DIFF
--- a/src/lease_binding.rs
+++ b/src/lease_binding.rs
@@ -171,7 +171,21 @@ pub(crate) async fn resolve_lease_binding(
     if lease_uid != expected_lease_uid || lease.name_any() != lease_name {
         return Err(BindingResolutionError::LeaseUidMismatch);
     }
-    if lease.metadata.deletion_timestamp.is_some() {
+    // A terminating handle is disqualifying for ACCESS and expected for
+    // LIFECYCLE. Access hands a tenant a live cluster, so a lease on its way
+    // out must not resolve. Lifecycle work is teardown — release, expiry,
+    // recycling — and deletion is where that progression ends; the uid was
+    // pinned immediately above, so a deleting lease here is provably the
+    // caller's own, and the retention finalizer keeps it readable precisely so
+    // teardown can still consume its proof.
+    //
+    // Rejecting it in both modes made Lifecycle unable to do the work it
+    // exists for: the Sandbox release path could not recover the child
+    // instance identity from a handle that was already terminating, quarantined
+    // as `child_binding_identity_unverifiable`, and withheld the pool slot
+    // forever. Same reasoning as #192, which fixed the ownership check for the
+    // same class of handle.
+    if mode == BindingResolveMode::Access && lease.metadata.deletion_timestamp.is_some() {
         return Err(BindingResolutionError::LeaseDeleting);
     }
 
@@ -616,6 +630,23 @@ mod tests {
         pool: serde_json::Value,
         expected_uid: &str,
     ) -> Result<ResolvedLeaseBinding, BindingResolutionError> {
+        resolve_objects_in_mode(
+            lease,
+            instance,
+            pool,
+            expected_uid,
+            BindingResolveMode::Access,
+        )
+        .await
+    }
+
+    async fn resolve_objects_in_mode(
+        lease: serde_json::Value,
+        instance: serde_json::Value,
+        pool: serde_json::Value,
+        expected_uid: &str,
+        mode: BindingResolveMode,
+    ) -> Result<ResolvedLeaseBinding, BindingResolutionError> {
         let _ = rustls::crypto::ring::default_provider().install_default();
         let server = MockServer::start().await;
         Mock::given(method("GET"))
@@ -640,14 +671,54 @@ mod tests {
             .mount(&server)
             .await;
         let client = crate::testutil::mock_k8s_client(&server);
-        resolve_lease_binding(
-            &client,
-            "test-ns",
-            "lease-a",
-            expected_uid,
+        resolve_lease_binding(&client, "test-ns", "lease-a", expected_uid, mode).await
+    }
+
+    /// A terminating handle is disqualifying for `Access` and expected for
+    /// `Lifecycle`.
+    ///
+    /// Access hands a tenant a live cluster, so a lease on its way out must not
+    /// resolve. Lifecycle work is teardown, and deletion is where release,
+    /// expiry and recycling end; the uid is pinned before this check, so a
+    /// deleting lease is provably the caller's own, and the retention finalizer
+    /// keeps it readable precisely so teardown can consume its proof.
+    ///
+    /// Rejecting it in both modes made Lifecycle unable to do the work it
+    /// exists for. The nightly caught it as
+    /// `cancelling_while_provisioning_leaves_nothing_behind` quarantining with
+    /// `child_binding_identity_unverifiable`, reason `lease_deleting`, holding
+    /// the pool slot forever.
+    #[tokio::test]
+    async fn a_terminating_lease_resolves_for_lifecycle_but_not_access() {
+        let (_binding, mut lease, instance, pool) = exact_objects();
+        lease["metadata"]["deletionTimestamp"] = "2026-09-07T18:00:00Z".into();
+
+        let denied = resolve_objects_in_mode(
+            lease.clone(),
+            instance.clone(),
+            pool.clone(),
+            "lease-uid",
             BindingResolveMode::Access,
         )
+        .await;
+        assert!(
+            matches!(denied, Err(BindingResolutionError::LeaseDeleting)),
+            "a tenant must not be handed a lease on its way out, got {denied:?}"
+        );
+
+        let resolved = resolve_objects_in_mode(
+            lease,
+            instance,
+            pool,
+            "lease-uid",
+            BindingResolveMode::Lifecycle,
+        )
         .await
+        .expect("teardown must still resolve its own terminating handle");
+        assert_eq!(
+            resolved.instance.metadata.uid.as_deref(),
+            Some("instance-uid")
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
## What the dispatch found

`cancelling_while_provisioning_leaves_nothing_behind` failed again on main **with #205 in it** — but with a different reason, and that difference is the whole story:

```
reason = child_binding_identity_unverifiable
WARN "recorded child binding is not reciprocally valid"  reason="lease_deleting"
```

That is the quarantine #205 *added*. The instance recovery it introduced now runs, `resolve_lease_binding` refuses, and the release quarantines there instead. Same withheld pool slot, one layer further in.

## The cause

```rust
if lease.metadata.deletion_timestamp.is_some() {
    return Err(BindingResolutionError::LeaseDeleting);
}
```

Unconditional, in both resolve modes.

| mode | a terminating lease is |
|---|---|
| `Access` | disqualifying — a tenant must not be handed a lease on its way out |
| `Lifecycle` | **expected** — release, expiry and recycling all end in deletion |

The uid is pinned immediately above this check, so a deleting lease here is provably the caller's own, and the retention finalizer keeps a deleted handle readable precisely so teardown can consume its proof.

#192 made this exact correction to the ownership check, with the same reasoning:

> `internal_lease_ownership` reports Foreign for any handle carrying a deletionTimestamp, which is right where it gates ADOPTION — placement must never adopt a dying handle. Here it is wrong.

The resolver kept the blind spot, so `Lifecycle` could not do the work it exists for.

## The change

Scope the deletion check to `Access`. Lifecycle callers are the instance controller, the lease controller and the Sandbox release paths — all teardown work on handles they have already identified by uid.

## Test

`a_terminating_lease_resolves_for_lifecycle_but_not_access` asserts both halves, because relaxing only one direction would be the actual danger. Without the fix:

```
teardown must still resolve its own terminating handle: LeaseDeleting
```

`cargo test --bin kobe-operator`: 1457 passed, 0 failed. `cargo fmt --check` and `cargo clippy --all-targets -D warnings` clean.

## Note

This is the **fifth** distinct cause behind that one test. It took one run instead of three because [#207](https://github.com/kunobi-ninja/kobe/pull/207) gave the quarantine sites distinct reasons and a log tail long enough to read the answer — the diagnosability work paid for itself immediately.

It also reproduced on a **dispatch**, not only the schedule, which contradicts what I said earlier about this race needing nightly conditions.