### PR TITLE
ci: do not install a release before its assets exist

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -99,6 +99,18 @@ jobs:
       - name: Set up mise
         uses: jdx/mise-action@v4
         with:
+          # Without a version the action installs the newest release, which can
+          # be advertised before its release assets exist: v0.43.1's tag run
+          # died five retries deep on a 404 for a linux-x64 tarball belonging to
+          # a version that had not been published, while the newest real release
+          # was the one before it. Every job here sets up mise, so that failure
+          # blocked all of CI and the release with it.
+          #
+          # Only consider releases that have been out long enough to be
+          # complete. This keeps floating on latest, so nothing goes stale the
+          # way a pinned version would, and skips the window where the two
+          # disagree.
+          minimum_release_age: 24h
           install: false
           cache: true
 
@@ -286,6 +298,8 @@ jobs:
       - name: Set up pinned contract-test tools
         uses: jdx/mise-action@v4
         with:
+          # See the first `Set up mise` above.
+          minimum_release_age: 24h
           install: false
           cache: true
 
@@ -345,6 +359,8 @@ jobs:
       - name: Set up pinned runtime-contract tools
         uses: jdx/mise-action@v4
         with:
+          # See the first `Set up mise` above.
+          minimum_release_age: 24h
           install: false
           cache: true
 
@@ -499,6 +515,9 @@ jobs:
       # recipe.
       - name: Set up mise tools
         uses: jdx/mise-action@v4
+        with:
+          # See the first `Set up mise` above.
+          minimum_release_age: 24h
 
       # The vkobe smokes build the `kobe` CLI from source (cargo run -p
       # kobectl), which needs a host C toolchain for proc-macro build scripts —


### PR DESCRIPTION
## What happened

v0.43.1's tag run failed in four minutes and created no release. Not the code — `Set up mise` retried five times on a download that could not succeed:

```
https://.../releases/download/v2026.9.3/mise-v2026.9.3-linux-x64.tar.gz
curl: (22) The requested URL returned error: 404
```

`v2026.9.3` does not exist. The newest published release is `v2026.9.2`. The action was asked for the latest version and resolved one whose assets had not been published yet.

## Why it took the whole release down

Every job in this workflow sets up mise:

| job | result |
|---|---|
| version-consistency | success |
| **Rust Checks** | **failure** — download 404 |
| conformance | skipped |
| docker-dry-run | skipped |
| publish | skipped |
| publish-chart | skipped |
| release-cli | skipped |

The tag is pushed and images, chart and CLI never published.

## The change

`minimum_release_age: 24h` on all four steps — only consider releases that have been out long enough to be complete.

Pinning an exact version would also fix today and then need bumping forever, and a stale pin is its own failure mode. This keeps floating on latest and simply skips the window where the version index and the published assets disagree.

`ci.yml` parses; four steps, four guards. The fourth step had no `with:` block at all and now has one.

## Follow-up

v0.43.1 is tagged but unreleased. Once this merges, the tag run needs re-running so the release actually publishes — the tag itself is fine, only the run failed.