### PR TITLE
chore: bump version to 0.43.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -3443,11 +3443,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.43.1"
+version = "0.43.2"
 
 [[package]]
 name = "kobectl"
-version = "0.43.1"
+version = "0.43.2"
 dependencies = [
  "anyhow",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.43.1"
+version = "0.43.2"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.43.1
-appVersion: "0.43.1"
+version: 0.43.2
+appVersion: "0.43.2"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.43.1
+      image: docker.io/zondax/kobe-operator:v0.43.2
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.43.1
+      image: docker.io/zondax/kobe-sync:v0.43.2
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
v0.43.1 was tagged but never shipped: its tag run died on `Set up mise` fetching a release whose assets did not exist, so `Rust Checks` failed and publish, publish-chart and release-cli were all skipped.

Re-running that tag would not help — a tag run checks out the tag's tree, and the guard that fixes this ([#212](https://github.com/kunobi-ninja/kobe/pull/212)) is not in it. The fix has to be inside the tagged commit, so this goes out as 0.43.2 and v0.43.1 stays an unreferenced tag: no images, no chart, no release.

Since v0.43.0, all fixes:

| commit | change |
|---|---|
| [#210](https://github.com/kunobi-ninja/kobe/pull/210) | teardown can resolve its own terminating handle |
| [#211](https://github.com/kunobi-ninja/kobe/pull/211) | terminating handle on the pre-checkpoint path, found by prediction rather than CI |
| [#207](https://github.com/kunobi-ninja/kobe/pull/207) | distinct quarantine reasons; a log tail long enough to read |
| [#208](https://github.com/kunobi-ninja/kobe/pull/208) | the admission-policy wait reports its own timing |
| [#212](https://github.com/kunobi-ninja/kobe/pull/212) | do not install a release before its assets exist |

Two real teardown fixes and three that make the next failure legible.

`just bump 0.43.2` moved the workspace, `Chart.yaml` `version` and `appVersion`, and the image pins in lockstep; `check-version-consistency.sh` passes.