### PR TITLE
fix(bake): keep one runner target in the push group

### DIFF
--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -233,7 +233,23 @@ target "agent-workspace" {
   }
 }
 
+# The runner context is repointed at `runner-push` rather than inherited as
+# `target:runner`. `runner` and `runner-push` deliberately share one local cache
+# directory, which is harmless only while they never appear in the same bake
+# group. Inheriting `target:runner` here put BOTH in the `push` group, so two
+# targets exported to `.tmp/buildx-cache/runner` concurrently and raced on the
+# ingest files:
+#
+#   ERROR: target runner: failed to solve: error writing layer blob:
+#     rename .tmp/buildx-cache/runner/ingest/.../startedat.tmp ...: no such file
+#
+# The `default` group has no `runner-push`, so `runner` builds once there and
+# `docker-dry-run` stayed green — the break only ever appeared on a publish.
+# Pointing at `runner-push` keeps exactly one runner target in this group.
 target "agent-workspace-push" {
   inherits = ["agent-workspace"]
-  output   = ["type=registry"]
+  contexts = {
+    runner = "target:runner-push"
+  }
+  output = ["type=registry"]
 }


### PR DESCRIPTION
The `publish` job on `main` has been failing since #214 merged, so `zondax/kobe-agent-workspace` was never pushed.

## Cause

```
ERROR: target runner: failed to solve: error writing layer blob:
  rename .tmp/buildx-cache/runner/ingest/.../startedat.tmp
  .tmp/buildx-cache/runner/ingest/.../startedat: no such file or directory
```

`runner` and `runner-push` deliberately share one local cache directory. That is harmless **only while they never appear in the same bake group.**

#214 gave `agent-workspace-push` an inherited `contexts = {runner = "target:runner"}`, which pulled the bare `runner` target into the `push` group alongside `runner-push`. Two targets then exported to `.tmp/buildx-cache/runner` concurrently and raced on the ingest files.

Printing the graph before the fix shows it plainly:

| target | cache-to |
|---|---|
| `runner-push` | `.tmp/buildx-cache/runner` |
| `runner` (via `agent-workspace-push`) | `.tmp/buildx-cache/runner` |

## Why CI didn't catch it

The `default` group has **no `runner-push`**, so `runner` builds exactly once there. `docker-dry-run` was therefore green on #214, and the defect only ever manifests on a group that publishes. The check meant to catch this was structurally incapable of seeing it.

## Fix

Repoint the push variant's runner context at `runner-push`, leaving exactly one runner target in the group. `agent-workspace` (non-push) still uses `target:runner`, so `default` is untouched.

## Verification

CI could not have caught either direction, so this was reproduced and verified locally:

| | command | result |
|---|---|---|
| before | `bake push --set '*.output=type=cacheonly'` | **exit 1**, same rename error, same directory |
| after | same command | **exit 0** |
| after | `bake --set '*.output=type=cacheonly'` (default) | **exit 0** |

## Follow-up worth considering (not in this PR)

`runner` and `runner-push` sharing a cache dir is a latent trap for the next target that takes a runner context. Giving each target its own `cache-to` path would remove the footgun rather than route around it — happy to do that separately if you'd like it.

Note the consuming `agent-workspace` SandboxPool is already merged and live in `tenant-int-pro`, sitting in `ImagePullBackOff` (not quarantined) until this lands and publishes.

https://claude.ai/code/session_016mibWVCJAgzkqWxt12MXFK