### PR TITLE
fix(agent-workspace): make the mise install survive a flaky download

### DIFF
--- a/docker/agent-workspace.Dockerfile
+++ b/docker/agent-workspace.Dockerfile
@@ -73,8 +73,24 @@ RUN groupadd --gid "${WORKLOAD_GID}" nonroot \
 # would put that same floating dependency in front of every CI build. Bump it
 # deliberately, with a green build as the gate.
 ARG MISE_VERSION=v2026.9.3
-RUN curl -fsSL https://mise.run \
-      | MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_PATH=/usr/local/bin/mise sh \
+# Fetched to a file rather than piped into `sh`. In `curl ... | sh` the
+# pipeline's exit status is SH's, not curl's, so a download that dies partway
+# leaves sh reading a truncated script, installing nothing, and STILL exiting 0.
+# That is not hypothetical: a publish run failed here with
+#
+#   curl: (18) HTTP/2 stream 1 was not closed cleanly before end of the
+#         underlying stream
+#   /bin/sh: 1: /usr/local/bin/mise: not found
+#
+# Only the version assertion below caught it. Retries absorb the transient
+# case, `test -s` refuses an empty download, and the assertion stays as the
+# backstop that proves the pinned binary is actually on disk.
+RUN curl -fsSL --retry 5 --retry-all-errors --retry-delay 2 \
+        https://mise.run -o /tmp/mise-install.sh \
+    && test -s /tmp/mise-install.sh \
+    && MISE_VERSION="${MISE_VERSION}" MISE_INSTALL_PATH=/usr/local/bin/mise \
+        sh /tmp/mise-install.sh \
+    && rm -f /tmp/mise-install.sh \
     && /usr/local/bin/mise --version | grep -q "${MISE_VERSION#v}"
 
 COPY --from=runner /kobe-runner /kobe-runner


### PR DESCRIPTION
The `publish` job on `main` failed again after #215, this time inside the image build:

```
curl: (18) HTTP/2 stream 1 was not closed cleanly before end of the underlying stream
/bin/sh: 1: /usr/local/bin/mise: not found
```

#215 did its job — the bake cache race is gone and the build now gets much further. This is a different, transient failure.

## The real problem is the shape of the command

The network drop was transient. But in `curl ... | sh`, **the pipeline's exit status is `sh`'s, not `curl`'s** — so a download that dies partway leaves `sh` reading a truncated script, installing nothing, and *still exiting 0*. The `mise --version` assertion was the only thing that caught it.

Demonstrated directly on amd64:

| form | against a failing URL | meaning |
|---|---|---|
| `curl -fsSL <url> \| sh` | **exit 0** | silent no-op — the bug |
| `curl -fsSL --retry ... -o f && test -s f` | **exit 22** | correctly fails |

## Fix

Fetch to a file, then run it: `--retry 5 --retry-all-errors` absorbs the transient case, `test -s` refuses an empty download, and the version assertion stays as the backstop that the pinned binary is actually on disk.

## Verification

On **linux/amd64** (the platform CI builds), and covering the failure mode rather than just the happy path:

- happy path → exit 0, `2026.9.3 linux-x64` at the pinned path
- empty script → `test -s` refuses it
- failing URL → old form exits 0, new form exits 22
- full `bake agent-workspace` build → green

Last time I verified this image with `--set '*.output=type=cacheonly'`, which overrode the very output types CI uses and tested a configuration that doesn't exist. Not repeated here.

The `agent-workspace` SandboxPool in `tenant-int-pro` is still in `ImagePullBackOff` (not quarantined) waiting on the first successful publish.

https://claude.ai/code/session_016mibWVCJAgzkqWxt12MXFK