### PR TITLE
feat(sandbox): let a pool declare a range of exposed ports

### DIFF
--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -851,6 +851,34 @@ spec:
                     - name
                     - uid
                     type: object
+                  serviceRequired:
+                    description: |-
+                      Whether the exact pool generation that placed this lease published a
+                      port, and therefore whether [`Self::service`] had to be filled.
+
+                      Recorded in the same status write as the workload identities, from the
+                      pool the reconciler has already fenced to this lease's admitted UID and
+                      generation. Release consults *this* rather than re-deriving the answer
+                      from whatever the pool says later.
+
+                      It exists because "no Service was ever required" and "the Service
+                      identity is missing" are the same absence, and telling them apart at
+                      release time used to need the original pool generation still to be
+                      live. Any edit to the pool bumps that generation, so a lease that
+                      legitimately owned no Service — a pool with no `exposedPorts`, or one
+                      that declares only a `portRange` — became permanently unreleasable the
+                      moment its pool was touched: quota, alias, and the finalizer stayed
+                      held, and the phase oscillated between `Releasing` and `Quarantined` on
+                      every retry. A negative that was known at Ready time has to be written
+                      down at Ready time; it cannot be reconstructed from a mutable object.
+
+                      `None` means the lease was placed before this field existed. Those
+                      leases fall back to the pool-generation derivation, which is what they
+                      have always used. Nothing backfills it: doing so would mean
+                      re-observing an already-Ready lease's Pod, and a Pod that has since
+                      been replaced would then fail a merge that today never runs.
+                    nullable: true
+                    type: boolean
                 required:
                 - namespace
                 type: object
@@ -878,6 +906,8 @@ spec:
           rule: '!has(oldSelf.status) || oldSelf.status == null || !has(oldSelf.status.target) || !has(oldSelf.status.target.childClusterKubeconfigSha256) || (has(self.status) && self.status != null && has(self.status.target) && has(self.status.target.childClusterKubeconfigSha256) && self.status.target.childClusterKubeconfigSha256 == oldSelf.status.target.childClusterKubeconfigSha256)'
         - message: child kubeconfig Secret identity and payload digest must be checkpointed together
           rule: '!has(self.status) || self.status == null || !has(self.status.target) || (has(self.status.target.childClusterKubeconfigSecret) == has(self.status.target.childClusterKubeconfigSha256))'
+        - message: status.target.serviceRequired is immutable once recorded
+          rule: '!has(oldSelf.status) || oldSelf.status == null || !has(oldSelf.status.target) || !has(oldSelf.status.target.serviceRequired) || (has(self.status) && self.status != null && has(self.status.target) && has(self.status.target.serviceRequired) && self.status.target.serviceRequired == oldSelf.status.target.serviceRequired)'
         - message: childClusterKubeconfigSecret must be the exact deterministic Secret for the recorded child instance
           rule: '!has(self.status) || self.status == null || !has(self.status.target) || !has(self.status.target.childClusterKubeconfigSecret) || (has(self.status.placement) && self.status.placement.type == ''childCluster'' && has(self.status.target.childClusterInstance) && self.status.target.childClusterKubeconfigSecret.apiVersion == ''v1'' && self.status.target.childClusterKubeconfigSecret.kind == ''Secret'' && has(self.status.target.childClusterKubeconfigSecret.__namespace__) && has(self.status.target.childClusterInstance.__namespace__) && self.status.target.childClusterKubeconfigSecret.__namespace__ == self.status.target.childClusterInstance.__namespace__ && !has(self.status.target.childClusterKubeconfigSecret.generation) && self.status.target.childClusterKubeconfigSecret.name == self.status.target.childClusterInstance.name + ''-kubeconfig'' && self.status.target.childClusterKubeconfigSha256.matches(''^[0-9a-f]{64}$''))'
         - message: status.childTeardownMode is immutable once recorded

--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -872,11 +872,28 @@ spec:
                       every retry. A negative that was known at Ready time has to be written
                       down at Ready time; it cannot be reconstructed from a mutable object.
 
-                      `None` means the lease was placed before this field existed. Those
-                      leases fall back to the pool-generation derivation, which is what they
-                      have always used. Nothing backfills it: doing so would mean
-                      re-observing an already-Ready lease's Pod, and a Pod that has since
-                      been replaced would then fail a merge that today never runs.
+                      `None` means the flag was never durably recorded for this lease, which
+                      is narrower than "this lease was Ready before the field existed".
+                      Readiness does not consult it: the gates on the Ready path
+                      (`workload_provenance_is_complete` / `management_provenance_is_complete`)
+                      ask whether the object identities are recorded, not whether this flag
+                      is. So a lease whose provenance a previous controller checkpointed
+                      complete while it was still `Provisioning` would reach Ready under the
+                      new controller without ever re-entering `observed_provenance`, the
+                      writer that fills this in. The Ready transition therefore records it
+                      itself, in the same status write, from the pool already fenced to this
+                      lease's admitted UID and generation.
+
+                      What is left in `None` is a lease made Ready by a release older than
+                      this field, or one whose Ready write landed against a SandboxLease CRD
+                      that still predates it — the API server prunes the unknown key under
+                      the default `Warn` validation and answers success, and the status
+                      writer does not re-read the stored object to notice. Both fall back to
+                      the pool-generation derivation, which is what they have always used.
+
+                      Nothing backfills a lease that is ALREADY Ready: that would mean
+                      re-observing its Pod, and a Pod that has since been replaced would then
+                      fail a merge that today never runs.
                     nullable: true
                     type: boolean
                 required:

--- a/charts/kobe/crds/sandboxleases.yaml
+++ b/charts/kobe/crds/sandboxleases.yaml
@@ -856,10 +856,11 @@ spec:
                       Whether the exact pool generation that placed this lease published a
                       port, and therefore whether [`Self::service`] had to be filled.
 
-                      Recorded in the same status write as the workload identities, from the
-                      pool the reconciler has already fenced to this lease's admitted UID and
-                      generation. Release consults *this* rather than re-deriving the answer
-                      from whatever the pool says later.
+                      Recorded from the pool the reconciler has already fenced to this
+                      lease's admitted UID and generation — normally in the same status write
+                      as the workload identities, and otherwise at the Ready transition (see
+                      below). Release consults *this* rather than re-deriving the answer from
+                      whatever the pool says later.
 
                       It exists because "no Service was ever required" and "the Service
                       identity is missing" are the same absence, and telling them apart at
@@ -884,16 +885,28 @@ spec:
                       itself, in the same status write, from the pool already fenced to this
                       lease's admitted UID and generation.
 
-                      What is left in `None` is a lease made Ready by a release older than
-                      this field, or one whose Ready write landed against a SandboxLease CRD
-                      that still predates it — the API server prunes the unknown key under
-                      the default `Warn` validation and answers success, and the status
-                      writer does not re-read the stored object to notice. Both fall back to
-                      the pool-generation derivation, which is what they have always used.
+                      `None` therefore covers a wider population than "Ready before this
+                      field existed", and is deliberately not narrowed by guesswork:
 
-                      Nothing backfills a lease that is ALREADY Ready: that would mean
-                      re-observing its Pod, and a Pod that has since been replaced would then
-                      fail a merge that today never runs.
+                      * a lease made Ready by a release older than the field;
+                      * a lease made Ready by a controller that HAS the field but predates
+                        the Ready-transition write above — it knows the field and still
+                        leaves it absent on this path;
+                      * a lease whose Ready write landed against a SandboxLease CRD that
+                        still predates the field. The API server prunes the unknown key under
+                        the default `Warn` validation and answers success, and the status
+                        writer does not re-read the stored object to notice.
+
+                      All of them fall back to the pool-generation derivation, which is what
+                      they have always used, and which is fail-closed.
+
+                      Nothing backfills a MANAGEMENT lease that is already Ready. Not because
+                      deriving the answer needs the Pod — it does not; the helper above
+                      derives it from the pool alone — but because the admitted pool
+                      GENERATION is what has since moved, and that is the one input a
+                      backfill cannot recover. (A child-placed lease is different: its branch
+                      re-enters `observed_provenance` unconditionally, so an already-Ready
+                      child with matching identities can pick the flag up there.)
                     nullable: true
                     type: boolean
                 required:

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -250,10 +250,38 @@ spec:
                   exposedPorts:
                     default: []
                     description: |-
-                      Ports that later access brokers may expose. Any undeclared port remains
-                      unauthorized.
+                      Ports that later access brokers may expose, each declared as one port
+                      or one contiguous range. Any undeclared port remains unauthorized.
+
+                      This list is the whole answer to "what may a caller of this pool
+                      reach". Ranges live in it rather than in a field of their own for that
+                      reason: an administrator auditing a pool, and the port-forward handler
+                      enforcing it, both read exactly one place. See [`SandboxPortSpec`] for
+                      what the two shapes mean.
                     items:
-                      description: One TCP port declared safe for later lease-scoped forwarding.
+                      description: |-
+                        One TCP port, or one contiguous band of them, declared safe for later
+                        lease-scoped forwarding.
+
+                        Exactly one of `port` and `portRange` is set. They are not two spellings of
+                        the same thing:
+
+                        - `port` **publishes** one port. It becomes a named `ContainerPort` on the
+                          Pod and a named port on the Sandbox's Service, and a caller may address
+                          it by that name.
+                        - `portRange` **authorizes** a band and publishes nothing. There is no
+                          `ContainerPort` and no Service port for a range — a name identifies one
+                          port, and a band spans too many for one name to pick from. Callers reach
+                          a ranged port by number; see
+                          [`SandboxTarget::resolve_port`](crate::api::sandbox_access::SandboxTarget::resolve_port).
+
+                        The split exists because the two express different administrator
+                        intentions. An agent pool enumerates the exact ports its workload serves
+                        and wants them published; the caller is untrusted and this template is the
+                        entire security surface. A human workstation pool wants a developer to
+                        reach whatever dev server they started today without an edit to GitOps and
+                        a re-lease — but the administrator still chooses the band. Undeclared still
+                        means unauthorized either way.
                       properties:
                         container:
                           maxLength: 63
@@ -261,19 +289,53 @@ spec:
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         name:
+                          description: |-
+                            Name for this declaration. Only a `port` answers to it; see the type
+                            doc-comment.
                           maxLength: 15
                           minLength: 1
                           pattern: ^[a-z0-9]([-a-z0-9]*[a-z0-9])?$
                           type: string
                         port:
+                          description: |-
+                            One published port. Mutually exclusive with `portRange`.
+
+                            Optional only so a range can take its place. A declaration that sets
+                            neither, or both, is refused at admission rather than resolved by
+                            preferring one: a pool whose port declaration is ambiguous is a pool
+                            whose reachable set nobody can state.
                           format: uint16
                           maximum: 65535.0
                           minimum: 1.0
+                          nullable: true
                           type: integer
+                        portRange:
+                          description: |-
+                            A contiguous band authorized for forwarding. Mutually exclusive with
+                            `port`.
+                          nullable: true
+                          properties:
+                            end:
+                              description: |-
+                                Highest authorized port, inclusive. At least `start`, and the band may
+                                not exceed [`MAX_PORT_RANGE_SPAN`] ports.
+                              format: uint16
+                              maximum: 65535.0
+                              minimum: 1.0
+                              type: integer
+                            start:
+                              description: Lowest authorized port, inclusive.
+                              format: uint16
+                              maximum: 65535.0
+                              minimum: 1.0
+                              type: integer
+                          required:
+                          - end
+                          - start
+                          type: object
                       required:
                       - container
                       - name
-                      - port
                       type: object
                     maxItems: 64
                     type: array
@@ -309,9 +371,15 @@ spec:
                 - message: exposed port names must be unique
                   rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.name == p.name).size() == 1)'
                 - message: a container port may be declared only once
-                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)'
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.port) || self.exposedPorts.filter(other, other.container == p.container && has(other.port) && other.port == p.port).size() == 1)'
                 - message: exposed port names must contain a letter and cannot contain consecutive hyphens
                   rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches(''.*[a-z].*'') && !p.name.contains(''--''))'
+                - message: each exposed port must set exactly one of port or portRange
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, has(p.port) != has(p.portRange))'
+                - message: portRange.start must not exceed portRange.end
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.portRange) || p.portRange.start <= p.portRange.end)'
+                - message: portRange may span at most 8192 ports
+                  rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.portRange) || p.portRange.end - p.portRange.start < 8192)'
               transport:
                 default: direct
                 description: |-

--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -304,6 +304,17 @@ spec:
                             neither, or both, is refused at admission rather than resolved by
                             preferring one: a pool whose port declaration is ambiguous is a pool
                             whose reachable set nobody can state.
+
+                            "Refused at admission" is a statement about *this* CRD. A both-fields
+                            entry written against the pre-range CRD is not refused — the API server
+                            prunes `portRange` as an unknown field under the default `Warn`
+                            validation and stores a plain `port` entry, so the ambiguity is gone
+                            before any Rust here can see it and no later check can reconstruct it.
+                            That direction cannot over-authorize (the surviving number is one the
+                            administrator wrote), but the band they also wrote is silently absent.
+                            The defence is `fieldValidation=Strict`, which is `kubectl apply`'s
+                            default and is documented as a requirement for pool manifests in
+                            `docs/kobe-docs/pools/sandbox-pools.mdx`.
                           format: uint16
                           maximum: 65535.0
                           minimum: 1.0

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -255,12 +255,19 @@ Forward a **pool-declared** port to a local one.
 ```bash
 kobe port-forward dev 8080:http    # by declared name
 kobe port-forward dev 8080:3000    # by declared number
+kobe port-forward dev 8080:5173    # by number, inside a declared range
 ```
 
-Only ports the pool published resolve. Anything else is refused — without
+Only ports the pool declared resolve. Anything else is refused — without
 that, a forward would be a general tunnel into the sandbox's network
 namespace, reaching a debug listener or a metrics endpoint the administrator
 never meant to publish.
+
+A pool declares each port either individually or as a range (see
+[`exposedPorts`](/docs/pools/sandbox-pools#exposedports)). A named port answers to
+its name or its number. A **range answers to a number only** — one name cannot
+identify one port out of thousands, so asking for the range's name is refused
+with reason `port_name_covers_range` rather than resolved to a guess.
 
 The listener binds `127.0.0.1` unless you pass `--bind`. A forward reachable
 from the network turns "a port on my machine" into "a port on the office LAN",

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -122,6 +122,92 @@ Linux capabilities, disables privilege escalation, and applies the
 user and must not require writable root-owned paths. Canary `argv` is executed
 directly, without an implicit shell.
 
+## `exposedPorts`
+
+`exposedPorts` is the complete answer to "what may a caller of this pool
+reach". Anything not in it stays unauthorized: without that list, a forward is
+a general tunnel into the sandbox's network namespace, reaching a debug
+listener or a metrics endpoint you never meant to publish.
+
+Each entry declares **either** one port **or** one contiguous range.
+
+```yaml
+    exposedPorts:
+      - name: http            # one published port
+        container: workspace
+        port: 8080
+      - name: dev             # a band, authorized for forwarding only
+        container: workspace
+        portRange:
+          start: 3000
+          end: 9999
+```
+
+The two shapes are not interchangeable.
+
+`port` **publishes** one port. It becomes a named `ContainerPort` on the Pod
+and a named port on the Sandbox's Service, and callers may address it by that
+name or by its number.
+
+`portRange` **authorizes** a band and publishes nothing — no `ContainerPort`,
+no Service port. Callers reach a ranged port **by number only**:
+
+```bash
+kobe port-forward dev 8080:5173   # 5173 is inside 3000-9999
+kobe port-forward dev 8080:dev    # refused: one name cannot pick one port
+```
+
+A range's name exists for the manifest and the audit trail, not for callers.
+Asking for it returns `400` with reason `port_name_covers_range`, because
+guessing which of 7000 ports you meant would forward you somewhere you never
+asked for.
+
+Which shape to use is a question about who the caller is. An **agent pool**
+enumerates each port its workload serves: the caller is untrusted and the
+template is the whole security surface, so declaring exactly what is needed is
+the point. A **workstation pool** for a human is different — a developer
+should be able to reach the dev server they started five minutes ago without
+editing GitOps and re-leasing. A range lets you authorize `3000-9999` once
+instead of predicting every port.
+
+It does not weaken the rule. Undeclared is still unauthorized, and you still
+decide what is declared — a range moves the decision from "which ports" to
+"which band", it does not remove it. Ranges are therefore capped at **8192
+ports**, so `portRange` cannot be spelled to mean "everything".
+
+Kobe refuses a bad declaration when the pool is admitted, not when a forward
+is attempted: an entry that sets both fields or neither, a range whose `start`
+is after its `end`, a bound outside 1-65535, or a band wider than the cap.
+Overlapping declarations simply union — a published `5173` inside a
+`3000-9999` band is fine, and the port resolves either way.
+
+A pool that declares only ranges gets no Service, because nothing is
+published. Port-forward does not need one; it addresses the Pod directly.
+
+### Rollout order
+
+`portRange` is a new field on a schema that rejects unknown ones, so an
+operator older than the release that introduced it will refuse to read a pool
+that uses it — and stop reconciling that pool, not just that field. Roll it
+out in order:
+
+1. Apply the new chart's CRD manifests. Helm does not upgrade objects from a
+   chart's `crds/` directory, so this step is explicit.
+2. Upgrade the operator, and wait until every replica is running the new
+   version. `kobe status` reports the version it is talking to.
+3. Only then write a `portRange` into a `SandboxPool`.
+
+Applying a `portRange` against the older CRD fails at `kubectl apply`: that
+schema requires `port` on every entry, and the API server prunes the field it
+does not know before it checks. That is the loud, harmless failure. The one to
+avoid is applying between steps 1 and 2 — the manifest is accepted and an old
+operator replica cannot parse the pool it now has to reconcile. Pools that
+declare only `port` are unaffected at every step.
+
+The same pruning is why a misspelled `portrange` is rejected rather than
+ignored: the unknown key is dropped, the entry is left declaring neither
+shape, and the exactly-one-of rule refuses it.
+
 ## Admission ledger namespace
 
 Sandbox quota slots, aliases, and distributed operation gates are coordination

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -172,8 +172,14 @@ instead of predicting every port.
 
 It does not weaken the rule. Undeclared is still unauthorized, and you still
 decide what is declared — a range moves the decision from "which ports" to
-"which band", it does not remove it. Ranges are therefore capped at **8192
-ports**, so `portRange` cannot be spelled to mean "everything".
+"which band", it does not remove it.
+
+A single `portRange` is capped at **8192 ports**. Read that as a limit on how
+much one line can do by accident, not as a ceiling on the pool: `exposedPorts`
+takes up to 64 entries, so eight adjacent bands still spell the whole port
+space. The cap refuses a `1-65535` written because it was easier than thinking
+about the range; it does not stop an administrator who means it and writes it
+out. Kobe insists the decision be visible, not that it be small.
 
 Kobe refuses a bad declaration when the pool is admitted, not when a forward
 is attempted: an entry that sets both fields or neither, a range whose `start`
@@ -188,8 +194,7 @@ published. Port-forward does not need one; it addresses the Pod directly.
 
 `portRange` is a new field on a schema that rejects unknown ones, so an
 operator older than the release that introduced it will refuse to read a pool
-that uses it — and stop reconciling that pool, not just that field. Roll it
-out in order:
+that uses it. Roll it out in order:
 
 1. Apply the new chart's CRD manifests. Helm does not upgrade objects from a
    chart's `crds/` directory, so this step is explicit.
@@ -197,16 +202,50 @@ out in order:
    version. `kobe status` reports the version it is talking to.
 3. Only then write a `portRange` into a `SandboxPool`.
 
-Applying a `portRange` against the older CRD fails at `kubectl apply`: that
-schema requires `port` on every entry, and the API server prunes the field it
-does not know before it checks. That is the loud, harmless failure. The one to
-avoid is applying between steps 1 and 2 — the manifest is accepted and an old
-operator replica cannot parse the pool it now has to reconcile. Pools that
-declare only `port` are unaffected at every step.
+**Do not write a range between steps 1 and 2.** An old operator that cannot
+decode one pool does not simply skip it: it lists `SandboxPool` objects as a
+typed collection, and one undecodable item fails the whole list. So during
+that window a single ranged pool can make the operator's pool watch fail on
+startup or relist, and can turn `kobe pools` into a `500` for every pool in
+the namespace — not just the edited one. Pools that declare only `port` are
+unaffected by the field itself, but they share that list. Finish step 2 first
+and the window never opens.
 
-The same pruning is why a misspelled `portrange` is rejected rather than
-ignored: the unknown key is dropped, the entry is left declaring neither
-shape, and the exactly-one-of rule refuses it.
+Applying a range **before** step 1 is the harmless failure: the older schema
+requires `port` on every entry, the unknown `portRange` is dropped, and the
+write is rejected for the missing `port`.
+
+### Apply pool manifests with strict field validation
+
+`kubectl apply` sends `fieldValidation=Strict` by default, and you should keep
+it that way for `SandboxPool`. Under the API server's default (`Warn`), an
+unknown field is **pruned and the write succeeds** — which means a manifest
+can be accepted as something other than what it says.
+
+The case that matters is a `portRange` written alongside a `port` against the
+older CRD:
+
+```yaml
+exposedPorts:
+  - name: dev
+    container: workspace
+    port: 8080
+    portRange: { start: 3000, end: 4000 }   # dropped by an older CRD
+```
+
+The new CRD rejects that entry outright — exactly one of the two fields, and
+this sets both. The old CRD does not know `portRange`, so a non-strict apply
+prunes it and stores a perfectly ordinary `port: 8080` declaration. Nothing is
+over-authorized: `8080` is a port you wrote. But `3000-4000` is silently not
+there, the ambiguity is gone before any operator can see it, and your manifest
+and the cluster now disagree. Strict validation turns that into an error at
+apply time, which is where you can still read the file that caused it.
+
+The same pruning is why a misspelled `portrange` needs strict validation to be
+caught. Without it the unknown key is dropped: if the entry declared nothing
+else, the exactly-one-of rule still refuses it — but if it also set `port`, it
+is accepted as a plain single-port declaration and the band you meant to write
+is gone.
 
 ## Admission ledger namespace
 

--- a/hack/test-teardown-authority-apiserver.ts
+++ b/hack/test-teardown-authority-apiserver.ts
@@ -33,7 +33,10 @@ function parseDocuments(yaml: string): Document[] {
 		.map((document) => document.trim())
 		.filter(Boolean)
 		.map((document) => Bun.YAML.parse(document) as Document)
-		.filter((document) => document && typeof document === "object" && "kind" in document);
+		.filter(
+			(document) =>
+				document && typeof document === "object" && "kind" in document,
+		);
 }
 
 async function runCommand(
@@ -76,14 +79,18 @@ async function kubectlAs(
 function policyRuleResources(policy: Document): string[] {
 	const spec = policy.spec as Record<string, unknown>;
 	const constraints = spec.matchConstraints as Record<string, unknown>;
-	return (constraints.resourceRules as Record<string, unknown>[]).flatMap((rule) =>
-		Array.isArray(rule.resources) ? rule.resources.map(String) : [],
+	return (constraints.resourceRules as Record<string, unknown>[]).flatMap(
+		(rule) => (Array.isArray(rule.resources) ? rule.resources.map(String) : []),
 	);
 }
 
 function policyExpressions(policy: Document): string[] {
-	return ((policy.spec as Record<string, unknown>).validations as Record<string, unknown>[])
-		.map((validation) => String(validation.expression));
+	return (
+		(policy.spec as Record<string, unknown>).validations as Record<
+			string,
+			unknown
+		>[]
+	).map((validation) => String(validation.expression));
 }
 
 /// The kind a validation is written for, read from its own resource guard.
@@ -91,7 +98,8 @@ function policyExpressions(policy: Document): string[] {
 /// Every expression opens by excluding the resources it does not apply to, so
 /// the guard names the one type whose fields it then reads.
 function guardedKind(expression: string): string | undefined {
-	if (expression.includes("!= 'verifiedteardownevidence'")) return "VerifiedTeardownEvidence";
+	if (expression.includes("!= 'verifiedteardownevidence'"))
+		return "VerifiedTeardownEvidence";
 	if (expression.includes("!= 'clusterleases'")) return "ClusterLease";
 	if (expression.includes("!= 'clusterinstances'")) return "ClusterInstance";
 	return undefined;
@@ -121,10 +129,14 @@ function offTargetWarnings(warnings: unknown, expressions: string[]): string[] {
 			continue;
 		}
 		// Warnings arrive as one text block per kind, each headed by the type.
-		const blocks = String(warning.warning).split(/(?=kobe\.kunobi\.ninja\/v1alpha1, Kind=)/);
+		const blocks = String(warning.warning).split(
+			/(?=kobe\.kunobi\.ninja\/v1alpha1, Kind=)/,
+		);
 		const targeted = blocks.find((block) => block.includes(`Kind=${kind}:`));
 		if (targeted && /ERROR:/.test(targeted)) {
-			fatal.push(`${warning.fieldRef} does not type-check against ${kind}: ${targeted}`);
+			fatal.push(
+				`${warning.fieldRef} does not type-check against ${kind}: ${targeted}`,
+			);
 		}
 	}
 	return fatal;
@@ -257,7 +269,9 @@ async function waitForTypeCheckedPolicy(name: string): Promise<void> {
 				const warnings = policy.status.typeChecking.expressionWarnings;
 				const fatal = offTargetWarnings(warnings, policyExpressions(policy));
 				if (fatal.length > 0) {
-					throw new Error(`${name} type-check warnings: ${JSON.stringify(fatal)}`);
+					throw new Error(
+						`${name} type-check warnings: ${JSON.stringify(fatal)}`,
+					);
 				}
 				return;
 			}
@@ -275,6 +289,7 @@ async function patchLeaseStatus(
 	username: string,
 	status: Record<string, unknown>,
 	allowFailure = false,
+	dryRun = false,
 ): Promise<CommandResult> {
 	return kubectlAs(
 		username,
@@ -286,6 +301,7 @@ async function patchLeaseStatus(
 			namespace,
 			"--subresource=status",
 			"--type=merge",
+			...(dryRun ? ["--dry-run=server"] : []),
 			"-p",
 			JSON.stringify({ status }),
 		],
@@ -313,12 +329,18 @@ const documents = parseDocuments(rendered.stdout);
 const policies = documents.filter(
 	(document) => document.kind === "ValidatingAdmissionPolicy",
 );
-assert(policies.length === 2, `rendered ${policies.length} authority policies, expected 2`);
+assert(
+	policies.length === 2,
+	`rendered ${policies.length} authority policies, expected 2`,
+);
 const authorityPolicy = policies.find((policy) =>
 	policyRuleResources(policy).includes("verifiedteardownevidence"),
 );
 const firewallPolicy = policies.find((policy) => policy !== authorityPolicy);
-assert(authorityPolicy && firewallPolicy, "could not identify the rendered policy pair");
+assert(
+	authorityPolicy && firewallPolicy,
+	"could not identify the rendered policy pair",
+);
 const authorityPolicyName = String(metadata(authorityPolicy).name);
 const firewallPolicyName = String(metadata(firewallPolicy).name);
 const authorityUsername = policyExpressions(authorityPolicy)
@@ -327,8 +349,14 @@ const authorityUsername = policyExpressions(authorityPolicy)
 const controlPlaneUsername = policyExpressions(firewallPolicy)
 	.join(" ")
 	.match(/system:serviceaccount:[a-z0-9-]+:[a-z0-9-]+/)?.[0];
-assert(authorityUsername, "rendered policy does not contain the authority identity");
-assert(controlPlaneUsername, "rendered firewall does not contain the control-plane identity");
+assert(
+	authorityUsername,
+	"rendered policy does not contain the authority identity",
+);
+assert(
+	controlPlaneUsername,
+	"rendered firewall does not contain the control-plane identity",
+);
 const authorityNamespace = authorityUsername.split(":")[2];
 
 await kubectl(["create", "namespace", namespace]);
@@ -362,13 +390,17 @@ try {
 	await patchLeaseStatus(controlPlaneUsername, { phase: "Pending" });
 
 	// Type-checked is not enforcing. Prove the binding is live on the admission
-	// path before reading a successful write as a forged proof.
+	// path before reading a successful write as a forged proof. Use server-side
+	// dry-run: an admitted probe must not persist its value. Otherwise every
+	// retry is an unchanged-field write, which the policy correctly permits
+	// even after enforcement starts, and readiness can never be observed.
 	await waitForEnforcingPolicy(
 		controlPlaneUsername,
 		() =>
 			patchLeaseStatus(
 				controlPlaneUsername,
 				{ phase: "Pending", teardownAttemptId: "enforcement-probe" },
+				true,
 				true,
 			),
 		"only the teardown authority may change status.teardownAttemptId",
@@ -381,11 +413,13 @@ try {
 	);
 	assert(
 		forged.exitCode !== 0 &&
-			forged.stderr.includes("only the teardown authority may change status.teardownAttemptId"),
+			forged.stderr.includes(
+				"only the teardown authority may change status.teardownAttemptId",
+			),
 		forged.exitCode === 0
 			? "control plane FORGED a teardown proof: the patch was admitted"
 			: "control plane patch was rejected for the wrong reason: " +
-				(forged.stderr.trim() || "<no stderr>"),
+					(forged.stderr.trim() || "<no stderr>"),
 	);
 
 	await patchLeaseStatus(authorityUsername, {
@@ -399,7 +433,9 @@ try {
 	);
 	assert(
 		lifecycle.exitCode !== 0 &&
-			lifecycle.stderr.includes("teardown authority may not change lifecycle phase"),
+			lifecycle.stderr.includes(
+				"teardown authority may not change lifecycle phase",
+			),
 		`authority changed lifecycle state or failed unexpectedly: ${lifecycle.stderr}`,
 	);
 
@@ -408,7 +444,10 @@ try {
 		{ phase: "Pending", teardownAttemptId: null },
 		true,
 	);
-	assert(erased.exitCode !== 0, "control plane erased authority-owned evidence");
+	assert(
+		erased.exitCode !== 0,
+		"control plane erased authority-owned evidence",
+	);
 	const live = JSON.parse(
 		(
 			await kubectl([
@@ -428,6 +467,27 @@ try {
 		"a rejected cross-boundary write changed live status",
 	);
 
+	// The namespace firewall has its own binding; authority enforcement does
+	// not prove this independent policy has propagated. Dry-run leaves no
+	// ConfigMap behind if the first probe reaches the server too early.
+	await waitForEnforcingPolicy(
+		controlPlaneUsername,
+		() =>
+			kubectlAs(
+				controlPlaneUsername,
+				[
+					"create",
+					"configmap",
+					"firewall-probe",
+					"-n",
+					authorityNamespace,
+					"--dry-run=server",
+				],
+				true,
+			),
+		"control plane may not mutate the teardown-authority namespace",
+	);
+
 	const namespaceMutation = await kubectlAs(
 		controlPlaneUsername,
 		["create", "configmap", "forged-authority", "-n", authorityNamespace],
@@ -442,7 +502,13 @@ try {
 	);
 	const rbacMutation = await kubectlAs(
 		controlPlaneUsername,
-		["create", "clusterrole", "forged-authority", "--verb=get", "--resource=pods"],
+		[
+			"create",
+			"clusterrole",
+			"forged-authority",
+			"--verb=get",
+			"--resource=pods",
+		],
 		true,
 	);
 	assert(
@@ -461,7 +527,14 @@ try {
 	});
 	for (const target of [authorityNamespace, namespace]) {
 		await kubectl(
-			["delete", "namespace", target, "--ignore-not-found", "--wait=true", "--timeout=60s"],
+			[
+				"delete",
+				"namespace",
+				target,
+				"--ignore-not-found",
+				"--wait=true",
+				"--timeout=60s",
+			],
 			{ allowFailure: true },
 		);
 	}

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -13902,6 +13902,7 @@ mod tests {
             sandbox: Some(reference("Sandbox", "sbx")),
             pod: Some(reference("Pod", "sbx-0")),
             service: Some(reference("Service", "sbx")),
+            service_required: None,
         };
 
         let visible = caller_visible_provenance(target.clone());

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -2597,7 +2597,9 @@ async fn sandbox_port_forward<B: ClusterBackend>(
 
     // Only what the pool declared. Without this the forward is a general
     // tunnel into the Pod's network namespace, reaching a debug listener or a
-    // metrics endpoint the administrator never meant to publish.
+    // metrics endpoint the administrator never meant to publish. A pool may
+    // declare a port or a range, but the rule is the same either way and lives
+    // in one place: see `SandboxTarget::resolve_port`.
     let port = match context.target.resolve_port(&query.port) {
         Ok(port) => port,
         Err(denied) => return access_denied(&identity, &id, "port-forward", denied),

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -269,6 +269,39 @@ fn expiry_permits_access(
 /// Pure, so the fencing rules are testable without a cluster, and separated
 /// from the lookup so that no code path can construct a target from anything
 /// other than what placement recorded.
+///
+/// # Identity is pinned; policy is not
+///
+/// The two halves of this function read from deliberately different places,
+/// and the split is the point.
+///
+/// *Which objects* this lease may address comes from `lease.status.target` —
+/// the exact UIDs placement recorded. Nothing here looks an object up by name.
+///
+/// *What a caller may do to them* — the default container, the port
+/// allowlist, `runnerPath`, `attachCommand` — comes from the pool as it exists
+/// **now**, fenced only on its UID. It is deliberately NOT pinned to
+/// `spec.poolRef.generation`, and that is the opposite of what lease
+/// reconciliation does with the same reference.
+///
+/// The reason they differ is that they are answering different questions.
+/// Reconciliation is *building* a workload, and building it against a spec
+/// nobody admitted the caller to would run their code under configuration
+/// they never agreed to; so it pins the generation and refuses to move.
+/// Access is *policy*, and policy is what the administrator believes today.
+/// An administrator who removes a port from a pool is revoking it, and a
+/// revocation that only applies to leases created afterwards is not a
+/// revocation — the live leases are exactly the ones reaching the port. So an
+/// edit takes effect on the next request against every existing lease, in both
+/// directions: a number that was added becomes reachable, a number that was
+/// removed stops resolving.
+///
+/// What that widening cannot do is reach past the pool: a newly authorized
+/// number reaches only the Pod this lease already owns, over a port-forward
+/// into its network namespace, and only if something in that Pod is listening.
+/// The UID fence is what still matters — a pool deleted and recreated under
+/// the same name is a different administrator's decision and is refused
+/// outright, because then "the current pool" is no longer this pool at all.
 pub fn target_from_provenance(
     lease: &SandboxLease,
     pool: &SandboxPool,
@@ -353,18 +386,37 @@ pub fn target_from_provenance(
             .exposed_ports
             .iter()
             .filter(|port| port.container == pool.spec.template.default_container)
-            // A declaration that sets neither field, or both, authorizes
-            // nothing and is dropped rather than repaired. Admission refuses
-            // that shape at the API server and again in
-            // `SandboxPoolSpec::validate`; if one still reaches here, the safe
-            // reading of an ambiguous declaration is the empty one.
+            // Every declaration is re-checked here, at the last place before
+            // it becomes an authorization, rather than trusted because
+            // admission should have checked it. This GET reads the pool
+            // directly and calls no validator, so a pool that reached etcd by
+            // some other route — a CRD applied without the CEL rules, a
+            // restore, a direct write — would otherwise be honoured unchecked.
+            //
+            // A declaration that sets neither field or both authorizes nothing
+            // and is dropped rather than repaired: the safe reading of an
+            // ambiguous declaration is the empty one, and it is the same
+            // reading `SandboxPortSpec::published_port` takes.
+            //
+            // A band is also held to the numbers `SandboxPoolSpec::validate`
+            // holds it to. An inverted band already matched nothing, so that
+            // part is belt-and-braces — but a band wider than
+            // `MAX_PORT_RANGE_SPAN` would have authorized more than any
+            // admissible manifest can express, which is the one case where
+            // skipping the check actually widens the reachable set.
             .filter_map(|port| {
                 let reach = match (port.port, port.port_range) {
-                    (Some(single), None) => DeclaredPortReach::Single(single),
-                    (None, Some(range)) => DeclaredPortReach::Range {
-                        start: range.start,
-                        end: range.end,
-                    },
+                    (Some(single), None) if single != 0 => DeclaredPortReach::Single(single),
+                    (None, Some(range))
+                        if range.start != 0
+                            && range.start <= range.end
+                            && range.span() <= crate::crd::MAX_PORT_RANGE_SPAN =>
+                    {
+                        DeclaredPortReach::Range {
+                            start: range.start,
+                            end: range.end,
+                        }
+                    }
                     _ => return None,
                 };
                 Some(DeclaredPort {
@@ -1068,6 +1120,7 @@ mod tests {
             sandbox: Some(reference("Sandbox", "sbx", "sandbox-uid")),
             pod: Some(reference("Pod", "sbx-0", "pod-uid")),
             service: None,
+            service_required: None,
         });
         lease
     }
@@ -1459,6 +1512,108 @@ mod tests {
                 "{requested:?} must be refused"
             );
         }
+    }
+
+    /// A band that no admissible manifest could express authorizes nothing.
+    ///
+    /// This resolver reads the pool with a plain GET and calls no validator,
+    /// so it is the last fence in front of a pool that reached etcd without
+    /// passing admission — a CRD applied without its CEL rules, an etcd
+    /// restore, a direct write. An inverted band already matched nothing, but
+    /// a band wider than [`crate::crd::MAX_PORT_RANGE_SPAN`], or one anchored
+    /// at the reserved zero, would have been honoured in full: the cap that
+    /// stops `portRange` from being spelled as "everything" only ever ran at
+    /// admission, and forwarding is where it would have mattered.
+    #[test]
+    fn a_band_outside_the_admissible_shape_authorizes_nothing() {
+        let band = |start: u16, end: u16| crate::crd::SandboxPortSpec {
+            name: "dev".into(),
+            container: "agent".into(),
+            port: None,
+            port_range: Some(crate::crd::SandboxPortRange { start, end }),
+        };
+        let cap = u16::try_from(crate::crd::MAX_PORT_RANGE_SPAN).unwrap();
+        let cases = [
+            // Wider than the cap by exactly one port.
+            (band(1, cap + 1), "8000", "a band one port over the cap"),
+            // The whole port space, which is the shape the cap exists for.
+            (band(1, u16::MAX), "8000", "a band covering everything"),
+            // Zero is not a port, so a band anchored at it is not a band.
+            (band(0, 100), "50", "a band starting at zero"),
+            // Already inert, pinned so it stays inert.
+            (band(9999, 3000), "5000", "an inverted band"),
+        ];
+
+        for (declaration, requested, what) in cases {
+            let mut pool = pool();
+            pool.spec.template.exposed_ports = vec![declaration];
+            let target = target_from_provenance(&ready_lease(), &pool, now()).unwrap();
+            assert!(
+                target.ports.is_empty(),
+                "{what} must be dropped, not carried"
+            );
+            assert_eq!(
+                target.resolve_port(requested).unwrap_err(),
+                SandboxAccessDenied::NotDeclared { what: "port" },
+                "{what} must authorize nothing"
+            );
+        }
+
+        // The widest band an administrator can actually write still works, so
+        // the check refuses only what admission would have refused.
+        let mut pool = pool();
+        pool.spec.template.exposed_ports = vec![band(1, cap)];
+        assert_eq!(
+            pool.spec.validate(),
+            Ok(()),
+            "the fixture must be exactly the widest band admission accepts"
+        );
+        let target = target_from_provenance(&ready_lease(), &pool, now()).unwrap();
+        assert_eq!(target.resolve_port("8000").unwrap(), 8000);
+    }
+
+    /// A pool edit is a policy change, and it reaches every live lease.
+    ///
+    /// Access resolution fences the pool on UID but deliberately does NOT pin
+    /// `spec.poolRef.generation`, which is the opposite of what lease
+    /// reconciliation does with the same reference. The asymmetry is the
+    /// design: reconciliation is building a workload and must build the one
+    /// that was admitted, while this is policy, and a revocation that applied
+    /// only to future leases would leave the ports reachable on exactly the
+    /// leases already reaching them. Pinned here so the choice cannot be
+    /// quietly reversed by pinning the generation "for consistency".
+    #[test]
+    fn a_pool_edit_changes_what_an_existing_lease_may_reach() {
+        let lease = ready_lease();
+        let mut edited = pool();
+        edited.metadata.generation = Some(lease.spec.pool_ref.generation + 40);
+        edited.spec.template.exposed_ports = vec![crate::crd::SandboxPortSpec {
+            name: "dev".into(),
+            container: "agent".into(),
+            port: Some(5173),
+            port_range: None,
+        }];
+
+        let target = target_from_provenance(&lease, &edited, now()).unwrap();
+        assert_eq!(
+            target.resolve_port("5173").unwrap(),
+            5173,
+            "a newly declared port is reachable on a lease admitted before it"
+        );
+        assert_eq!(
+            target.resolve_port("3000").unwrap_err(),
+            SandboxAccessDenied::NotDeclared { what: "port" },
+            "a withdrawn port is revoked on a lease admitted while it was declared"
+        );
+
+        // The UID fence is what still holds: a pool deleted and recreated
+        // under the same name is a different administrator's decision.
+        let mut recreated = pool();
+        recreated.metadata.uid = Some("pool-uid-2".into());
+        assert_eq!(
+            target_from_provenance(&lease, &recreated, now()).unwrap_err(),
+            SandboxAccessDenied::PoolUnresolvable
+        );
     }
 
     /// The forwardable set is exactly what the pool declared.

--- a/src/api/sandbox_access.rs
+++ b/src/api/sandbox_access.rs
@@ -60,7 +60,9 @@ pub struct SandboxTarget {
     pub pod_uid: String,
     /// The single container operations may address.
     pub container: String,
-    /// Ports the pool declared. Nothing else is forwardable.
+    /// Ports the pool declared, each as one published port or one authorized
+    /// band. Nothing else is forwardable — a band widens what an
+    /// administrator can *write*, never what a caller may reach beyond it.
     pub ports: Vec<DeclaredPort>,
     /// Where `kobe-runner` lives inside the container, if the pool's image
     /// ships one. `None` means this Sandbox cannot provide the durable
@@ -86,10 +88,38 @@ pub enum TargetPlacement {
     ChildCluster,
 }
 
+/// One entry of the pool's port allowlist, as the resolver sees it.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DeclaredPort {
+    /// The pool's name for this declaration.
     pub name: String,
-    pub port: u16,
+    /// What it authorizes.
+    pub reach: DeclaredPortReach,
+}
+
+/// What one [`DeclaredPort`] authorizes.
+///
+/// The two shapes are kept apart rather than collapsed into a `start..=end`
+/// pair because they differ in more than width: only a `Single` answers to its
+/// name, and only a `Single` was published as a `ContainerPort`. Flattening
+/// them would make a one-port range indistinguishable from a published port,
+/// which is a difference the administrator wrote down on purpose.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum DeclaredPortReach {
+    /// Exactly one port, published by the pool and addressable by name.
+    Single(u16),
+    /// A contiguous inclusive band, authorized for forwarding only.
+    Range { start: u16, end: u16 },
+}
+
+impl DeclaredPortReach {
+    /// Whether this declaration authorizes `port`.
+    pub fn contains(&self, port: u16) -> bool {
+        match *self {
+            Self::Single(single) => single == port,
+            Self::Range { start, end } => start <= port && port <= end,
+        }
+    }
 }
 
 /// Why an operation cannot be resolved.
@@ -124,6 +154,11 @@ pub enum SandboxAccessDenied {
     /// The caller asked for a container or port the pool never declared.
     #[error("{what} is not part of this sandbox")]
     NotDeclared { what: &'static str },
+    /// The caller named a port declaration that is a range. The name is real;
+    /// it just does not identify one port, and guessing which of the band they
+    /// meant would forward them somewhere they did not ask for.
+    #[error("that port name covers a range; ask for a port number inside it")]
+    PortNameCoversRange,
     /// More than one live lease carries the alias.
     #[error("more than one sandbox uses this alias")]
     AmbiguousAlias,
@@ -162,6 +197,7 @@ impl SandboxAccessDenied {
             Self::ProvenanceIncomplete => "provenance_incomplete",
             Self::PoolUnresolvable => "pool_unresolvable",
             Self::NotDeclared { .. } => "not_declared",
+            Self::PortNameCoversRange => "port_name_covers_range",
             Self::AmbiguousAlias => "ambiguous_alias",
             Self::Backend => "backend_error",
         }
@@ -177,7 +213,7 @@ impl SandboxAccessDenied {
             Self::NotFound => StatusCode::NOT_FOUND,
             Self::NotReady { .. } | Self::TargetUnresolved => StatusCode::CONFLICT,
             Self::Expired => StatusCode::GONE,
-            Self::NotDeclared { .. } => StatusCode::BAD_REQUEST,
+            Self::NotDeclared { .. } | Self::PortNameCoversRange => StatusCode::BAD_REQUEST,
             // 409 rather than 400: the request is well-formed, and the caller
             // fixes it by changing their leases rather than their command.
             Self::AmbiguousAlias => StatusCode::CONFLICT,
@@ -317,9 +353,24 @@ pub fn target_from_provenance(
             .exposed_ports
             .iter()
             .filter(|port| port.container == pool.spec.template.default_container)
-            .map(|port| DeclaredPort {
-                name: port.name.clone(),
-                port: port.port,
+            // A declaration that sets neither field, or both, authorizes
+            // nothing and is dropped rather than repaired. Admission refuses
+            // that shape at the API server and again in
+            // `SandboxPoolSpec::validate`; if one still reaches here, the safe
+            // reading of an ambiguous declaration is the empty one.
+            .filter_map(|port| {
+                let reach = match (port.port, port.port_range) {
+                    (Some(single), None) => DeclaredPortReach::Single(single),
+                    (None, Some(range)) => DeclaredPortReach::Range {
+                        start: range.start,
+                        end: range.end,
+                    },
+                    _ => return None,
+                };
+                Some(DeclaredPort {
+                    name: port.name.clone(),
+                    reach,
+                })
             })
             .collect(),
         // Taken from the pool that admitted this lease, never from the caller.
@@ -336,18 +387,37 @@ pub fn target_from_provenance(
 impl SandboxTarget {
     /// Resolve a caller-named port against the pool's declaration.
     ///
-    /// Accepts a declared name or a declared number, and nothing else. Without
-    /// this, port-forward is a general tunnel into the Pod's network namespace
-    /// — reaching a debug listener, a metrics endpoint, or anything else bound
-    /// on localhost that the administrator never meant to publish.
+    /// The rule, exactly:
+    ///
+    /// 1. A **name** resolves only against a single-port declaration, to that
+    ///    port. A name that belongs to a `portRange` is refused with
+    ///    [`SandboxAccessDenied::PortNameCoversRange`] — the name is real, but
+    ///    it covers thousands of ports and picking one would forward the
+    ///    caller somewhere they never asked for.
+    /// 2. A **number** resolves when some declaration authorizes it: it equals
+    ///    a declared single port, or it falls inside a declared `portRange`.
+    ///    Overlapping declarations union; the number is the answer either way,
+    ///    so which declaration matched cannot change the result.
+    /// 3. Anything else is refused.
+    ///
+    /// So a ranged port is reached by number, and only by number.
+    ///
+    /// Widening the *shape* of a declaration does not widen the rule: what a
+    /// caller may reach is still exactly what an administrator wrote in the
+    /// pool. Without that, port-forward is a general tunnel into the Pod's
+    /// network namespace — reaching a debug listener, a metrics endpoint, or
+    /// anything else bound on localhost that nobody meant to publish.
     pub fn resolve_port(&self, requested: &str) -> Result<u16, SandboxAccessDenied> {
         if let Some(port) = self.ports.iter().find(|port| port.name == requested) {
-            return Ok(port.port);
+            return match port.reach {
+                DeclaredPortReach::Single(single) => Ok(single),
+                DeclaredPortReach::Range { .. } => Err(SandboxAccessDenied::PortNameCoversRange),
+            };
         }
         if let Ok(number) = requested.parse::<u16>()
-            && let Some(port) = self.ports.iter().find(|port| port.port == number)
+            && self.ports.iter().any(|port| port.reach.contains(number))
         {
-            return Ok(port.port);
+            return Ok(number);
         }
         Err(SandboxAccessDenied::NotDeclared { what: "port" })
     }
@@ -1220,6 +1290,177 @@ mod tests {
         assert_eq!(target.resolve_port("03000").unwrap(), 3000);
     }
 
+    /// A pool that declares only single ports behaves exactly as it did
+    /// before ranges existed.
+    ///
+    /// The `portRange` shape is additive, and this is the test that says so:
+    /// the same declaration, the same target, the same resolutions, the same
+    /// refusals. A regression here means an administrator's existing manifest
+    /// changed meaning under them.
+    #[test]
+    fn a_single_port_pool_is_unchanged_by_the_range_shape() {
+        let target = target_from_provenance(&ready_lease(), &pool(), now()).unwrap();
+
+        assert_eq!(
+            target.ports,
+            vec![DeclaredPort {
+                name: "http".into(),
+                reach: DeclaredPortReach::Single(3000),
+            }],
+            "a single-port declaration must still carry exactly one port"
+        );
+        assert_eq!(target.resolve_port("http").unwrap(), 3000);
+        assert_eq!(target.resolve_port("3000").unwrap(), 3000);
+        assert_eq!(
+            target.resolve_port("2999").unwrap_err(),
+            SandboxAccessDenied::NotDeclared { what: "port" },
+            "a neighbour of a declared single port is not a range"
+        );
+        assert_eq!(
+            target.resolve_port("3001").unwrap_err(),
+            SandboxAccessDenied::NotDeclared { what: "port" },
+            "a neighbour of a declared single port is not a range"
+        );
+    }
+
+    /// A number inside a declared range resolves to itself.
+    ///
+    /// This is the whole point of `portRange`: a workstation pool authorizes
+    /// the dev-server band once, and a developer reaches whatever they started
+    /// today without an edit to GitOps and a re-lease.
+    #[test]
+    fn a_number_inside_a_declared_range_is_forwardable() {
+        let target = ranged_target();
+
+        for inside in ["3000", "3001", "5173", "8080", "9998", "9999"] {
+            assert_eq!(
+                target.resolve_port(inside).unwrap(),
+                inside.parse::<u16>().unwrap(),
+                "port {inside} is inside the declared range"
+            );
+        }
+
+        // The single declaration alongside the range keeps working, by name
+        // and by number, and the two do not interfere.
+        assert_eq!(target.resolve_port("http").unwrap(), 80);
+        assert_eq!(target.resolve_port("80").unwrap(), 80);
+    }
+
+    /// Undeclared still means unauthorized. A range widens the shape of a
+    /// declaration, never the rule.
+    ///
+    /// This is the invariant `portRange` exists inside, not beside: the
+    /// administrator still decides. Every number here is one an operator might
+    /// plausibly have listening — an SSH daemon, a metrics endpoint, a
+    /// kubelet — and each sits outside every declaration, so each is refused.
+    /// Without this the forward is a general tunnel into the Pod's network
+    /// namespace.
+    #[test]
+    fn a_number_outside_every_declaration_is_refused() {
+        let target = ranged_target();
+
+        for outside in [
+            "22",    // ssh
+            "79",    // one below the declared single
+            "81",    // one above the declared single
+            "2379",  // etcd, below the band
+            "2999",  // one below the band
+            "10000", // one above the band
+            "10250", // kubelet
+            "65535", // the top of the space
+        ] {
+            assert_eq!(
+                target.resolve_port(outside).unwrap_err(),
+                SandboxAccessDenied::NotDeclared { what: "port" },
+                "port {outside} is outside every declaration and must be refused"
+            );
+        }
+
+        // A port inside the band IS reachable, including one an operator
+        // might not have thought about — that is the administrator's decision
+        // to make when they choose a band instead of an enumeration, and the
+        // reason the cap on how wide a band may be exists at all.
+        assert_eq!(target.resolve_port("9090").unwrap(), 9090);
+
+        // Nor can a malformed number, a negative, or an overflowing one slip
+        // past the parse into the band.
+        for malformed in [
+            "", "-1", "3000 ", " 3000", "65536", "3000.0", "0x1f90", "ssh",
+        ] {
+            assert_eq!(
+                target.resolve_port(malformed).unwrap_err(),
+                SandboxAccessDenied::NotDeclared { what: "port" },
+                "port {malformed:?} must be refused"
+            );
+        }
+    }
+
+    /// A range's NAME does not resolve; only a number inside it does.
+    ///
+    /// One name cannot identify one port out of thousands, and picking one for
+    /// the caller would forward them somewhere they never asked for. Refused
+    /// with its own reason rather than "not declared", because the name IS
+    /// declared and telling the caller otherwise sends them looking for a
+    /// typo that is not there.
+    #[test]
+    fn a_range_is_addressed_by_number_and_never_by_name() {
+        let target = ranged_target();
+
+        assert_eq!(
+            target.resolve_port("dev").unwrap_err(),
+            SandboxAccessDenied::PortNameCoversRange,
+        );
+        assert_eq!(
+            SandboxAccessDenied::PortNameCoversRange.http_status(),
+            axum::http::StatusCode::BAD_REQUEST,
+            "the caller fixes this by changing their command"
+        );
+        assert_eq!(
+            SandboxAccessDenied::PortNameCoversRange.reason_code(),
+            "port_name_covers_range",
+        );
+    }
+
+    /// A declaration that is neither a port nor a range authorizes nothing.
+    ///
+    /// Admission refuses that shape twice over, so this is the third fence:
+    /// were one ever to reach the resolver, it must not become a wildcard, an
+    /// implicit zero, or a port the pool never wrote down.
+    #[test]
+    fn an_ambiguous_declaration_authorizes_nothing() {
+        let mut pool = pool();
+        pool.spec.template.exposed_ports = vec![
+            crate::crd::SandboxPortSpec {
+                name: "broken".into(),
+                container: "agent".into(),
+                port: None,
+                port_range: None,
+            },
+            crate::crd::SandboxPortSpec {
+                name: "both".into(),
+                container: "agent".into(),
+                port: Some(3000),
+                port_range: Some(crate::crd::SandboxPortRange {
+                    start: 4000,
+                    end: 4100,
+                }),
+            },
+        ];
+        let target = target_from_provenance(&ready_lease(), &pool, now()).unwrap();
+
+        assert!(
+            target.ports.is_empty(),
+            "an ambiguous declaration must be dropped, not repaired"
+        );
+        for requested in ["broken", "both", "3000", "4050", "0"] {
+            assert_eq!(
+                target.resolve_port(requested).unwrap_err(),
+                SandboxAccessDenied::NotDeclared { what: "port" },
+                "{requested:?} must be refused"
+            );
+        }
+    }
+
     /// The forwardable set is exactly what the pool declared.
     ///
     /// Carried on the target so #83's port-forward cannot improvise one:
@@ -1233,9 +1474,55 @@ mod tests {
             target.ports,
             vec![DeclaredPort {
                 name: "http".into(),
-                port: 3000
+                reach: DeclaredPortReach::Single(3000),
             }]
         );
+
+        let ranged = ranged_target();
+        assert_eq!(
+            ranged.ports,
+            vec![
+                DeclaredPort {
+                    name: "http".into(),
+                    reach: DeclaredPortReach::Single(80),
+                },
+                DeclaredPort {
+                    name: "dev".into(),
+                    reach: DeclaredPortReach::Range {
+                        start: 3000,
+                        end: 9999,
+                    },
+                },
+            ],
+            "a range is carried as a band, not expanded and not dropped"
+        );
+    }
+
+    /// A workstation-shaped pool: one published port and one authorized band.
+    ///
+    /// Both on the default container, since that is the only container a
+    /// caller may address and therefore the only one whose ports reach the
+    /// target at all.
+    fn ranged_target() -> SandboxTarget {
+        let mut pool = pool();
+        pool.spec.template.exposed_ports = vec![
+            crate::crd::SandboxPortSpec {
+                name: "http".into(),
+                container: "agent".into(),
+                port: Some(80),
+                port_range: None,
+            },
+            crate::crd::SandboxPortSpec {
+                name: "dev".into(),
+                container: "agent".into(),
+                port: None,
+                port_range: Some(crate::crd::SandboxPortRange {
+                    start: 3000,
+                    end: 9999,
+                }),
+            },
+        ];
+        target_from_provenance(&ready_lease(), &pool, now()).unwrap()
     }
 
     /// A caller cannot ask the operator to buffer an unbounded log.

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -1531,7 +1531,10 @@ pub async fn reconcile_lease(
     // a name reused between placement and access would send a caller's exec
     // into somebody else's Pod. Recorded here, where the objects have just
     // been observed, rather than looked up again at access time.
-    let service_required = !pool.spec.template.exposed_ports.is_empty();
+    // A Service exists only when the pool PUBLISHES a port. A `portRange`
+    // authorizes forwarding without publishing anything, so a range-only pool
+    // correctly records no Service identity here and is not held to one.
+    let service_required = pool.spec.template.requires_service();
     if target.owned && !management_provenance_is_complete(&status, service_required) {
         let provenance = match observed_provenance(&target, &claim, &status, service_required).await
         {
@@ -3540,7 +3543,7 @@ async fn missing_service_provenance_is_allowed(
             if pool.uid().as_deref() == Some(lease.spec.pool_ref.uid.as_str())
                 && pool.metadata.generation == Some(lease.spec.pool_ref.generation) =>
         {
-            if pool.spec.template.exposed_ports.is_empty() {
+            if !pool.spec.template.requires_service() {
                 TargetFootprintCheck::Verified
             } else {
                 TargetFootprintCheck::Quarantine("required_service_provenance_missing")
@@ -10105,7 +10108,8 @@ pub(crate) mod tests {
                     exposed_ports: vec![SandboxPortSpec {
                         name: "http".into(),
                         container: "agent".into(),
-                        port: 3000,
+                        port: Some(3000),
+                        port_range: None,
                     }],
                     runner_path: None,
                     attach_command: None,

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -1617,7 +1617,10 @@ pub async fn reconcile_lease(
     let ready_at = persisted_ready_at(&status).unwrap_or_else(chrono::Utc::now);
     let resource_version = claim.resource_version().unwrap_or_default();
 
-    let next_status = match crate::sandbox::mark_sandbox_ready(
+    // Captured BEFORE the transition: only the pass that actually moves the
+    // lease into Ready may record the Service requirement below.
+    let phase_before_ready = status.phase;
+    let mut next_status = match crate::sandbox::mark_sandbox_ready(
         &status,
         observed_generation,
         ready_at,
@@ -1640,6 +1643,8 @@ pub async fn reconcile_lease(
             return Ok(Action::requeue(std::time::Duration::from_secs(30)));
         }
     };
+
+    record_service_requirement_at_ready(phase_before_ready, &mut next_status, service_required);
 
     // Stamp the upstream absolute shutdown time as a BACKSTOP. If Kobe stops
     // reconciling — crash, upgrade, lost credentials — the upstream controller
@@ -8039,6 +8044,44 @@ fn workload_provenance_is_complete(
             && target.pod.is_some()
             && (!service_required || target.service.is_some())
     })
+}
+
+/// Record, in the same status write that makes a lease Ready, whether the pool
+/// that placed it published a port.
+///
+/// [`observed_provenance`] is the only other writer of
+/// `target.serviceRequired`, and it runs only while provenance is incomplete —
+/// a predicate about object identities, which never mentions this flag. A
+/// controller that checkpointed complete provenance while the lease was still
+/// `Provisioning` and stopped before the separate Ready write therefore hands
+/// the next controller a lease it carries all the way to Ready without ever
+/// re-entering that writer. Left alone, such a lease would be Ready with no
+/// record and would be stranded on the legacy pool-generation fallback the
+/// moment anyone edited its pool — the exact failure this field exists to
+/// remove.
+///
+/// Written from the pool already fenced to the lease's admitted UID *and*
+/// generation, into the status patch that is happening anyway, so it costs no
+/// extra round trip and — unlike a backfill — re-observes nothing.
+///
+/// Only the transition writes it. A lease that is ALREADY Ready is left as it
+/// is: backfilling one would mean re-observing its Pod, and a Pod replaced
+/// since would fail a provenance merge that today never runs.
+fn record_service_requirement_at_ready(
+    phase_before_ready: crate::crd::SandboxLeasePhase,
+    next: &mut crate::crd::SandboxLeaseStatus,
+    service_required: bool,
+) {
+    if phase_before_ready == crate::crd::SandboxLeasePhase::Ready {
+        return;
+    }
+    if let Some(target) = next.target.as_mut() {
+        // Never overwrites. The flag is monotonic in `merge_target_provenance`
+        // and immutable in CEL once recorded, and a second opinion about a
+        // fenced pool could only come from re-deriving against a pool this
+        // lease was never admitted against.
+        target.service_required.get_or_insert(service_required);
+    }
 }
 
 fn management_provenance_is_complete(
@@ -18532,16 +18575,22 @@ current-context: child
         assert!(!pool_was_read(&server).await);
     }
 
-    /// The check is idempotent, which is what stops the phase from flapping.
+    /// The recorded answer does not move when the pool underneath it does.
     ///
-    /// Quarantine retries its persisted cause through the same evidence path
-    /// that produced it, and `drive_release` checkpoints `Releasing` first. A
-    /// check that answered "verified" once and "quarantine" the next time made
-    /// the lease oscillate between the two phases while pool accounting
-    /// counted `Quarantined` separately — a capacity number that moved on
-    /// every reconcile without any capacity ever being returned. A decision
-    /// read from immutable status cannot do that, so it is asserted across
-    /// repeated calls with the pool moving underneath.
+    /// That is narrower than "the phase cannot flap", and deliberately so:
+    /// flapping never needed an oscillating verdict. `drive_release` moves any
+    /// non-`Releasing` phase — `Quarantined` included — to `Releasing` and
+    /// returns, and the next evidence failure writes `Quarantined` again, so a
+    /// CONSTANT quarantine verdict already cycles the phase on its own while
+    /// pool accounting counts `Quarantined` separately: a capacity number that
+    /// moved on every reconcile without any capacity ever coming back. What
+    /// ends the cycle for these leases is that the verdict is now `Verified`
+    /// and stays `Verified`, because it is read from immutable status and no
+    /// edit to the pool can reach it.
+    ///
+    /// So this pins the validator only, across repeated calls with the pool
+    /// moving underneath. It drives no phase transitions and asserts nothing
+    /// about the phase machine.
     #[tokio::test]
     async fn the_service_requirement_answer_does_not_change_between_release_attempts() {
         let lease = ready_lease_without_service(Some(false));
@@ -18571,14 +18620,16 @@ current-context: child
         );
     }
 
-    /// A lease placed before the record existed keeps the old derivation,
-    /// unchanged.
+    /// A lease with no record keeps the old derivation, unchanged.
     ///
-    /// Nothing backfills `serviceRequired`: a backfill would re-observe an
-    /// already-Ready lease's Pod, and a Pod replaced since would fail a
-    /// provenance merge that today never runs. So the pool-generation path
-    /// stays, and stays fail-closed, for exactly the leases that have no
-    /// record — which are only leases from before this release.
+    /// Nothing backfills `serviceRequired` onto a lease that is already Ready:
+    /// a backfill would re-observe its Pod, and a Pod replaced since would
+    /// fail a provenance merge that today never runs. So the pool-generation
+    /// path stays, and stays fail-closed, for the leases that have no record —
+    /// leases made Ready by an older release, or by a Ready write that landed
+    /// against a SandboxLease CRD which still prunes the field. Leases this
+    /// controller carries to Ready itself are not among them; see
+    /// [`record_service_requirement_at_ready`].
     #[tokio::test]
     async fn a_lease_without_the_record_still_falls_back_to_the_pool_generation() {
         let (ctx, server) = provenance_context(Some(range_only_pool(POOL_GENERATION + 1))).await;
@@ -18591,6 +18642,59 @@ current-context: child
         assert!(
             pool_was_read(&server).await,
             "only the recordless lease may consult the pool"
+        );
+    }
+
+    /// Every lease this controller carries to Ready records its Service
+    /// requirement, including one a previous controller left mid-flight.
+    ///
+    /// The gates on the Ready path ask whether the object identities are
+    /// recorded, never whether this flag is. A controller that checkpointed
+    /// complete provenance while the lease was still `Provisioning` and
+    /// stopped before the separate Ready write therefore hands the next
+    /// controller a lease that reaches Ready without re-entering
+    /// `observed_provenance` — Ready, with no record, and stranded on the
+    /// pool-generation fallback at the first edit of its pool. A lease that is
+    /// already Ready is still left alone, because backfilling one would mean
+    /// re-observing its Pod.
+    #[test]
+    fn a_lease_made_ready_by_this_controller_always_records_its_service_requirement() {
+        let mut resumed = ready_lease_without_service(None).status.unwrap();
+        resumed.phase = crate::crd::SandboxLeasePhase::Provisioning;
+        record_service_requirement_at_ready(
+            crate::crd::SandboxLeasePhase::Provisioning,
+            &mut resumed,
+            false,
+        );
+        assert_eq!(
+            resumed.target.as_ref().unwrap().service_required,
+            Some(false),
+            "the Ready transition is the last moment the answer is still knowable"
+        );
+
+        let mut already_ready = ready_lease_without_service(None).status.unwrap();
+        record_service_requirement_at_ready(
+            crate::crd::SandboxLeasePhase::Ready,
+            &mut already_ready,
+            false,
+        );
+        assert_eq!(
+            already_ready.target.as_ref().unwrap().service_required,
+            None,
+            "backfilling an already-Ready lease is the Pod re-observation this design avoids"
+        );
+
+        let mut recorded = ready_lease_without_service(Some(true)).status.unwrap();
+        recorded.phase = crate::crd::SandboxLeasePhase::Provisioning;
+        record_service_requirement_at_ready(
+            crate::crd::SandboxLeasePhase::Provisioning,
+            &mut recorded,
+            false,
+        );
+        assert_eq!(
+            recorded.target.as_ref().unwrap().service_required,
+            Some(true),
+            "the flag is monotonic in the merge and immutable in CEL; it is never re-derived"
         );
     }
 }

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -8050,8 +8050,10 @@ fn workload_provenance_is_complete(
 /// that placed it published a port.
 ///
 /// [`observed_provenance`] is the only other writer of
-/// `target.serviceRequired`, and it runs only while provenance is incomplete —
-/// a predicate about object identities, which never mentions this flag. A
+/// `target.serviceRequired`. On the MANAGEMENT path it runs only while
+/// provenance is incomplete — a predicate about object identities, which never
+/// mentions this flag. (The child-placed branch calls it unconditionally, so a
+/// child lease is not exposed to the gap below.) A
 /// controller that checkpointed complete provenance while the lease was still
 /// `Provisioning` and stopped before the separate Ready write therefore hands
 /// the next controller a lease it carries all the way to Ready without ever
@@ -8064,9 +8066,12 @@ fn workload_provenance_is_complete(
 /// generation, into the status patch that is happening anyway, so it costs no
 /// extra round trip and — unlike a backfill — re-observes nothing.
 ///
-/// Only the transition writes it. A lease that is ALREADY Ready is left as it
-/// is: backfilling one would mean re-observing its Pod, and a Pod replaced
-/// since would fail a provenance merge that today never runs.
+/// Only the transition writes it. A management lease that is ALREADY Ready is
+/// left as it is — not because the answer needs its Pod (this function proves
+/// it does not: the pool alone decides) but because the admitted pool
+/// GENERATION has since moved, and that is the input a backfill cannot
+/// recover. Re-entering `observed_provenance` for one would also re-observe a
+/// Pod that may have been replaced, failing a merge that today never runs.
 fn record_service_requirement_at_ready(
     phase_before_ready: crate::crd::SandboxLeasePhase,
     next: &mut crate::crd::SandboxLeaseStatus,
@@ -12470,6 +12475,17 @@ pub(crate) mod tests {
         );
         advance_lease_to_latest_status(&mut lease, &server, "lease-rv-8").await;
 
+        // Resume the checkpoint an older controller could leave behind:
+        // complete workload identities, still Provisioning, and no flag. Without
+        // this the test never exercises the Ready-path insertion at all — it
+        // passed even with that production call deleted, which is no guard.
+        let resumed = lease.status.as_mut().unwrap();
+        assert_eq!(resumed.phase, crate::crd::SandboxLeasePhase::Provisioning);
+        let target = resumed.target.as_mut().unwrap();
+        assert_eq!(target.service_required, Some(true));
+        target.service_required = None;
+        assert!(management_provenance_is_complete(resumed, true));
+
         reconcile_lease(Arc::new(lease), ctx).await.unwrap();
 
         assert!(
@@ -12488,6 +12504,11 @@ pub(crate) mod tests {
             .filter_map(status_value_of)
             .find(|status| status["phase"] == "Ready")
             .expect("Ready status write");
+        assert_eq!(
+            ready_status["target"]["serviceRequired"],
+            serde_json::json!(true),
+            "the Ready patch must fill the flag even when provenance was already complete"
+        );
         assert!(
             ready_status["conditions"]
                 .as_array()

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -1534,6 +1534,12 @@ pub async fn reconcile_lease(
     // A Service exists only when the pool PUBLISHES a port. A `portRange`
     // authorizes forwarding without publishing anything, so a range-only pool
     // correctly records no Service identity here and is not held to one.
+    //
+    // `pool` is fenced above to the exact UID *and* generation this lease was
+    // admitted against, which is what makes this answer safe to persist: the
+    // negative is recorded as `service_required` in the same status write, and
+    // release reads it back instead of asking a pool that may since have been
+    // edited into a different generation, or deleted.
     let service_required = pool.spec.template.requires_service();
     if target.owned && !management_provenance_is_complete(&status, service_required) {
         let provenance = match observed_provenance(&target, &claim, &status, service_required).await
@@ -3514,28 +3520,53 @@ fn recorded_reference_is_exact(
         && !reference.uid.is_empty()
 }
 
+/// Decide from the lease alone whether an absent Service reference is
+/// legitimate, or `None` when only the pool can answer.
+///
+/// Split out from [`missing_service_provenance_is_allowed`] so the decision
+/// that gates a release can be pinned by a test without a backend: the two
+/// answers that strand capacity forever are exactly the ones worth asserting.
+fn recorded_service_requirement(lease: &SandboxLease) -> Option<TargetFootprintCheck> {
+    let status = lease.status.as_ref();
+    // A cancelled Provisioning lease may legitimately never have reached the
+    // point where the upstream controller created a Service. Label-scoped
+    // enumeration behind the inert Claim tombstone proves that negative. Once
+    // Ready was reached, however, a published port implies a Service existed
+    // and its exact identity had to be checkpointed.
+    if status.and_then(|status| status.ready_at.as_ref()).is_none() {
+        return Some(TargetFootprintCheck::Verified);
+    }
+    let status = status?;
+    // Placement wrote this down while the pool it was fenced to was still the
+    // pool that admitted the lease. That is the only moment the answer is
+    // knowable, so it is the moment it is recorded — see
+    // [`crate::crd::SandboxTargetProvenance::service_required`].
+    match status.target.as_ref()?.service_required? {
+        false => Some(TargetFootprintCheck::Verified),
+        true => Some(TargetFootprintCheck::Quarantine(
+            "required_service_provenance_missing",
+        )),
+    }
+}
+
 /// Determine whether an absent Service reference is legitimate.
 ///
-/// New exposed-port leases checkpoint the exact Service UID before Ready. For
-/// an older lease that lacks it, the exact Pool generation is the only durable
-/// source for whether a Service was required. A missing/replaced/stale Pool
-/// cannot prove the negative and therefore fails closed.
+/// A lease that published a port checkpoints the exact Service UID before
+/// Ready, and records alongside it whether one was required at all. When that
+/// record is present it is the answer, and the pool is never consulted: the
+/// pool is mutable and the lease is not, so asking it would make release
+/// depend on whether an administrator has since edited an unrelated field.
+///
+/// Only a lease placed before that record existed falls through to the pool,
+/// where the exact admitted generation is the sole durable source for the same
+/// question. A missing, replaced, or moved-on pool cannot prove the negative
+/// and therefore fails closed — which is exactly why the record exists.
 async fn missing_service_provenance_is_allowed(
     lease: &SandboxLease,
     ctx: &SandboxContext,
 ) -> TargetFootprintCheck {
-    // A cancelled Provisioning lease may legitimately never have reached the
-    // point where the upstream controller created a Service. Label-scoped
-    // enumeration behind the inert Claim tombstone proves that negative. Once Ready was
-    // reached, however, exposed ports imply a Service existed and its exact
-    // identity had to be checkpointed.
-    if lease
-        .status
-        .as_ref()
-        .and_then(|status| status.ready_at.as_ref())
-        .is_none()
-    {
-        return TargetFootprintCheck::Verified;
+    if let Some(recorded) = recorded_service_requirement(lease) {
+        return recorded;
     }
     let pools: Api<SandboxPool> = Api::namespaced(ctx.client.clone(), &ctx.namespace);
     match pools.get(&lease.spec.pool_ref.name).await {
@@ -4961,6 +4992,7 @@ async fn drive_release(
                 sandbox: None,
                 pod: None,
                 service: None,
+                service_required: None,
             });
         if target.namespace != ctx.namespace {
             return quarantine_lease(lease, ctx, "claim_namespace_changed").await;
@@ -5852,6 +5884,7 @@ async fn release_child_composition(
                                 sandbox: None,
                                 pod: None,
                                 service: None,
+                                service_required: None,
                             });
                     proposed.namespace = CHILD_SANDBOX_NAMESPACE.to_string();
                     proposed.child_cluster_lease = Some(reference);
@@ -5908,6 +5941,7 @@ async fn release_child_composition(
                                 sandbox: None,
                                 pod: None,
                                 service: None,
+                                service_required: None,
                             });
                     if target.namespace != CHILD_SANDBOX_NAMESPACE {
                         return quarantine_lease(lease, ctx, "child_target_namespace_changed")
@@ -7985,6 +8019,7 @@ async fn observed_management_pool_provenance(
             sandbox: None,
             pod: None,
             service: None,
+            service_required: None,
         });
     proposed.sandbox_template = Some(observed.remove(0));
     proposed.sandbox_warm_pool = Some(observed.remove(0));
@@ -8102,6 +8137,13 @@ async fn observed_provenance(
             .as_deref()
             .zip(resolved.service_uid.as_deref())
             .map(|(name, uid)| reference("v1", "Service", name, uid)),
+        // The caller derived this from the pool the reconciler already fenced
+        // to this lease's admitted UID and generation, so it is the admitted
+        // answer and not the current one. Written here, in the same status
+        // patch as the identities above, because release has to be able to
+        // tell "no Service was ever required" from "the Service identity is
+        // missing" long after that pool generation is gone.
+        service_required: Some(service_required),
     }))
 }
 
@@ -8614,6 +8656,7 @@ async fn compose_child_target(
             sandbox: None,
             pod: None,
             service: None,
+            service_required: None,
         });
     proposed.namespace = CHILD_SANDBOX_NAMESPACE.to_string();
     proposed.child_cluster_lease = Some(crate::crd::SandboxObjectReference {
@@ -10347,6 +10390,7 @@ pub(crate) mod tests {
                     )),
                     pod: Some(reference("v1", "Pod", "sandbox-pod", "pod-uid")),
                     service: Some(reference("v1", "Service", "sandbox-service", "service-uid")),
+                    service_required: None,
                 }),
                 ..Default::default()
             }),
@@ -15486,6 +15530,7 @@ pub(crate) mod tests {
             sandbox: None,
             pod: None,
             service: None,
+            service_required: None,
         });
         status.allocation_fence = Some(crate::crd::SandboxObjectReference {
             api_version: "coordination.k8s.io/v1".into(),
@@ -18362,6 +18407,190 @@ current-context: child
             resource.api_version,
             crate::sandbox_runtime::REQUIRED_AGENT_SANDBOX_API_VERSION,
             "placement must write the version #72 validates"
+        );
+    }
+
+    /// A Ready lease that owns no Service, with the pool it was admitted
+    /// against still reachable at some generation.
+    ///
+    /// `service_required` is what placement would have written: the answer
+    /// derived from the exact fenced generation, at the only moment it was
+    /// knowable.
+    fn ready_lease_without_service(recorded_requirement: Option<bool>) -> SandboxLease {
+        let mut lease = admitted_lease();
+        let status = lease.status.as_mut().unwrap();
+        status.phase = crate::crd::SandboxLeasePhase::Ready;
+        status.ready_at = Some("2026-08-20T01:00:00Z".into());
+        let target = status.target.as_mut().unwrap();
+        target.service = None;
+        target.service_required = recorded_requirement;
+        lease
+    }
+
+    /// A pool that authorizes a band and publishes nothing, so it owns no
+    /// Service — served at whatever generation the test needs.
+    fn range_only_pool(generation: i64) -> SandboxPool {
+        let mut pool = management_pool(POOL_UID, generation);
+        pool.spec.template.exposed_ports = vec![SandboxPortSpec {
+            name: "dev".into(),
+            container: "agent".into(),
+            port: None,
+            port_range: Some(crate::crd::SandboxPortRange {
+                start: 3000,
+                end: 9999,
+            }),
+        }];
+        assert!(
+            !pool.spec.template.requires_service(),
+            "fixture must be the shape that legitimately owns no Service"
+        );
+        pool
+    }
+
+    async fn provenance_context(pool: Option<SandboxPool>) -> (Arc<SandboxContext>, MockServer) {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+        let server = MockServer::start().await;
+        if let Some(pool) = pool {
+            Mock::given(method("GET"))
+                .and(path(format!(
+                    "/apis/kobe.kunobi.ninja/v1alpha1/namespaces/{NS}/sandboxpools/agents"
+                )))
+                .respond_with(ResponseTemplate::new(200).set_body_json(pool))
+                .mount(&server)
+                .await;
+        }
+        let ctx = Arc::new(SandboxContext {
+            client: crate::testutil::mock_k8s_client(&server),
+            namespace: NS.into(),
+            reservation_namespace: NS.into(),
+            shutdown: CancellationToken::new(),
+            access_ledger_enabled: false,
+            placement_enabled: true,
+            runtime_mode: crate::sandbox_runtime::AgentSandboxMode::External,
+            managed_runtime_identity: None,
+        });
+        (ctx, server)
+    }
+
+    async fn pool_was_read(server: &MockServer) -> bool {
+        server
+            .received_requests()
+            .await
+            .unwrap_or_default()
+            .iter()
+            .any(|request| request.url.path().ends_with("/sandboxpools/agents"))
+    }
+
+    /// A lease that never owed a Service stays releasable after its pool is
+    /// edited.
+    ///
+    /// This is the capacity leak. Release used to prove "no Service was
+    /// required" by re-reading the pool and demanding its generation still
+    /// equal the admitted one. Every edit to a pool bumps that generation, so
+    /// one unrelated field change turned every live range-only lease into a
+    /// permanent `service_requirement_pool_identity_changed` quarantine:
+    /// finalizer, quota, and alias held forever, with no operator action —
+    /// not restoring the spec, not deleting the workload — able to undo it,
+    /// because a generation only ever moves forward.
+    ///
+    /// The record placement wrote is now the answer, and the pool is not
+    /// consulted at all. That is asserted directly: a pool served at a
+    /// different generation is *available* here, and the counterexample is
+    /// that nothing asks it.
+    #[tokio::test]
+    async fn a_lease_that_owed_no_service_releases_after_its_pool_generation_moves() {
+        let (ctx, server) = provenance_context(Some(range_only_pool(POOL_GENERATION + 1))).await;
+        let lease = ready_lease_without_service(Some(false));
+
+        assert_eq!(
+            validate_management_target_provenance(&lease, &ctx).await,
+            TargetFootprintCheck::Verified,
+            "an edited pool must not strand a lease that legitimately owns no Service"
+        );
+        assert!(
+            !pool_was_read(&server).await,
+            "the durable record decides; a mutable pool must not be able to change the answer"
+        );
+    }
+
+    /// Deleting the pool outright does not strand the lease either.
+    ///
+    /// The generation check had a companion failure: with the pool gone the
+    /// answer became `service_requirement_pool_missing`, which is the same
+    /// dead end reached from the other direction. Release is evaluated before
+    /// the pool is resolved precisely because a deleted pool is when capacity
+    /// most needs to come back.
+    #[tokio::test]
+    async fn a_lease_that_owed_no_service_releases_after_its_pool_is_deleted() {
+        let (ctx, server) = provenance_context(None).await;
+        let lease = ready_lease_without_service(Some(false));
+
+        assert_eq!(
+            validate_management_target_provenance(&lease, &ctx).await,
+            TargetFootprintCheck::Verified
+        );
+        assert!(!pool_was_read(&server).await);
+    }
+
+    /// The check is idempotent, which is what stops the phase from flapping.
+    ///
+    /// Quarantine retries its persisted cause through the same evidence path
+    /// that produced it, and `drive_release` checkpoints `Releasing` first. A
+    /// check that answered "verified" once and "quarantine" the next time made
+    /// the lease oscillate between the two phases while pool accounting
+    /// counted `Quarantined` separately — a capacity number that moved on
+    /// every reconcile without any capacity ever being returned. A decision
+    /// read from immutable status cannot do that, so it is asserted across
+    /// repeated calls with the pool moving underneath.
+    #[tokio::test]
+    async fn the_service_requirement_answer_does_not_change_between_release_attempts() {
+        let lease = ready_lease_without_service(Some(false));
+        for generation in [POOL_GENERATION, POOL_GENERATION + 1, POOL_GENERATION + 2] {
+            let (ctx, _server) = provenance_context(Some(range_only_pool(generation))).await;
+            assert_eq!(
+                validate_management_target_provenance(&lease, &ctx).await,
+                TargetFootprintCheck::Verified,
+                "release must not depend on what generation the pool is at now"
+            );
+        }
+    }
+
+    /// Recording the answer does not soften it. A lease that DID owe a
+    /// Service and has no identity for it still quarantines, because the
+    /// missing reference is then real evidence of a footprint nobody can
+    /// prove absent.
+    #[tokio::test]
+    async fn a_lease_that_owed_a_service_still_quarantines_without_its_identity() {
+        let (ctx, _server) =
+            provenance_context(Some(management_pool(POOL_UID, POOL_GENERATION))).await;
+        let lease = ready_lease_without_service(Some(true));
+
+        assert_eq!(
+            validate_management_target_provenance(&lease, &ctx).await,
+            TargetFootprintCheck::Quarantine("required_service_provenance_missing")
+        );
+    }
+
+    /// A lease placed before the record existed keeps the old derivation,
+    /// unchanged.
+    ///
+    /// Nothing backfills `serviceRequired`: a backfill would re-observe an
+    /// already-Ready lease's Pod, and a Pod replaced since would fail a
+    /// provenance merge that today never runs. So the pool-generation path
+    /// stays, and stays fail-closed, for exactly the leases that have no
+    /// record — which are only leases from before this release.
+    #[tokio::test]
+    async fn a_lease_without_the_record_still_falls_back_to_the_pool_generation() {
+        let (ctx, server) = provenance_context(Some(range_only_pool(POOL_GENERATION + 1))).await;
+        let lease = ready_lease_without_service(None);
+
+        assert_eq!(
+            validate_management_target_provenance(&lease, &ctx).await,
+            TargetFootprintCheck::Quarantine("service_requirement_pool_identity_changed")
+        );
+        assert!(
+            pool_was_read(&server).await,
+            "only the recordless lease may consult the pool"
         );
     }
 }

--- a/src/controllers/sandbox_child.rs
+++ b/src/controllers/sandbox_child.rs
@@ -756,6 +756,7 @@ pub fn child_provenance(
         sandbox: None,
         pod: None,
         service: None,
+        service_required: None,
     }
 }
 

--- a/src/controllers/sandbox_pool_certification.rs
+++ b/src/controllers/sandbox_pool_certification.rs
@@ -944,18 +944,23 @@ fn policy_selects_pod(policy: &NetworkPolicy, pod: &Pod) -> bool {
     })
 }
 
+/// Service ports the upstream controller must have produced for this pool.
+///
+/// Derived from the pool's **published** ports only. A `portRange` authorizes
+/// forwarding and publishes nothing, so it contributes no Service port and
+/// must not be expected as one — otherwise certification would demand a port
+/// the upstream controller had no `ContainerPort` to build from.
 fn expected_service_ports(pool: &SandboxPool) -> Vec<(String, i32)> {
     let mut by_port = BTreeMap::<i32, String>::new();
     for container in &pool.spec.template.containers {
-        for port in pool
+        for (port, number) in pool
             .spec
             .template
-            .exposed_ports
-            .iter()
-            .filter(|port| port.container == container.name)
+            .published_ports()
+            .filter(|(port, _)| port.container == container.name)
         {
             by_port
-                .entry(i32::from(port.port))
+                .entry(i32::from(number))
                 .or_insert_with(|| port.name.clone());
         }
     }
@@ -1309,7 +1314,7 @@ async fn validate_resolved_workload(
         .map_err(|error| format!("Sandbox node lookup failed: {error}"))?;
     validate_node(&node)?;
 
-    if pool.spec.template.exposed_ports.is_empty() {
+    if !pool.spec.template.requires_service() {
         if resolved.service_name.is_some() || resolved.service_uid.is_some() {
             return Err("Sandbox unexpectedly exposes a Service".into());
         }

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -361,9 +361,9 @@ impl JsonSchema for SandboxPlacement {
     validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.portRange) || p.portRange.start <= p.portRange.end)")
         .message("portRange.start must not exceed portRange.end")
 )]
-// Keeps `portRange` from being spelled as "everything". See
-// [`MAX_PORT_RANGE_SPAN`]: both ends are inclusive, so the span is the
-// difference plus one.
+// Caps how wide ONE band may be, which is not the same as capping the pool —
+// see [`MAX_PORT_RANGE_SPAN`] for why that is deliberate. Both ends are
+// inclusive, so the span is the difference plus one.
 #[x_kube(
     validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.portRange) || p.portRange.end - p.portRange.start < 8192)")
         .message("portRange may span at most 8192 ports")
@@ -507,14 +507,24 @@ pub struct SandboxResourceCeiling {
     pub max_memory: String,
 }
 
-/// Widest contiguous band one `portRange` may authorize.
+/// Widest contiguous band **one** `portRange` may authorize.
 ///
-/// A cap exists so `portRange` cannot be spelled to mean "everything". The
-/// point of `exposedPorts` is that the administrator decides what is
-/// reachable; a range wide enough to cover the port space would keep the
-/// syntax and discard the decision. This value is large enough to declare the
-/// entire conventional dev-server band (`3000-9999`) in one line, and small
-/// enough that no single range reaches an eighth of the 65535 ports.
+/// The point of `exposedPorts` is that the administrator decides what is
+/// reachable, and a single range wide enough to cover the port space would
+/// keep the syntax while discarding the decision. This value is large enough
+/// to declare the entire conventional dev-server band (`3000-9999`) in one
+/// line, and small enough that no single range reaches an eighth of the 65535
+/// ports.
+///
+/// It is a per-declaration cap and nothing more. `exposedPorts` holds up to 64
+/// entries, so eight adjacent bands still spell the whole port space — the cap
+/// does not make "everything" unwriteable, and it is not a security boundary.
+/// It is a limit on how much one line can do by accident: a typo in a bound,
+/// or a `1-65535` written because it was easier than thinking about the range,
+/// is refused where it is written. An administrator who means to authorize
+/// everything can still say so, deliberately, over several lines that a
+/// reviewer will see. That is the same trade the whole field makes — the
+/// administrator decides, and Kobe only insists the decision be visible.
 pub const MAX_PORT_RANGE_SPAN: u32 = 8192;
 
 /// One TCP port, or one contiguous band of them, declared safe for later
@@ -554,6 +564,17 @@ pub struct SandboxPortSpec {
     /// neither, or both, is refused at admission rather than resolved by
     /// preferring one: a pool whose port declaration is ambiguous is a pool
     /// whose reachable set nobody can state.
+    ///
+    /// "Refused at admission" is a statement about *this* CRD. A both-fields
+    /// entry written against the pre-range CRD is not refused — the API server
+    /// prunes `portRange` as an unknown field under the default `Warn`
+    /// validation and stores a plain `port` entry, so the ambiguity is gone
+    /// before any Rust here can see it and no later check can reconstruct it.
+    /// That direction cannot over-authorize (the surviving number is one the
+    /// administrator wrote), but the band they also wrote is silently absent.
+    /// The defence is `fieldValidation=Strict`, which is `kubectl apply`'s
+    /// default and is documented as a requirement for pool manifests in
+    /// `docs/kobe-docs/pools/sandbox-pools.mdx`.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
     pub port: Option<u16>,
@@ -604,9 +625,23 @@ impl SandboxPortSpec {
     /// ports can see one. Every such site goes through this rather than
     /// reading `port` directly, which keeps "is this publishable" a decision
     /// made in one place.
+    ///
+    /// Also `None` when *both* fields are set. That shape is refused at
+    /// admission and again in [`SandboxPoolSpec::validate`], so it should not
+    /// reach here — but if one ever does, this helper has to give the same
+    /// answer as the forwarding path, which drops an ambiguous declaration
+    /// rather than repairing it (see
+    /// [`target_from_provenance`](crate::api::sandbox_access::target_from_provenance)).
+    /// Returning `self.port` published the number and silently discarded the
+    /// band, so one invalid declaration had two readings depending on which
+    /// consumer asked, and the manifest's author would have seen the half they
+    /// did not write. Ambiguity resolves to the empty set on both sides.
     #[allow(dead_code)]
     pub fn published_port(&self) -> Option<u16> {
-        self.port
+        match (self.port, self.port_range) {
+            (Some(single), None) => Some(single),
+            _ => None,
+        }
     }
 }
 
@@ -723,6 +758,12 @@ struct BoundedSandboxArgSchema(#[schemars(length(max = 4096))] String);
         .message("status.target.childClusterKubeconfigSha256 is immutable once recorded"),
     validation = Rule::new("!has(self.status) || self.status == null || !has(self.status.target) || (has(self.status.target.childClusterKubeconfigSecret) == has(self.status.target.childClusterKubeconfigSha256))")
         .message("child kubeconfig Secret identity and payload digest must be checkpointed together"),
+    // Release reads `serviceRequired` back as proof that this lease was never
+    // supposed to own a Service. A value that could be flipped or cleared later
+    // would be proof of nothing, so it is pinned at the API server as well as
+    // in `merge_target_provenance`.
+    validation = Rule::new("!has(oldSelf.status) || oldSelf.status == null || !has(oldSelf.status.target) || !has(oldSelf.status.target.serviceRequired) || (has(self.status) && self.status != null && has(self.status.target) && has(self.status.target.serviceRequired) && self.status.target.serviceRequired == oldSelf.status.target.serviceRequired)")
+        .message("status.target.serviceRequired is immutable once recorded"),
     validation = Rule::new("!has(self.status) || self.status == null || !has(self.status.target) || !has(self.status.target.childClusterKubeconfigSecret) || (has(self.status.placement) && self.status.placement.type == 'childCluster' && has(self.status.target.childClusterInstance) && self.status.target.childClusterKubeconfigSecret.apiVersion == 'v1' && self.status.target.childClusterKubeconfigSecret.kind == 'Secret' && has(self.status.target.childClusterKubeconfigSecret.__namespace__) && has(self.status.target.childClusterInstance.__namespace__) && self.status.target.childClusterKubeconfigSecret.__namespace__ == self.status.target.childClusterInstance.__namespace__ && !has(self.status.target.childClusterKubeconfigSecret.generation) && self.status.target.childClusterKubeconfigSecret.name == self.status.target.childClusterInstance.name + '-kubeconfig' && self.status.target.childClusterKubeconfigSha256.matches('^[0-9a-f]{64}$'))")
         .message("childClusterKubeconfigSecret must be the exact deterministic Secret for the recorded child instance"),
     validation = Rule::new("!has(oldSelf.status) || oldSelf.status == null || !has(oldSelf.status.childTeardownMode) || (has(self.status) && self.status != null && has(self.status.childTeardownMode) && self.status.childTeardownMode == oldSelf.status.childTeardownMode)")
@@ -1311,6 +1352,32 @@ pub struct SandboxTargetProvenance {
     /// proves every nested dependent is gone.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service: Option<SandboxObjectReference>,
+    /// Whether the exact pool generation that placed this lease published a
+    /// port, and therefore whether [`Self::service`] had to be filled.
+    ///
+    /// Recorded in the same status write as the workload identities, from the
+    /// pool the reconciler has already fenced to this lease's admitted UID and
+    /// generation. Release consults *this* rather than re-deriving the answer
+    /// from whatever the pool says later.
+    ///
+    /// It exists because "no Service was ever required" and "the Service
+    /// identity is missing" are the same absence, and telling them apart at
+    /// release time used to need the original pool generation still to be
+    /// live. Any edit to the pool bumps that generation, so a lease that
+    /// legitimately owned no Service — a pool with no `exposedPorts`, or one
+    /// that declares only a `portRange` — became permanently unreleasable the
+    /// moment its pool was touched: quota, alias, and the finalizer stayed
+    /// held, and the phase oscillated between `Releasing` and `Quarantined` on
+    /// every retry. A negative that was known at Ready time has to be written
+    /// down at Ready time; it cannot be reconstructed from a mutable object.
+    ///
+    /// `None` means the lease was placed before this field existed. Those
+    /// leases fall back to the pool-generation derivation, which is what they
+    /// have always used. Nothing backfills it: doing so would mean
+    /// re-observing an already-Ready lease's Pod, and a Pod that has since
+    /// been replaced would then fail a merge that today never runs.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub service_required: Option<bool>,
 }
 
 /// Kubernetes-style condition with the generation from which it was derived.
@@ -1711,6 +1778,49 @@ mod tests {
         assert!(
             !spec.template.requires_service(),
             "a range-only pool must not be held to a Service it never gets"
+        );
+    }
+
+    /// An ambiguous declaration publishes nothing, exactly as the forwarding
+    /// path authorizes nothing from it.
+    ///
+    /// `port` and `portRange` together are refused at admission and again in
+    /// [`SandboxPoolSpec::validate`], so this shape reaches neither consumer on
+    /// any normal path. It is pinned anyway because the two consumers used to
+    /// disagree: `target_from_provenance` dropped the entry while
+    /// `published_port` returned the number, which published a
+    /// `ContainerPort`, a Service port, and a Service *requirement* for a
+    /// declaration the forwarding path treats as empty. One invalid input, two
+    /// answers, and the half that survived was the half the author did not
+    /// write down last.
+    #[test]
+    fn an_ambiguous_port_declaration_publishes_nothing() {
+        let ambiguous = SandboxPortSpec {
+            name: "dev".into(),
+            container: "agent".into(),
+            port: Some(8080),
+            port_range: Some(SandboxPortRange {
+                start: 3000,
+                end: 4000,
+            }),
+        };
+        assert_eq!(
+            ambiguous.published_port(),
+            None,
+            "a declaration that sets both fields must not publish either one"
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.exposed_ports = vec![ambiguous];
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::PortAndRange("dev".into())),
+            "the shape is still refused where a pool is admitted"
+        );
+        assert_eq!(spec.template.published_ports().count(), 0);
+        assert!(
+            !spec.template.requires_service(),
+            "an ambiguous declaration must not demand a Service that certification would then have to prove"
         );
     }
 
@@ -2198,6 +2308,7 @@ mod tests {
             "childClusterKubeconfigSecret must be the exact deterministic Secret for the recorded child instance",
             "status.childTeardownMode is immutable once recorded",
             "childTeardownMode requires exact child placement and kubeconfig Secret provenance",
+            "status.target.serviceRequired is immutable once recorded",
         ] {
             assert!(
                 validations
@@ -2413,10 +2524,19 @@ mod tests {
     /// way. That is why the docs give an order: apply the CRDs, finish the
     /// operator rollout, then write a range.
     ///
-    /// The second half is what bounds the risk, and is the reason the shape is
-    /// safe to ship: a pool that declares only `port` is byte-identical on the
-    /// wire and still parses under the old struct. The skew is opt-in, one
-    /// pool at a time, and never reaches a pool nobody edited.
+    /// The second half is what makes the shape safe to ship: a pool that
+    /// declares only `port` is byte-identical on the wire and still parses
+    /// under the old struct, so no pool that nobody edited changes meaning.
+    ///
+    /// What that does NOT mean is that the failure is confined to the edited
+    /// pool. Both readers use a *typed collection*: the API's pool listing
+    /// (`Api<SandboxPool>::list`) and the controller's `Controller::new` over
+    /// the same typed `Api`. One undecodable item fails the whole list, so
+    /// during the skew window a single ranged pool can 500 the listing for
+    /// every pool in the namespace and can break the controller's watch at
+    /// startup or relist. The mitigation is the documented order, not a
+    /// narrow blast radius — which is why the rollout note says to finish the
+    /// operator upgrade before writing the first range, in those words.
     #[test]
     fn pre_range_replica_rejects_port_range_but_still_reads_single_ports() {
         #[allow(dead_code)]

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -1371,11 +1371,28 @@ pub struct SandboxTargetProvenance {
     /// every retry. A negative that was known at Ready time has to be written
     /// down at Ready time; it cannot be reconstructed from a mutable object.
     ///
-    /// `None` means the lease was placed before this field existed. Those
-    /// leases fall back to the pool-generation derivation, which is what they
-    /// have always used. Nothing backfills it: doing so would mean
-    /// re-observing an already-Ready lease's Pod, and a Pod that has since
-    /// been replaced would then fail a merge that today never runs.
+    /// `None` means the flag was never durably recorded for this lease, which
+    /// is narrower than "this lease was Ready before the field existed".
+    /// Readiness does not consult it: the gates on the Ready path
+    /// (`workload_provenance_is_complete` / `management_provenance_is_complete`)
+    /// ask whether the object identities are recorded, not whether this flag
+    /// is. So a lease whose provenance a previous controller checkpointed
+    /// complete while it was still `Provisioning` would reach Ready under the
+    /// new controller without ever re-entering `observed_provenance`, the
+    /// writer that fills this in. The Ready transition therefore records it
+    /// itself, in the same status write, from the pool already fenced to this
+    /// lease's admitted UID and generation.
+    ///
+    /// What is left in `None` is a lease made Ready by a release older than
+    /// this field, or one whose Ready write landed against a SandboxLease CRD
+    /// that still predates it — the API server prunes the unknown key under
+    /// the default `Warn` validation and answers success, and the status
+    /// writer does not re-read the stored object to notice. Both fall back to
+    /// the pool-generation derivation, which is what they have always used.
+    ///
+    /// Nothing backfills a lease that is ALREADY Ready: that would mean
+    /// re-observing its Pod, and a Pod that has since been replaced would then
+    /// fail a merge that today never runs.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_required: Option<bool>,
 }

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -180,20 +180,58 @@ impl SandboxPoolSpec {
                     port.name.clone(),
                 ));
             }
-            if port.port == 0 {
-                return Err(SandboxPoolValidationError::ZeroPort(port.name.clone()));
-            }
             if !container_names.contains(port.container.as_str()) {
                 return Err(SandboxPoolValidationError::UnknownPortContainer {
                     port: port.name.clone(),
                     container: port.container.clone(),
                 });
             }
-            if !target_ports.insert((port.container.as_str(), port.port)) {
-                return Err(SandboxPoolValidationError::DuplicateContainerPort {
-                    container: port.container.clone(),
-                    port: port.port,
-                });
+            // Exactly one of the two shapes, checked here as well as in CEL.
+            // CEL runs at the API server, which is the right place to refuse a
+            // bad manifest; this runs wherever a pool spec is rendered, which
+            // is the last place to catch one that arrived some other way — a
+            // CRD applied from an older chart, or a test fixture.
+            match (port.port, port.port_range) {
+                (Some(_), Some(_)) => {
+                    return Err(SandboxPoolValidationError::PortAndRange(port.name.clone()));
+                }
+                (None, None) => {
+                    return Err(SandboxPoolValidationError::NeitherPortNorRange(
+                        port.name.clone(),
+                    ));
+                }
+                (Some(single), None) => {
+                    if single == 0 {
+                        return Err(SandboxPoolValidationError::ZeroPort(port.name.clone()));
+                    }
+                    // Only published ports contend for a container port
+                    // number. A range publishes nothing, so it cannot collide
+                    // with anything, and overlapping declarations simply union.
+                    if !target_ports.insert((port.container.as_str(), single)) {
+                        return Err(SandboxPoolValidationError::DuplicateContainerPort {
+                            container: port.container.clone(),
+                            port: single,
+                        });
+                    }
+                }
+                (None, Some(range)) => {
+                    if range.start == 0 || range.end == 0 {
+                        return Err(SandboxPoolValidationError::ZeroPort(port.name.clone()));
+                    }
+                    if range.end < range.start {
+                        return Err(SandboxPoolValidationError::InvertedPortRange {
+                            name: port.name.clone(),
+                            start: range.start,
+                            end: range.end,
+                        });
+                    }
+                    if range.span() > MAX_PORT_RANGE_SPAN {
+                        return Err(SandboxPoolValidationError::PortRangeTooWide {
+                            name: port.name.clone(),
+                            span: range.span(),
+                        });
+                    }
+                }
             }
         }
 
@@ -304,12 +342,31 @@ impl JsonSchema for SandboxPlacement {
         .message("exposed port names must be unique")
 )]
 #[x_kube(
-    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.exposedPorts.filter(other, other.container == p.container && other.port == p.port).size() == 1)")
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.port) || self.exposedPorts.filter(other, other.container == p.container && has(other.port) && other.port == p.port).size() == 1)")
         .message("a container port may be declared only once")
 )]
 #[x_kube(
     validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, p.name.matches('.*[a-z].*') && !p.name.contains('--'))")
         .message("exposed port names must contain a letter and cannot contain consecutive hyphens")
+)]
+// The exactly-one-of invariant, at admission rather than at stream-open time.
+// A declaration with neither field authorizes nothing while looking like it
+// authorizes something, and one with both leaves the reachable set to whichever
+// branch a reader happens to check first.
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, has(p.port) != has(p.portRange))")
+        .message("each exposed port must set exactly one of port or portRange")
+)]
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.portRange) || p.portRange.start <= p.portRange.end)")
+        .message("portRange.start must not exceed portRange.end")
+)]
+// Keeps `portRange` from being spelled as "everything". See
+// [`MAX_PORT_RANGE_SPAN`]: both ends are inclusive, so the span is the
+// difference plus one.
+#[x_kube(
+    validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, !has(p.portRange) || p.portRange.end - p.portRange.start < 8192)")
+        .message("portRange may span at most 8192 ports")
 )]
 pub struct SandboxTemplateSpec {
     /// Container selected by default for execution operations.
@@ -319,8 +376,14 @@ pub struct SandboxTemplateSpec {
     /// context, service accounts, and arbitrary Pod fields are not exposed.
     #[schemars(length(min = 1, max = 16))]
     pub containers: Vec<SandboxContainerSpec>,
-    /// Ports that later access brokers may expose. Any undeclared port remains
-    /// unauthorized.
+    /// Ports that later access brokers may expose, each declared as one port
+    /// or one contiguous range. Any undeclared port remains unauthorized.
+    ///
+    /// This list is the whole answer to "what may a caller of this pool
+    /// reach". Ranges live in it rather than in a field of their own for that
+    /// reason: an administrator auditing a pool, and the port-forward handler
+    /// enforcing it, both read exactly one place. See [`SandboxPortSpec`] for
+    /// what the two shapes mean.
     #[serde(default)]
     #[schemars(length(max = 64))]
     pub exposed_ports: Vec<SandboxPortSpec>,
@@ -354,6 +417,38 @@ pub struct SandboxTemplateSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(min = 1, max = 255), pattern(r"^/[A-Za-z0-9._/-]*$"))]
     pub runner_path: Option<String>,
+}
+
+impl SandboxTemplateSpec {
+    /// Every port this template **publishes**, as `(declaration, port)`.
+    ///
+    /// Exactly the single-port declarations. A `portRange` is authorization
+    /// for forwarding and nothing more, so it is absent here: there is no
+    /// `ContainerPort` and no Service port for a band, because a
+    /// `ContainerPort` carries one number and one name and a band supplies
+    /// neither uniquely.
+    ///
+    /// Every projection site — the Pod's `ContainerPort`s, the Service's
+    /// ports, and the certification that re-derives both — reads this instead
+    /// of `exposed_ports` directly, so "what gets published" is decided once.
+    #[allow(dead_code)]
+    pub fn published_ports(&self) -> impl Iterator<Item = (&SandboxPortSpec, u16)> {
+        self.exposed_ports
+            .iter()
+            .filter_map(|port| port.published_port().map(|number| (port, number)))
+    }
+
+    /// Whether this template's Sandbox must own a Service.
+    ///
+    /// True exactly when something is published. A range-only pool gets no
+    /// Service, and certification must expect none: port-forward reaches the
+    /// Pod's network namespace directly, so a Service would be an object with
+    /// no ports whose absence nothing would notice — except the provenance
+    /// check that demands an exact Service identity whenever one was required.
+    #[allow(dead_code)]
+    pub fn requires_service(&self) -> bool {
+        self.published_ports().next().is_some()
+    }
 }
 
 /// One administrator-controlled container in a Sandbox template.
@@ -412,16 +507,107 @@ pub struct SandboxResourceCeiling {
     pub max_memory: String,
 }
 
-/// One TCP port declared safe for later lease-scoped forwarding.
+/// Widest contiguous band one `portRange` may authorize.
+///
+/// A cap exists so `portRange` cannot be spelled to mean "everything". The
+/// point of `exposedPorts` is that the administrator decides what is
+/// reachable; a range wide enough to cover the port space would keep the
+/// syntax and discard the decision. This value is large enough to declare the
+/// entire conventional dev-server band (`3000-9999`) in one line, and small
+/// enough that no single range reaches an eighth of the 65535 ports.
+pub const MAX_PORT_RANGE_SPAN: u32 = 8192;
+
+/// One TCP port, or one contiguous band of them, declared safe for later
+/// lease-scoped forwarding.
+///
+/// Exactly one of `port` and `portRange` is set. They are not two spellings of
+/// the same thing:
+///
+/// - `port` **publishes** one port. It becomes a named `ContainerPort` on the
+///   Pod and a named port on the Sandbox's Service, and a caller may address
+///   it by that name.
+/// - `portRange` **authorizes** a band and publishes nothing. There is no
+///   `ContainerPort` and no Service port for a range — a name identifies one
+///   port, and a band spans too many for one name to pick from. Callers reach
+///   a ranged port by number; see
+///   [`SandboxTarget::resolve_port`](crate::api::sandbox_access::SandboxTarget::resolve_port).
+///
+/// The split exists because the two express different administrator
+/// intentions. An agent pool enumerates the exact ports its workload serves
+/// and wants them published; the caller is untrusted and this template is the
+/// entire security surface. A human workstation pool wants a developer to
+/// reach whatever dev server they started today without an edit to GitOps and
+/// a re-lease — but the administrator still chooses the band. Undeclared still
+/// means unauthorized either way.
 #[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct SandboxPortSpec {
+    /// Name for this declaration. Only a `port` answers to it; see the type
+    /// doc-comment.
     #[schemars(length(min = 1, max = 15), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
     pub name: String,
     #[schemars(length(min = 1, max = 63), pattern("^[a-z0-9]([-a-z0-9]*[a-z0-9])?$"))]
     pub container: String,
+    /// One published port. Mutually exclusive with `portRange`.
+    ///
+    /// Optional only so a range can take its place. A declaration that sets
+    /// neither, or both, is refused at admission rather than resolved by
+    /// preferring one: a pool whose port declaration is ambiguous is a pool
+    /// whose reachable set nobody can state.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(range(min = 1))]
-    pub port: u16,
+    pub port: Option<u16>,
+    /// A contiguous band authorized for forwarding. Mutually exclusive with
+    /// `port`.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub port_range: Option<SandboxPortRange>,
+}
+
+/// An inclusive band of TCP ports.
+///
+/// Inclusive on both ends because that is how an administrator says it:
+/// `3000-9999` means 9999 is reachable. A half-open bound would make every
+/// declaration one port narrower than it reads, and the only place that error
+/// surfaces is a refused forward at 3am.
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxPortRange {
+    /// Lowest authorized port, inclusive.
+    #[schemars(range(min = 1))]
+    pub start: u16,
+    /// Highest authorized port, inclusive. At least `start`, and the band may
+    /// not exceed [`MAX_PORT_RANGE_SPAN`] ports.
+    #[schemars(range(min = 1))]
+    pub end: u16,
+}
+
+impl SandboxPortRange {
+    /// Number of ports the band authorizes, counting both ends.
+    ///
+    /// Widened to `u32` because a full-width band counts 65536, one more than
+    /// `u16` holds: the arithmetic that checks the cap must not be the
+    /// arithmetic that overflows it. An inverted band counts zero rather than
+    /// wrapping, and [`SandboxPoolSpec::validate`] refuses it separately, so a
+    /// span check can never be the thing that lets one through.
+    pub fn span(&self) -> u32 {
+        if self.end < self.start {
+            return 0;
+        }
+        u32::from(self.end) - u32::from(self.start) + 1
+    }
+}
+
+impl SandboxPortSpec {
+    /// The single port this declaration publishes, if it declares one.
+    ///
+    /// `None` for a range, so nothing that renders `ContainerPort`s or Service
+    /// ports can see one. Every such site goes through this rather than
+    /// reading `port` directly, which keeps "is this publishable" a decision
+    /// made in one place.
+    #[allow(dead_code)]
+    pub fn published_port(&self) -> Option<u16> {
+        self.port
+    }
 }
 
 /// Isolation is a tagged enum so a hardened claim cannot omit its exact
@@ -1192,6 +1378,14 @@ pub enum SandboxPoolValidationError {
     UnknownPortContainer { port: String, container: String },
     #[error("container {container} exposes port {port} more than once")]
     DuplicateContainerPort { container: String, port: u16 },
+    #[error("exposed port {0} sets both port and portRange")]
+    PortAndRange(String),
+    #[error("exposed port {0} sets neither port nor portRange")]
+    NeitherPortNorRange(String),
+    #[error("exposed port {name} has portRange {start}-{end} with start after end")]
+    InvertedPortRange { name: String, start: u16, end: u16 },
+    #[error("exposed port {name} spans {span} ports, more than the {MAX_PORT_RANGE_SPAN} allowed")]
+    PortRangeTooWide { name: String, span: u32 },
     #[error("hardened isolation requires a non-empty runtimeClassName")]
     EmptyRuntimeClass,
     #[error("readiness canary argv must contain non-empty arguments")]
@@ -1237,7 +1431,8 @@ mod tests {
                 exposed_ports: vec![SandboxPortSpec {
                     name: "http".into(),
                     container: "agent".into(),
-                    port: 3000,
+                    port: Some(3000),
+                    port_range: None,
                 }],
                 runner_path: None,
                 attach_command: None,
@@ -1442,6 +1637,253 @@ mod tests {
                 container: "missing".into(),
             })
         );
+    }
+
+    /// A `port` declaration written before ranges existed still deserializes,
+    /// validates, and serializes identically.
+    ///
+    /// `port` became optional so a range could take its place. The reason that
+    /// is safe is written down here: an existing manifest is byte-identical on
+    /// the way in and on the way out, and still refuses everything it refused.
+    #[test]
+    fn an_existing_single_port_declaration_is_unchanged() {
+        let declared = serde_json::json!({
+            "name": "http",
+            "container": "agent",
+            "port": 8080
+        });
+        let port: SandboxPortSpec = serde_json::from_value(declared.clone()).unwrap();
+        assert_eq!(port.port, Some(8080));
+        assert_eq!(port.port_range, None);
+        assert_eq!(port.published_port(), Some(8080));
+        assert_eq!(
+            serde_json::to_value(&port).unwrap(),
+            declared,
+            "an absent portRange must not appear on the wire"
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.exposed_ports = vec![port];
+        assert_eq!(spec.validate(), Ok(()));
+        assert!(spec.template.requires_service());
+        assert_eq!(
+            spec.template
+                .published_ports()
+                .map(|(port, number)| (port.name.as_str(), number))
+                .collect::<Vec<_>>(),
+            vec![("http", 8080)]
+        );
+
+        // Unknown fields are still refused, so a future shape cannot be
+        // smuggled through a declaration that looks familiar.
+        assert!(
+            serde_json::from_value::<SandboxPortSpec>(serde_json::json!({
+                "name": "http",
+                "container": "agent",
+                "port": 8080,
+                "hostPort": 8080
+            }))
+            .is_err()
+        );
+    }
+
+    /// A range publishes nothing.
+    ///
+    /// It authorizes forwarding, which reaches the Pod's network namespace
+    /// directly. Turning it into `ContainerPort`s or Service ports would mean
+    /// synthesising thousands of names the administrator never wrote, and
+    /// certification would then demand a Service the upstream controller had
+    /// no way to build.
+    #[test]
+    fn a_range_authorizes_without_publishing() {
+        let mut spec = valid_pool_spec();
+        spec.template.exposed_ports = vec![SandboxPortSpec {
+            name: "dev".into(),
+            container: "agent".into(),
+            port: None,
+            port_range: Some(SandboxPortRange {
+                start: 3000,
+                end: 9999,
+            }),
+        }];
+        assert_eq!(spec.validate(), Ok(()));
+        assert_eq!(spec.template.published_ports().count(), 0);
+        assert!(
+            !spec.template.requires_service(),
+            "a range-only pool must not be held to a Service it never gets"
+        );
+    }
+
+    /// Nonsense ranges are refused where the pool is admitted, not where a
+    /// stream is opened.
+    ///
+    /// A caller who discovers a bad declaration by having a forward fail has
+    /// already built on it; the administrator who wrote it has moved on. Each
+    /// case below is refused with its own reason so the message names the
+    /// mistake.
+    #[test]
+    fn pool_validation_rejects_impossible_port_declarations() {
+        let with_port = |port: Option<u16>, range: Option<SandboxPortRange>| {
+            let mut spec = valid_pool_spec();
+            spec.template.exposed_ports = vec![SandboxPortSpec {
+                name: "dev".into(),
+                container: "agent".into(),
+                port,
+                port_range: range,
+            }];
+            spec.validate()
+        };
+
+        assert_eq!(
+            with_port(None, None),
+            Err(SandboxPoolValidationError::NeitherPortNorRange(
+                "dev".into()
+            )),
+            "a declaration that authorizes nothing must not look like one that does"
+        );
+        assert_eq!(
+            with_port(
+                Some(3000),
+                Some(SandboxPortRange {
+                    start: 4000,
+                    end: 4100
+                })
+            ),
+            Err(SandboxPoolValidationError::PortAndRange("dev".into())),
+            "two shapes at once leaves the reachable set to whoever reads first"
+        );
+        assert_eq!(
+            with_port(
+                None,
+                Some(SandboxPortRange {
+                    start: 9999,
+                    end: 3000
+                })
+            ),
+            Err(SandboxPoolValidationError::InvertedPortRange {
+                name: "dev".into(),
+                start: 9999,
+                end: 3000,
+            }),
+            "an inverted band authorizes nothing and almost certainly meant the reverse"
+        );
+        assert_eq!(
+            with_port(None, Some(SandboxPortRange { start: 0, end: 100 })),
+            Err(SandboxPoolValidationError::ZeroPort("dev".into()))
+        );
+        assert_eq!(
+            with_port(Some(0), None),
+            Err(SandboxPoolValidationError::ZeroPort("dev".into()))
+        );
+
+        // The cap is what keeps `portRange` from being spelled as
+        // "everything". One port past it is refused; the cap itself is not.
+        assert_eq!(
+            with_port(
+                None,
+                Some(SandboxPortRange {
+                    start: 1,
+                    end: 65535
+                })
+            ),
+            Err(SandboxPoolValidationError::PortRangeTooWide {
+                name: "dev".into(),
+                span: 65535,
+            })
+        );
+        let widest = u16::try_from(MAX_PORT_RANGE_SPAN).unwrap();
+        assert_eq!(
+            with_port(
+                None,
+                Some(SandboxPortRange {
+                    start: 1,
+                    end: widest
+                })
+            ),
+            Ok(()),
+            "a band of exactly MAX_PORT_RANGE_SPAN ports is allowed"
+        );
+        assert_eq!(
+            with_port(
+                None,
+                Some(SandboxPortRange {
+                    start: 1,
+                    end: widest + 1
+                })
+            ),
+            Err(SandboxPoolValidationError::PortRangeTooWide {
+                name: "dev".into(),
+                span: MAX_PORT_RANGE_SPAN + 1,
+            })
+        );
+        assert_eq!(
+            SandboxPortRange {
+                start: 3000,
+                end: 9999
+            }
+            .span(),
+            7000,
+            "both ends are inclusive"
+        );
+        assert_eq!(
+            SandboxPortRange {
+                start: 9999,
+                end: 3000
+            }
+            .span(),
+            0,
+            "an inverted band must not wrap into a large span"
+        );
+
+        // A range publishes nothing, so it cannot collide with a published
+        // port that falls inside it. The two simply union.
+        let mut spec = valid_pool_spec();
+        spec.template.exposed_ports = vec![
+            SandboxPortSpec {
+                name: "http".into(),
+                container: "agent".into(),
+                port: Some(5173),
+                port_range: None,
+            },
+            SandboxPortSpec {
+                name: "dev".into(),
+                container: "agent".into(),
+                port: None,
+                port_range: Some(SandboxPortRange {
+                    start: 3000,
+                    end: 9999,
+                }),
+            },
+        ];
+        assert_eq!(spec.validate(), Ok(()));
+    }
+
+    /// The CEL rules the API server enforces and the Rust checks the operator
+    /// enforces must agree on the cap.
+    ///
+    /// They are written in two languages at two layers, and a cap that drifted
+    /// between them would admit a pool the operator then refuses to render —
+    /// a pool that is valid to Kubernetes and broken to Kobe.
+    #[test]
+    fn the_published_schema_enforces_the_same_range_cap_as_the_operator() {
+        let crd = serde_json::to_value(SandboxPool::crd()).unwrap();
+        let rules = crd.to_string();
+
+        assert!(
+            rules.contains(&format!(
+                "p.portRange.end - p.portRange.start < {MAX_PORT_RANGE_SPAN}"
+            )),
+            "the CEL span rule must be written with MAX_PORT_RANGE_SPAN"
+        );
+        for rule in [
+            "has(p.port) != has(p.portRange)",
+            "p.portRange.start <= p.portRange.end",
+        ] {
+            assert!(
+                rules.contains(rule),
+                "the schema must carry the rule {rule}"
+            );
+        }
     }
 
     #[test]
@@ -1961,5 +2403,57 @@ mod tests {
             .err()
             .expect("older strict replica must reject the field");
         assert!(error.to_string().contains("placementAuthority"));
+    }
+
+    /// The `portRange` rollout skew, pinned, and its exact blast radius.
+    ///
+    /// `SandboxPortSpec` rejects unknown fields, so an operator replica older
+    /// than the release that introduced `portRange` cannot read a pool that
+    /// uses one — the same skew `placementAuthority` has, checked the same
+    /// way. That is why the docs give an order: apply the CRDs, finish the
+    /// operator rollout, then write a range.
+    ///
+    /// The second half is what bounds the risk, and is the reason the shape is
+    /// safe to ship: a pool that declares only `port` is byte-identical on the
+    /// wire and still parses under the old struct. The skew is opt-in, one
+    /// pool at a time, and never reaches a pool nobody edited.
+    #[test]
+    fn pre_range_replica_rejects_port_range_but_still_reads_single_ports() {
+        #[allow(dead_code)]
+        #[derive(Deserialize)]
+        #[serde(rename_all = "camelCase", deny_unknown_fields)]
+        struct PreRangeSandboxPortSpec {
+            name: String,
+            container: String,
+            port: u16,
+        }
+
+        let ranged = SandboxPortSpec {
+            name: "dev".into(),
+            container: "agent".into(),
+            port: None,
+            port_range: Some(SandboxPortRange {
+                start: 3000,
+                end: 9999,
+            }),
+        };
+        let error = serde_json::from_value::<PreRangeSandboxPortSpec>(
+            serde_json::to_value(&ranged).unwrap(),
+        )
+        .err()
+        .expect("an older strict replica must reject a ranged declaration");
+        assert!(error.to_string().contains("portRange"));
+
+        let single = SandboxPortSpec {
+            name: "http".into(),
+            container: "agent".into(),
+            port: Some(8080),
+            port_range: None,
+        };
+        let read = serde_json::from_value::<PreRangeSandboxPortSpec>(
+            serde_json::to_value(&single).unwrap(),
+        )
+        .expect("an unchanged single-port declaration must still parse pre-upgrade");
+        assert_eq!(read.port, 8080);
     }
 }

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -1355,10 +1355,11 @@ pub struct SandboxTargetProvenance {
     /// Whether the exact pool generation that placed this lease published a
     /// port, and therefore whether [`Self::service`] had to be filled.
     ///
-    /// Recorded in the same status write as the workload identities, from the
-    /// pool the reconciler has already fenced to this lease's admitted UID and
-    /// generation. Release consults *this* rather than re-deriving the answer
-    /// from whatever the pool says later.
+    /// Recorded from the pool the reconciler has already fenced to this
+    /// lease's admitted UID and generation — normally in the same status write
+    /// as the workload identities, and otherwise at the Ready transition (see
+    /// below). Release consults *this* rather than re-deriving the answer from
+    /// whatever the pool says later.
     ///
     /// It exists because "no Service was ever required" and "the Service
     /// identity is missing" are the same absence, and telling them apart at
@@ -1383,16 +1384,28 @@ pub struct SandboxTargetProvenance {
     /// itself, in the same status write, from the pool already fenced to this
     /// lease's admitted UID and generation.
     ///
-    /// What is left in `None` is a lease made Ready by a release older than
-    /// this field, or one whose Ready write landed against a SandboxLease CRD
-    /// that still predates it — the API server prunes the unknown key under
-    /// the default `Warn` validation and answers success, and the status
-    /// writer does not re-read the stored object to notice. Both fall back to
-    /// the pool-generation derivation, which is what they have always used.
+    /// `None` therefore covers a wider population than "Ready before this
+    /// field existed", and is deliberately not narrowed by guesswork:
     ///
-    /// Nothing backfills a lease that is ALREADY Ready: that would mean
-    /// re-observing its Pod, and a Pod that has since been replaced would then
-    /// fail a merge that today never runs.
+    /// * a lease made Ready by a release older than the field;
+    /// * a lease made Ready by a controller that HAS the field but predates
+    ///   the Ready-transition write above — it knows the field and still
+    ///   leaves it absent on this path;
+    /// * a lease whose Ready write landed against a SandboxLease CRD that
+    ///   still predates the field. The API server prunes the unknown key under
+    ///   the default `Warn` validation and answers success, and the status
+    ///   writer does not re-read the stored object to notice.
+    ///
+    /// All of them fall back to the pool-generation derivation, which is what
+    /// they have always used, and which is fail-closed.
+    ///
+    /// Nothing backfills a MANAGEMENT lease that is already Ready. Not because
+    /// deriving the answer needs the Pod — it does not; the helper above
+    /// derives it from the pool alone — but because the admitted pool
+    /// GENERATION is what has since moved, and that is the one input a
+    /// backfill cannot recover. (A child-placed lease is different: its branch
+    /// re-enters `observed_provenance` unconditionally, so an already-Ready
+    /// child with matching identities can pick the flag up there.)
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub service_required: Option<bool>,
 }

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -891,6 +891,17 @@ pub fn merge_target_provenance(
         sandbox: merge_reference("sandbox", &existing.sandbox, proposed.sandbox)?,
         pod: merge_reference("pod", &existing.pod, proposed.pod)?,
         service: merge_reference("service", &existing.service, proposed.service)?,
+        // Monotonic for the same reason every reference above is. The pool
+        // generation is fenced for the life of a lease, so an honest reconcile
+        // always proposes the same answer; a proposal that flips it is a lease
+        // being re-derived against a pool it was never admitted against, and
+        // release would then either demand a Service that never existed or
+        // excuse one that did.
+        service_required: merge_flag(
+            "serviceRequired",
+            &existing.service_required,
+            proposed.service_required,
+        )?,
     })
 }
 
@@ -1142,6 +1153,23 @@ fn merge_string(
         (None, proposed) => Ok(proposed),
         (Some(_), None) => Err(SandboxProvenanceError::ReferenceCleared(field)),
         (Some(current), Some(proposed)) if current == &proposed => Ok(Some(current.clone())),
+        (Some(_), Some(_)) => Err(SandboxProvenanceError::ReferenceChanged(field)),
+    }
+}
+
+/// Same monotonic rule as [`merge_reference`], for a recorded fact rather than
+/// an identity. Clearing is refused as loudly as changing: a flag that can go
+/// back to "unknown" is a flag release cannot rely on, which is the whole
+/// reason it is written down.
+fn merge_flag(
+    field: &'static str,
+    existing: &Option<bool>,
+    proposed: Option<bool>,
+) -> Result<Option<bool>, SandboxProvenanceError> {
+    match (existing, proposed) {
+        (None, proposed) => Ok(proposed),
+        (Some(_), None) => Err(SandboxProvenanceError::ReferenceCleared(field)),
+        (Some(current), Some(proposed)) if *current == proposed => Ok(Some(proposed)),
         (Some(_), Some(_)) => Err(SandboxProvenanceError::ReferenceChanged(field)),
     }
 }
@@ -1678,6 +1706,7 @@ mod tests {
             sandbox: None,
             pod: None,
             service: None,
+            service_required: None,
         }
     }
 
@@ -2122,6 +2151,7 @@ mod tests {
             sandbox: None,
             pod: None,
             service: None,
+            service_required: None,
         };
         assert_eq!(
             merge_target_provenance(Some(&target), target.clone(), &placement, "kobe"),

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -234,13 +234,19 @@ pub fn build_sandbox_template(
         .containers
         .iter()
         .map(|container| {
+            // Only published ports become `ContainerPort`s. A `portRange`
+            // authorizes forwarding and publishes nothing: one band supplies
+            // neither the single number nor the single name a `ContainerPort`
+            // carries, and a Pod rendering thousands of synthesised ports
+            // would be a spec the administrator never wrote. Forwarding does
+            // not need them — it addresses the Pod's network namespace, which
+            // `ContainerPort` only documents.
             let ports: Vec<ContainerPort> = pool
                 .template
-                .exposed_ports
-                .iter()
-                .filter(|port| port.container == container.name)
-                .map(|port| ContainerPort {
-                    container_port: i32::from(port.port),
+                .published_ports()
+                .filter(|(port, _)| port.container == container.name)
+                .map(|(port, number)| ContainerPort {
+                    container_port: i32::from(number),
                     name: Some(port.name.clone()),
                     protocol: Some("TCP".to_string()),
                     ..Default::default()
@@ -307,7 +313,7 @@ pub fn build_sandbox_template(
                     },
                     "spec": pod_spec
                 },
-                "service": !pool.template.exposed_ports.is_empty(),
+                "service": pool.template.requires_service(),
                 "networkPolicyManagement": "Managed",
                 "envVarsInjectionPolicy": "Disallowed",
                 "volumeClaimTemplatesPolicy": "Disallowed"
@@ -1396,7 +1402,8 @@ mod tests {
                 exposed_ports: vec![SandboxPortSpec {
                     name: "http".into(),
                     container: "agent".into(),
-                    port: 3000,
+                    port: Some(3000),
+                    port_range: None,
                 }],
                 runner_path: None,
                 attach_command: None,


### PR DESCRIPTION
Pools can now authorize a bounded band of development ports, so a leased workspace can forward a dev server without a GitOps edit for each port. An exposedPorts entry declares exactly one port or one portRange. Single ports retain named resolution and Pod/Service publication; ranges resolve by number and publish no Service. Each range is capped at 8192 ports; multiple ranges can authorize a larger union.

Range-only lease teardown now uses an immutable serviceRequired flag recorded from the admitted pool at provisioning or the Ready transition. Pool edits or deletion therefore do not strand new Service-free leases. Already-Ready leases without the flag retain the existing fail-closed fallback.

Rollout order: update CRDs, finish every operator replica's upgrade, then apply ranges with strict field validation. An older operator cannot deserialize a range-bearing pool, which can break its pool list/watch across all pools. Against an older CRD, range-only entries fail, but a both-fields entry may have its unknown range pruned unless strict validation is used.

Validation: three Codex review rounds and follow-up fixes; full workspace formatting, clippy, tests, and CRD drift checks passed on 843685f. The final Ready-path regression was proven to fail when the production write was removed. The subsequent CI fix uses server-side dry-run for authority and firewall readiness probes, avoiding persistent early probes that become permitted no-op writes. Current CI checks are shown below by GitHub.

Known pre-existing adjacent issue: #222 tracks child-allocation teardown's separate ClusterPool generation fence; this PR does not change that path.
