### PR TITLE
feat(exec): forward stdin to the executed process so secrets stay out of argv

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3450,6 +3450,7 @@ name = "kobectl"
 version = "0.43.2"
 dependencies = [
  "anyhow",
+ "base64 0.22.1",
  "chrono",
  "clap",
  "crossterm",

--- a/crates/kobe-runner/src/main.rs
+++ b/crates/kobe-runner/src/main.rs
@@ -23,6 +23,13 @@
 //! hash Kobe derived — ever appears as an argument; the command itself travels
 //! on stdin, which nothing on the path records. It is one line, so the runner
 //! never has to wait for an EOF that the exec transport may never deliver.
+//!
+//! The request may carry the supervised process's own stdin for the same
+//! reason. A command that reads a credential — `gh auth login --with-token` —
+//! could otherwise only be given one in a flag, which is precisely the argv
+//! this design exists to keep secrets out of. Those bytes are never written to
+//! the spool: `start` hands them to the supervisor over a pipe and only their
+//! length appears in an argument.
 
 use std::io::BufRead;
 
@@ -66,6 +73,17 @@ enum Commands {
     Supervise {
         #[arg(long)]
         id: String,
+        /// How many bytes of the command's stdin are waiting on this process's
+        /// own stdin.
+        ///
+        /// A count, never the bytes: the count is all the supervisor needs, and
+        /// a count is not a secret. (This argv is an internal re-exec inside
+        /// the container, so it never reaches the apiserver's audit log either
+        /// way.) Absent means the command reads `/dev/null`, exactly as it did
+        /// before stdin forwarding existed — which is also what keeps a
+        /// `supervise` run by hand from blocking on a terminal.
+        #[arg(long)]
+        stdin_bytes: Option<usize>,
     },
     /// Report what one execution is doing.
     Status {
@@ -96,9 +114,9 @@ fn main() {
 
     // `supervise` is the one subcommand that is not a request/response: it IS
     // the long-lived process, and it prints nothing because nobody is reading.
-    if let Commands::Supervise { id } = &cli.command {
+    if let Commands::Supervise { id, stdin_bytes } = &cli.command {
         #[cfg(unix)]
-        supervisor::supervise(&spool, id);
+        supervisor::supervise(&spool, id, *stdin_bytes, std::io::stdin());
         return;
     }
 
@@ -166,6 +184,15 @@ fn start(
     if let Err(code) = validate(&request) {
         return error(code);
     }
+    // Decoded before anything is reserved, and held only in memory from here
+    // on. `validate` has already proved this succeeds; re-deriving the failure
+    // rather than defaulting to "no stdin" is deliberate, because silently
+    // dropping the bytes would start the command with an empty stdin and then
+    // report success.
+    let stdin = match request.stdin_bytes() {
+        Ok(stdin) => stdin,
+        Err(_) => return error(RunnerErrorCode::InvalidRequest),
+    };
 
     match spool.reserve(&request) {
         Ok(Reservation::Created(_start_reservation)) => {
@@ -176,7 +203,7 @@ fn start(
                 // without ever manufacturing the command.
                 std::process::exit(TEST_EXECUTION_CRASH_EXIT_CODE);
             }
-            match spawn_supervisor(state_dir, &request.id) {
+            match spawn_supervisor(state_dir, &request.id, stdin.as_deref()) {
                 Ok(()) if exit_after_spawn_before_ack => {
                     // The reservation and supervisor are both durable, but no
                     // reply is written. Kobe must settle the lost
@@ -259,6 +286,13 @@ fn validate(request: &StartRequest) -> Result<(), RunnerErrorCode> {
         // ephemeral disk the whole Pod shares.
         return Err(RunnerErrorCode::InvalidRequest);
     }
+    if request.stdin_bytes().is_err() {
+        // Refused, never truncated to fit. Half a token is still a secret, and
+        // the command that received it would fail somewhere a long way from
+        // the request that caused it. Checked here — before the reservation —
+        // so an unusable stdin cannot spend an idempotency key.
+        return Err(RunnerErrorCode::InvalidRequest);
+    }
     Ok(())
 }
 
@@ -270,8 +304,16 @@ fn validate(request: &StartRequest) -> Result<(), RunnerErrorCode> {
 /// afterwards, so the supervisor is reparented to the container's init and
 /// survives the teardown of the exec that started it — which is the entire
 /// reason "detached" means anything.
+///
+/// The command's stdin, when it has any, is handed over through a pipe rather
+/// than through the spool. That is the whole reason this feature is worth
+/// having: a secret that never touches a filesystem cannot be read out of one
+/// later. Only its LENGTH travels as an argument, so the supervisor can read
+/// exactly that many bytes and can tell a short read — a lost secret — from a
+/// caller who asked for an empty stdin.
 #[cfg(unix)]
-fn spawn_supervisor(state_dir: &str, id: &str) -> std::io::Result<()> {
+fn spawn_supervisor(state_dir: &str, id: &str, stdin: Option<&[u8]>) -> std::io::Result<()> {
+    use std::io::Write;
     use std::os::unix::process::CommandExt;
     use std::process::{Command, Stdio};
 
@@ -295,9 +337,22 @@ fn spawn_supervisor(state_dir: &str, id: &str) -> std::io::Result<()> {
         // holding the exec's stdout would keep the connection's pipe open, and
         // the caller's client would wait for a stream that nobody is going to
         // close.
-        .stdin(Stdio::null())
         .stdout(Stdio::null())
         .stderr(Stdio::null());
+    match stdin {
+        // A fresh pipe, never this process's own stdin: that descriptor belongs
+        // to the exec connection, and a supervisor holding it would keep the
+        // connection alive after the caller stopped reading.
+        Some(stdin) => {
+            command
+                .arg("--stdin-bytes")
+                .arg(stdin.len().to_string())
+                .stdin(Stdio::piped());
+        }
+        None => {
+            command.stdin(Stdio::null());
+        }
+    }
 
     // SAFETY: `setsid` is async-signal-safe and is the only call between fork
     // and exec. It detaches the supervisor from this process's session, so the
@@ -310,7 +365,24 @@ fn spawn_supervisor(state_dir: &str, id: &str) -> std::io::Result<()> {
             Ok(())
         });
     }
-    let child = command.spawn()?;
+    let mut child = command.spawn()?;
+
+    if let Some(stdin) = stdin {
+        // Written and then closed, in that order, before this process returns.
+        // The supervisor reads exactly this many bytes as its first act, so a
+        // payload larger than the pipe buffer blocks here only until it is
+        // drained. A failure is fatal to the spawn on purpose: the alternative
+        // is a supervisor that starts the command with a truncated secret.
+        let mut sink = child
+            .stdin
+            .take()
+            .ok_or_else(|| std::io::Error::other("the supervisor has no stdin to write"))?;
+        sink.write_all(stdin)?;
+        // Explicit, so the supervisor's bounded read cannot be left waiting on
+        // a descriptor that only closes when this process happens to exit.
+        drop(sink);
+    }
+
     // Recorded so a later `status` or `cancel` can tell "still running" from
     // "the supervisor is gone and nobody will ever record an outcome".
     let _ = spool.write_supervisor_pid(id, child.id());
@@ -318,7 +390,7 @@ fn spawn_supervisor(state_dir: &str, id: &str) -> std::io::Result<()> {
 }
 
 #[cfg(not(unix))]
-fn spawn_supervisor(_state_dir: &str, _id: &str) -> std::io::Result<()> {
+fn spawn_supervisor(_state_dir: &str, _id: &str, _stdin: Option<&[u8]>) -> std::io::Result<()> {
     Err(std::io::Error::other("the runner supervises only on unix"))
 }
 
@@ -487,6 +559,7 @@ mod tests {
             cwd: Some("/work".into()),
             timeout_seconds: 60,
             max_output_bytes: 1024,
+            stdin_base64: None,
         }
     }
 
@@ -558,6 +631,77 @@ mod tests {
             );
         }
         assert!(with(&|r| r.cwd = None).is_ok());
+    }
+
+    /// Stdin that cannot be delivered whole reserves nothing.
+    ///
+    /// Refusing before the reservation is what keeps an oversized or malformed
+    /// secret from spending an idempotency key on a command that could never
+    /// have been given its input. Truncating to fit is the one response that is
+    /// never correct: half a token is still a secret, and the command would
+    /// fail somewhere a long way from the cause.
+    #[test]
+    fn stdin_that_cannot_be_delivered_whole_reserves_nothing() {
+        use base64::Engine;
+        use kobe_runner::protocol::MAX_STDIN_BYTES;
+
+        let encode = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
+        let with = |encoded: Option<String>| {
+            let mut request = request();
+            request.stdin_base64 = encoded;
+            validate(&request)
+        };
+
+        assert!(with(None).is_ok(), "no stdin at all stays valid");
+        assert!(
+            with(Some(String::new())).is_ok(),
+            "an empty stdin is a request"
+        );
+        assert!(with(Some(encode(b"ghp_token"))).is_ok());
+        assert!(with(Some(encode(&vec![b'x'; MAX_STDIN_BYTES]))).is_ok());
+
+        assert_eq!(
+            with(Some(encode(&vec![b'x'; MAX_STDIN_BYTES + 1]))),
+            Err(RunnerErrorCode::InvalidRequest),
+            "one byte past the bound is refused, not trimmed"
+        );
+        assert_eq!(
+            with(Some("not base64!!".into())),
+            Err(RunnerErrorCode::InvalidRequest)
+        );
+    }
+
+    /// A request carrying stdin still has to fit the encoded-request bound.
+    ///
+    /// [`MAX_STDIN_BYTES`] and [`MAX_REQUEST_BYTES`] are two different ceilings
+    /// and both apply. Neither is allowed to become a silent truncation of the
+    /// other.
+    #[test]
+    fn stdin_is_bounded_inside_the_encoded_request_bound() {
+        use base64::Engine;
+        use kobe_runner::protocol::MAX_STDIN_BYTES;
+
+        let mut request = request();
+        request.stdin_base64 =
+            Some(base64::engine::general_purpose::STANDARD.encode(vec![b'x'; MAX_STDIN_BYTES]));
+        let mut encoded = serde_json::to_vec(&request).unwrap();
+        encoded.push(b'\n');
+        assert!(
+            encoded.len() < MAX_REQUEST_BYTES,
+            "a maximal stdin must still leave room for a command: {} bytes",
+            encoded.len()
+        );
+        assert_eq!(read_start_request(encoded.as_slice()).unwrap(), request);
+
+        // Padding the argv past the whole-request bound is refused by the
+        // reader, before the stdin ceiling is ever consulted.
+        request.argv.push("y".repeat(MAX_REQUEST_BYTES));
+        let mut oversized = serde_json::to_vec(&request).unwrap();
+        oversized.push(b'\n');
+        assert_eq!(
+            read_start_request(oversized.as_slice()).unwrap_err(),
+            RunnerErrorCode::InvalidRequest
+        );
     }
 
     /// Neither bound may be absent, and neither may be unbounded.

--- a/crates/kobe-runner/src/protocol.rs
+++ b/crates/kobe-runner/src/protocol.rs
@@ -68,6 +68,21 @@ pub const MAX_LOG_CHUNK_BYTES: usize = 256 * 1024;
 /// installed runner can only reject after its idempotency key is durable.
 pub const MAX_REQUEST_BYTES: usize = 64 * 1024;
 
+/// Most stdin one execution may carry to its process.
+///
+/// This is a channel for **secrets and small inputs** — a token for
+/// `gh auth login --with-token`, a password, a short configuration document. It
+/// is emphatically not file transfer: the bytes travel base64-encoded inside
+/// the single start request that [`MAX_REQUEST_BYTES`] bounds as a whole, and
+/// both Kobe and the runner hold them in memory for the duration of the spawn.
+///
+/// Sixteen KiB encodes to just under 22 KiB of base64, which leaves the argv,
+/// the cwd and the JSON scaffolding comfortable room inside the 64 KiB request.
+/// A caller who exceeds it is **refused**, never truncated: half a token is
+/// still a secret, and a command that read half its input and then saw EOF
+/// would fail somewhere a long way from the cause.
+pub const MAX_STDIN_BYTES: usize = 16 * 1024;
+
 /// Hidden runner flag used only by the administrator-driven #82 live gate.
 ///
 /// The process exits after its target-side reservation is durable, but before
@@ -123,6 +138,10 @@ pub fn is_valid_id(id: &str) -> bool {
 /// an argument — and the exec request's argv is a URL that the target
 /// apiserver's audit log records verbatim. stdin is the only channel into the
 /// container that nothing on the way logs.
+///
+/// [`StartRequest::stdin_base64`] extends that same channel one hop further, to
+/// the supervised process itself, so a command that reads a credential from
+/// stdin no longer has to be given one in a flag.
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase", deny_unknown_fields)]
 pub struct StartRequest {
@@ -143,6 +162,34 @@ pub struct StartRequest {
     /// Per-stream retention cap. Output past it is discarded and the fact is
     /// reported — never silently dropped.
     pub max_output_bytes: u64,
+    /// Bytes to write to the process's stdin, base64, then close.
+    ///
+    /// The whole point of the field: a Sandbox has no other way to receive a
+    /// secret. Everything else a caller can say about a command ends up in
+    /// argv, and the exec request's argv is a URL the target apiserver
+    /// audit-logs verbatim — so `gh auth login --with-token`, which reads its
+    /// token from stdin, was previously only expressible by putting the token
+    /// somewhere it would be recorded. This is the other half of the intent
+    /// that already puts the request itself on the runner's stdin.
+    ///
+    /// Bounded by [`MAX_STDIN_BYTES`], and for secrets rather than files — see
+    /// that constant for why the bound is what it is. Base64 so exact bytes
+    /// survive the JSON: a token is not required to be UTF-8, and a lossy
+    /// conversion here would corrupt a credential in a way nothing downstream
+    /// could diagnose.
+    ///
+    /// **Absent when unused, and that is load-bearing.** A request that carries
+    /// no stdin serialises byte-for-byte as it did before this field existed,
+    /// so a released runner that denies unknown fields still accepts it. A
+    /// request that *does* carry stdin is refused outright by such a runner —
+    /// loudly, before anything is reserved — which is the correct failure for a
+    /// Sandbox image too old to honour it. Silently dropping the field would
+    /// run the command with no stdin at all and report success.
+    ///
+    /// Never persisted. The runner keeps it out of its spool and Kobe keeps it
+    /// out of the `SandboxExecution` record; only a digest of it is durable.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub stdin_base64: Option<String>,
 }
 
 impl StartRequest {
@@ -152,12 +199,71 @@ impl StartRequest {
     /// the id — a retry carries the same id anyway. Timeout remains part of the
     /// v1 identity: changing it would require either a negotiated protocol or a
     /// second authority that an older runner understands.
+    ///
+    /// stdin is excluded, and not by oversight. The comparison runs against the
+    /// request the runner kept in its spool, and the spool deliberately does
+    /// not keep the stdin bytes — see [`StartRequest::without_stdin`]. Nor
+    /// could a digest stored there stand in: the spool shares a UID with the
+    /// tenant's workload, which can forge every file in it. The authority that
+    /// two same-key requests are the same command is Kobe's own request digest,
+    /// which *does* cover stdin and is checked in the API server before this
+    /// runner is ever reached.
     pub fn same_command(&self, other: &Self) -> bool {
         self.argv == other.argv
             && self.cwd == other.cwd
             && self.timeout_seconds == other.timeout_seconds
             && self.max_output_bytes == other.max_output_bytes
     }
+
+    /// The same request with the stdin bytes removed.
+    ///
+    /// What the runner writes to its spool. The spool lives on a filesystem the
+    /// tenant's workload shares, survives the command that needed the secret,
+    /// and is read back by a separate process on every `status` and `cancel` —
+    /// none of which has any use for the bytes. A secret that only ever exists
+    /// in memory cannot be read out of a file later.
+    pub fn without_stdin(&self) -> Self {
+        Self {
+            stdin_base64: None,
+            ..self.clone()
+        }
+    }
+
+    /// The decoded stdin bytes, or why they are unusable.
+    ///
+    /// `Ok(None)` means the caller asked for no stdin at all, which is not the
+    /// same as asking for an empty one: the first leaves the process reading
+    /// `/dev/null`, the second hands it a pipe that is immediately closed. Both
+    /// see EOF, but only the second is a statement the caller made.
+    ///
+    /// The bound is checked on the decoded bytes rather than the encoding, so
+    /// the error a caller gets names the size they actually sent.
+    pub fn stdin_bytes(&self) -> Result<Option<Vec<u8>>, StdinRejected> {
+        use base64::Engine;
+
+        let Some(encoded) = self.stdin_base64.as_deref() else {
+            return Ok(None);
+        };
+        let bytes = base64::engine::general_purpose::STANDARD
+            .decode(encoded)
+            .map_err(|_| StdinRejected::NotBase64)?;
+        if bytes.len() > MAX_STDIN_BYTES {
+            return Err(StdinRejected::TooLarge);
+        }
+        Ok(Some(bytes))
+    }
+}
+
+/// Why stdin could not be accepted.
+///
+/// Two distinct reasons rather than one, because they are two different
+/// mistakes: a client that encoded badly and a client that sent too much need
+/// to look in different places. Neither is ever repaired by truncation.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum StdinRejected {
+    NotBase64,
+    /// More than [`MAX_STDIN_BYTES`] once decoded.
+    TooLarge,
 }
 
 /// Where one supervised command is.
@@ -432,6 +538,7 @@ mod tests {
             cwd: Some("/work".into()),
             timeout_seconds: 60,
             max_output_bytes: 1024,
+            stdin_base64: None,
         };
         assert!(base.same_command(&base.clone()));
 
@@ -491,6 +598,7 @@ mod tests {
             cwd: None,
             timeout_seconds: 5,
             max_output_bytes: 16,
+            stdin_base64: None,
         };
         let encoded = serde_json::to_string(&request).unwrap();
         let decoded: StartRequest = serde_json::from_str(&encoded).unwrap();
@@ -534,6 +642,7 @@ mod tests {
             cwd: Some("/work".into()),
             timeout_seconds: 60,
             max_output_bytes: 1024,
+            stdin_base64: None,
         };
         let emitted = serde_json::to_string(&current).unwrap();
         let released: ReleasedV1StartRequest = serde_json::from_str(&emitted)
@@ -553,5 +662,140 @@ mod tests {
             !emitted.contains("requestDigest"),
             "v1 must not grow a field an older strict runner rejects: {emitted}"
         );
+        assert!(
+            !emitted.contains("stdin"),
+            "a request with no stdin must be byte-identical to the released shape: {emitted}"
+        );
+
+        // A request that DOES carry stdin is refused by the released runner
+        // rather than run without it. Loud is the correct behaviour here: a
+        // Sandbox image too old to forward stdin would otherwise start the
+        // command with an empty one and report success, which for
+        // `gh auth login --with-token` means an unauthenticated agent and no
+        // indication why.
+        let with_stdin = StartRequest {
+            stdin_base64: Some("dG9rZW4=".into()),
+            ..current
+        };
+        let emitted = serde_json::to_string(&with_stdin).unwrap();
+        assert!(
+            serde_json::from_str::<ReleasedV1StartRequest>(&emitted).is_err(),
+            "an older strict runner must refuse stdin rather than silently drop it"
+        );
+    }
+
+    /// stdin is bounded, and the boundary refuses rather than truncates.
+    ///
+    /// Truncation is the failure mode that must never exist here: half a token
+    /// is still a secret, and the command that received it would fail
+    /// somewhere a long way from the request that caused it.
+    #[test]
+    fn oversized_stdin_is_refused_at_the_documented_boundary() {
+        use base64::Engine;
+        let encode = |bytes: &[u8]| base64::engine::general_purpose::STANDARD.encode(bytes);
+
+        let mut request = StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: "sbxe-1".into(),
+            argv: vec!["/agent".into()],
+            cwd: None,
+            timeout_seconds: 60,
+            max_output_bytes: 1024,
+            stdin_base64: None,
+        };
+        assert_eq!(request.stdin_bytes(), Ok(None));
+
+        // Absent and present-but-empty are different requests. The first leaves
+        // the process reading /dev/null; the second is a caller deliberately
+        // handing it an immediately-closed pipe.
+        request.stdin_base64 = Some(String::new());
+        assert_eq!(request.stdin_bytes(), Ok(Some(Vec::new())));
+
+        request.stdin_base64 = Some(encode(&vec![b'x'; MAX_STDIN_BYTES]));
+        assert_eq!(
+            request.stdin_bytes().unwrap().unwrap().len(),
+            MAX_STDIN_BYTES,
+            "exactly the bound is accepted"
+        );
+
+        request.stdin_base64 = Some(encode(&vec![b'x'; MAX_STDIN_BYTES + 1]));
+        assert_eq!(request.stdin_bytes(), Err(StdinRejected::TooLarge));
+
+        request.stdin_base64 = Some("not base64!!".into());
+        assert_eq!(request.stdin_bytes(), Err(StdinRejected::NotBase64));
+
+        // The encoded request still has to fit the whole-request bound, so the
+        // stdin ceiling must leave room for a command beside it.
+        let encoded_ceiling = MAX_STDIN_BYTES.div_ceil(3) * 4;
+        assert!(
+            encoded_ceiling + 1024 < MAX_REQUEST_BYTES,
+            "the stdin bound must leave room for argv inside MAX_REQUEST_BYTES"
+        );
+    }
+
+    /// Exact bytes survive, including the ones that are not text.
+    ///
+    /// A credential is not required to be UTF-8, and a lossy conversion at this
+    /// layer would corrupt it in a way nothing downstream could diagnose.
+    #[test]
+    fn stdin_bytes_survive_the_wire_exactly() {
+        use base64::Engine;
+
+        let raw: Vec<u8> = (0u8..=255).collect();
+        let request = StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: "sbxe-1".into(),
+            argv: vec!["/agent".into()],
+            cwd: None,
+            timeout_seconds: 60,
+            max_output_bytes: 1024,
+            stdin_base64: Some(base64::engine::general_purpose::STANDARD.encode(&raw)),
+        };
+        let decoded: StartRequest =
+            serde_json::from_str(&serde_json::to_string(&request).unwrap()).unwrap();
+        assert_eq!(decoded.stdin_bytes().unwrap().unwrap(), raw);
+    }
+
+    /// The runner's own copy of a request never carries the secret.
+    ///
+    /// `without_stdin` is what reaches the spool, which shares a filesystem
+    /// with the tenant's workload and outlives the command that needed the
+    /// secret. Everything else about the request is preserved, because the
+    /// supervisor still has to run it.
+    #[test]
+    fn a_request_stripped_for_the_spool_keeps_everything_but_the_secret() {
+        let request = StartRequest {
+            protocol: PROTOCOL_VERSION,
+            id: "sbxe-1".into(),
+            argv: vec!["/agent".into(), "run".into()],
+            cwd: Some("/work".into()),
+            timeout_seconds: 60,
+            max_output_bytes: 1024,
+            stdin_base64: Some("czNjcmV0".into()),
+        };
+        let stripped = request.without_stdin();
+        assert_eq!(stripped.stdin_base64, None);
+        assert_eq!(
+            stripped,
+            StartRequest {
+                stdin_base64: None,
+                ..request.clone()
+            }
+        );
+
+        let encoded = serde_json::to_string(&stripped).unwrap();
+        assert!(
+            !encoded.contains("czNjcmV0"),
+            "the spool copy leaked: {encoded}"
+        );
+        assert!(
+            !encoded.contains("stdin"),
+            "the spool copy leaked: {encoded}"
+        );
+
+        // And a retry still recognises it as the same command, even though the
+        // stored copy can no longer prove anything about stdin.
+        assert!(stripped.same_command(&request));
+        assert!(request.same_command(&stripped));
     }
 }

--- a/crates/kobe-runner/src/spool.rs
+++ b/crates/kobe-runner/src/spool.rs
@@ -144,7 +144,13 @@ impl Spool {
         let assemble = || -> Result<(), SpoolError> {
             std::fs::write(
                 staging.join(REQUEST_FILE),
-                serde_json::to_vec(request).map_err(|_| SpoolError::Corrupt)?,
+                // Stripped of stdin, deliberately. Those bytes are the one part
+                // of a request that exists to carry a secret, and this file
+                // sits on a filesystem the tenant's workload shares, outlives
+                // the command that needed them, and is re-read by every later
+                // `status` and `cancel` — none of which has any use for them.
+                // The supervisor is handed them in memory instead.
+                serde_json::to_vec(&request.without_stdin()).map_err(|_| SpoolError::Corrupt)?,
             )?;
             // Written before the supervisor exists, so a poll that arrives
             // between the reservation and the spawn finds a state rather than
@@ -470,7 +476,73 @@ mod tests {
             cwd: None,
             timeout_seconds: 60,
             max_output_bytes: 1024,
+            stdin_base64: None,
         }
+    }
+
+    /// A reserved request never puts its stdin on disk.
+    ///
+    /// The whole reason stdin exists on this contract is that a secret must
+    /// not end up somewhere it is recorded. The spool shares a filesystem and
+    /// a UID with the tenant's workload and outlives the command, so writing
+    /// the bytes here would trade an audit-log leak for a longer-lived one.
+    #[test]
+    fn a_reservation_never_writes_stdin_to_the_spool() {
+        use base64::Engine;
+
+        let root = tempdir();
+        let spool = Spool::new(root.path());
+
+        let secret = b"ghp_averysecrettokenvalue";
+        let mut reserved = request("sbxe-1", &["/agent", "run"]);
+        reserved.stdin_base64 =
+            Some(base64::engine::general_purpose::STANDARD.encode(secret.as_slice()));
+
+        assert!(matches!(
+            spool.reserve(&reserved).unwrap(),
+            Reservation::Created(_)
+        ));
+
+        // Nothing anywhere below the spool root, not just the request file: a
+        // future file that happened to serialise the whole request would be
+        // exactly the regression this pins.
+        let mut seen_files = 0usize;
+        let mut pending = vec![root.path().to_path_buf()];
+        while let Some(directory) = pending.pop() {
+            for entry in std::fs::read_dir(&directory).unwrap() {
+                let path = entry.unwrap().path();
+                if path.is_dir() {
+                    pending.push(path);
+                    continue;
+                }
+                seen_files += 1;
+                let bytes = std::fs::read(&path).unwrap();
+                assert!(
+                    !bytes.windows(secret.len()).any(|window| window == secret),
+                    "{} holds the raw stdin",
+                    path.display()
+                );
+                assert!(
+                    !String::from_utf8_lossy(&bytes)
+                        .contains(reserved.stdin_base64.as_ref().unwrap()),
+                    "{} holds the encoded stdin",
+                    path.display()
+                );
+            }
+        }
+        assert!(seen_files > 0, "the reservation wrote nothing at all");
+
+        // The rest of the request is still there — the supervisor has to run it.
+        let stored = spool.read_request("sbxe-1").unwrap();
+        assert_eq!(stored.argv, reserved.argv);
+        assert_eq!(stored.stdin_base64, None);
+
+        // And a retry carrying the same stdin is still recognised as a retry,
+        // not as a different command wearing the same id.
+        assert!(matches!(
+            spool.reserve(&reserved).unwrap(),
+            Reservation::AlreadyReserved
+        ));
     }
 
     /// One id reserves at most one command, whoever asks second.

--- a/crates/kobe-runner/src/supervisor.rs
+++ b/crates/kobe-runner/src/supervisor.rs
@@ -166,8 +166,16 @@ pub fn supervise(spool: &Spool, id: &str, stdin_bytes: Option<usize>, source: im
     // command is already running in a session of its own. A supervisor that
     // gave up here without killing the group would leave that command with no
     // deadline and nobody to reap it — the very failure the whole "outlives the
-    // connection" design exists to make impossible. So the group is torn down
-    // first, and only then is the execution settled.
+    // connection" design exists to make impossible. So teardown is ATTEMPTED
+    // before the execution is settled, in that order.
+    //
+    // Attempted, not guaranteed: [`terminate_group`] signals the group and then
+    // waits at most TERMINATION_GRACE per drain for it to actually leave, and
+    // the call below discards its answer. Signal delivery is not reaping, so a
+    // process that outlives both windows outlives this supervisor too. That is
+    // exactly why the report is `Unknown` — the honest word for a group whose
+    // absence nobody proved — and why the lease, not this function, is the last
+    // line of defence: the Pod dying takes the group with it.
     let helpers = feed(child.stdin.take(), stdin).and_then(|()| {
         let stdout = pump(
             child.stdout.take(),
@@ -196,6 +204,14 @@ pub fn supervise(spool: &Spool, id: &str, stdin_bytes: Option<usize>, source: im
             // same code the pre-spawn setup failures use, and means the same
             // thing to Kobe — this process never reached the point of watching
             // anything, so the target is destroyed rather than reused.
+            //
+            // The write can fail and the error is discarded, so this is a
+            // terminal report ATTEMPTED rather than one guaranteed: a workload
+            // that removed its own `state.lock` gets a refused pump here and
+            // then a `write_report` that cannot take the lock either, and the
+            // supervisor exits leaving `Running` behind. Nothing better can be
+            // done from inside a spool the tenant owns, and Kobe's verdict
+            // deadline is what turns that stale `Running` into `Unknown`.
             let _ = spool.write_report(&ExecutionReport {
                 id: id.to_string(),
                 state: RunnerState::Unknown,

--- a/crates/kobe-runner/src/supervisor.rs
+++ b/crates/kobe-runner/src/supervisor.rs
@@ -24,6 +24,16 @@
 //!
 //! Its own session, separate from the supervisor's, is what lets the supervisor
 //! survive the kill it just issued and record the outcome.
+//!
+//! # Why the command's stdin arrives through a pipe and not the spool
+//!
+//! stdin exists on this contract so a Sandbox can receive a secret without it
+//! appearing in argv, which the target apiserver audit-logs verbatim. Passing
+//! those bytes to the supervisor through the spool would move the secret off
+//! the audit log and onto a filesystem the tenant's workload shares and that
+//! outlives the command — a worse place, not a better one. So `start` hands
+//! them over a pipe, this process holds them in memory, writes them to the
+//! command, and closes.
 
 use std::io::{Read, Write};
 use std::os::unix::process::{CommandExt, ExitStatusExt};
@@ -32,7 +42,9 @@ use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::{Duration, Instant};
 
-use crate::protocol::{ExecutionReport, LogStream, RunnerState, StartRequest, reason};
+use crate::protocol::{
+    ExecutionReport, LogStream, MAX_STDIN_BYTES, RunnerState, StartRequest, reason,
+};
 use crate::spool::{Spool, now_unix_ms};
 
 /// How often the supervisor looks at the world.
@@ -57,7 +69,40 @@ const TERMINATION_GRACE: Duration = Duration::from_secs(5);
 const OUTPUT_SETTLE: Duration = Duration::from_secs(2);
 
 /// Supervise one reserved execution until it settles, then exit.
-pub fn supervise(spool: &Spool, id: &str) {
+///
+/// `stdin_bytes` says how many bytes of the command's stdin are waiting on
+/// `source` — this process's own stdin in production. They are read first,
+/// before the spool and before anything is spawned: the writer is the `start`
+/// process, which exits as soon as the handover completes, so the bytes have to
+/// be taken while they are still there. `None` means the command reads
+/// `/dev/null`, which is what every execution did before stdin forwarding
+/// existed.
+///
+/// The bytes stay in this process's memory and are never written to the spool.
+/// That is the point of the feature: the request travels on stdin because argv
+/// is audit-logged, and it would be a poor trade to move a secret off the audit
+/// log and onto a disk the tenant's workload shares.
+pub fn supervise(spool: &Spool, id: &str, stdin_bytes: Option<usize>, source: impl Read) {
+    let started_at = now_unix_ms();
+    let stdin = match read_stdin(stdin_bytes, source) {
+        Ok(stdin) => stdin,
+        Err(_) => {
+            // Part of a secret arrived and the rest did not. Running the
+            // command anyway would hand it a truncated credential and then
+            // report whatever it made of that, so nothing is spawned and the
+            // execution settles as the state that never invites a blind retry.
+            let _ = spool.write_report(&ExecutionReport {
+                id: id.to_string(),
+                state: RunnerState::Unknown,
+                started_at_unix_ms: Some(started_at),
+                finished_at_unix_ms: Some(now_unix_ms()),
+                reason: Some(reason::SUPERVISOR_SETUP_FAILED.into()),
+                ..Default::default()
+            });
+            return;
+        }
+    };
+
     let request = match spool.read_request(id) {
         Ok(request) => request,
         Err(_) => {
@@ -68,7 +113,6 @@ pub fn supervise(spool: &Spool, id: &str) {
         }
     };
 
-    let started_at = now_unix_ms();
     if enable_child_subreaper().is_err() {
         // A Linux container's PID 1 is not required to reap orphans. Without
         // becoming a subreaper, this process cannot prove that every member of
@@ -83,7 +127,7 @@ pub fn supervise(spool: &Spool, id: &str) {
         });
         return;
     }
-    let mut child = match spawn(&request) {
+    let mut child = match spawn(&request, stdin.is_some()) {
         Ok(child) => child,
         Err(_) => {
             // The command definitely did not run, but this process cannot tell
@@ -105,6 +149,8 @@ pub fn supervise(spool: &Spool, id: &str) {
     // every descendant that has not deliberately left the group — the four
     // compilers a build script spawned before exiting.
     let group = child.id() as i32;
+
+    feed(child.stdin.take(), stdin);
 
     let stdout = pump(
         child.stdout.take(),
@@ -257,8 +303,64 @@ pub fn settle_report(
     }
 }
 
+/// Take the command's stdin off this process's own, exactly.
+///
+/// `read_exact` rather than "read to EOF" for the same reason the request
+/// itself is one line: the number of bytes is known in advance, so waiting for
+/// an EOF is waiting for something a writer is not obliged to deliver promptly.
+/// It is also what turns a partial handover into an error instead of a silently
+/// shorter secret — a short read here is a lost credential, not an empty one.
+fn read_stdin(
+    stdin_bytes: Option<usize>,
+    mut source: impl Read,
+) -> std::io::Result<Option<Vec<u8>>> {
+    let Some(length) = stdin_bytes else {
+        return Ok(None);
+    };
+    if length > MAX_STDIN_BYTES {
+        // The same ceiling Kobe and `start` enforce. A supervisor is only ever
+        // launched by `start`, so reaching this means the argv was tampered
+        // with — and allocating whatever it asked for is not the response.
+        return Err(std::io::Error::other("stdin length exceeds the bound"));
+    }
+    let mut bytes = vec![0u8; length];
+    source.read_exact(&mut bytes)?;
+    Ok(Some(bytes))
+}
+
+/// Hand the bytes to the process, then close its stdin.
+///
+/// On a thread, because the command is under no obligation to read: anything
+/// larger than a pipe buffer would otherwise block the supervisor's wait loop,
+/// and a supervisor that is not looping cannot cancel, time out, or drain
+/// output.
+///
+/// Closing is the half that makes this useful at all. `gh auth login
+/// --with-token` reads its token until EOF; a stdin that was written and left
+/// open would leave it waiting for the timeout to kill it. Dropping the handle
+/// — on every path, including a write that failed because the command already
+/// exited — is what delivers that EOF.
+fn feed(sink: Option<std::process::ChildStdin>, bytes: Option<Vec<u8>>) {
+    let (Some(mut sink), Some(bytes)) = (sink, bytes) else {
+        return;
+    };
+    std::thread::spawn(move || {
+        // A command that exits without reading gives EPIPE here. That is its
+        // choice, not a fault of the execution, and its own exit status is the
+        // outcome that gets reported.
+        let _ = sink.write_all(&bytes);
+        let _ = sink.flush();
+        drop(sink);
+    });
+}
+
 /// Start the command, in a session of its own.
-fn spawn(request: &StartRequest) -> std::io::Result<Child> {
+///
+/// `with_stdin` decides between a pipe this supervisor feeds and `/dev/null`.
+/// The distinction is the caller's to make: a command handed an immediately
+/// closed pipe and one handed `/dev/null` both see EOF, but only the first is
+/// something somebody asked for.
+fn spawn(request: &StartRequest, with_stdin: bool) -> std::io::Result<Child> {
     let mut command = Command::new(&request.argv[0]);
     command.args(&request.argv[1..]);
     if let Some(cwd) = &request.cwd {
@@ -267,9 +369,15 @@ fn spawn(request: &StartRequest) -> std::io::Result<Child> {
         // tenant's own untrusted input.
         command.current_dir(cwd);
     }
-    // No stdin at all. A detached command has no connection to read from, and
-    // an inherited terminal would let it stop on SIGTTIN and look like a hang.
-    command.stdin(Stdio::null());
+    // Never the supervisor's own stdin, and never an inherited terminal: a
+    // detached command has no connection to read from, and a terminal would let
+    // it stop on SIGTTIN and look like a hang. Either a pipe carrying exactly
+    // what the caller supplied, or nothing at all.
+    command.stdin(if with_stdin {
+        Stdio::piped()
+    } else {
+        Stdio::null()
+    });
     command.stdout(Stdio::piped());
     command.stderr(Stdio::piped());
 

--- a/crates/kobe-runner/src/supervisor.rs
+++ b/crates/kobe-runner/src/supervisor.rs
@@ -81,7 +81,19 @@ const OUTPUT_SETTLE: Duration = Duration::from_secs(2);
 /// The bytes stay in this process's memory and are never written to the spool.
 /// That is the point of the feature: the request travels on stdin because argv
 /// is audit-logged, and it would be a poor trade to move a secret off the audit
-/// log and onto a disk the tenant's workload shares.
+/// log and onto a disk the tenant's workload shares. In *memory* they are an
+/// ordinary `Vec<u8>`, neither zeroized nor `mlock`ed: a core dump of this
+/// process, or the container's swap, can still hold them. Bounding the exposure
+/// to one process's lifetime is the guarantee on offer here; defeating an
+/// attacker who can read the runner's own address space is not.
+///
+/// Once the command exists, nothing may unwind out of this function. It has
+/// been spawned into a session of its own and dropping [`Child`] does not kill
+/// it, so a supervisor that dies here leaves a command running past its
+/// deadline with nobody to cancel or reap it. Every step after the spawn
+/// therefore reports its failure instead of panicking on it — see
+/// [`spawn_helper`] — and each one tears the process group down before
+/// settling the execution.
 pub fn supervise(spool: &Spool, id: &str, stdin_bytes: Option<usize>, source: impl Read) {
     let started_at = now_unix_ms();
     let stdin = match read_stdin(stdin_bytes, source) {
@@ -150,22 +162,51 @@ pub fn supervise(spool: &Spool, id: &str, stdin_bytes: Option<usize>, source: im
     // compilers a build script spawned before exiting.
     let group = child.id() as i32;
 
-    feed(child.stdin.take(), stdin);
+    // Everything below this point needs a thread the OS may refuse, and the
+    // command is already running in a session of its own. A supervisor that
+    // gave up here without killing the group would leave that command with no
+    // deadline and nobody to reap it — the very failure the whole "outlives the
+    // connection" design exists to make impossible. So the group is torn down
+    // first, and only then is the execution settled.
+    let helpers = feed(child.stdin.take(), stdin).and_then(|()| {
+        let stdout = pump(
+            child.stdout.take(),
+            spool,
+            id,
+            LogStream::Stdout,
+            request.max_output_bytes,
+        )?;
+        let stderr = pump(
+            child.stderr.take(),
+            spool,
+            id,
+            LogStream::Stderr,
+            request.max_output_bytes,
+        )?;
+        Ok((stdout, stderr))
+    });
 
-    let stdout = pump(
-        child.stdout.take(),
-        spool,
-        id,
-        LogStream::Stdout,
-        request.max_output_bytes,
-    );
-    let stderr = pump(
-        child.stderr.take(),
-        spool,
-        id,
-        LogStream::Stderr,
-        request.max_output_bytes,
-    );
+    let (stdout, stderr) = match helpers {
+        Ok(pumps) => pumps,
+        Err(_) => {
+            terminate_group(group, &mut child);
+            // `Unknown`, not `Failed`: the command may have done all of its
+            // work in the moment it had, and `Failed` is the answer that tells
+            // a caller their retry is safe. `supervisor_setup_failed` is the
+            // same code the pre-spawn setup failures use, and means the same
+            // thing to Kobe — this process never reached the point of watching
+            // anything, so the target is destroyed rather than reused.
+            let _ = spool.write_report(&ExecutionReport {
+                id: id.to_string(),
+                state: RunnerState::Unknown,
+                started_at_unix_ms: Some(started_at),
+                finished_at_unix_ms: Some(now_unix_ms()),
+                reason: Some(reason::SUPERVISOR_SETUP_FAILED.into()),
+                ..Default::default()
+            });
+            return;
+        }
+    };
 
     let deadline = Instant::now() + Duration::from_secs(request.timeout_seconds);
     let mut ended_by: Option<&'static str> = None;
@@ -328,6 +369,31 @@ fn read_stdin(
     Ok(Some(bytes))
 }
 
+/// Start one of the supervisor's helper threads, or say that it could not.
+///
+/// `std::thread::Builder` rather than `std::thread::spawn`, because
+/// `thread::spawn` **panics** when the OS refuses a thread — and this is the
+/// one process where that panic is not an option. Every helper is started
+/// *after* the command has been spawned into a session of its own, and
+/// dropping Rust's [`Child`] does not kill anything: unwinding out of
+/// [`supervise`] would leave a command with no deadline, no cancellation and
+/// nobody to reap it, still charging the lease that paid for it.
+///
+/// The refusal is not hypothetical. The runner lives inside a tenant's
+/// container under a PID cgroup, and the command it just spawned is itself a
+/// consumer of that budget — so "the child started and the helper cannot" is
+/// exactly the shape thread exhaustion takes here.
+///
+/// The handle is dropped on purpose: these threads are detached and observed
+/// through the spool and the pipes, never joined.
+fn spawn_helper(body: impl FnOnce() + Send + 'static) -> std::io::Result<()> {
+    #[cfg(test)]
+    if tests::helper_thread_is_refused() {
+        return Err(std::io::Error::from_raw_os_error(libc::EAGAIN));
+    }
+    std::thread::Builder::new().spawn(body).map(drop)
+}
+
 /// Hand the bytes to the process, then close its stdin.
 ///
 /// On a thread, because the command is under no obligation to read: anything
@@ -340,18 +406,24 @@ fn read_stdin(
 /// open would leave it waiting for the timeout to kill it. Dropping the handle
 /// — on every path, including a write that failed because the command already
 /// exited — is what delivers that EOF.
-fn feed(sink: Option<std::process::ChildStdin>, bytes: Option<Vec<u8>>) {
+///
+/// Returns the OS's refusal instead of panicking on it; see [`spawn_helper`]
+/// for why that distinction is load-bearing, and [`supervise`] for what is
+/// done with it. The bytes are dropped along with the failed closure, which is
+/// the correct disposal for them: nothing else in this process wants a
+/// credential it can no longer deliver.
+fn feed(sink: Option<std::process::ChildStdin>, bytes: Option<Vec<u8>>) -> std::io::Result<()> {
     let (Some(mut sink), Some(bytes)) = (sink, bytes) else {
-        return;
+        return Ok(());
     };
-    std::thread::spawn(move || {
+    spawn_helper(move || {
         // A command that exits without reading gives EPIPE here. That is its
         // choice, not a fault of the execution, and its own exit status is the
         // outcome that gets reported.
         let _ = sink.write_all(&bytes);
         let _ = sink.flush();
         drop(sink);
-    });
+    })
 }
 
 /// Start the command, in a session of its own.
@@ -540,13 +612,19 @@ impl Pump {
 /// drains fills, and a command blocked writing to a full pipe hangs until the
 /// timeout kills it. A caller would see a command that printed too much
 /// reported as a timeout, which is a wrong answer rather than a bounded one.
+///
+/// A source that is absent, or a stream file that cannot be named, yields a
+/// `Pump` that is already finished — the output is lost but the command is not,
+/// and the wait loop still runs. Only the OS refusing the thread is an `Err`,
+/// because that is the case where the loop would not run at all; see
+/// [`spawn_helper`].
 fn pump<R: Read + Send + 'static>(
     source: Option<R>,
     spool: &Spool,
     id: &str,
     stream: LogStream,
     cap: u64,
-) -> Pump {
+) -> std::io::Result<Pump> {
     let truncated = Arc::new(AtomicBool::new(false));
     let finished = Arc::new(AtomicBool::new(false));
     let pump = Pump {
@@ -556,14 +634,14 @@ fn pump<R: Read + Send + 'static>(
 
     let Some(mut source) = source else {
         finished.store(true, Ordering::SeqCst);
-        return pump;
+        return Ok(pump);
     };
     let Ok(path) = spool.stream_path(id, stream) else {
         finished.store(true, Ordering::SeqCst);
-        return pump;
+        return Ok(pump);
     };
 
-    std::thread::spawn(move || {
+    spawn_helper(move || {
         let mut written: u64 = 0;
         let mut file = std::fs::OpenOptions::new().append(true).open(&path).ok();
         let mut buffer = vec![0u8; 64 * 1024];
@@ -595,15 +673,140 @@ fn pump<R: Read + Send + 'static>(
             let _ = file.flush();
         }
         finished.store(true, Ordering::SeqCst);
-    });
+    })?;
 
-    pump
+    Ok(pump)
 }
 
 #[cfg(test)]
 mod tests {
     use super::*;
     use std::process::ExitStatus;
+
+    thread_local! {
+        /// Which helper thread this supervisor is to be refused, if any.
+        ///
+        /// Thread-local rather than global so the injection cannot leak into
+        /// tests running in parallel in the same binary: only the thread
+        /// calling [`supervise`] consults it, and that is the test's own.
+        static REFUSE_HELPER_AT: std::cell::Cell<Option<u32>> = const { std::cell::Cell::new(None) };
+        static HELPERS_STARTED: std::cell::Cell<u32> = const { std::cell::Cell::new(0) };
+    }
+
+    /// Whether [`spawn_helper`] should behave as an OS out of threads.
+    pub(super) fn helper_thread_is_refused() -> bool {
+        let index = HELPERS_STARTED.with(|started| {
+            let index = started.get();
+            started.set(index + 1);
+            index
+        });
+        REFUSE_HELPER_AT.with(|at| at.get()) == Some(index)
+    }
+
+    /// Refuse the `index`-th helper thread this thread's supervisor starts.
+    ///
+    /// Real thread exhaustion cannot be provoked from a test without putting
+    /// the whole test binary under the same PID pressure, which would break
+    /// every other test in it. This reproduces the one thing that matters —
+    /// the refusal reaching the supervisor after the command is already
+    /// running — at exactly the call site the OS would refuse.
+    fn refuse_helper_thread(index: u32) {
+        REFUSE_HELPER_AT.with(|at| at.set(Some(index)));
+        HELPERS_STARTED.with(|started| started.set(0));
+    }
+
+    struct Scratch(std::path::PathBuf);
+
+    impl Scratch {
+        fn new() -> Self {
+            static NEXT: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+            let path = std::env::temp_dir().join(format!(
+                "kobe-supervisor-test-{}-{}-{}",
+                std::process::id(),
+                now_unix_ms(),
+                NEXT.fetch_add(1, std::sync::atomic::Ordering::SeqCst)
+            ));
+            std::fs::create_dir_all(&path).unwrap();
+            Self(path)
+        }
+    }
+
+    impl Drop for Scratch {
+        fn drop(&mut self) {
+            let _ = std::fs::remove_dir_all(&self.0);
+        }
+    }
+
+    /// A command that outlives the supervisor is never left running.
+    ///
+    /// The child is spawned before any helper thread exists, in a session of
+    /// its own, and dropping Rust's `Child` does not kill it. So a supervisor
+    /// that dies between those two points — which is what an OS refusing a
+    /// thread used to do — leaves a command with no deadline, no cancellation
+    /// and nobody to reap it, on CPU a lease is still paying for. The marker
+    /// file is the proof: it is written after this test has finished waiting,
+    /// so it can only exist if the command survived.
+    #[test]
+    fn a_refused_helper_thread_never_leaves_the_command_running() {
+        // The feeder is helper 0; the stdout and stderr pumps are 1 and 2. All
+        // three run after the spawn, so all three have to be covered.
+        for refused in [0u32, 1, 2] {
+            let scratch = Scratch::new();
+            let spool = Spool::new(scratch.0.clone());
+            let id = "sbxe-refused";
+            let marker = scratch.0.join(format!("outlived-{refused}"));
+
+            let request = StartRequest {
+                protocol: crate::protocol::PROTOCOL_VERSION,
+                id: id.into(),
+                argv: vec![
+                    "/bin/sh".into(),
+                    "-c".into(),
+                    format!("sleep 3; : > {}", marker.display()),
+                ],
+                cwd: None,
+                timeout_seconds: 60,
+                max_output_bytes: 4096,
+                stdin_base64: None,
+            };
+            spool.reserve(&request).unwrap();
+
+            let secret = b"ghp_the_supervisor_holds_this".to_vec();
+            refuse_helper_thread(refused);
+            let outcome = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+                supervise(&spool, id, Some(secret.len()), secret.as_slice());
+            }));
+            REFUSE_HELPER_AT.with(|at| at.set(None));
+
+            assert!(
+                outcome.is_ok(),
+                "helper {refused} being refused unwound out of the supervisor"
+            );
+
+            // Terminal, and honest about which end it came from: the command
+            // may well have done work before it was torn down, so `Unknown` is
+            // the only state that does not invite a blind retry.
+            let report = spool.read_report(id).unwrap();
+            assert_eq!(
+                report.state,
+                RunnerState::Unknown,
+                "helper {refused}: {report:?}"
+            );
+            assert_eq!(
+                report.reason.as_deref(),
+                Some(reason::SUPERVISOR_SETUP_FAILED),
+                "helper {refused}: {report:?}"
+            );
+
+            // Past the command's own 3 seconds. If it was still running, this
+            // is where it would have written the marker.
+            std::thread::sleep(Duration::from_secs(4));
+            assert!(
+                !marker.exists(),
+                "helper {refused} being refused left the command running to completion"
+            );
+        }
+    }
 
     /// An outcome nobody observed is `Unknown`, never `Failed`.
     ///

--- a/crates/kobe-runner/tests/supervision.rs
+++ b/crates/kobe-runner/tests/supervision.rs
@@ -1074,14 +1074,22 @@ fn an_execution_with_no_stdin_still_reads_nothing_and_exits() {
     assert!(read_stream(&scratch, "sbxe-no-stdin", "stdout").is_empty());
 }
 
-/// The secret is never written anywhere under the spool.
+/// The runner itself never puts the secret anywhere under the spool.
 ///
 /// This is the property the whole design exists for. stdin carries a token so
 /// that it does not appear in an argv the apiserver audit-logs; writing it to a
 /// filesystem the tenant's workload shares — and which outlives the command —
 /// would trade one durable copy for another.
+///
+/// The command here neither reads nor echoes its stdin, and that is what makes
+/// the assertion about the *runner*. A command that does echo — `cat` — puts
+/// the bytes in `stdout.log` by doing exactly what it was asked to do, and
+/// captured output is a caller's own decision about their own secret. The
+/// boundary this pins is the one Kobe owns: nothing the runner writes of its
+/// own accord — the request file, the report, the stream files it opens —
+/// contains the bytes.
 #[test]
-fn stdin_is_never_written_to_the_spool() {
+fn the_runner_itself_never_writes_stdin_to_the_spool() {
     let scratch = Scratch::new();
     let secret = b"ghp_never-on-disk-anywhere";
 

--- a/crates/kobe-runner/tests/supervision.rs
+++ b/crates/kobe-runner/tests/supervision.rs
@@ -85,6 +85,33 @@ fn start_in(
     ))
 }
 
+/// Start a command with bytes for its own stdin.
+///
+/// Kept apart from [`start`] so the ordinary path keeps sending exactly the
+/// request a released runner would accept: with nobody asking for stdin, the
+/// key must be absent rather than null.
+fn start_with_stdin(
+    scratch: &Scratch,
+    id: &str,
+    argv: &[&str],
+    stdin: &[u8],
+    timeout: u64,
+    cap: u64,
+) -> Reply {
+    use base64::Engine;
+
+    reply(start_output_with_stdin(
+        scratch,
+        &["start"],
+        id,
+        argv,
+        None,
+        timeout,
+        cap,
+        Some(base64::engine::general_purpose::STANDARD.encode(stdin)),
+    ))
+}
+
 fn start_output(
     scratch: &Scratch,
     runner_arguments: &[&str],
@@ -93,6 +120,20 @@ fn start_output(
     cwd: Option<&str>,
     timeout: u64,
     cap: u64,
+) -> std::process::Output {
+    start_output_with_stdin(scratch, runner_arguments, id, argv, cwd, timeout, cap, None)
+}
+
+#[allow(clippy::too_many_arguments)]
+fn start_output_with_stdin(
+    scratch: &Scratch,
+    runner_arguments: &[&str],
+    id: &str,
+    argv: &[&str],
+    cwd: Option<&str>,
+    timeout: u64,
+    cap: u64,
+    stdin_base64: Option<String>,
 ) -> std::process::Output {
     use std::io::Write;
 
@@ -110,6 +151,14 @@ fn start_output(
     let mut request = request;
     if cwd.is_none() {
         request.as_object_mut().unwrap().remove("cwd");
+    }
+    // Absent when unused, for the same reason: this is the shape an older
+    // runner has to keep accepting.
+    if let Some(stdin_base64) = stdin_base64 {
+        request
+            .as_object_mut()
+            .unwrap()
+            .insert("stdinBase64".into(), stdin_base64.into());
     }
 
     let mut child = runner(scratch, runner_arguments)
@@ -899,6 +948,215 @@ fn output_is_retained_after_the_command_has_finished() {
 fn an_unknown_execution_is_not_found() {
     let scratch = Scratch::new();
     let reply = status(&scratch, "sbxe-never");
+    assert!(
+        matches!(
+            reply,
+            Reply::Error {
+                code: kobe_runner::protocol::RunnerErrorCode::NotFound
+            }
+        ),
+        "expected not found, got {reply:?}"
+    );
+}
+
+/// A secret reaches the process on stdin, and its stdin is then closed.
+///
+/// Both halves in one exercise, because `cat` proves both and neither alone is
+/// the feature. If the bytes never arrive, stdout is empty. If the descriptor
+/// is left open, `cat` never sees EOF, never exits, and the execution ends as a
+/// timeout instead of a success — which is exactly how a caller running
+/// `gh auth login --with-token` would discover a half-implemented forward.
+#[test]
+fn stdin_reaches_the_process_and_is_then_closed() {
+    let scratch = Scratch::new();
+    let secret = b"ghp_a-token-that-must-never-be-an-argument\n";
+
+    start_with_stdin(&scratch, "sbxe-stdin", &["/bin/cat"], secret, 20, 4096);
+
+    let report = settled(&scratch, "sbxe-stdin", Duration::from_secs(20));
+    assert_eq!(
+        report.state,
+        RunnerState::Succeeded,
+        "a process waiting on EOF must not hang: {report:?}"
+    );
+    assert_eq!(report.exit_code, Some(0));
+    assert_eq!(read_stream(&scratch, "sbxe-stdin", "stdout"), secret);
+}
+
+/// Exact bytes, including the ones that are not text.
+///
+/// A credential is not required to be UTF-8. A lossy conversion anywhere on
+/// this path would corrupt one in a way that surfaces as an authentication
+/// failure a long way from the cause.
+#[test]
+fn stdin_bytes_arrive_exactly_as_they_were_sent() {
+    let scratch = Scratch::new();
+    let raw: Vec<u8> = (0u8..=255).collect();
+
+    start_with_stdin(&scratch, "sbxe-stdin-bytes", &["/bin/cat"], &raw, 20, 4096);
+
+    let report = settled(&scratch, "sbxe-stdin-bytes", Duration::from_secs(20));
+    assert_eq!(report.state, RunnerState::Succeeded);
+    assert_eq!(read_stream(&scratch, "sbxe-stdin-bytes", "stdout"), raw);
+}
+
+/// A maximal payload survives the whole handover intact.
+///
+/// The bytes cross two pipes — `start` to the supervisor, supervisor to the
+/// command — and the first read is exact rather than "until EOF". A payload at
+/// the documented ceiling is where a short read or a partial write would
+/// actually show up, and where it would show up as a corrupted credential
+/// rather than an obvious failure.
+#[test]
+fn a_maximal_stdin_payload_arrives_whole() {
+    let scratch = Scratch::new();
+    // Non-repeating, so a duplicated or dropped block cannot pass unnoticed.
+    let payload: Vec<u8> = (0..kobe_runner::protocol::MAX_STDIN_BYTES)
+        .map(|index| (index % 251) as u8)
+        .collect();
+
+    start_with_stdin(
+        &scratch,
+        "sbxe-stdin-max",
+        &["/bin/cat"],
+        &payload,
+        30,
+        1 << 20,
+    );
+
+    let report = settled(&scratch, "sbxe-stdin-max", Duration::from_secs(30));
+    assert_eq!(report.state, RunnerState::Succeeded, "{report:?}");
+    assert!(!report.stdout_truncated);
+    assert_eq!(read_stream(&scratch, "sbxe-stdin-max", "stdout"), payload);
+}
+
+/// A command that ignores its stdin still finishes, however much was sent.
+///
+/// The bytes are written on a thread precisely so this cannot deadlock: a
+/// payload larger than a pipe buffer, handed to a process that never reads,
+/// would otherwise block the supervisor's own wait loop — and a supervisor that
+/// is not looping cannot cancel, time out, or drain output.
+#[test]
+fn stdin_nobody_reads_never_blocks_the_supervisor() {
+    let scratch = Scratch::new();
+    let bulk = vec![b'x'; kobe_runner::protocol::MAX_STDIN_BYTES];
+
+    start_with_stdin(
+        &scratch,
+        "sbxe-stdin-ignored",
+        &["/bin/sh", "-c", "echo done"],
+        &bulk,
+        20,
+        4096,
+    );
+
+    let report = settled(&scratch, "sbxe-stdin-ignored", Duration::from_secs(20));
+    assert_eq!(report.state, RunnerState::Succeeded, "{report:?}");
+    assert_eq!(
+        read_stream(&scratch, "sbxe-stdin-ignored", "stdout"),
+        b"done\n"
+    );
+}
+
+/// Sending no stdin still means `/dev/null`, exactly as before.
+///
+/// The forwarding path must not change what an ordinary execution gets. A
+/// command that reads stdin and was given none has to see EOF immediately, not
+/// wait for a writer that will never appear.
+#[test]
+fn an_execution_with_no_stdin_still_reads_nothing_and_exits() {
+    let scratch = Scratch::new();
+
+    start(&scratch, "sbxe-no-stdin", &["/bin/cat"], 20, 4096);
+
+    let report = settled(&scratch, "sbxe-no-stdin", Duration::from_secs(20));
+    assert_eq!(report.state, RunnerState::Succeeded, "{report:?}");
+    assert!(read_stream(&scratch, "sbxe-no-stdin", "stdout").is_empty());
+}
+
+/// The secret is never written anywhere under the spool.
+///
+/// This is the property the whole design exists for. stdin carries a token so
+/// that it does not appear in an argv the apiserver audit-logs; writing it to a
+/// filesystem the tenant's workload shares — and which outlives the command —
+/// would trade one durable copy for another.
+#[test]
+fn stdin_is_never_written_to_the_spool() {
+    let scratch = Scratch::new();
+    let secret = b"ghp_never-on-disk-anywhere";
+
+    start_with_stdin(
+        &scratch,
+        "sbxe-stdin-secret",
+        &["/bin/sh", "-c", "exit 0"],
+        secret,
+        20,
+        4096,
+    );
+    settled(&scratch, "sbxe-stdin-secret", Duration::from_secs(20));
+
+    let encoded = {
+        use base64::Engine;
+        base64::engine::general_purpose::STANDARD.encode(secret.as_slice())
+    };
+    let mut inspected = 0usize;
+    let mut pending = vec![scratch.path().to_path_buf()];
+    while let Some(directory) = pending.pop() {
+        for entry in std::fs::read_dir(&directory).unwrap() {
+            let path = entry.unwrap().path();
+            if path.is_dir() {
+                pending.push(path);
+                continue;
+            }
+            inspected += 1;
+            let bytes = std::fs::read(&path).unwrap();
+            assert!(
+                !bytes.windows(secret.len()).any(|window| window == secret),
+                "{} holds the raw stdin",
+                path.display()
+            );
+            assert!(
+                !String::from_utf8_lossy(&bytes).contains(&encoded),
+                "{} holds the encoded stdin",
+                path.display()
+            );
+        }
+    }
+    assert!(inspected > 0, "the execution wrote nothing at all");
+}
+
+/// Stdin past the documented bound is refused, and reserves nothing.
+///
+/// Refused rather than trimmed: half a token is still a secret, and a command
+/// that received half of its input would fail somewhere a long way from the
+/// request that caused it. Refusing before the reservation is what keeps the
+/// caller's id reusable.
+#[test]
+fn oversized_stdin_is_refused_before_anything_is_reserved() {
+    let scratch = Scratch::new();
+    let too_much = vec![b'x'; kobe_runner::protocol::MAX_STDIN_BYTES + 1];
+
+    let reply = start_with_stdin(
+        &scratch,
+        "sbxe-stdin-too-big",
+        &["/bin/cat"],
+        &too_much,
+        20,
+        4096,
+    );
+    assert!(
+        matches!(
+            reply,
+            Reply::Error {
+                code: kobe_runner::protocol::RunnerErrorCode::InvalidRequest
+            }
+        ),
+        "expected an invalid request, got {reply:?}"
+    );
+
+    // Nothing was reserved, so the id is still free rather than occupied by a
+    // command that could never have run.
+    let reply = status(&scratch, "sbxe-stdin-too-big");
     assert!(
         matches!(
             reply,

--- a/crates/kobectl/Cargo.toml
+++ b/crates/kobectl/Cargo.toml
@@ -22,6 +22,10 @@ path = "src/main.rs"
 # crates (kube, axum, sqlx, aws-sdk-s3 → aws-lc-sys, kunobi-ha, kunobi-reload).
 # Keeping this tree slim is what makes the Windows (msvc) cross-build viable.
 anyhow = "1"
+# `kobe exec --stdin` encodes the bytes it forwards. Tiny, pure Rust, no
+# platform surface — it does not threaten the Windows cross-build this
+# dependency set is kept slim for.
+base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 ratatui = "0.29"
 crossterm = { version = "0.28", features = ["event-stream"] }

--- a/crates/kobectl/src/commands/sandbox.rs
+++ b/crates/kobectl/src/commands/sandbox.rs
@@ -174,17 +174,73 @@ struct ExecRequestBody<'a> {
     #[serde(skip_serializing_if = "Option::is_none")]
     timeout: Option<&'a str>,
     idempotency_key: &'a str,
+    /// Base64 bytes for the remote process's stdin.
+    ///
+    /// Omitted entirely when unused, so an ordinary `kobe exec` keeps sending
+    /// exactly the body an older Kobe accepts. Serialised into the SAME buffer
+    /// the transport retry re-sends, which is what keeps a retried request the
+    /// same request rather than one that happens to share an idempotency key.
+    #[serde(skip_serializing_if = "Option::is_none")]
+    stdin: Option<&'a str>,
+}
+
+/// Most stdin `kobe exec --stdin` will read before refusing.
+///
+/// The server owns the real bound and returns its own message when a payload
+/// exceeds it — this CLI does not invent explanations for limits it does not
+/// enforce. What this ceiling prevents is the local mistake: an accidental
+/// `kobe exec ... --stdin < a-large-file` buffering gigabytes into memory
+/// before the server ever sees it. Generous on purpose, so the refusal a caller
+/// normally meets is the server's.
+const MAX_LOCAL_STDIN_BYTES: usize = 1024 * 1024;
+
+/// Read the bytes `--stdin` forwards, from this process's own stdin.
+///
+/// Read whole and only then sent, because the request is one JSON document:
+/// there is no streaming half of this API, and pretending otherwise would mean
+/// discovering at byte 900,000 that the request was never going to be accepted.
+/// Bytes rather than text — a token is not required to be UTF-8, and a lossy
+/// conversion would corrupt a credential in a way that surfaces as an
+/// authentication failure far from the cause.
+fn read_stdin_payload(source: &mut impl std::io::Read) -> Result<Vec<u8>> {
+    use std::io::Read;
+
+    let mut bytes = Vec::new();
+    // One byte past the ceiling, so "exactly at the limit" and "over it" are
+    // distinguishable and the refusal is explicit rather than a silent trim.
+    source
+        .take(MAX_LOCAL_STDIN_BYTES as u64 + 1)
+        .read_to_end(&mut bytes)
+        .context("could not read stdin")?;
+    if bytes.len() > MAX_LOCAL_STDIN_BYTES {
+        anyhow::bail!(
+            "--stdin is for secrets and small inputs, not file transfer: \
+             refusing to send more than {MAX_LOCAL_STDIN_BYTES} bytes"
+        );
+    }
+    Ok(bytes)
 }
 
 /// Run one command in an existing Sandbox lease.
 ///
 /// Returns the exit code the process should use, so the caller decides when to
 /// exit rather than this function calling `exit` from inside a library path.
+///
+/// With `forward_stdin`, this process's own stdin is read to EOF and handed to
+/// the remote process. That is how a secret reaches a Sandbox without being
+/// typed into the argv: the exec argv becomes a URL the target apiserver
+/// audit-logs verbatim, so `--token s3cret` records the token and
+/// `--stdin` does not.
+// One argument past clippy's threshold. These are the CLI's own flags, in the
+// order `kobe exec` declares them; folding them into a struct would move the
+// same list somewhere the command definition no longer sits beside it.
+#[allow(clippy::too_many_arguments)]
 pub async fn exec(
     lease: &str,
     argv: &[String],
     cwd: Option<&str>,
     timeout: Option<&str>,
+    forward_stdin: bool,
     target_override: Option<&str>,
     endpoint_override: Option<&str>,
     output: OutputFormat,
@@ -196,12 +252,23 @@ pub async fn exec(
         anyhow::bail!("a command is required: kobe exec <lease> -- <argv...>");
     }
 
+    // Read before the request is built, so a refusal costs no idempotency key
+    // and no round trip.
+    let stdin = if forward_stdin {
+        use base64::Engine;
+        let bytes = read_stdin_payload(&mut std::io::stdin())?;
+        Some(base64::engine::general_purpose::STANDARD.encode(bytes))
+    } else {
+        None
+    };
+
     let result = exec_once(
         &config,
         lease,
         argv,
         cwd,
         timeout,
+        stdin.as_deref(),
         &new_idempotency_key(),
         output,
     )
@@ -211,12 +278,14 @@ pub async fn exec(
     Ok(code)
 }
 
+#[allow(clippy::too_many_arguments)]
 async fn exec_once(
     config: &ResolvedConfig,
     lease: &str,
     argv: &[String],
     cwd: Option<&str>,
     timeout: Option<&str>,
+    stdin: Option<&str>,
     idempotency_key: &str,
     output: OutputFormat,
 ) -> Result<ExecutionResponse> {
@@ -226,6 +295,7 @@ async fn exec_once(
         cwd,
         timeout,
         idempotency_key,
+        stdin,
     })?;
     let (status, payload) =
         retry_transport_once(|| send_exec_request(config, &path, &body, output))
@@ -1149,6 +1219,9 @@ async fn exec_once_for_run(
         cwd,
         timeout,
         idempotency_key,
+        // `kobe run` leases, runs and releases in one shot; there is no
+        // interactive stdin to forward and no flag that asks for one.
+        stdin: None,
     })
     .map_err(|error| RunExecutionError::Failure(anyhow::Error::from(error)))?;
     let (status, payload) =
@@ -2152,12 +2225,58 @@ mod tests {
             cwd: Some("/workspace"),
             timeout: Some("60s"),
             idempotency_key: "key-1",
+            stdin: None,
         })
         .unwrap();
 
         assert_eq!(body["idempotencyKey"], "key-1");
         assert!(body.get("idempotency_key").is_none());
         assert_eq!(body["cwd"], "/workspace");
+        // Absent, not null: an older Kobe denies unknown fields, and a request
+        // that forwards no stdin must stay byte-identical to what it accepted
+        // before `--stdin` existed.
+        assert!(body.get("stdin").is_none());
+
+        let body = serde_json::to_value(ExecRequestBody {
+            command: &argv,
+            cwd: None,
+            timeout: None,
+            idempotency_key: "key-1",
+            stdin: Some("czNjcmV0"),
+        })
+        .unwrap();
+        assert_eq!(body["stdin"], "czNjcmV0");
+    }
+
+    /// `--stdin` refuses a file rather than buffering one.
+    ///
+    /// The bound is local and generous — the server owns the real one and its
+    /// message is what a caller normally sees. This exists so an accidental
+    /// `--stdin < a-large-file` fails immediately instead of reading gigabytes
+    /// into memory to build a request that was never going to be accepted.
+    #[test]
+    fn forwarded_stdin_is_refused_rather_than_truncated_past_the_local_bound() {
+        let exact = vec![b'x'; MAX_LOCAL_STDIN_BYTES];
+        assert_eq!(
+            read_stdin_payload(&mut exact.as_slice()).unwrap().len(),
+            MAX_LOCAL_STDIN_BYTES
+        );
+
+        let over = vec![b'x'; MAX_LOCAL_STDIN_BYTES + 1];
+        let error = read_stdin_payload(&mut over.as_slice()).unwrap_err();
+        assert!(
+            error.to_string().contains("not file transfer"),
+            "the refusal must say why: {error}"
+        );
+
+        // Exact bytes, including the ones that are not text: a credential is
+        // not required to be UTF-8.
+        let raw: Vec<u8> = (0u8..=255).collect();
+        assert_eq!(read_stdin_payload(&mut raw.as_slice()).unwrap(), raw);
+
+        // Empty is a legitimate thing to forward, and is not the same as not
+        // passing `--stdin` at all.
+        assert!(read_stdin_payload(&mut [].as_slice()).unwrap().is_empty());
     }
 
     /// An ambiguous transport loss repeats the exact semantic request once.

--- a/crates/kobectl/src/main.rs
+++ b/crates/kobectl/src/main.rs
@@ -69,6 +69,15 @@ enum Commands {
         cwd: Option<String>,
         #[arg(long)]
         timeout: Option<String>,
+        /// Forward this process's stdin to the remote command, then close it.
+        ///
+        /// How a secret reaches a Sandbox without being typed into the command
+        /// line: the exec argv becomes a URL the target apiserver audit-logs
+        /// verbatim, so `--token s3cret` records the token where
+        /// `printf %s "$TOKEN" | kobe exec ... --stdin -- gh auth login
+        /// --with-token` does not.
+        #[arg(long)]
+        stdin: bool,
         #[arg(last = true, required = true)]
         command: Vec<String>,
     },
@@ -223,6 +232,13 @@ enum SandboxAction {
         /// Wall-clock bound for the command (e.g. `30s`, `5m`).
         #[arg(long)]
         timeout: Option<String>,
+        /// Forward this process's stdin to the remote command, then close it.
+        ///
+        /// For secrets and small inputs. The command sees EOF once the bytes
+        /// are delivered, so anything that reads until EOF — `gh auth login
+        /// --with-token` — completes rather than waiting for its timeout.
+        #[arg(long)]
+        stdin: bool,
         /// The command. Everything after `--`.
         #[arg(last = true, required = true)]
         command: Vec<String>,
@@ -468,6 +484,7 @@ async fn main() -> anyhow::Result<()> {
             lease,
             cwd,
             timeout,
+            stdin,
             command,
         } => {
             let lease =
@@ -479,6 +496,7 @@ async fn main() -> anyhow::Result<()> {
                     lease,
                     cwd,
                     timeout,
+                    stdin,
                     command,
                 },
                 target,
@@ -636,6 +654,7 @@ async fn dispatch_resource_action(
             lease,
             cwd,
             timeout,
+            stdin,
             command,
         } => {
             commands::sandbox::exec(
@@ -643,6 +662,7 @@ async fn dispatch_resource_action(
                 &command,
                 cwd.as_deref(),
                 timeout.as_deref(),
+                stdin,
                 target,
                 endpoint,
                 output,
@@ -892,6 +912,51 @@ mod tests {
             .is_err()
         );
         assert!(Cli::try_parse_from(["kobe", "logs", "sandbox-1", "--follow"]).is_err());
+    }
+
+    /// Forwarding stdin is opt-in, and the flag belongs to kobe rather than to
+    /// the remote command.
+    ///
+    /// Opt-in because a `kobe exec` in a pipeline must not silently start
+    /// consuming the script's own stdin. Before `--` because everything after
+    /// it is the tenant's argv — the argv this feature exists to keep secrets
+    /// out of — so `cat --stdin` has to stay a request to run `cat --stdin`.
+    #[test]
+    fn exec_forwards_stdin_only_when_asked() {
+        let cli = Cli::try_parse_from(["kobe", "exec", "sandbox-1", "--", "true"]).unwrap();
+        assert!(
+            matches!(cli.command, Commands::Exec { stdin: false, .. }),
+            "forwarding stdin must be opt-in: an ordinary exec sends none"
+        );
+
+        // Before `--`, so it cannot be confused with an argument of the remote
+        // command — which is exactly what `--stdin` exists to avoid needing.
+        let cli = Cli::try_parse_from([
+            "kobe",
+            "exec",
+            "sandbox-1",
+            "--stdin",
+            "--",
+            "gh",
+            "auth",
+            "login",
+            "--with-token",
+        ])
+        .unwrap();
+        let Commands::Exec { stdin, command, .. } = cli.command else {
+            panic!("expected exec");
+        };
+        assert!(stdin);
+        assert_eq!(command, ["gh", "auth", "login", "--with-token"]);
+
+        // A `--stdin` after `--` belongs to the remote command, not to kobe.
+        let cli =
+            Cli::try_parse_from(["kobe", "exec", "sandbox-1", "--", "cat", "--stdin"]).unwrap();
+        let Commands::Exec { stdin, command, .. } = cli.command else {
+            panic!("expected exec");
+        };
+        assert!(!stdin);
+        assert_eq!(command, ["cat", "--stdin"]);
     }
 
     #[test]

--- a/docs/kobe-docs/api/reference.mdx
+++ b/docs/kobe-docs/api/reference.mdx
@@ -498,8 +498,8 @@ changing after a few attempts, the API answers `409 Conflict` with reason
 Reserves the execution before starting its process, so retrying the same
 request cannot run a command twice. `idempotencyKey` is required, contains
 1–253 bytes, and must be new for each deliberate execution. Reusing it with
-different command, working directory, timeout, container, or detach intent
-returns `409 Conflict`.
+different command, working directory, timeout, container, stdin, or detach
+intent returns `409 Conflict`.
 
 ```json
 {
@@ -508,13 +508,40 @@ returns `409 Conflict`.
   "timeout": "5m",
   "container": "agent",
   "idempotencyKey": "execution-018f8f4f",
-  "detach": false
+  "detach": false,
+  "stdin": "Z2hwX2V4YW1wbGV0b2tlbg=="
 }
 ```
 
 `command` is an argv array and is never interpreted by a shell. `cwd` and
 `container` are optional. `timeout` defaults to 60 seconds, is capped at one
 hour, and can never extend past the lease expiry.
+
+`stdin` is optional, base64-encoded, and written to the command's standard
+input before it is closed. **It is how you pass a secret to a Sandbox.** The
+exec request Kobe makes against the target cluster puts the command line in a
+URL that the target apiserver's audit log records verbatim, so a token in
+`command` is a token in somebody's log. A token in `stdin` is not: it is
+forwarded to the process and hashed into the execution's request digest, and no
+part of it is stored in the execution record, its status, or etcd.
+
+```sh
+# The token never appears in an argument.
+printf %s "$GITHUB_TOKEN" | base64 | \
+  jq -Rn --argjson cmd '["gh","auth","login","--with-token"]' \
+    '{command: $cmd, idempotencyKey: "execution-018f8f50", stdin: input}'
+```
+
+The command's stdin is **closed** once the bytes are delivered, so a tool that
+reads until EOF — `gh auth login --with-token` does — completes rather than
+waiting for its timeout. Omitting `stdin` leaves the process reading
+`/dev/null`, exactly as before; an empty string gives it a pipe that is
+immediately closed.
+
+This is a channel for secrets and small inputs, not a file transfer: at most
+16 KiB once decoded. More than that is refused with `400`, never truncated —
+half a token is still a secret, and a command that received half of one would
+fail somewhere a long way from the cause.
 
 Wait mode (`detach: false`) returns `200 OK` after the supervised command ends:
 
@@ -540,8 +567,8 @@ Execution states are `Queued`, `Running`, `Succeeded`, `Failed`, `Cancelled`,
 reported one. `Unknown` means Kobe could not establish the outcome and must not
 be treated as permission to rerun effects automatically.
 
-Common failures are `400` for an invalid command, timeout, cwd, or idempotency
-key; `403`/`404` for unavailable lease access; `409` for key reuse with changed
+Common failures are `400` for an invalid command, timeout, cwd, stdin, or
+idempotency key; `403`/`404` for unavailable lease access; `409` for key reuse with changed
 intent and for the per-lifetime execution bound (`reason:
 execution_limit_exhausted` — retrying cannot succeed, request a new lease);
 `501` when the pool has no Kobe runner; and `503` when the execution store or

--- a/docs/kobe-docs/commands/reference.mdx
+++ b/docs/kobe-docs/commands/reference.mdx
@@ -12,7 +12,7 @@ description: All kobe CLI commands with flags and examples.
 | `kobe status` | Show endpoint status, auth methods, and pool summary |
 | `kobe version` | Show CLI and endpoint versions |
 | `kobe run` | Lease an executable resource, run one command, release it ([details](/commands/sandbox)) |
-| `kobe exec` | Run a command in a lease that supports `exec` |
+| `kobe exec` | Run a command in a lease that supports `exec` (`--stdin` forwards a secret without putting it in argv) |
 | `kobe logs` | Read output from a lease that supports `logs` |
 | `kobe cancel` | Cancel a running execution |
 | `kobe attach` | Open an interactive session through an `attach` capability |

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -96,6 +96,35 @@ reason about:
 kobe exec sandbox-a1b2c3d4e5f60718293a4b5c -- /bin/sh -lc 'a && b'
 ```
 
+### Passing a secret with `--stdin`
+
+`--stdin` forwards this process's standard input to the remote command and then
+closes it. **It is how you give a Sandbox a token.** The exec request Kobe makes
+against the target cluster puts the command line in a URL that the target
+apiserver's audit log records verbatim, so a token in `argv` is a token in
+somebody's log:
+
+```bash
+# Don't: the token is now in an audit log you do not control.
+kobe exec dev -- gh auth login --with-token "$GITHUB_TOKEN"
+
+# Do: the token travels on stdin, which nothing on the path records.
+printf %s "$GITHUB_TOKEN" | kobe exec dev --stdin -- gh auth login --with-token
+```
+
+The flag goes **before** `--`; anything after `--` belongs to the remote
+command. Nothing is forwarded unless you ask, so an ordinary `kobe exec` inside
+a pipeline does not start consuming the script's own input.
+
+The remote stdin is closed once the bytes are delivered, which is what lets a
+tool that reads until EOF finish instead of hanging until its timeout. Without
+`--stdin` the command reads `/dev/null`, exactly as it always has.
+
+For secrets and small inputs, not file transfer: the server refuses more than
+16 KiB rather than truncating it, and the CLI refuses to buffer a large file
+into a request that was never going to be accepted. Kobe stores none of it —
+only a digest of the request reaches the execution record.
+
 ## `kobe logs`
 
 A bounded tail of the sandbox's own output.

--- a/src/api/sandbox.rs
+++ b/src/api/sandbox.rs
@@ -158,6 +158,26 @@ struct CreateExecutionRequest {
     /// Return once reserved rather than waiting for the result.
     #[serde(default)]
     detach: bool,
+    /// Base64 bytes to write to the process's stdin, then close.
+    ///
+    /// The one way to give a Sandbox a secret. Everything else a caller can say
+    /// about a command ends up in `command`, and the resulting exec argv is a
+    /// URL the target apiserver audit-logs verbatim — so `gh auth login
+    /// --with-token`, which reads its token from stdin, previously had no
+    /// expression on this API that did not record the token.
+    ///
+    /// Base64 because a credential is not required to be UTF-8 and a JSON
+    /// string is. Absent means the process reads `/dev/null`; an empty string
+    /// means a pipe that is immediately closed, which is a different thing to
+    /// ask for. Bounded once decoded by
+    /// [`MAX_EXECUTION_STDIN_BYTES`](crate::api::sandbox_executions::MAX_EXECUTION_STDIN_BYTES)
+    /// and refused rather than truncated past it: this is a channel for secrets
+    /// and small inputs, not a file transfer.
+    ///
+    /// Never persisted. It is hashed into the execution's request digest and
+    /// forwarded to the runner; no field of the durable record can hold it.
+    #[serde(default)]
+    stdin: Option<String>,
 }
 
 #[derive(Debug, Serialize)]
@@ -223,6 +243,24 @@ fn reused_execution_response_status(
     (!execution_is_runner_managed(&execution.spec)).then_some(StatusCode::OK)
 }
 
+/// Decode one caller-supplied stdin payload, or refuse it.
+///
+/// The error carries nothing back but the fact of it. Reporting where the
+/// decode failed, or how many bytes came out, would describe a secret to
+/// whoever can read the response — and the caller already knows what they sent.
+///
+/// The length bound belongs to
+/// [`validate_request`](crate::api::sandbox_executions::validate_request),
+/// which runs on the decoded bytes so a caller who sent too much is told about
+/// the size they actually sent rather than its encoding.
+fn decode_execution_stdin(encoded: &str) -> Result<Vec<u8>, ()> {
+    use base64::Engine;
+
+    base64::engine::general_purpose::STANDARD
+        .decode(encoded)
+        .map_err(|_| ())
+}
+
 fn execution_denied(
     identity: &AuthIdentity,
     lease: &str,
@@ -284,6 +322,21 @@ async fn create_sandbox_execution<B: ClusterBackend>(
         Err(denied) => return access_denied(&identity, &id, "execution", denied),
     };
 
+    // Decoded before anything is reserved. A malformed encoding is the caller's
+    // mistake and must cost them nothing — least of all an idempotency key
+    // spent on a command that could never have been given its input.
+    let stdin = match request.stdin.as_deref().map(decode_execution_stdin) {
+        None => None,
+        Some(Ok(stdin)) => Some(stdin),
+        Some(Err(())) => {
+            return execution_denied(
+                &identity,
+                &id,
+                &executions::ExecutionRequestError::Invalid { what: "stdin" },
+            );
+        }
+    };
+
     let requested = executions::ExecutionRequest {
         argv: request.command,
         cwd: request.cwd,
@@ -292,6 +345,7 @@ async fn create_sandbox_execution<B: ClusterBackend>(
             .unwrap_or_else(|| DEFAULT_EXECUTION_TIMEOUT.to_string()),
         idempotency_key: request.idempotency_key,
         detached: request.detach,
+        stdin,
     };
 
     // The runner is the execution contract, not just a detached-mode helper.
@@ -331,6 +385,10 @@ async fn create_sandbox_execution<B: ClusterBackend>(
         &requested.argv,
         requested.cwd.as_deref(),
         initial_timeout,
+        // Included, because base64 stdin is part of what has to fit. A bound
+        // proved on a request smaller than the one Kobe will actually send is
+        // not a bound.
+        requested.stdin.as_deref(),
     );
     if crate::api::sandbox_runner::start_line(&candidate_start).is_err() {
         return execution_denied(
@@ -613,6 +671,10 @@ async fn run_with_runner<B: ClusterBackend>(
         &requested.argv,
         requested.cwd.as_deref(),
         timeout,
+        // Carried on the runner's stdin with the rest of the request, and read
+        // back out of the reserved record by nothing: the record holds only a
+        // digest, so this is the last place the bytes exist inside Kobe.
+        requested.stdin.as_deref(),
     );
     let runner_crash = if executions::crash_requested(
         executions::ExecutionCrashWindow::BeforeSpawn,
@@ -8242,6 +8304,46 @@ mod tests {
         }
     }
 
+    /// The execution body accepts stdin as base64 and only as base64.
+    ///
+    /// A credential is not required to be UTF-8 and a JSON string is, so raw
+    /// bytes have no expression here. Decoding before the reservation means a
+    /// caller who encoded badly is told so without spending an idempotency key
+    /// on a command that could never have been given its input — and absent
+    /// stays distinguishable from present-but-empty, which are two different
+    /// things to hand a process.
+    #[test]
+    fn execution_stdin_is_accepted_as_base64_and_refused_otherwise() {
+        let body = |json: &str| serde_json::from_str::<CreateExecutionRequest>(json).unwrap();
+
+        let plain = body(r#"{"command":["/bin/true"],"idempotencyKey":"k"}"#);
+        assert_eq!(plain.stdin, None, "absent means /dev/null");
+
+        let with = body(r#"{"command":["/bin/true"],"idempotencyKey":"k","stdin":"czNjcmV0"}"#);
+        assert_eq!(
+            decode_execution_stdin(with.stdin.as_deref().unwrap()),
+            Ok(b"s3cret".to_vec())
+        );
+
+        let empty = body(r#"{"command":["/bin/true"],"idempotencyKey":"k","stdin":""}"#);
+        assert_eq!(empty.stdin.as_deref(), Some(""));
+        assert_eq!(
+            decode_execution_stdin(""),
+            Ok(Vec::new()),
+            "an empty stdin is a request, not an absent one"
+        );
+
+        // Exact bytes survive, including the ones that are not text.
+        let raw: Vec<u8> = (0u8..=255).collect();
+        let encoded = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(&raw)
+        };
+        assert_eq!(decode_execution_stdin(&encoded), Ok(raw));
+
+        assert_eq!(decode_execution_stdin("not base64!!"), Err(()));
+    }
+
     /// The attach query is parsed by hand because axum's `Query` cannot carry
     /// repeated keys into `Option<Vec<String>>`: every value arrives as a
     /// string, so the CLI's `?tty=true&command=bash` used to die inside the
@@ -9842,6 +9944,7 @@ mod tests {
                 container: None,
                 idempotency_key: "kobe-verbs-1".into(),
                 detach: false,
+                stdin: None,
             }),
         )
         .await;

--- a/src/api/sandbox_executions.rs
+++ b/src/api/sandbox_executions.rs
@@ -206,7 +206,29 @@ pub struct ExecutionRequest {
     pub timeout: String,
     pub idempotency_key: String,
     pub detached: bool,
+    /// Bytes to write to the process's stdin, then close.
+    ///
+    /// The only channel by which a Sandbox can receive a secret without it
+    /// appearing in argv — and argv is what the target apiserver audit-logs
+    /// verbatim. `None` and `Some(vec![])` are different requests: the first
+    /// leaves the process reading `/dev/null`, the second hands it a pipe that
+    /// is immediately closed.
+    ///
+    /// This field lives on the in-memory request and nowhere else. It is hashed
+    /// into the record's `requestDigest` and forwarded to the runner; it is
+    /// never persisted. See [`crate::crd::execution`] for why the durable
+    /// record must not hold it. Bounded by [`MAX_EXECUTION_STDIN_BYTES`], which
+    /// refuses rather than truncates.
+    pub stdin: Option<Vec<u8>>,
 }
+
+/// Most stdin one execution may carry.
+///
+/// The runner's own ceiling, re-exported rather than copied: two hand-kept
+/// copies of a limit drift, and the drift would show up as a reservation the
+/// target can only reject after the caller's idempotency key is already spent.
+/// Kobe checks it first for exactly that reason.
+pub const MAX_EXECUTION_STDIN_BYTES: usize = kobe_runner::protocol::MAX_STDIN_BYTES;
 
 /// Longest a caller-supplied idempotency key may be.
 ///
@@ -283,6 +305,18 @@ pub fn validate_request(request: &ExecutionRequest) -> Result<(), ExecutionReque
         if cwd.is_empty() || !cwd.starts_with('/') || cwd.contains('\0') {
             return Err(ExecutionRequestError::Invalid { what: "cwd" });
         }
+    }
+    if request
+        .stdin
+        .as_ref()
+        .is_some_and(|stdin| stdin.len() > MAX_EXECUTION_STDIN_BYTES)
+    {
+        // Refused, never trimmed to fit. stdin exists on this API to carry a
+        // secret, and half a secret is still a secret — the command would
+        // receive it, fail an authentication, and report something that looks
+        // nothing like "your input was too large". Checked before the
+        // reservation so an oversized request cannot spend an idempotency key.
+        return Err(ExecutionRequestError::Invalid { what: "stdin" });
     }
     match crate::pool::parse_duration(&request.timeout) {
         Some(timeout) if timeout > chrono::Duration::zero() && timeout <= MAX_EXECUTION_TIMEOUT => {
@@ -390,6 +424,7 @@ pub async fn reserve_execution(
         &request.timeout,
         container,
         request.detached,
+        request.stdin.as_deref(),
     );
     let legacy_digest =
         legacy_request_digest(&request.argv, request.cwd.as_deref(), &request.timeout);
@@ -1943,6 +1978,7 @@ mod tests {
             timeout: "60s".into(),
             idempotency_key: "key-1".into(),
             detached: false,
+            stdin: None,
         }
     }
 
@@ -2031,6 +2067,59 @@ mod tests {
                 runner_path: "/kobe-runner".into(),
             })
         );
+    }
+
+    /// The record Kobe writes never carries the caller's stdin.
+    ///
+    /// This is the property the whole feature depends on. A caller sends stdin
+    /// precisely so a secret stays out of the argv the target apiserver
+    /// audit-logs; writing it into a `SandboxExecution` would move it into
+    /// etcd, every replica of etcd, and every backup — read by more people and
+    /// kept for longer than any audit log. Only the digest crosses.
+    #[test]
+    fn a_reserved_record_never_carries_the_callers_stdin() {
+        let secret = "ghp_never-persisted-anywhere";
+        let request = ExecutionRequest {
+            stdin: Some(secret.as_bytes().to_vec()),
+            ..request()
+        };
+        let digest = crate::crd::request_digest(
+            &request.argv,
+            request.cwd.as_deref(),
+            &request.timeout,
+            "workspace",
+            request.detached,
+            request.stdin.as_deref(),
+        );
+        let record = build_execution_record(
+            "kobe-system",
+            "execution-a",
+            &lease(),
+            &target(),
+            &request,
+            &digest,
+            recorded_target("workspace"),
+        );
+
+        let encoded = serde_json::to_string(&record).unwrap();
+        assert!(
+            !encoded.contains(secret),
+            "the reserved record leaked its stdin: {encoded}"
+        );
+        assert!(
+            !encoded.to_lowercase().contains("stdin"),
+            "no persisted field may even be named for stdin: {encoded}"
+        );
+        let base64_secret = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(secret)
+        };
+        assert!(!encoded.contains(&base64_secret));
+
+        // The digest is what makes the reservation answerable at all, and it is
+        // the only thing derived from the secret that survives the request.
+        assert_eq!(record.spec.request_digest, digest);
+        assert_eq!(digest.len(), 64);
     }
 
     /// A retry may observe only the same immutable runner address. Legacy
@@ -2707,6 +2796,122 @@ mod tests {
         assert!(with(&|r| r.idempotency_key = "k".repeat(MAX_IDEMPOTENCY_KEY)).is_ok());
     }
 
+    /// Oversized stdin is refused at the documented boundary, not trimmed.
+    ///
+    /// stdin exists on this API to carry a secret. Half a secret is still a
+    /// secret: the command would receive it, fail an authentication, and report
+    /// something that looks nothing like "your input was too large". Refusing
+    /// before the reservation is what keeps the caller's idempotency key
+    /// reusable for the request they meant to make.
+    #[test]
+    fn oversized_stdin_is_refused_before_anything_is_reserved() {
+        let with_stdin = |stdin: Option<Vec<u8>>| {
+            let mut request = request();
+            request.stdin = stdin;
+            validate_request(&request)
+        };
+
+        assert!(with_stdin(None).is_ok(), "no stdin at all stays valid");
+        assert!(
+            with_stdin(Some(Vec::new())).is_ok(),
+            "an empty stdin is a request a caller may make"
+        );
+        assert!(with_stdin(Some(b"ghp_token".to_vec())).is_ok());
+        assert!(with_stdin(Some(vec![b'x'; MAX_EXECUTION_STDIN_BYTES])).is_ok());
+
+        assert_eq!(
+            with_stdin(Some(vec![b'x'; MAX_EXECUTION_STDIN_BYTES + 1])),
+            Err(ExecutionRequestError::Invalid { what: "stdin" }),
+            "one byte past the bound is refused, not trimmed"
+        );
+
+        // The caller is told to fix their request, not to send it again.
+        assert_eq!(
+            ExecutionRequestError::Invalid { what: "stdin" }.http_status(),
+            axum::http::StatusCode::BAD_REQUEST
+        );
+
+        // Kobe's ceiling is the runner's ceiling. Two hand-kept copies would
+        // drift, and the drift would surface only after the reservation was
+        // already durable.
+        assert_eq!(
+            MAX_EXECUTION_STDIN_BYTES,
+            kobe_runner::protocol::MAX_STDIN_BYTES
+        );
+    }
+
+    /// A maximal stdin still fits the one line the runner reads.
+    ///
+    /// [`MAX_EXECUTION_STDIN_BYTES`] and the runner's whole-request bound are
+    /// two different ceilings and both apply. If the first could produce a
+    /// request that violates the second, an accepted reservation would be
+    /// followed by a target-side rejection — after the idempotency key was
+    /// already spent.
+    #[test]
+    fn a_maximal_stdin_still_fits_the_encoded_start_request() {
+        let request = crate::api::sandbox_runner::start_request(
+            "sbxe-0123456789abcdef0123456789abcdef",
+            &["/usr/bin/gh".into(), "auth".into(), "login".into()],
+            Some("/workspace"),
+            std::time::Duration::from_secs(60),
+            Some(&vec![b'x'; MAX_EXECUTION_STDIN_BYTES]),
+        );
+        let line = crate::api::sandbox_runner::start_line(&request)
+            .expect("a maximal stdin must still encode inside the request bound");
+        assert!(line.len() <= kobe_runner::protocol::MAX_REQUEST_BYTES);
+    }
+
+    /// A reused key with a different secret conflicts rather than returning the
+    /// first run's result.
+    ///
+    /// Two `gh auth login` calls under one key, fed different tokens, are two
+    /// different commands. Answering the second with the first's record would
+    /// report an authentication that never happened.
+    #[test]
+    fn a_reused_key_with_different_stdin_is_a_different_request() {
+        let digest = |stdin: Option<&[u8]>| {
+            crate::crd::request_digest(
+                &["/agent".into(), "run".into()],
+                Some("/work"),
+                "60s",
+                "workspace",
+                false,
+                stdin,
+            )
+        };
+
+        let existing = SandboxExecutionSpec {
+            lease_name: None,
+            lease_uid: "lease-uid".into(),
+            pod_uid: "pod-uid".into(),
+            idempotency_key: "key-1".into(),
+            request_digest: digest(Some(b"token-a")),
+            timeout: "60s".into(),
+            detached: false,
+            runner_managed: Some(true),
+            target: None,
+        };
+
+        assert_eq!(
+            crate::crd::reuse_verdict(&existing, "lease-uid", &digest(Some(b"token-a"))),
+            ReuseVerdict::SameRequest,
+            "the same secret under the same key is a retry"
+        );
+        assert_eq!(
+            crate::crd::reuse_verdict(&existing, "lease-uid", &digest(Some(b"token-b"))),
+            ReuseVerdict::Conflict
+        );
+        assert_eq!(
+            crate::crd::reuse_verdict(&existing, "lease-uid", &digest(None)),
+            ReuseVerdict::Conflict,
+            "dropping the secret is a different command, not the same one"
+        );
+
+        // The record that decides all of this holds only the digest.
+        let encoded = serde_json::to_string(&existing).unwrap();
+        assert!(!encoded.contains("token-a"), "the record leaked: {encoded}");
+    }
+
     /// `cwd` is a path, and a nul byte is not part of one.
     ///
     /// Kobe never implements `cwd` with a shell — `cd X && ...` would make
@@ -2804,7 +3009,7 @@ mod tests {
     fn legacy_digest_reuse_is_exact_and_upgrade_bounded() {
         let argv = vec!["/agent".to_string(), "run".to_string()];
         let legacy_digest = legacy_request_digest(&argv, Some("/work"), "60s");
-        let current_digest = request_digest(&argv, Some("/work"), "60s", "workspace", false);
+        let current_digest = request_digest(&argv, Some("/work"), "60s", "workspace", false, None);
         assert_eq!(
             legacy_digest, "030c080c54aa88834e6249c7c3b544e9754b49a565a0c7696c4a06d38a8b5751",
             "the pre-upgrade digest format is a persisted compatibility vector"
@@ -2836,7 +3041,7 @@ mod tests {
             compatible_reuse_verdict(
                 &existing,
                 "lease-uid",
-                &request_digest(&argv, Some("/work"), "60s", "workspace", true),
+                &request_digest(&argv, Some("/work"), "60s", "workspace", true, None),
                 &legacy_digest,
                 true,
             ),
@@ -2848,7 +3053,14 @@ mod tests {
             compatible_reuse_verdict(
                 &existing,
                 "lease-uid",
-                &request_digest(&changed_argv, Some("/work"), "60s", "workspace", false,),
+                &request_digest(
+                    &changed_argv,
+                    Some("/work"),
+                    "60s",
+                    "workspace",
+                    false,
+                    None
+                ),
                 &legacy_request_digest(&changed_argv, Some("/work"), "60s"),
                 false,
             ),

--- a/src/api/sandbox_runner.rs
+++ b/src/api/sandbox_runner.rs
@@ -166,6 +166,13 @@ pub struct RunnerLogChunk {
 ///   `128 + signal` convention because [`crate::crd::SandboxExecutionStatus`]
 ///   requires a code for `Failed`, and `reason = signalled` is what keeps it
 ///   distinguishable from a command that deliberately exited 137.
+/// * A `Failed` code outside 1-255, or a signal outside 1-127, becomes
+///   `Unknown` and carries no code. `exit_code` crosses the same boundary as
+///   the reason ([`bounded_reason`]) and lands in
+///   [`crate::crd::SandboxExecutionStatus`], so an unbounded `i32` would be 32
+///   bits of a workload's choosing in etcd and every backup. A real
+///   `WEXITSTATUS` is one byte; a number outside it was never observed, and an
+///   outcome nobody observed is `Unknown` by the rule below.
 /// * Everything the runner could not establish becomes `Unknown`, never
 ///   `Failed`: `Failed` reads as "it ran and said no", which tells a caller
 ///   their retry is safe when it may not be.
@@ -185,8 +192,16 @@ pub fn outcome_from_report(report: &ExecutionReport) -> RunnerOutcome {
             _ => (ExecutionState::Unknown, None),
         },
         RunnerState::Failed => match (report.exit_code, report.signal) {
-            (Some(code), _) if code != 0 => (ExecutionState::Failed, Some(code)),
-            (_, Some(signal)) => (ExecutionState::Failed, Some(128i32.saturating_add(signal))),
+            // A wait status is eight bits, so 1-255 is every code a process on
+            // this host could have exited with; zero contradicts `Failed`. A
+            // report outside that range is not describing an exit status at
+            // all, so nothing here may forward it.
+            (Some(code), _) if (1..=255).contains(&code) => (ExecutionState::Failed, Some(code)),
+            // Linux stops at `SIGRTMAX` (64), so a real `128 + signal` stays
+            // inside those same eight bits and cannot overflow.
+            (_, Some(signal)) if (1..=127).contains(&signal) => {
+                (ExecutionState::Failed, Some(128i32.saturating_add(signal)))
+            }
             _ => (ExecutionState::Unknown, None),
         },
         RunnerState::Cancelled => (ExecutionState::Cancelled, None),
@@ -203,11 +218,13 @@ pub fn outcome_from_report(report: &ExecutionReport) -> RunnerOutcome {
 
 /// Clamp a runner-supplied reason to something that may be persisted.
 ///
-/// The reason is the ONE value that crosses from inside a tenant's container
-/// into a Kubernetes object. A runner that is old, broken, or replaced could
-/// put anything here — a path, an error message, a line of the command's own
-/// output — and object status is readable by anyone with `get` on the type,
-/// replicated to every etcd member, and included in backups. So anything
+/// The reason is one of two values that cross from inside a tenant's container
+/// into a Kubernetes object — the exit code is the other, bounded to a wait
+/// status's eight bits in [`outcome_from_report`]. A runner that is old,
+/// broken, or replaced could put anything here — a path, an error message, a
+/// line of the command's own output — and object status is readable by anyone
+/// with `get` on the type, replicated to every etcd member, and included in
+/// backups. So anything
 /// outside the closed vocabulary is replaced rather than truncated: a
 /// truncated secret is still a secret.
 ///
@@ -1138,12 +1155,83 @@ mod tests {
         }
     }
 
+    /// An exit code no wait status could produce never reaches the record.
+    ///
+    /// `exit_code` crosses the same tenant boundary as the reason: the runner's
+    /// spool is written by the workload's own UID (see [`kobe_runner::spool`]),
+    /// so a workload can forge a terminal report for its own execution. The
+    /// field is an `i32` on the wire and lands in
+    /// [`crate::crd::SandboxExecutionStatus`], so forwarding it unchanged would
+    /// hand a workload 32 bits of its choosing in etcd and every backup — the
+    /// same class of channel already closed for the reason. A real
+    /// `WEXITSTATUS` is one byte, so anything else is a number nobody observed.
+    #[test]
+    fn an_exit_code_no_wait_status_could_produce_is_never_persisted() {
+        for forged in [-1, 0, 256, 1_885_434_739, i32::MIN, i32::MAX] {
+            let outcome = outcome_from_report(&ExecutionReport {
+                exit_code: Some(forged),
+                ..report(RunnerState::Failed)
+            });
+            assert_eq!(
+                outcome.state,
+                ExecutionState::Unknown,
+                "exit {forged} was never observed, so nothing may claim it as a failure"
+            );
+            assert_eq!(
+                outcome.exit_code, None,
+                "exit {forged} must not be persisted"
+            );
+        }
+
+        // The signalled path lands in the same status field and gets the same
+        // bound: `128 + signal` is only an exit code for a signal that exists.
+        for forged in [-1, 0, 128, 1_000_000, i32::MAX] {
+            let outcome = outcome_from_report(&ExecutionReport {
+                exit_code: None,
+                signal: Some(forged),
+                ..report(RunnerState::Failed)
+            });
+            assert_eq!(
+                outcome.state,
+                ExecutionState::Unknown,
+                "signal {forged} does not exist, so no code may be derived from it"
+            );
+            assert_eq!(
+                outcome.exit_code, None,
+                "signal {forged} must not be persisted"
+            );
+        }
+
+        // Every code a process on this host could really have exited with still
+        // survives untouched — the bound must not cost a real diagnosis.
+        for real in [1, 2, 42, 137, 255] {
+            let outcome = outcome_from_report(&ExecutionReport {
+                exit_code: Some(real),
+                ..report(RunnerState::Failed)
+            });
+            assert_eq!(outcome.state, ExecutionState::Failed, "exit {real}");
+            assert_eq!(outcome.exit_code, Some(real), "exit {real}");
+        }
+        for signal in [1, 9, 15, 64] {
+            let outcome = outcome_from_report(&ExecutionReport {
+                exit_code: None,
+                signal: Some(signal),
+                ..report(RunnerState::Failed)
+            });
+            assert_eq!(outcome.state, ExecutionState::Failed, "signal {signal}");
+            assert_eq!(outcome.exit_code, Some(128 + signal), "signal {signal}");
+        }
+    }
+
     /// Nothing from inside the container reaches a Kubernetes object unbounded.
     ///
-    /// The reason is the one value that crosses that boundary. A runner that is
-    /// old, broken, or replaced could put a path, an error message, or a line
-    /// of the command's own output there — and object status is readable by
-    /// anyone with `get`, replicated to every etcd member, and in every backup.
+    /// The reason is one of the two values that cross that boundary; the exit
+    /// code is the other, pinned by
+    /// [`an_exit_code_no_wait_status_could_produce_is_never_persisted`]. A
+    /// runner that is old, broken, or replaced could put a path, an error
+    /// message, or a line of the command's own output in the reason — and
+    /// object status is readable by anyone with `get`, replicated to every etcd
+    /// member, and in every backup.
     #[test]
     fn a_runner_reason_can_never_reach_the_record_unbounded() {
         assert_eq!(bounded_reason("completed"), "completed");

--- a/src/api/sandbox_runner.rs
+++ b/src/api/sandbox_runner.rs
@@ -192,16 +192,26 @@ pub fn outcome_from_report(report: &ExecutionReport) -> RunnerOutcome {
             _ => (ExecutionState::Unknown, None),
         },
         RunnerState::Failed => match (report.exit_code, report.signal) {
+            // Reject an out-of-range field BEFORE reading the other one. Written
+            // as accept-guards first, these two arms fell through: a report of
+            // `(exit_code: 256, signal: 9)` failed the code guard, matched the
+            // signal arm, and persisted 137 — a number nobody observed, in a
+            // record whose whole point is that it was. Symmetrically, a valid
+            // code hid an out-of-range signal. A field outside the range it
+            // could have been observed in makes the REPORT malformed; choosing
+            // which half of a contradiction to believe is not a repair kobe is
+            // entitled to make.
+            //
             // A wait status is eight bits, so 1-255 is every code a process on
-            // this host could have exited with; zero contradicts `Failed`. A
-            // report outside that range is not describing an exit status at
-            // all, so nothing here may forward it.
-            (Some(code), _) if (1..=255).contains(&code) => (ExecutionState::Failed, Some(code)),
+            // this host could have exited with; zero contradicts `Failed`. The
+            // runner emits `(None, Some(signal))` for a signalled process, so
+            // no legitimate report is refused by rejecting a zero code here.
+            (Some(code), _) if !(1..=255).contains(&code) => (ExecutionState::Unknown, None),
             // Linux stops at `SIGRTMAX` (64), so a real `128 + signal` stays
             // inside those same eight bits and cannot overflow.
-            (_, Some(signal)) if (1..=127).contains(&signal) => {
-                (ExecutionState::Failed, Some(128i32.saturating_add(signal)))
-            }
+            (_, Some(signal)) if !(1..=127).contains(&signal) => (ExecutionState::Unknown, None),
+            (Some(code), _) => (ExecutionState::Failed, Some(code)),
+            (_, Some(signal)) => (ExecutionState::Failed, Some(128i32.saturating_add(signal))),
             _ => (ExecutionState::Unknown, None),
         },
         RunnerState::Cancelled => (ExecutionState::Cancelled, None),
@@ -1165,6 +1175,51 @@ mod tests {
     /// hand a workload 32 bits of its choosing in etcd and every backup — the
     /// same class of channel already closed for the reason. A real
     /// `WEXITSTATUS` is one byte, so anything else is a number nobody observed.
+    /// A malformed field poisons the whole report, rather than deferring to
+    /// whichever sibling field still looks plausible.
+    ///
+    /// Written as accept-guards, the `Failed` arms fell through: a forged
+    /// `(exit_code: 256, signal: 9)` failed the code guard, matched the signal
+    /// arm, and persisted 137 — a number nobody observed, in the one record
+    /// whose value is that it was. The mirror case let a valid code mask an
+    /// impossible signal. Both now settle `Unknown`.
+    #[test]
+    fn one_malformed_field_is_never_repaired_by_its_sibling() {
+        for (code, signal, why) in [
+            (Some(256), Some(9), "an out-of-range code must not fall through to the signal"),
+            (Some(0), Some(9), "a zero code contradicts Failed and must not defer to a signal"),
+            (Some(-1), Some(15), "a negative code must not fall through to the signal"),
+            (Some(42), Some(i32::MAX), "a valid code must not mask an impossible signal"),
+            (Some(42), Some(0), "a valid code must not mask a zero signal"),
+        ] {
+            let outcome = outcome_from_report(&ExecutionReport {
+                exit_code: code,
+                signal,
+                ..report(RunnerState::Failed)
+            });
+            assert_eq!(outcome.state, ExecutionState::Unknown, "{why}");
+            assert_eq!(outcome.exit_code, None, "{why}");
+        }
+
+        // The bound must not cost a real diagnosis: the shapes the runner
+        // actually emits still translate exactly as before.
+        let exited = outcome_from_report(&ExecutionReport {
+            exit_code: Some(137),
+            signal: None,
+            ..report(RunnerState::Failed)
+        });
+        assert_eq!(exited.state, ExecutionState::Failed);
+        assert_eq!(exited.exit_code, Some(137));
+
+        let signalled = outcome_from_report(&ExecutionReport {
+            exit_code: None,
+            signal: Some(9),
+            ..report(RunnerState::Failed)
+        });
+        assert_eq!(signalled.state, ExecutionState::Failed);
+        assert_eq!(signalled.exit_code, Some(137));
+    }
+
     #[test]
     fn an_exit_code_no_wait_status_could_produce_is_never_persisted() {
         for forged in [-1, 0, 256, 1_885_434_739, i32::MIN, i32::MAX] {

--- a/src/api/sandbox_runner.rs
+++ b/src/api/sandbox_runner.rs
@@ -1186,11 +1186,31 @@ mod tests {
     #[test]
     fn one_malformed_field_is_never_repaired_by_its_sibling() {
         for (code, signal, why) in [
-            (Some(256), Some(9), "an out-of-range code must not fall through to the signal"),
-            (Some(0), Some(9), "a zero code contradicts Failed and must not defer to a signal"),
-            (Some(-1), Some(15), "a negative code must not fall through to the signal"),
-            (Some(42), Some(i32::MAX), "a valid code must not mask an impossible signal"),
-            (Some(42), Some(0), "a valid code must not mask a zero signal"),
+            (
+                Some(256),
+                Some(9),
+                "an out-of-range code must not fall through to the signal",
+            ),
+            (
+                Some(0),
+                Some(9),
+                "a zero code contradicts Failed and must not defer to a signal",
+            ),
+            (
+                Some(-1),
+                Some(15),
+                "a negative code must not fall through to the signal",
+            ),
+            (
+                Some(42),
+                Some(i32::MAX),
+                "a valid code must not mask an impossible signal",
+            ),
+            (
+                Some(42),
+                Some(0),
+                "a valid code must not mask a zero signal",
+            ),
         ] {
             let outcome = outcome_from_report(&ExecutionReport {
                 exit_code: code,

--- a/src/api/sandbox_runner.rs
+++ b/src/api/sandbox_runner.rs
@@ -210,12 +210,38 @@ pub fn outcome_from_report(report: &ExecutionReport) -> RunnerOutcome {
 /// replicated to every etcd member, and included in backups. So anything
 /// outside the closed vocabulary is replaced rather than truncated: a
 /// truncated secret is still a secret.
+///
+/// The vocabulary is [`kobe_runner::protocol::reason`] itself, matched
+/// literally, because a *shape* check is not a vocabulary. "Nonempty, at most
+/// 64 bytes, lowercase ASCII and underscores" admits `password` and
+/// `ghp_never_persist_this` unchanged, which is precisely the class of string
+/// this function exists to stop. The distinction stopped being theoretical
+/// once a caller could hand the container a secret on stdin: the runner's
+/// spool is written by the workload's own UID (see
+/// [`kobe_runner::spool`]), so a workload that wants its secret in etcd only
+/// has to forge a terminal report carrying it as the reason.
+///
+/// Matching the shared constants rather than a copied list is what keeps this
+/// honest across an upgrade — a reason code renamed on the runner side stops
+/// compiling here instead of silently becoming unrecognised. A *newly added*
+/// code does degrade to `runner_reason_unrecognised` on an older Kobe, and
+/// that is the correct direction: nothing downstream branches on the string,
+/// so the cost is a less precise diagnosis rather than a wrong decision.
 pub fn bounded_reason(reason: &str) -> String {
-    let recognised = !reason.is_empty()
-        && reason.len() <= 64
-        && reason
-            .bytes()
-            .all(|byte| byte.is_ascii_lowercase() || byte == b'_');
+    use kobe_runner::protocol::reason as code;
+
+    let recognised = matches!(
+        reason,
+        code::COMPLETED
+            | code::TIMED_OUT
+            | code::CANCELLED
+            | code::SIGNALLED
+            | code::SPAWN_FAILED
+            | code::SUPERVISOR_NOT_STARTED
+            | code::SUPERVISOR_SETUP_FAILED
+            | code::SUPERVISOR_LOST
+            | code::OUTCOME_UNOBSERVED
+    );
     if recognised {
         reason.to_string()
     } else {
@@ -1150,6 +1176,55 @@ mod tests {
         ] {
             let outcome = outcome_from_report(&report(state));
             assert!(outcome.reason.len() <= 64);
+        }
+    }
+
+    /// Only the runner protocol's own reason codes are ever persisted.
+    ///
+    /// The shape check the vocabulary used to be — nonempty, short, lowercase
+    /// ASCII — admits `password` and `ghp_never_persist_this` unchanged. That
+    /// is a closed vocabulary in the doc-comment only, and stdin forwarding
+    /// gives a workload a secret worth routing through it: the spool is
+    /// writable by the tenant's own UID, so a forged terminal report is the
+    /// tenant's to write.
+    #[test]
+    fn only_the_runner_protocols_own_reason_codes_are_persisted() {
+        use kobe_runner::protocol::reason as code;
+
+        // Every code the runner can actually emit survives unchanged. A fix
+        // that silently retired one of these would turn a real diagnosis into
+        // `runner_reason_unrecognised` on the next upgrade.
+        for recognised in [
+            code::COMPLETED,
+            code::TIMED_OUT,
+            code::CANCELLED,
+            code::SIGNALLED,
+            code::SPAWN_FAILED,
+            code::SUPERVISOR_NOT_STARTED,
+            code::SUPERVISOR_SETUP_FAILED,
+            code::SUPERVISOR_LOST,
+            code::OUTCOME_UNOBSERVED,
+        ] {
+            assert_eq!(
+                bounded_reason(recognised),
+                recognised,
+                "{recognised} is a protocol reason code and must reach the record"
+            );
+        }
+
+        // Each of these passes the old shape check verbatim.
+        for smuggled in [
+            "password",
+            "ghp_never_persist_this",
+            &"a".repeat(64),
+            "completed_",
+            "aws_secret_access_key",
+        ] {
+            assert_eq!(
+                bounded_reason(smuggled),
+                "runner_reason_unrecognised",
+                "reason {smuggled:?} is not a protocol code and must not be persisted"
+            );
         }
     }
 

--- a/src/api/sandbox_runner.rs
+++ b/src/api/sandbox_runner.rs
@@ -36,6 +36,12 @@
 //! Only the execution id — a hash Kobe derived — is ever passed as an argument;
 //! the command itself is written to the runner's stdin, which nothing on the
 //! path records.
+//!
+//! The same document may carry the supervised process's own stdin, which is the
+//! only way to give a Sandbox a secret at all: without it, a command that reads
+//! a token — `gh auth login --with-token` — could be driven only by putting
+//! that token in a flag, in the argv that gets audit-logged. Those bytes are
+//! forwarded and hashed; they are never persisted, on either side.
 
 use kobe_runner::protocol::{
     Envelope, ExecutionReport, LogStream, MAX_LOG_CHUNK_BYTES, MAX_REQUEST_BYTES, PROTOCOL_VERSION,
@@ -218,12 +224,23 @@ pub fn bounded_reason(reason: &str) -> String {
 }
 
 /// The request Kobe writes to the runner's stdin.
+///
+/// `stdin` is the caller's bytes for the supervised process, base64-encoded
+/// here and carried inside this one document. It is emitted only when present:
+/// a request that forwards no stdin serialises byte-for-byte as it did before
+/// the field existed, so a Sandbox image older than this Kobe keeps accepting
+/// ordinary executions. One that *does* forward stdin is refused by such an
+/// image — loudly, and before anything is spawned — rather than run without the
+/// input it was meant to receive.
 pub fn start_request(
     id: &str,
     argv: &[String],
     cwd: Option<&str>,
     timeout: std::time::Duration,
+    stdin: Option<&[u8]>,
 ) -> StartRequest {
+    use base64::Engine;
+
     StartRequest {
         protocol: PROTOCOL_VERSION,
         id: id.to_string(),
@@ -233,6 +250,10 @@ pub fn start_request(
         // became one would kill a command before its own bound elapsed.
         timeout_seconds: (timeout.as_secs() + u64::from(timeout.subsec_nanos() > 0)).max(1),
         max_output_bytes: crate::api::sandbox_executions::EXECUTION_OUTPUT_RETENTION_BYTES,
+        // Base64 so exact bytes survive the JSON: a credential is not required
+        // to be UTF-8, and a lossy conversion here would corrupt it in a way
+        // that surfaces as an authentication failure far from the cause.
+        stdin_base64: stdin.map(|stdin| base64::engine::general_purpose::STANDARD.encode(stdin)),
     }
 }
 
@@ -657,6 +678,7 @@ mod tests {
             &["/agent".into(), "--token".into(), "s3cret".into()],
             Some("/work"),
             std::time::Duration::from_secs(60),
+            None,
         );
         let line = String::from_utf8(start_line(&request).unwrap()).unwrap();
         assert!(line.contains("s3cret"), "the command travels on stdin");
@@ -827,6 +849,91 @@ mod tests {
         }
     }
 
+    /// A forwarded secret travels on stdin and appears in no argument.
+    ///
+    /// This is the whole reason the field exists. If the bytes reached the
+    /// runner through argv instead, they would be in the exec URL the target
+    /// apiserver audit-logs verbatim — the exact leak `--stdin` is offered to
+    /// avoid, and one nobody could redact after the fact.
+    #[test]
+    fn forwarded_stdin_travels_on_stdin_and_never_in_an_argument() {
+        let secret = b"ghp_a-token-that-must-not-be-audit-logged";
+        let request = start_request(
+            "sbxe-abc123",
+            &["/usr/bin/gh".into(), "auth".into(), "login".into()],
+            None,
+            std::time::Duration::from_secs(60),
+            Some(secret),
+        );
+
+        // Base64 on the wire, so the exact bytes survive JSON.
+        let encoded = {
+            use base64::Engine;
+            base64::engine::general_purpose::STANDARD.encode(secret.as_slice())
+        };
+        assert_eq!(request.stdin_base64.as_deref(), Some(encoded.as_str()));
+        assert_eq!(request.stdin_bytes().unwrap().unwrap(), secret);
+
+        let line = String::from_utf8(start_line(&request).unwrap()).unwrap();
+        assert!(line.contains(&encoded), "the secret must travel on stdin");
+        assert!(line.ends_with('\n'), "the runner reads exactly one line");
+
+        // The exec argv is unchanged by the presence of stdin: two fixed words.
+        assert_eq!(start_argv("/kobe-runner", None), ["/kobe-runner", "start"]);
+        for argument in start_argv("/kobe-runner", None) {
+            assert!(!argument.contains(&encoded));
+            assert!(!argument.contains("gh"));
+        }
+    }
+
+    /// A request that forwards no stdin is byte-identical to the released one.
+    ///
+    /// A Sandbox image is built by an administrator and can be months older
+    /// than the Kobe talking to it, and the runner denies unknown fields. An
+    /// always-emitted `stdinBase64` — even null — would make every ordinary
+    /// execution fail against every already-deployed image.
+    #[test]
+    fn a_request_without_stdin_stays_wire_compatible_with_an_older_runner() {
+        let without = start_request(
+            "sbxe-abc123",
+            &["/agent".into(), "run".into()],
+            Some("/work"),
+            std::time::Duration::from_secs(60),
+            None,
+        );
+        let line = String::from_utf8(start_line(&without).unwrap()).unwrap();
+        assert!(
+            !line.contains("stdin"),
+            "no stdin means no field at all: {line}"
+        );
+
+        let with = start_request(
+            "sbxe-abc123",
+            &["/agent".into(), "run".into()],
+            Some("/work"),
+            std::time::Duration::from_secs(60),
+            Some(b"token"),
+        );
+        assert!(
+            String::from_utf8(start_line(&with).unwrap())
+                .unwrap()
+                .contains("stdinBase64"),
+            "and a request that forwards stdin must say so explicitly"
+        );
+
+        // Present-but-empty is not absent: one hands the process a closed pipe,
+        // the other hands it /dev/null.
+        let empty = start_request(
+            "sbxe-abc123",
+            &["/agent".into(), "run".into()],
+            Some("/work"),
+            std::time::Duration::from_secs(60),
+            Some(b""),
+        );
+        assert_eq!(empty.stdin_base64.as_deref(), Some(""));
+        assert_ne!(empty, without);
+    }
+
     /// Kobe and the runner share the exact encoded request ceiling.
     #[test]
     fn start_request_bound_includes_the_newline() {
@@ -835,6 +942,7 @@ mod tests {
             &[String::new()],
             None,
             std::time::Duration::from_secs(1),
+            None,
         );
         let base = start_line(&request).unwrap().len();
         request.argv[0] = "x".repeat(MAX_REQUEST_BYTES - base);
@@ -1053,7 +1161,7 @@ mod tests {
     #[test]
     fn a_timeout_is_never_rounded_down() {
         let seconds = |timeout: std::time::Duration| {
-            start_request("sbxe-1", &["/agent".into()], None, timeout).timeout_seconds
+            start_request("sbxe-1", &["/agent".into()], None, timeout, None).timeout_seconds
         };
 
         assert_eq!(seconds(std::time::Duration::from_secs(60)), 60);
@@ -1077,6 +1185,7 @@ mod tests {
             &["/agent".into()],
             None,
             std::time::Duration::from_secs(60),
+            None,
         );
         assert_eq!(
             request.max_output_bytes,

--- a/src/crd/execution.rs
+++ b/src/crd/execution.rs
@@ -323,6 +323,16 @@ pub fn state_for_exit_code(exit_code: i32) -> ExecutionState {
 /// with those bytes anywhere in Kobe's durable path — see the module
 /// documentation for why they must not survive the request.
 ///
+/// The digest is an **unkeyed** SHA-256, and it is persisted — in
+/// `spec.requestDigest` and in the Lease annotations that survive the record.
+/// Stated plainly because it is a real property and not an implied one: a
+/// high-entropy token is safe under it, but anyone who can read the digest can
+/// test candidate stdin values offline, so a low-entropy secret (a short
+/// password, a PIN) is confirmable rather than merely committed to. Keying it
+/// would need a durable operator secret that survives a rolling upgrade and
+/// stays identical across replicas, which would trade this property for a key
+/// distribution problem that fails less obviously.
+///
 /// `None` for `stdin` contributes nothing to the hash, so a request that
 /// forwards no stdin digests exactly as it did before this parameter existed.
 /// That is what lets a Kobe rollout recognise the records its predecessor

--- a/src/crd/execution.rs
+++ b/src/crd/execution.rs
@@ -22,6 +22,14 @@
 //! What is stored is a **digest** of the request. That is enough to answer "is
 //! this the same command as last time?" without ever holding the command.
 //!
+//! stdin is the sharpest case, because it is the one field a caller uses
+//! *specifically* to move a secret out of argv — argv being what the target
+//! apiserver's audit log records verbatim. Persisting the bytes here would take
+//! them straight back out of the audit log and into etcd, which is strictly
+//! worse: etcd copies are read by more people and kept for longer. So stdin
+//! goes into [`request_digest`] and nowhere else, and no field of
+//! [`SandboxExecutionSpec`] or [`SandboxExecutionStatus`] can hold it.
+//!
 //! # Unknown is a real outcome
 //!
 //! If Kobe cannot establish what happened — it crashed between spawning and
@@ -307,6 +315,18 @@ pub fn state_for_exit_code(exit_code: i32) -> ExecutionState {
 /// idempotency key must agree on all of it — otherwise the second is a
 /// different command wearing the first one's name, and returning the first
 /// one's result would be a wrong answer rather than a cached one.
+///
+/// `stdin` is part of that identity and is hashed rather than kept: two runs of
+/// the same argv differing only in the token they are fed are two different
+/// commands, and answering the second with the first's result would report an
+/// authentication that never happened. Hashing is also the *only* thing done
+/// with those bytes anywhere in Kobe's durable path — see the module
+/// documentation for why they must not survive the request.
+///
+/// `None` for `stdin` contributes nothing to the hash, so a request that
+/// forwards no stdin digests exactly as it did before this parameter existed.
+/// That is what lets a Kobe rollout recognise the records its predecessor
+/// created, and is the same technique `container` and `detached` use.
 #[allow(dead_code)]
 pub fn request_digest(
     argv: &[String],
@@ -314,8 +334,9 @@ pub fn request_digest(
     timeout: &str,
     container: &str,
     detached: bool,
+    stdin: Option<&[u8]>,
 ) -> String {
-    request_digest_with_mode(argv, cwd, timeout, Some(container), Some(detached))
+    request_digest_with_mode(argv, cwd, timeout, Some(container), Some(detached), stdin)
 }
 
 /// Digest emitted before resolved container and lifecycle mode became part of
@@ -324,9 +345,13 @@ pub fn request_digest(
 /// Kept only to recognise exact live records across a rolling upgrade. New
 /// reservations always use [`request_digest`], and callers must also match the
 /// legacy record's explicit `detached` field before this digest is accepted.
+///
+/// No stdin parameter, deliberately: a record from that era cannot have carried
+/// one, so a request that forwards stdin must never be recognised as a retry of
+/// it.
 #[allow(dead_code)]
 pub fn legacy_request_digest(argv: &[String], cwd: Option<&str>, timeout: &str) -> String {
-    request_digest_with_mode(argv, cwd, timeout, None, None)
+    request_digest_with_mode(argv, cwd, timeout, None, None, None)
 }
 
 fn request_digest_with_mode(
@@ -335,6 +360,7 @@ fn request_digest_with_mode(
     timeout: &str,
     container: Option<&str>,
     detached: Option<bool>,
+    stdin: Option<&[u8]>,
 ) -> String {
     use sha2::{Digest, Sha256};
 
@@ -369,6 +395,16 @@ fn request_digest_with_mode(
         // them as one request could return a wait-mode record to a caller that
         // asked for a reconnectable execution, or vice versa.
         hasher.update([u8::from(detached)]);
+    }
+    if let Some(stdin) = stdin {
+        // Nothing at all when absent, so a no-stdin request keeps digesting the
+        // way the previous release digested it and a rolling upgrade still
+        // recognises its own live records. A marker byte plus a length keeps
+        // "an empty stdin" distinguishable from "no stdin", which are two
+        // different things to hand a process.
+        hasher.update([2u8]);
+        hasher.update((stdin.len() as u64).to_be_bytes());
+        hasher.update(stdin);
     }
     format!("{:x}", hasher.finalize())
 }
@@ -617,6 +653,7 @@ mod tests {
             "60s",
             "workspace",
             false,
+            None,
         );
 
         assert_eq!(
@@ -627,6 +664,7 @@ mod tests {
                 "60s",
                 "workspace",
                 false,
+                None
             ),
             "the same request must digest identically"
         );
@@ -634,11 +672,25 @@ mod tests {
         // Argument boundaries.
         assert_ne!(
             base,
-            request_digest(&["/agentrun".into()], None, "60s", "workspace", false)
+            request_digest(&["/agentrun".into()], None, "60s", "workspace", false, None)
         );
         assert_ne!(
-            request_digest(&["a".into(), "bc".into()], None, "60s", "workspace", false,),
-            request_digest(&["ab".into(), "c".into()], None, "60s", "workspace", false,)
+            request_digest(
+                &["a".into(), "bc".into()],
+                None,
+                "60s",
+                "workspace",
+                false,
+                None
+            ),
+            request_digest(
+                &["ab".into(), "c".into()],
+                None,
+                "60s",
+                "workspace",
+                false,
+                None
+            )
         );
         // Order.
         assert_ne!(
@@ -649,6 +701,7 @@ mod tests {
                 "60s",
                 "workspace",
                 false,
+                None
             )
         );
         // Working directory, including present-but-empty versus absent.
@@ -659,7 +712,8 @@ mod tests {
                 Some("/work"),
                 "60s",
                 "workspace",
-                false
+                false,
+                None,
             )
         );
         assert_ne!(
@@ -670,6 +724,7 @@ mod tests {
                 "60s",
                 "workspace",
                 false,
+                None,
             )
         );
         // Timeout: the same command with a different bound is a different
@@ -682,6 +737,7 @@ mod tests {
                 "600s",
                 "workspace",
                 false,
+                None
             )
         );
         // The resolved container is part of where the command runs.
@@ -693,6 +749,7 @@ mod tests {
                 "60s",
                 "sidecar",
                 false,
+                None
             )
         );
         // Lifecycle mode is part of the request. Returning a wait-mode result
@@ -705,10 +762,128 @@ mod tests {
                 "60s",
                 "workspace",
                 true,
+                None
             )
         );
 
         assert_eq!(base.len(), 64);
+    }
+
+    /// stdin changes the request, and its absence changes nothing.
+    ///
+    /// Both halves matter. Two runs of the same argv fed different tokens are
+    /// two different commands — answering the second with the first's result
+    /// would report an authentication that never happened. And a request with
+    /// no stdin has to digest exactly as it did before the parameter existed,
+    /// or a Kobe rollout would stop recognising the live records its own
+    /// predecessor created and would turn every in-flight retry into a
+    /// conflict.
+    #[test]
+    fn the_request_digest_covers_stdin_without_disturbing_requests_that_have_none() {
+        let argv = vec!["/agent".into(), "run".into()];
+        let digest = |stdin: Option<&[u8]>| {
+            request_digest(&argv, Some("/work"), "60s", "workspace", false, stdin)
+        };
+
+        assert_eq!(
+            digest(None),
+            digest_without_the_stdin_parameter(&argv),
+            "no stdin must contribute nothing at all to the hash"
+        );
+
+        // A different secret is a different command.
+        assert_ne!(digest(Some(b"token-a")), digest(Some(b"token-b")));
+        assert_eq!(digest(Some(b"token-a")), digest(Some(b"token-a")));
+
+        // Present-but-empty is not absent: one hands the process a closed pipe,
+        // the other hands it /dev/null.
+        assert_ne!(digest(Some(b"")), digest(None));
+
+        // Length-prefixed like the argv, so a boundary cannot be moved to make
+        // two different inputs collide.
+        assert_ne!(digest(Some(b"ab")), digest(Some(b"a\0b")));
+
+        // A record from before container/lifecycle identity existed is never
+        // recognised as a retry of a request that forwards stdin.
+        assert_ne!(
+            legacy_request_digest(&argv, Some("/work"), "60s"),
+            digest(Some(b"token-a"))
+        );
+    }
+
+    /// The digest a released Kobe computed for a request with no stdin.
+    ///
+    /// Written out rather than delegating, so the compatibility assertion above
+    /// checks behaviour instead of restating the code under test.
+    fn digest_without_the_stdin_parameter(argv: &[String]) -> String {
+        use sha2::{Digest, Sha256};
+
+        let mut hasher = Sha256::new();
+        hasher.update((argv.len() as u64).to_be_bytes());
+        for argument in argv {
+            hasher.update((argument.len() as u64).to_be_bytes());
+            hasher.update(argument.as_bytes());
+        }
+        hasher.update([1u8]);
+        hasher.update(("/work".len() as u64).to_be_bytes());
+        hasher.update(b"/work");
+        hasher.update(("60s".len() as u64).to_be_bytes());
+        hasher.update(b"60s");
+        hasher.update(("workspace".len() as u64).to_be_bytes());
+        hasher.update(b"workspace");
+        hasher.update([0u8]);
+        format!("{:x}", hasher.finalize())
+    }
+
+    /// No stored field can carry the stdin bytes.
+    ///
+    /// The record is readable by anyone with `get` on the type, lands in every
+    /// etcd member, and is included in backups. A caller sends stdin precisely
+    /// to keep a secret out of an argv the apiserver audit-logs, so a copy here
+    /// would undo the point of the feature. This is the test that fails if
+    /// somebody later adds a convenient `stdin` field "just for debugging".
+    #[test]
+    fn no_persisted_execution_field_can_carry_stdin() {
+        let secret = "ghp_never-persisted-anywhere";
+        let record = SandboxExecution {
+            metadata: Default::default(),
+            spec: SandboxExecutionSpec {
+                request_digest: request_digest(
+                    &["/agent".into()],
+                    None,
+                    "60s",
+                    "workspace",
+                    false,
+                    Some(secret.as_bytes()),
+                ),
+                ..spec("lease-a", "unused")
+            },
+            status: Some(SandboxExecutionStatus {
+                state: Succeeded,
+                exit_code: Some(0),
+                reason: Some("completed".into()),
+                ..Default::default()
+            }),
+        };
+
+        let encoded = serde_json::to_string(&record).unwrap();
+        assert!(
+            !encoded.contains(secret),
+            "a persisted execution leaked its stdin: {encoded}"
+        );
+        assert!(
+            !encoded.to_lowercase().contains("stdin"),
+            "no persisted field may even be named for stdin: {encoded}"
+        );
+
+        // The schema the apiserver enforces has no home for it either, so a
+        // client cannot smuggle one past `deny_unknown_fields`.
+        let crd = serde_json::to_value(SandboxExecution::crd()).unwrap();
+        let schema = crd["spec"]["versions"][0]["schema"]["openAPIV3Schema"].to_string();
+        assert!(
+            !schema.to_lowercase().contains("stdin"),
+            "the CRD schema declares a place to store stdin: {schema}"
+        );
     }
 
     /// Names are derived and fenced, so the reservation can be a `create`.

--- a/src/telemetry.rs
+++ b/src/telemetry.rs
@@ -3,12 +3,70 @@ use opentelemetry::trace::TracerProvider;
 use opentelemetry_sdk::trace::SdkTracerProvider;
 use tracing_subscriber::{EnvFilter, layer::SubscriberExt, util::SubscriberInitExt};
 
+/// Log targets whose own diagnostics print the bytes on the wire.
+///
+/// `tungstenite` is the WebSocket implementation underneath `kube`'s exec
+/// channel, and several of its `trace`/`debug` records are payload dumps: the
+/// frame writer renders the complete frame — `payload: 0x…` — as hex, and the
+/// client handshake logs the request verbatim.
+///
+/// That matters here more than it would in most services. A caller's stdin is
+/// carried to a Sandbox as a binary WebSocket frame *specifically* so the
+/// secret stays out of the argv the target apiserver audit-logs; a frame dump
+/// puts it straight back into a durable log, and hex-decode → strip the channel
+/// byte → base64-decode recovers it exactly. Kobe's own masking cannot help:
+/// it is applied to what Kobe formats, and this record is formatted inside the
+/// transport.
+const PAYLOAD_DUMPING_TARGETS: &[&str] = &["tungstenite"];
+
+/// Whether an event may be emitted at all, before any `RUST_LOG` is consulted.
+///
+/// The default filter already excludes [`PAYLOAD_DUMPING_TARGETS`], but
+/// "excluded by default" is a configuration, not a property: `RUST_LOG=trace`,
+/// or a `tungstenite=debug` directive added while chasing an unrelated
+/// connection problem, re-enables the dump — and nothing would tell the
+/// operator they had just started logging every forwarded credential.
+///
+/// `WARN` and above still pass. A WebSocket that is failing must be able to say
+/// so; nothing tungstenite logs at that level carries a frame.
+fn payload_is_never_dumped(metadata: &tracing::Metadata<'_>) -> bool {
+    if *metadata.level() <= tracing::Level::WARN {
+        return true;
+    }
+    let target = metadata.target();
+    !PAYLOAD_DUMPING_TARGETS.iter().any(|dumping| {
+        target
+            .strip_prefix(dumping)
+            .is_some_and(|rest| rest.is_empty() || rest.starts_with("::"))
+    })
+}
+
+/// The suppression, as a layer of its own.
+///
+/// A *global* filter on the registry rather than another [`EnvFilter`]
+/// directive: directive precedence is a property of the string an operator
+/// supplied, so competing with it there would leave the guarantee depending on
+/// what they wrote. A separate layer is consulted for every event whatever the
+/// filter says — including events bridged in from the `log` crate, which is how
+/// `tungstenite` (a `log` user, not a `tracing` one) actually reaches this
+/// subscriber.
+fn payload_dump_guard() -> tracing_subscriber::filter::FilterFn<fn(&tracing::Metadata<'_>) -> bool>
+{
+    tracing_subscriber::filter::filter_fn(
+        payload_is_never_dumped as fn(&tracing::Metadata<'_>) -> bool,
+    )
+}
+
 /// Initialize the tracing subscriber with optional OpenTelemetry export.
 ///
 /// When `OTEL_EXPORTER_OTLP_ENDPOINT` is set, spans are exported via OTLP gRPC.
 /// The Helm chart exposes this through `telemetry.otlp`; `OTEL_SERVICE_NAME`
 /// and standard OpenTelemetry resource attributes distinguish deployments in
 /// a shared backend. When unset, only the fmt/JSON layer is active.
+///
+/// The operator's `RUST_LOG` is honoured for everything except
+/// [`PAYLOAD_DUMPING_TARGETS`], which [`payload_dump_guard`] holds at `WARN`
+/// unconditionally — see there for why that one exception is not negotiable.
 ///
 /// Returns the tracer provider handle for graceful shutdown (flush on drop).
 pub fn init() -> Result<Option<SdkTracerProvider>> {
@@ -41,6 +99,7 @@ pub fn init() -> Result<Option<SdkTracerProvider>> {
 
         tracing_subscriber::registry()
             .with(env_filter)
+            .with(payload_dump_guard())
             .with(fmt_layer)
             .with(otel_layer)
             .init();
@@ -49,6 +108,7 @@ pub fn init() -> Result<Option<SdkTracerProvider>> {
     } else {
         tracing_subscriber::registry()
             .with(env_filter)
+            .with(payload_dump_guard())
             .with(fmt_layer)
             .init();
 
@@ -62,5 +122,121 @@ pub fn shutdown(provider: Option<SdkTracerProvider>) {
         && let Err(e) = provider.shutdown()
     {
         eprintln!("OpenTelemetry shutdown error: {e}");
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::sync::{Arc, Mutex};
+
+    /// A writer that keeps what the subscriber emitted.
+    #[derive(Clone, Default)]
+    struct Captured(Arc<Mutex<Vec<u8>>>);
+
+    impl std::io::Write for Captured {
+        fn write(&mut self, buffer: &[u8]) -> std::io::Result<usize> {
+            self.0
+                .lock()
+                .expect("capture buffer")
+                .extend_from_slice(buffer);
+            Ok(buffer.len())
+        }
+
+        fn flush(&mut self) -> std::io::Result<()> {
+            Ok(())
+        }
+    }
+
+    impl<'writer> tracing_subscriber::fmt::MakeWriter<'writer> for Captured {
+        type Writer = Captured;
+
+        fn make_writer(&'writer self) -> Self::Writer {
+            self.clone()
+        }
+    }
+
+    /// Emit through exactly the stack [`init`] installs, for one `RUST_LOG`.
+    ///
+    /// The spec is passed rather than read from the environment so a hostile
+    /// operator setting can be exercised without a process-wide mutation that
+    /// every other test in this binary would see.
+    fn emitted_under(spec: &str, emit: impl FnOnce()) -> String {
+        let captured = Captured::default();
+        let subscriber = tracing_subscriber::registry()
+            .with(EnvFilter::new(spec))
+            .with(payload_dump_guard())
+            .with(
+                tracing_subscriber::fmt::layer()
+                    .json()
+                    .with_writer(captured.clone()),
+            );
+        tracing::subscriber::with_default(subscriber, emit);
+        String::from_utf8(captured.0.lock().expect("capture buffer").clone())
+            .expect("subscriber output is UTF-8")
+    }
+
+    /// No `RUST_LOG` can turn the WebSocket frame dump back on.
+    ///
+    /// A caller's stdin reaches the Sandbox as a binary WebSocket frame, which
+    /// is the whole point: it keeps the secret out of the argv the target
+    /// apiserver audit-logs. `tungstenite` renders that frame's complete
+    /// payload as hex at `trace`, so an operator debugging an unrelated
+    /// connection problem with `RUST_LOG=trace` would write every forwarded
+    /// token into Kobe's own JSON logs, in a form a hex-then-base64 decode
+    /// recovers exactly.
+    #[test]
+    fn no_rust_log_can_re_enable_the_websocket_payload_dump() {
+        // The hex a frame carrying "hunter2" would print.
+        let payload_hex = "68756e74657232";
+
+        for hostile in [
+            "trace",
+            "tungstenite=trace",
+            "tungstenite::protocol::frame=trace",
+            "kobe_operator=info,tungstenite=debug",
+        ] {
+            let emitted = emitted_under(hostile, || {
+                tracing::trace!(
+                    target: "tungstenite::protocol::frame",
+                    "writing frame <FRAME> payload: 0x{payload_hex}"
+                );
+                tracing::debug!(target: "tungstenite", "Sending frame: 0x{payload_hex}");
+            });
+
+            assert!(
+                !emitted.contains(payload_hex),
+                "RUST_LOG={hostile} put a frame payload in the logs: {emitted}"
+            );
+        }
+    }
+
+    /// The suppression is a level floor on one target, not a blanket mute.
+    ///
+    /// A guard that silenced the transport outright would trade a disclosure
+    /// for a blind spot: a WebSocket that keeps resetting is exactly what an
+    /// operator turns `RUST_LOG` up to diagnose, and nothing tungstenite emits
+    /// at `WARN` or above carries a frame. Everything outside the guarded
+    /// targets stays entirely the operator's decision.
+    #[test]
+    fn the_payload_guard_costs_no_diagnostics_above_warn() {
+        let emitted = emitted_under("trace", || {
+            tracing::warn!(target: "tungstenite", "connection reset by peer");
+            tracing::error!(target: "tungstenite::protocol", "protocol violation");
+            tracing::trace!(target: "kobe_operator::api", "execution started");
+            tracing::trace!(target: "tungstenite_lookalike", "not a guarded target");
+        });
+
+        for surviving in [
+            "connection reset by peer",
+            "protocol violation",
+            "execution started",
+            "not a guarded target",
+        ] {
+            assert!(
+                emitted.contains(surviving),
+                "the guard swallowed {surviving:?}: {emitted}"
+            );
+        }
     }
 }


### PR DESCRIPTION
A Sandbox currently has no way to receive a secret without it appearing in argv. `kobe exec` forwards no process stdin, and `kobe attach` needs a real TTY (piping to it fails with "reader source not set"). So `gh auth login --with-token`, which exists precisely to read a token from stdin, is impossible — the token has to go in a flag instead.

That contradicts the design intent already stated in `protocol.rs`: the runner's own request is sent on **its** stdin, "never as command-line arguments", because the exec request's argv becomes a URL the apiserver audit-logs verbatim. This is the missing half of that.

## Shape

- `stdin_base64` on `StartRequest`, bounded at **16 KiB** (~22 KiB encoded, leaving argv room inside the existing 64 KiB `MAX_REQUEST_BYTES`; a maximal-stdin request is asserted to still fit).
- Delivery deliberately **does not use the spool**. The supervisor is a separately re-exec'd process, so `start` spawns it with a piped stdin, writes, and closes; only the byte *count* rides the internal re-exec's argv. The child's stdin handle is dropped on every path — that is the EOF — and a short read on handover settles `Unknown`/`supervisor_setup_failed` and spawns nothing, rather than running a command with half a credential.
- **Not persisted:** `spool.reserve` writes `request.without_stdin()`; `SandboxExecutionSpec` is untouched; `crdgen` output is byte-identical. stdin enters only `request_digest`.
- Wire-compatible both ways via `skip_serializing_if`, following the `detached` / `legacy_request_digest` precedent: a no-stdin request is byte-for-byte what a released runner already accepts, and a stdin-bearing one is refused loudly rather than run without its input.

## Adversarial review

Three blind Codex legs reviewed this (3/3 usable after one timeout retry). They confirmed the mechanism — no pipe deadlock, partial handover never executes, the bound is enforced before any reservation is spent, wire compat holds in both directions — and found **three defects, all now fixed**, each with a test that was red before and green after:

**1. `bounded_reason` was not a closed vocabulary** *(pre-existing; this branch makes it consequential)*. Its doc promised one; the body checked a character class, so `"password"` passed into `SandboxExecution.status.reason` → etcd, backups, audit. The spool is tenant-writable *by design*, so a workload could forge `state.json` with the secret it just received on stdin. Now matched against the 9 real protocol constants, verified to be the complete emitted set.

**2. A trace-log leak that defeated the feature's own purpose.** `stdin → stdinBase64 → kube-client WebSocket → tungstenite frame trace → operator JSON logs`, hex-encoded and trivially reversible, needing no malicious command and no echoed output. Wider than first reported: five payload-dumping call sites, reached through the `log`→`tracing` bridge. Fixed with a `filter_fn` layer pinning that target at WARN **regardless of `RUST_LOG`** — a layer rather than a directive, because directive precedence would leave the guarantee depending on an operator-supplied string. A second test pins the narrowness: tungstenite WARN/ERROR, Kobe's own TRACE, and a lookalike target all still get through.

**3. A thread-creation panic left a command running unsupervised.** The child spawns before `feed`'s `thread::spawn`, which *panics* on OS refusal — so under PID pressure the supervisor died before its timeout loop while the command ran on past its deadline, unreaped. Now `thread::Builder` for the feeder and both output pumps, tearing down the process group and settling a terminal report.

**On the honesty of that third test:** real OS thread exhaustion would break every other test in the binary, so it injects `EAGAIN` at the exact call site instead. It does *not* prove `Builder::spawn` reports the same conditions `thread::spawn` panics on — that is `std`'s contract, taken on trust. It *does* prove the failure mode: the supervisor doesn't unwind, tears down the group, and records a terminal report, with a marker file written 3s after spawn against a 4s wait as the load-bearing assertion.

## Also documented, not changed
The digest is unkeyed SHA-256 over stdin and is persisted, so a low-entropy secret is confirmable offline. The bytes are an ordinary `Vec<u8>` — a core dump or swap can hold them; no secret-memory machinery was built. And `stdin_is_never_written_to_the_spool` was renamed to `the_runner_itself_never_writes_stdin_to_the_spool`, because its `sh -c "exit 0"` command makes it a statement about the runner, not about captured output — a `cat` legitimately puts stdin in `stdout.log`.

## Second review round (falsification)

A second blind Codex leg tried to falsify the three fixes above. All three were confirmed closed, and the trace-log guard could not be falsified at all. It found **one more defect of the same class, now fixed**, red-before/green-after:

**4. `exitCode` was a second unbounded channel into persisted status.** Closing `reason` (#1 above) fixed one of *two* values that cross out of a tenant's container — `outcome_from_report` forwarded any nonzero `i32` from a `Failed` report straight into `SandboxExecution.status.exitCode`, i.e. 32 forgeable bits into etcd and backups, through the same tenant-writable spool. A wait status is eight bits, so a `Failed` code is now accepted only in 1-255 and a signal only in 1-127 (Linux stops at `SIGRTMAX`=64); anything else was never observed on this host and settles `Unknown` with no code. Real codes and real signals are untouched. The doc-comment asserting `reason` was "the ONE value that crosses" was provably false and now names both.

It also caught **two doc-comments claiming more than the code delivers** (comment-only, no behaviour change): teardown-before-settling is bounded best-effort rather than guaranteed (`terminate_group`'s result is discarded, and signal delivery is not reaping — reporting `Unknown` was already the honest answer, the comment was the overclaim), and the terminal report on a helper refusal is *attempted*, not guaranteed, since a workload that removes its own `state.lock` makes `write_report` fail into a discarded error.

## Verification
`cargo fmt --check` clean · `cargo clippy --workspace --all-targets -- -D warnings` clean · `cargo test --workspace` **2272 passed, 0 failed** (26 ignored are the pre-existing live-cluster gates).

One caveat, reported rather than hidden: `spool::tests::the_reserve_to_spawn_owner_is_observable_even_after_rename` is a **pre-existing flake** — ~1 failure in 8 runs of the `kobe-runner` lib suite under load, on `main` as well, in a test this branch does not touch. Filed as **#221** so a red run here is not misread as this PR's doing.

## Known adjacent surface

Two findings from the same review are **pre-existing, not introduced by this PR, and deliberately out of scope** — they are separate paths out of a tenant's container that this branch neither creates nor widens, and expanding an already-large PR into them would only make it harder to review. Filed instead:

- **#219** — Sandbox containers inherit the kubelet's termination-log defaults, so `cat > /dev/termination-log` puts a secret into persisted `Pod.status`. `src/sandbox.rs` leaves `terminationMessagePath`/`terminationMessagePolicy` unset, and `container_matches` in `sandbox_pool_certification.rs` inspects neither.
- **#220** — a workload can replace its spool `state.json` with a FIFO; `read_existing` uses blocking `std::fs::read`, so `write_report` blocks forever while holding the state lock. Same documented tenant-writable-spool trust model.

Both are worth reading alongside this PR: it closes the runner-report channels (`reason`, `exitCode`) and not those.


https://claude.ai/code/session_01Xd7c1Uq38mZSaTMTofC3bR

