### PR TITLE
feat(workspace): ship the GUI workspace image in Kobe v0.44.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.43.2"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.43.2"
+version = "0.44.0"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -3443,11 +3443,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.43.2"
+version = "0.44.0"
 
 [[package]]
 name = "kobectl"
-version = "0.43.2"
+version = "0.44.0"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.43.2"
+version = "0.44.0"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.43.2
-appVersion: "0.43.2"
+version: 0.44.0
+appVersion: "0.44.0"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.43.2
+      image: docker.io/zondax/kobe-operator:v0.44.0
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.43.2
+      image: docker.io/zondax/kobe-sync:v0.44.0
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true

--- a/docker-bake.hcl
+++ b/docker-bake.hcl
@@ -76,11 +76,11 @@ function "tags" {
 # Groups
 # =============================================================================
 group "default" {
-  targets = ["operator", "kobe-sync", "runner", "agent-workspace"]
+  targets = ["operator", "kobe-sync", "runner", "agent-workspace", "agent-workspace-gui"]
 }
 
 group "push" {
-  targets = ["operator-push", "kobe-sync-push", "runner-push", "agent-workspace-push"]
+  targets = ["operator-push", "kobe-sync-push", "runner-push", "agent-workspace-push", "agent-workspace-gui-push"]
 }
 
 # =============================================================================
@@ -200,7 +200,7 @@ target "sandbox-e2e" {
   contexts = {
     runner = "target:runner"
   }
-  platforms = [PLATFORM]
+  platforms  = [PLATFORM]
   tags       = [SANDBOX_E2E_IMAGE]
   cache-from = ["type=local,src=${LOCAL_CACHE_ROOT}/sandbox-e2e"]
   cache-to   = ["type=local,dest=${LOCAL_CACHE_ROOT}/sandbox-e2e,mode=max"]
@@ -250,6 +250,29 @@ target "agent-workspace-push" {
   inherits = ["agent-workspace"]
   contexts = {
     runner = "target:runner-push"
+  }
+  output = ["type=registry"]
+}
+
+# GUI adds system libraries and a desktop to the exact headless image. Keep the
+# push dependency on the push variant, so neither the base nor its runner is
+# exported twice to the same local cache during one bake invocation.
+target "agent-workspace-gui" {
+  dockerfile = "docker/agent-workspace-gui.Dockerfile"
+  context    = "."
+  contexts = {
+    workspace = "target:agent-workspace"
+  }
+  platforms  = [PLATFORM]
+  tags       = tags("kobe-agent-workspace-gui")
+  cache-from = ["type=local,src=${LOCAL_CACHE_ROOT}/agent-workspace-gui"]
+  cache-to   = ["type=local,dest=${LOCAL_CACHE_ROOT}/agent-workspace-gui,mode=max"]
+}
+
+target "agent-workspace-gui-push" {
+  inherits = ["agent-workspace-gui"]
+  contexts = {
+    workspace = "target:agent-workspace-push"
   }
   output = ["type=registry"]
 }

--- a/docker/agent-workspace-gui.Dockerfile
+++ b/docker/agent-workspace-gui.Dockerfile
@@ -1,0 +1,46 @@
+# syntax=docker/dockerfile:1
+
+# Reuse the headless workspace and its exact runner through Docker Bake.
+FROM workspace
+
+USER root
+
+# Tauri 2 Linux prerequisites plus an unprivileged software-rendered desktop.
+# Language runtimes and project tools still come from the project's mise.toml.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+        dbus \
+        file \
+        fonts-dejavu-core \
+        libayatana-appindicator3-dev \
+        libgl1-mesa-dri \
+        librsvg2-dev \
+        libwebkit2gtk-4.1-dev \
+        novnc \
+        openbox \
+        procps \
+        websockify \
+        wget \
+        x11-utils \
+        x11vnc \
+        xauth \
+        xvfb \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --chmod=0755 docker/kobe-desktop-up /usr/local/bin/kobe-desktop-up
+
+USER 65532:65532
+
+# Fixed paths let independent runner executions join the same desktop/session.
+# All desktop state is writable by the workload, without /run or root access.
+ENV DISPLAY=:99 \
+    XDG_RUNTIME_DIR=/home/agent/.cache/kobe-desktop \
+    XAUTHORITY=/home/agent/.cache/kobe-desktop/Xauthority \
+    DBUS_SESSION_BUS_ADDRESS=unix:path=/home/agent/.cache/kobe-desktop/bus \
+    LIBGL_ALWAYS_SOFTWARE=1 \
+    WEBKIT_DISABLE_DMABUF_RENDERER=1
+
+LABEL org.opencontainers.image.title="kobe-agent-workspace-gui"
+LABEL org.opencontainers.image.description="Kobe agent workspace with Tauri Linux libraries and an opt-in loopback-only noVNC desktop"
+
+# Inherit the idle command. The lease explicitly starts kobe-desktop-up as a
+# foreground managed execution; building or leasing does not start a desktop.

--- a/docker/kobe-desktop-up
+++ b/docker/kobe-desktop-up
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Own the entire desktop lifetime in one foreground runner execution. Independent
+# application executions inherit DISPLAY, XAUTHORITY and the session bus address
+# from the image. Only Kobe's declared-port tunnel should expose the browser UI.
+set -euo pipefail
+
+umask 077
+mkdir -p "$XDG_RUNTIME_DIR"
+chmod 700 "$XDG_RUNTIME_DIR"
+exec 9>"$XDG_RUNTIME_DIR/desktop.lock"
+flock -n 9 || {
+  echo "A desktop is already running." >&2
+  exit 1
+}
+
+pids=()
+# Invoked by the EXIT trap, including signal and startup failures.
+# shellcheck disable=SC2329
+cleanup() {
+  trap - EXIT TERM INT
+  if ((${#pids[@]})); then
+    kill "${pids[@]}" 2>/dev/null || true
+    # Bound cleanup even if a component stops responding to TERM.
+    for _ in {1..20}; do
+      [[ -z $(jobs -pr) ]] && break
+      sleep 0.1
+    done
+    kill -KILL "${pids[@]}" 2>/dev/null || true
+    wait "${pids[@]}" 2>/dev/null || true
+  fi
+  rm -f "$XAUTHORITY" "$XDG_RUNTIME_DIR/bus"
+}
+trap cleanup EXIT
+trap 'exit 143' TERM
+trap 'exit 130' INT
+
+start() {
+  "$@" 9>&- &
+  pids+=("$!")
+}
+
+ready() {
+  local deadline=$((SECONDS + 30))
+  until "$@" >/dev/null 2>&1; do
+    for pid in "${pids[@]}"; do
+      kill -0 "$pid" 2>/dev/null || {
+        echo "Desktop component exited during startup." >&2
+        exit 1
+      }
+    done
+    ((SECONDS < deadline)) || {
+      echo "Desktop readiness timed out: $1" >&2
+      exit 1
+    }
+    sleep 0.1
+  done
+}
+
+# Unix-domain X11 only, with a fresh cookie readable only by this workload UID.
+rm -f "$XAUTHORITY" "$XDG_RUNTIME_DIR/bus"
+touch "$XAUTHORITY"
+xauth -f "$XAUTHORITY" add "$DISPLAY" . "$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
+start Xvfb "$DISPLAY" -screen 0 1440x900x24 -nolisten tcp -auth "$XAUTHORITY"
+ready xdpyinfo -display "$DISPLAY"
+
+start dbus-daemon --session --nofork --address="$DBUS_SESSION_BUS_ADDRESS"
+ready dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply / org.freedesktop.DBus.ListNames
+start openbox --sm-disable
+start x11vnc -display "$DISPLAY" -auth "$XAUTHORITY" -forever -shared \
+  -localhost -listen 127.0.0.1 -rfbport 5900 -nopw -noxdamage
+ready bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900'
+# No VNC password: both listeners are loopback-only within the leased Sandbox.
+start websockify --web=/usr/share/novnc 127.0.0.1:6080 127.0.0.1:5900
+ready curl --fail --silent http://127.0.0.1:6080/vnc.html
+printf '%s\n' 'Desktop ready on DISPLAY=:99. Forward port 6080 and open /vnc.html?autoconnect=1&resize=scale&path=websockify'
+
+# Any component exit (even zero) ends the desktop and fails the execution.
+status=0
+wait -n "${pids[@]}" || status=$?
+echo "Desktop component exited (status $status); stopping desktop." >&2
+exit 1

--- a/docker/kobe-desktop-up
+++ b/docker/kobe-desktop-up
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
-# Own the entire desktop lifetime in one foreground runner execution. Independent
+# Own the desktop lifetime in one foreground process (runner exec or tmux).
+# Runner executions are capped at one hour; tmux follows the lease lifetime.
+# Independent
 # application executions inherit DISPLAY, XAUTHORITY and the session bus address
 # from the image. Only Kobe's declared-port tunnel should expose the browser UI.
 set -euo pipefail

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -258,3 +258,69 @@ contract. Lease callers cannot override either placement or isolation.
 See the [API reference](/docs/api/reference#sandbox-leases) for lease operations
 and [authentication and authorization](/docs/auth/overview) for Sandbox policy
 verbs and limits.
+
+## Agent workspace images
+
+`zondax/kobe-agent-workspace` includes `kobe-runner`, `mise`, `tmux`, Git,
+OpenSSL headers, and a C toolchain. The workload runs as `65532:65532`, with
+`HOME=/home/agent` and a writable `/home/agent/work`. Clone projects there and
+run `mise install`; the image trusts mise configurations under that workspace
+and puts tool shims on `PATH` for direct `kobe exec` commands.
+
+`zondax/kobe-agent-workspace-gui` adds the [Tauri 2 Linux system prerequisites](https://v2.tauri.app/start/prerequisites/#linux),
+software rendering, Xvfb, Openbox, and noVNC. Node, Rust, package managers, and
+other project tools still come from the project's `mise.toml`. Both images use
+the same release tags and runner. Pin a release tag or digest in your pool.
+
+For a GUI pool, set these fields in its template (alongside your resource
+requests and limits):
+
+```yaml
+template:
+  defaultContainer: workspace
+  runnerPath: /kobe-runner
+  attachCommand: ["tmux", "new-session", "-A", "-s", "agent"]
+  containers:
+    - name: workspace
+      image: zondax/kobe-agent-workspace-gui:v0.44.0
+  exposedPorts:
+    - name: desktop
+      container: workspace
+      port: 6080
+```
+
+The desktop is opt-in. After leasing this pool, start it as a managed execution
+and keep that terminal running:
+
+```bash
+kobe exec gui --timeout 2h -- kobe-desktop-up
+```
+
+Here `gui` is your lease ID or alias. In another terminal, forward its declared
+port:
+
+```bash
+kobe port-forward gui 6080:6080
+```
+
+Open `http://127.0.0.1:6080/vnc.html?autoconnect=1&resize=scale&path=websockify`.
+Run your project's normal Linux desktop development command in another
+execution, using `--cwd /home/agent/work/your-project`. Each execution already
+inherits `DISPLAY=:99`, the X11 authority file, and the session D-Bus address.
+
+Both noVNC (6080) and its VNC backend (5900) listen only on the Sandbox's
+loopback interface; X11 uses a Unix socket with a per-session cookie. Access
+comes through Kobe's authorized port forward, without a separate desktop
+password. Authorize port 6080 with an explicit port declaration or a permitted
+development port range. This does not require host networking, privilege
+escalation, or container capabilities. Files and sockets live under `HOME` or
+`/tmp`.
+
+`kobe-desktop-up` stays in the foreground and supervises every desktop
+component. A component exit fails the execution and stops its siblings;
+cancelling that execution or releasing the lease stops the desktop. Restart
+with a new execution if needed. Only one desktop can run in a Sandbox.
+
+Build locally with `docker buildx bake agent-workspace-gui --load` (set
+`PLATFORM=linux/arm64` on an ARM host). The `default` and `push` Bake groups
+include both workspace variants.

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -6,9 +6,9 @@ description: Define bounded, administrator-owned Agent Sandbox templates and pla
 # Sandbox pools
 
 <Callout type="warn">
-  `SandboxPool` and `SandboxLease` are alpha APIs. Set
-  Use `agentSandbox.mode=managed` for Kobe-owned management and child runtimes,
-  or `external` after installing Agent Sandbox v1.0.0 yourself. Kobe validates
+  `SandboxPool` and `SandboxLease` are alpha APIs. Set Use
+  `agentSandbox.mode=managed` for Kobe-owned management and child runtimes, or
+  `external` after installing Agent Sandbox v1.0.0 yourself. Kobe validates
   consumed APIs before mounting the Sandbox HTTP API; `disabled` mounts no
   Sandbox endpoints.
 </Callout>
@@ -59,9 +59,9 @@ Claim. Helm contains no operational canary hook.
 <Callout type="info">
   If a cluster still runs v0.5.x, follow the upstream v1.0.0 migration: prune
   `v1alpha1` from CRD `status.storedVersions`, install v1.0.0, then delete the
-  leftover webhook Service, cert Secret, and namespaced Role/RoleBinding.
-  Update operator-authored child bootstrap content at the same time. Managed
-  child pools must be recycled after changing the pinned runtime; Kobe rejects
+  leftover webhook Service, cert Secret, and namespaced Role/RoleBinding. Update
+  operator-authored child bootstrap content at the same time. Managed child
+  pools must be recycled after changing the pinned runtime; Kobe rejects
   mismatched children. Kobe never performs this upgrade.
 </Callout>
 
@@ -199,9 +199,9 @@ process, and reconnecting starts over instead of resuming. Declare what attach
 should run instead:
 
 ```yaml
-  template:
-    defaultContainer: agent
-    attachCommand: ["zellij", "attach", "--create", "kobe"]
+template:
+  defaultContainer: agent
+  attachCommand: ["zellij", "attach", "--create", "kobe"]
 ```
 
 Now `kobe attach dev` lands in a multiplexer session that outlives the
@@ -293,8 +293,13 @@ The desktop is opt-in. After leasing this pool, start it as a managed execution
 and keep that terminal running:
 
 ```bash
-kobe exec gui --timeout 2h -- kobe-desktop-up
+kobe exec gui --timeout 1h -- kobe-desktop-up
 ```
+
+A runner execution is limited to one hour, independently of the lease TTL.
+For a longer desktop session, run `kobe attach gui` to enter the pool's tmux
+session and start `kobe-desktop-up` there. Detach with `Ctrl-b`, then `d`; the
+desktop remains alive until you stop it in tmux or the lease ends.
 
 Here `gui` is your lease ID or alias. In another terminal, forward its declared
 port:
@@ -318,7 +323,8 @@ escalation, or container capabilities. Files and sockets live under `HOME` or
 
 `kobe-desktop-up` stays in the foreground and supervises every desktop
 component. A component exit fails the execution and stops its siblings;
-cancelling that execution or releasing the lease stops the desktop. Restart
+cancelling its runner execution or releasing the lease stops the desktop.
+When started in tmux, use `Ctrl-c` in that pane to stop it. Restart
 with a new execution if needed. Only one desktop can run in a Sandbox.
 
 Build locally with `docker buildx bake agent-workspace-gui --load` (set

--- a/hack/test-teardown-authority-apiserver.ts
+++ b/hack/test-teardown-authority-apiserver.ts
@@ -33,7 +33,10 @@ function parseDocuments(yaml: string): Document[] {
 		.map((document) => document.trim())
 		.filter(Boolean)
 		.map((document) => Bun.YAML.parse(document) as Document)
-		.filter((document) => document && typeof document === "object" && "kind" in document);
+		.filter(
+			(document) =>
+				document && typeof document === "object" && "kind" in document,
+		);
 }
 
 async function runCommand(
@@ -76,14 +79,18 @@ async function kubectlAs(
 function policyRuleResources(policy: Document): string[] {
 	const spec = policy.spec as Record<string, unknown>;
 	const constraints = spec.matchConstraints as Record<string, unknown>;
-	return (constraints.resourceRules as Record<string, unknown>[]).flatMap((rule) =>
-		Array.isArray(rule.resources) ? rule.resources.map(String) : [],
+	return (constraints.resourceRules as Record<string, unknown>[]).flatMap(
+		(rule) => (Array.isArray(rule.resources) ? rule.resources.map(String) : []),
 	);
 }
 
 function policyExpressions(policy: Document): string[] {
-	return ((policy.spec as Record<string, unknown>).validations as Record<string, unknown>[])
-		.map((validation) => String(validation.expression));
+	return (
+		(policy.spec as Record<string, unknown>).validations as Record<
+			string,
+			unknown
+		>[]
+	).map((validation) => String(validation.expression));
 }
 
 /// The kind a validation is written for, read from its own resource guard.
@@ -91,7 +98,8 @@ function policyExpressions(policy: Document): string[] {
 /// Every expression opens by excluding the resources it does not apply to, so
 /// the guard names the one type whose fields it then reads.
 function guardedKind(expression: string): string | undefined {
-	if (expression.includes("!= 'verifiedteardownevidence'")) return "VerifiedTeardownEvidence";
+	if (expression.includes("!= 'verifiedteardownevidence'"))
+		return "VerifiedTeardownEvidence";
 	if (expression.includes("!= 'clusterleases'")) return "ClusterLease";
 	if (expression.includes("!= 'clusterinstances'")) return "ClusterInstance";
 	return undefined;
@@ -121,10 +129,14 @@ function offTargetWarnings(warnings: unknown, expressions: string[]): string[] {
 			continue;
 		}
 		// Warnings arrive as one text block per kind, each headed by the type.
-		const blocks = String(warning.warning).split(/(?=kobe\.kunobi\.ninja\/v1alpha1, Kind=)/);
+		const blocks = String(warning.warning).split(
+			/(?=kobe\.kunobi\.ninja\/v1alpha1, Kind=)/,
+		);
 		const targeted = blocks.find((block) => block.includes(`Kind=${kind}:`));
 		if (targeted && /ERROR:/.test(targeted)) {
-			fatal.push(`${warning.fieldRef} does not type-check against ${kind}: ${targeted}`);
+			fatal.push(
+				`${warning.fieldRef} does not type-check against ${kind}: ${targeted}`,
+			);
 		}
 	}
 	return fatal;
@@ -257,7 +269,9 @@ async function waitForTypeCheckedPolicy(name: string): Promise<void> {
 				const warnings = policy.status.typeChecking.expressionWarnings;
 				const fatal = offTargetWarnings(warnings, policyExpressions(policy));
 				if (fatal.length > 0) {
-					throw new Error(`${name} type-check warnings: ${JSON.stringify(fatal)}`);
+					throw new Error(
+						`${name} type-check warnings: ${JSON.stringify(fatal)}`,
+					);
 				}
 				return;
 			}
@@ -275,6 +289,7 @@ async function patchLeaseStatus(
 	username: string,
 	status: Record<string, unknown>,
 	allowFailure = false,
+	dryRun = false,
 ): Promise<CommandResult> {
 	return kubectlAs(
 		username,
@@ -286,6 +301,7 @@ async function patchLeaseStatus(
 			namespace,
 			"--subresource=status",
 			"--type=merge",
+			...(dryRun ? ["--dry-run=server"] : []),
 			"-p",
 			JSON.stringify({ status }),
 		],
@@ -313,12 +329,18 @@ const documents = parseDocuments(rendered.stdout);
 const policies = documents.filter(
 	(document) => document.kind === "ValidatingAdmissionPolicy",
 );
-assert(policies.length === 2, `rendered ${policies.length} authority policies, expected 2`);
+assert(
+	policies.length === 2,
+	`rendered ${policies.length} authority policies, expected 2`,
+);
 const authorityPolicy = policies.find((policy) =>
 	policyRuleResources(policy).includes("verifiedteardownevidence"),
 );
 const firewallPolicy = policies.find((policy) => policy !== authorityPolicy);
-assert(authorityPolicy && firewallPolicy, "could not identify the rendered policy pair");
+assert(
+	authorityPolicy && firewallPolicy,
+	"could not identify the rendered policy pair",
+);
 const authorityPolicyName = String(metadata(authorityPolicy).name);
 const firewallPolicyName = String(metadata(firewallPolicy).name);
 const authorityUsername = policyExpressions(authorityPolicy)
@@ -327,8 +349,14 @@ const authorityUsername = policyExpressions(authorityPolicy)
 const controlPlaneUsername = policyExpressions(firewallPolicy)
 	.join(" ")
 	.match(/system:serviceaccount:[a-z0-9-]+:[a-z0-9-]+/)?.[0];
-assert(authorityUsername, "rendered policy does not contain the authority identity");
-assert(controlPlaneUsername, "rendered firewall does not contain the control-plane identity");
+assert(
+	authorityUsername,
+	"rendered policy does not contain the authority identity",
+);
+assert(
+	controlPlaneUsername,
+	"rendered firewall does not contain the control-plane identity",
+);
 const authorityNamespace = authorityUsername.split(":")[2];
 
 await kubectl(["create", "namespace", namespace]);
@@ -362,13 +390,17 @@ try {
 	await patchLeaseStatus(controlPlaneUsername, { phase: "Pending" });
 
 	// Type-checked is not enforcing. Prove the binding is live on the admission
-	// path before reading a successful write as a forged proof.
+	// path before reading a successful write as a forged proof. Use server-side
+	// dry-run: an admitted probe must not persist its value. Otherwise every
+	// retry is an unchanged-field write, which the policy correctly permits
+	// even after enforcement starts, and readiness can never be observed.
 	await waitForEnforcingPolicy(
 		controlPlaneUsername,
 		() =>
 			patchLeaseStatus(
 				controlPlaneUsername,
 				{ phase: "Pending", teardownAttemptId: "enforcement-probe" },
+				true,
 				true,
 			),
 		"only the teardown authority may change status.teardownAttemptId",
@@ -381,11 +413,13 @@ try {
 	);
 	assert(
 		forged.exitCode !== 0 &&
-			forged.stderr.includes("only the teardown authority may change status.teardownAttemptId"),
+			forged.stderr.includes(
+				"only the teardown authority may change status.teardownAttemptId",
+			),
 		forged.exitCode === 0
 			? "control plane FORGED a teardown proof: the patch was admitted"
 			: "control plane patch was rejected for the wrong reason: " +
-				(forged.stderr.trim() || "<no stderr>"),
+					(forged.stderr.trim() || "<no stderr>"),
 	);
 
 	await patchLeaseStatus(authorityUsername, {
@@ -399,7 +433,9 @@ try {
 	);
 	assert(
 		lifecycle.exitCode !== 0 &&
-			lifecycle.stderr.includes("teardown authority may not change lifecycle phase"),
+			lifecycle.stderr.includes(
+				"teardown authority may not change lifecycle phase",
+			),
 		`authority changed lifecycle state or failed unexpectedly: ${lifecycle.stderr}`,
 	);
 
@@ -408,7 +444,10 @@ try {
 		{ phase: "Pending", teardownAttemptId: null },
 		true,
 	);
-	assert(erased.exitCode !== 0, "control plane erased authority-owned evidence");
+	assert(
+		erased.exitCode !== 0,
+		"control plane erased authority-owned evidence",
+	);
 	const live = JSON.parse(
 		(
 			await kubectl([
@@ -428,6 +467,27 @@ try {
 		"a rejected cross-boundary write changed live status",
 	);
 
+	// The namespace firewall has its own binding; authority enforcement does
+	// not prove this independent policy has propagated. Dry-run leaves no
+	// ConfigMap behind if the first probe reaches the server too early.
+	await waitForEnforcingPolicy(
+		controlPlaneUsername,
+		() =>
+			kubectlAs(
+				controlPlaneUsername,
+				[
+					"create",
+					"configmap",
+					"firewall-probe",
+					"-n",
+					authorityNamespace,
+					"--dry-run=server",
+				],
+				true,
+			),
+		"control plane may not mutate the teardown-authority namespace",
+	);
+
 	const namespaceMutation = await kubectlAs(
 		controlPlaneUsername,
 		["create", "configmap", "forged-authority", "-n", authorityNamespace],
@@ -442,7 +502,13 @@ try {
 	);
 	const rbacMutation = await kubectlAs(
 		controlPlaneUsername,
-		["create", "clusterrole", "forged-authority", "--verb=get", "--resource=pods"],
+		[
+			"create",
+			"clusterrole",
+			"forged-authority",
+			"--verb=get",
+			"--resource=pods",
+		],
 		true,
 	);
 	assert(
@@ -461,7 +527,14 @@ try {
 	});
 	for (const target of [authorityNamespace, namespace]) {
 		await kubectl(
-			["delete", "namespace", target, "--ignore-not-found", "--wait=true", "--timeout=60s"],
+			[
+				"delete",
+				"namespace",
+				target,
+				"--ignore-not-found",
+				"--wait=true",
+				"--timeout=60s",
+			],
 			{ allowFailure: true },
 		);
 	}


### PR DESCRIPTION
Adds an opt-in GUI workspace image for building and running Linux desktop applications in leased Kobe workspaces, and bumps the workspace, runner, CLI, and Helm chart to v0.44.0. The image extends the headless workspace with Tauri system libraries, Xvfb, Openbox, and noVNC; project toolchains remain managed by mise.

The foreground kobe-desktop-up command supervises the display, session D-Bus, VNC, and WebSocket processes. X11 uses a private cookie; VNC and noVNC bind only to pod loopback and are reached through authorized lease port forwarding. A component failure stops its siblings; cancellation and duplicate startup are handled explicitly. Docker Bake reuses the exact headless image and runner for both build and publish groups.

This is the v0.44.0 release PR. Both #217 (port ranges and the CI readiness fix) and #218 (stdin forwarding) are now merged on main. After this PR passes CI and is squashed, just release will publish the signed v0.44.0 tag and start artifact publication.

Validation:
- Native ARM64 Docker image build passed; shellcheck, shfmt, HCL/MDX formatting, and diff checks passed.
- Real noVNC HTTP and WebSocket/RFB handshake passed under UID/GID 65532, zero capabilities, and no-new-privileges.
- Native WebKitGTK compiled and visibly rendered HTML without disabling its sandbox.
- Duplicate startup, TERM cleanup, component-failure cleanup, and restart checks passed.
- Version consistency and workspace formatting checked after the v0.44.0 bump; GitHub runs the full CI gates.

The local GUI check used a WebKitGTK smoke application, not the full Kunobi frontend. AMD64 image/runtime validation follows in CI and the live pool rollout.

