### PR TITLE
feat(workspace): improve GUI development leases

### DIFF
--- a/docker/agent-workspace-gui.Dockerfile
+++ b/docker/agent-workspace-gui.Dockerfile
@@ -8,6 +8,7 @@ USER root
 # Tauri 2 Linux prerequisites plus an unprivileged software-rendered desktop.
 # Language runtimes and project tools still come from the project's mise.toml.
 RUN apt-get update && apt-get install -y --no-install-recommends \
+        chromium \
         dbus \
         file \
         fonts-dejavu-core \
@@ -17,16 +18,20 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         libwebkit2gtk-4.1-dev \
         novnc \
         openbox \
-        procps \
         websockify \
         wget \
         x11-utils \
+        x11-xserver-utils \
         x11vnc \
         xauth \
+        xdg-utils \
+        xterm \
         xvfb \
     && rm -rf /var/lib/apt/lists/*
 
-COPY --chmod=0755 docker/kobe-desktop-up /usr/local/bin/kobe-desktop-up
+COPY --chmod=0755 docker/kobe-desktop docker/kobe-desktop-up /usr/local/bin/
+COPY --chown=65532:65532 docker/kobe-openbox-menu.xml /home/agent/.config/openbox/menu.xml
+COPY --chown=65532:65532 docker/kobe-mimeapps.list /home/agent/.config/mimeapps.list
 
 USER 65532:65532
 

--- a/docker/agent-workspace.Dockerfile
+++ b/docker/agent-workspace.Dockerfile
@@ -42,9 +42,16 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
         build-essential \
         ca-certificates \
         curl \
+        gh \
         git \
+        iproute2 \
+        jq \
+        less \
         libssl-dev \
+        openssh-client \
         pkg-config \
+        procps \
+        ripgrep \
         tmux \
         unzip \
         xz-utils \

--- a/docker/kobe-desktop
+++ b/docker/kobe-desktop
@@ -1,0 +1,128 @@
+#!/usr/bin/env bash
+# Manage the lease-lived noVNC desktop through a dedicated tmux server.
+# `kobe-desktop-up` remains the foreground supervisor; this wrapper makes it
+# safe to start from a short runner execution without inheriting its 1h limit.
+set -euo pipefail
+
+runtime_dir="${XDG_RUNTIME_DIR:?XDG_RUNTIME_DIR is required}"
+socket="$runtime_dir/kobe-desktop.tmux"
+session="kobe-desktop"
+log_file="$runtime_dir/kobe-desktop.log"
+
+usage() {
+  cat <<'USAGE'
+Usage: kobe-desktop <start|status|stop|logs|terminal|browser> [arguments]
+
+  start       Start the desktop in its lease-lived tmux session (idempotent).
+  status      Report X11, D-Bus, noVNC, and browser readiness.
+  stop        Stop the tmux-managed desktop.
+  logs        Print the supervisor log (pass a line count, default 100).
+  terminal    Open an xterm window on the desktop.
+  browser     Open Chromium on the desktop (pass an optional URL).
+USAGE
+}
+
+in_tmux() {
+  tmux -S "$socket" has-session -t "$session" 2>/dev/null
+}
+
+check() {
+  local label="$1"
+  shift
+  if "$@" >/dev/null 2>&1; then
+    printf '%-15s ready\n' "$label"
+    return 0
+  fi
+  printf '%-15s unavailable\n' "$label"
+  return 1
+}
+
+ready() {
+  xdpyinfo >/dev/null 2>&1 \
+    && dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply / org.freedesktop.DBus.ListNames >/dev/null 2>&1 \
+    && curl --fail --silent http://127.0.0.1:6080/vnc.html >/dev/null 2>&1
+}
+
+status() {
+  local failed=0
+  if in_tmux; then
+    printf '%-15s ready\n' 'supervisor'
+  else
+    printf '%-15s unavailable\n' 'supervisor'
+    failed=1
+  fi
+  check 'x11' xdpyinfo || failed=1
+  check 'dbus' dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply / org.freedesktop.DBus.ListNames || failed=1
+  check 'novnc' curl --fail --silent http://127.0.0.1:6080/vnc.html || failed=1
+  check 'browser' chromium --version || failed=1
+  return "$failed"
+}
+
+start() {
+  if in_tmux; then
+    if ready; then
+      printf '%s\n' 'Desktop is already running.'
+      return 0
+    fi
+    printf '%s\n' 'The previous desktop supervisor is unhealthy; inspect kobe-desktop logs or run kobe-desktop stop.' >&2
+    return 1
+  fi
+
+  if ready; then
+    printf '%s\n' 'A desktop is already running outside kobe-desktop management.' >&2
+    return 1
+  fi
+
+  mkdir -p "$runtime_dir"
+  tmux -S "$socket" new-session -d -s "$session" "exec kobe-desktop-up >'$log_file' 2>&1"
+
+  local deadline=$((SECONDS + 30))
+  until ready; do
+    if ! in_tmux; then
+      printf '%s\n' 'Desktop supervisor exited during startup.' >&2
+      logs 80 >&2 || true
+      return 1
+    fi
+    if (( SECONDS >= deadline )); then
+      printf '%s\n' 'Desktop readiness timed out.' >&2
+      logs 80 >&2 || true
+      return 1
+    fi
+    sleep 0.2
+  done
+  printf '%s\n' 'Desktop ready. Forward port 6080 and open /vnc.html?autoconnect=1&resize=scale&path=websockify'
+}
+
+stop() {
+  if in_tmux; then
+    tmux -S "$socket" kill-session -t "$session"
+    printf '%s\n' 'Desktop stopped.'
+  else
+    printf '%s\n' 'No tmux-managed desktop is running.' >&2
+    return 1
+  fi
+}
+
+logs() {
+  local lines="${1:-100}"
+  tail -n "$lines" "$log_file"
+}
+
+terminal() {
+  xterm -title 'Kobe workspace' -fa Monospace -fs 11 -e "${SHELL:-/bin/bash}" >/dev/null 2>&1 &
+}
+
+browser() {
+  chromium "${1:-about:blank}" >/dev/null 2>&1 &
+}
+
+case "${1:-}" in
+  start) start ;;
+  status) status ;;
+  stop) stop ;;
+  logs) shift; logs "$@" ;;
+  terminal) terminal ;;
+  browser) shift; browser "$@" ;;
+  -h|--help|'') usage ;;
+  *) usage >&2; exit 2 ;;
+esac

--- a/docker/kobe-desktop-up
+++ b/docker/kobe-desktop-up
@@ -41,6 +41,12 @@ start() {
   pids+=("$!")
 }
 
+# Convenience windows must not control the desktop lifetime: users should be
+# able to close the initial terminal without taking down Xvfb or noVNC.
+start_optional() {
+  "$@" 9>&- &
+}
+
 ready() {
   local deadline=$((SECONDS + 30))
   until "$@" >/dev/null 2>&1; do
@@ -64,10 +70,14 @@ touch "$XAUTHORITY"
 xauth -f "$XAUTHORITY" add "$DISPLAY" . "$(od -An -N16 -tx1 /dev/urandom | tr -d ' \n')"
 start Xvfb "$DISPLAY" -screen 0 1440x900x24 -nolisten tcp -auth "$XAUTHORITY"
 ready xdpyinfo -display "$DISPLAY"
+xsetroot -solid '#17324d'
 
 start dbus-daemon --session --nofork --address="$DBUS_SESSION_BUS_ADDRESS"
 ready dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply / org.freedesktop.DBus.ListNames
 start openbox --sm-disable
+# A visible terminal makes an otherwise empty desktop immediately usable. The
+# Openbox right-click menu also exposes Terminal, Browser, and desktop status.
+start_optional xterm -title 'Kobe workspace' -geometry 100x28+32+32 -fa Monospace -fs 11 -e bash -lc 'printf "Kobe GUI workspace ready.\nRight-click the desktop for Terminal, Browser, and status.\n\n"; exec bash'
 start x11vnc -display "$DISPLAY" -auth "$XAUTHORITY" -forever -shared \
   -localhost -listen 127.0.0.1 -rfbport 5900 -nopw -noxdamage
 ready bash -c 'exec 3<>/dev/tcp/127.0.0.1/5900'

--- a/docker/kobe-mimeapps.list
+++ b/docker/kobe-mimeapps.list
@@ -1,0 +1,4 @@
+[Default Applications]
+x-scheme-handler/http=chromium.desktop
+x-scheme-handler/https=chromium.desktop
+text/html=chromium.desktop

--- a/docker/kobe-openbox-menu.xml
+++ b/docker/kobe-openbox-menu.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<openbox_menu xmlns="http://openbox.org/3.4/menu">
+  <menu id="root-menu" label="Kobe workspace">
+    <item label="Terminal">
+      <action name="Execute"><execute>kobe-desktop terminal</execute></action>
+    </item>
+    <item label="Browser">
+      <action name="Execute"><execute>kobe-desktop browser</execute></action>
+    </item>
+    <item label="Desktop status">
+      <action name="Execute"><execute>xterm -title 'Kobe desktop status' -e kobe-desktop status</execute></action>
+    </item>
+    <separator />
+    <item label="Restart Openbox">
+      <action name="Restart" />
+    </item>
+  </menu>
+</openbox_menu>

--- a/docs/kobe-docs/commands/sandbox.mdx
+++ b/docs/kobe-docs/commands/sandbox.mdx
@@ -120,6 +120,20 @@ The remote stdin is closed once the bytes are delivered, which is what lets a
 tool that reads until EOF finish instead of hanging until its timeout. Without
 `--stdin` the command reads `/dev/null`, exactly as it always has.
 
+Agent workspace images include `gh`. To give one an authenticated HTTPS Git
+credential, forward the host token over stdin, then configure Git without ever
+putting the token in command arguments:
+
+```bash
+gh auth token | kobe exec gui --stdin -- \
+  sh -lc 'gh auth login --hostname github.com --git-protocol https --with-token && gh auth setup-git'
+kobe exec gui -- git clone https://github.com/ORG/PRIVATE-REPOSITORY.git /home/agent/work/project
+```
+
+This stores the credential only in the active lease. Run `gh auth logout -h
+github.com` in the workspace before releasing it if the credential must be
+removed early.
+
 For secrets and small inputs, not file transfer: the server refuses more than
 16 KiB rather than truncating it, and the CLI refuses to buffer a large file
 into a request that was never going to be accepted. Kobe stores none of it —

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -387,14 +387,18 @@ verbs and limits.
 ## Agent workspace images
 
 `zondax/kobe-agent-workspace` includes `kobe-runner`, `mise`, `tmux`, Git,
-OpenSSL headers, and a C toolchain. The workload runs as `65532:65532`, with
-`HOME=/home/agent` and a writable `/home/agent/work`. Clone projects there and
-run `mise install`; the image trusts mise configurations under that workspace
-and puts tool shims on `PATH` for direct `kobe exec` commands.
+GitHub CLI (`gh`), OpenSSH, JSON/search/network diagnostics, OpenSSL headers,
+and a C toolchain. The workload runs as `65532:65532`, with `HOME=/home/agent`
+and a writable `/home/agent/work`. Clone projects there and run `mise install`;
+the image trusts mise configurations under that workspace and puts tool shims
+on `PATH` for direct `kobe exec` commands.
 
 `zondax/kobe-agent-workspace-gui` adds the [Tauri 2 Linux system prerequisites](https://v2.tauri.app/start/prerequisites/#linux),
-software rendering, Xvfb, Openbox, and noVNC. Node, Rust, package managers, and
-other project tools still come from the project's `mise.toml`. Both images use
+software rendering, Xvfb, Openbox, noVNC, Chromium, and a
+visible terminal. Chromium is registered for HTTP and HTTPS links, so OAuth
+flows opened by desktop applications stay inside the noVNC desktop. Node, Rust,
+package managers, and other project tools still come from the project's
+`mise.toml`. Both images use
 the same release tags and runner. Pin a release tag or digest in your pool.
 
 For a GUI pool, set these fields in its template (alongside your resource
@@ -414,17 +418,17 @@ template:
       port: 6080
 ```
 
-The desktop is opt-in. After leasing this pool, start it as a managed execution
-and keep that terminal running:
+The desktop is opt-in. Start it with the lease-lived manager:
 
 ```bash
-kobe exec gui --timeout 1h -- kobe-desktop-up
+kobe exec gui -- kobe-desktop start
+kobe exec gui -- kobe-desktop status
 ```
 
-A runner execution is limited to one hour, independently of the lease TTL.
-For a longer desktop session, run `kobe attach gui` to enter the pool's tmux
-session and start `kobe-desktop-up` there. Detach with `Ctrl-b`, then `d`; the
-desktop remains alive until you stop it in tmux or the lease ends.
+`kobe-desktop start` is idempotent and runs the desktop supervisor in a dedicated
+tmux server, so it outlives the one-hour runner-execution limit. Use
+`kobe-desktop logs`, `kobe-desktop terminal`, or `kobe-desktop browser` to
+inspect the session. `kobe-desktop stop` stops only that managed desktop.
 
 Here `gui` is your lease ID or alias. In another terminal, forward its declared
 port:
@@ -434,9 +438,15 @@ kobe port-forward gui 6080:6080
 ```
 
 Open `http://127.0.0.1:6080/vnc.html?autoconnect=1&resize=scale&path=websockify`.
-Run your project's normal Linux desktop development command in another
+This is the whole virtual 1440×900 desktop. It starts with a terminal and a
+blue background; right-click the desktop for Terminal, Browser, and Desktop
+status. Run your project's normal Linux desktop development command in another
 execution, using `--cwd /home/agent/work/your-project`. Each execution already
 inherits `DISPLAY=:99`, the X11 authority file, and the session D-Bus address.
+
+`kobe-desktop-up` remains the foreground low-level supervisor for diagnostics.
+Starting it directly through `kobe exec` is limited to that execution's
+one-hour timeout; prefer `kobe-desktop start` for an interactive workspace.
 
 Both noVNC (6080) and its VNC backend (5900) listen only on the Sandbox's
 loopback interface; X11 uses a Unix socket with a per-session cookie. Access


### PR DESCRIPTION
Adds developer essentials (`gh`, SSH, diagnostics), a lease-lived `kobe-desktop` manager, an immediately visible terminal/Openbox menu, and Chromium URL handling for GUI workspace leases.\n\nValidation: `just fmt-check`, `cargo fmt --check`, `bash -n`, `shellcheck`, XML parse, and a local ARM64 noVNC manager smoke test. The local Docker Desktop sandbox rejects Chromium graphical launch; this will be verified in the actual Kobe runtime after deployment.