### PR TITLE
chore: bump kobe to v0.44.2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3365,7 +3365,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-operator"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -3432,7 +3432,7 @@ dependencies = [
 
 [[package]]
 name = "kobe-runner"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "base64 0.22.1",
  "clap",
@@ -3443,11 +3443,11 @@ dependencies = [
 
 [[package]]
 name = "kobe-state-machine"
-version = "0.44.1"
+version = "0.44.2"
 
 [[package]]
 name = "kobectl"
-version = "0.44.1"
+version = "0.44.2"
 dependencies = [
  "anyhow",
  "base64 0.22.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -9,7 +9,7 @@ resolver = "3"
 # CLI so they always publish in lockstep. `just bump X.Y.Z` rewrites this; the
 # version-consistency gate enforces tag == this == Chart.yaml at release time.
 [workspace.package]
-version = "0.44.1"
+version = "0.44.2"
 edition = "2024"
 rust-version = "1.94.1"
 license = "Apache-2.0"

--- a/charts/kobe/Chart.yaml
+++ b/charts/kobe/Chart.yaml
@@ -4,8 +4,8 @@ description: >-
   Kubernetes operator for instant cluster provisioning via warm pools.
   Supports multiple backends: k3s, k0s, vcluster, vkobe, and CAPI.
 type: application
-version: 0.44.1
-appVersion: "0.44.1"
+version: 0.44.2
+appVersion: "0.44.2"
 keywords:
   - kubernetes
   - operator
@@ -61,9 +61,9 @@ annotations:
   # bundled path should scan that image via the etcd chart's own listing.
   artifacthub.io/images: |
     - name: kobe-operator
-      image: docker.io/zondax/kobe-operator:v0.44.1
+      image: docker.io/zondax/kobe-operator:v0.44.2
     - name: kobe-sync
-      image: docker.io/zondax/kobe-sync:v0.44.1
+      image: docker.io/zondax/kobe-sync:v0.44.2
     - name: kine
       image: docker.io/rancher/kine:v0.13.2
       whitelisted: true


### PR DESCRIPTION
Bumps the Kobe workspace and Helm chart to v0.44.2. After CI, this will be squashed and released from synced main.