### PR TITLE
fix(workspace): use Firefox in GUI leases

### DIFF
--- a/docker/agent-workspace-gui.Dockerfile
+++ b/docker/agent-workspace-gui.Dockerfile
@@ -8,9 +8,9 @@ USER root
 # Tauri 2 Linux prerequisites plus an unprivileged software-rendered desktop.
 # Language runtimes and project tools still come from the project's mise.toml.
 RUN apt-get update && apt-get install -y --no-install-recommends \
-        chromium \
         dbus \
         file \
+        firefox-esr \
         fonts-dejavu-core \
         libayatana-appindicator3-dev \
         libgl1-mesa-dri \

--- a/docker/kobe-desktop
+++ b/docker/kobe-desktop
@@ -18,7 +18,7 @@ Usage: kobe-desktop <start|status|stop|logs|terminal|browser> [arguments]
   stop        Stop the tmux-managed desktop.
   logs        Print the supervisor log (pass a line count, default 100).
   terminal    Open an xterm window on the desktop.
-  browser     Open Chromium on the desktop (pass an optional URL).
+  browser     Open Firefox on the desktop (pass an optional URL).
 USAGE
 }
 
@@ -54,7 +54,7 @@ status() {
   check 'x11' xdpyinfo || failed=1
   check 'dbus' dbus-send --session --dest=org.freedesktop.DBus --type=method_call --print-reply / org.freedesktop.DBus.ListNames || failed=1
   check 'novnc' curl --fail --silent http://127.0.0.1:6080/vnc.html || failed=1
-  check 'browser' chromium --version || failed=1
+  check 'browser' firefox-esr --version || failed=1
   return "$failed"
 }
 
@@ -113,7 +113,7 @@ terminal() {
 }
 
 browser() {
-  chromium "${1:-about:blank}" >/dev/null 2>&1 &
+  firefox-esr "${1:-about:blank}" >/dev/null 2>&1 &
 }
 
 case "${1:-}" in

--- a/docker/kobe-mimeapps.list
+++ b/docker/kobe-mimeapps.list
@@ -1,4 +1,4 @@
 [Default Applications]
-x-scheme-handler/http=chromium.desktop
-x-scheme-handler/https=chromium.desktop
-text/html=chromium.desktop
+x-scheme-handler/http=firefox-esr.desktop
+x-scheme-handler/https=firefox-esr.desktop
+text/html=firefox-esr.desktop

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -394,8 +394,8 @@ the image trusts mise configurations under that workspace and puts tool shims
 on `PATH` for direct `kobe exec` commands.
 
 `zondax/kobe-agent-workspace-gui` adds the [Tauri 2 Linux system prerequisites](https://v2.tauri.app/start/prerequisites/#linux),
-software rendering, Xvfb, Openbox, noVNC, Chromium, and a
-visible terminal. Chromium is registered for HTTP and HTTPS links, so OAuth
+software rendering, Xvfb, Openbox, noVNC, Firefox, and a
+visible terminal. Firefox is registered for HTTP and HTTPS links, so OAuth
 flows opened by desktop applications stay inside the noVNC desktop. Node, Rust,
 package managers, and other project tools still come from the project's
 `mise.toml`. Both images use


### PR DESCRIPTION
Chromium cannot start under the production Kubernetes sandbox without disabling its security sandbox. Replace it with Firefox, register it as the desktop browser, and preserve the secure runtime policy. Validation: shellcheck, bash syntax, cargo fmt, and real-lease Chromium failure reproduced without unsafe flags.