### PR TITLE
feat(sandbox): support private image pull secrets

### DIFF
--- a/charts/kobe/crds/sandboxpools.yaml
+++ b/charts/kobe/crds/sandboxpools.yaml
@@ -350,6 +350,31 @@ spec:
                       type: object
                     maxItems: 64
                     type: array
+                  imagePullSecrets:
+                    description: |-
+                      Administrator-owned image-pull credentials in the SandboxPool's own
+                      namespace. This is deliberately limited to `LocalObjectReference`s:
+                      callers cannot select a secret, a namespace, a service account, or any
+                      other Pod identity field.
+                    items:
+                      description: |-
+                        A same-namespace Kubernetes Secret used only for pulling an image.
+
+                        `SandboxPool` is an administrator-authored resource, and the controller
+                        projects this exact reference into `PodSpec.imagePullSecrets`. Keeping the
+                        namespace implicit prevents a pool from selecting credentials outside the
+                        namespace in which its controller-owned workload runs.
+                      properties:
+                        name:
+                          maxLength: 253
+                          minLength: 1
+                          pattern: ^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$
+                          type: string
+                      required:
+                      - name
+                      type: object
+                    maxItems: 16
+                    type: array
                   runnerPath:
                     description: |-
                       Absolute path to `kobe-runner` inside `defaultContainer`, when the
@@ -377,6 +402,8 @@ spec:
                   rule: self.containers.exists(c, c.name == self.defaultContainer)
                 - message: container names must be unique
                   rule: self.containers.all(c, self.containers.filter(other, other.name == c.name).size() == 1)
+                - message: image pull secret names must be unique
+                  rule: '!has(self.imagePullSecrets) || self.imagePullSecrets.all(s, self.imagePullSecrets.filter(other, other.name == s.name).size() == 1)'
                 - message: every exposed port must name one declared container
                   rule: '!has(self.exposedPorts) || self.exposedPorts.all(p, self.containers.exists(c, c.name == p.container))'
                 - message: exposed port names must be unique

--- a/docs/kobe-docs/pools/sandbox-pools.mdx
+++ b/docs/kobe-docs/pools/sandbox-pools.mdx
@@ -88,6 +88,8 @@ spec:
     type: management
   template:
     defaultContainer: workspace
+    imagePullSecrets:
+      - name: private-workspace-registry
     containers:
       - name: workspace
         image: ghcr.io/example/agent-sandbox:v1
@@ -121,6 +123,28 @@ Linux capabilities, disables privilege escalation, and applies the
 `RuntimeDefault` seccomp profile. Images must therefore work as that non-root
 user and must not require writable root-owned paths. Canary `argv` is executed
 directly, without an implicit shell.
+
+## Private images
+
+For a private container registry, an administrator creates a Kubernetes image
+pull Secret in the same namespace as the `SandboxPool`, then references that
+Secret from `template.imagePullSecrets`. Kobe projects only these
+administrator-authored, same-namespace names into the resulting Pod's
+`imagePullSecrets`; callers cannot choose credentials or alter the Pod identity.
+
+```yaml
+template:
+  defaultContainer: workspace
+  imagePullSecrets:
+    - name: zondax-workspace-registry
+  containers:
+    - name: workspace
+      image: docker.io/zondax/kobe-workspace:sha-0123456
+```
+
+Create and rotate the registry Secret through the cluster's normal secret
+management path. Do not put registry tokens in the pool manifest, the image,
+or a caller command. Existing public-image pools may omit the field.
 
 ## `exposedPorts`
 

--- a/src/controllers/sandbox.rs
+++ b/src/controllers/sandbox.rs
@@ -10196,6 +10196,7 @@ pub(crate) mod tests {
                             limits: quantity("1", "1Gi", "2Gi"),
                         },
                     }],
+                    image_pull_secrets: vec![],
                     exposed_ports: vec![SandboxPortSpec {
                         name: "http".into(),
                         container: "agent".into(),

--- a/src/crd/sandbox.rs
+++ b/src/crd/sandbox.rs
@@ -122,6 +122,18 @@ impl SandboxPoolSpec {
             return Err(SandboxPoolValidationError::NoContainers);
         }
 
+        let mut image_pull_secret_names = BTreeSet::new();
+        for secret in &self.template.image_pull_secrets {
+            if secret.name.trim().is_empty() {
+                return Err(SandboxPoolValidationError::EmptyImagePullSecret);
+            }
+            if !image_pull_secret_names.insert(secret.name.as_str()) {
+                return Err(SandboxPoolValidationError::DuplicateImagePullSecret(
+                    secret.name.clone(),
+                ));
+            }
+        }
+
         let mut container_names = BTreeSet::new();
         for container in &self.template.containers {
             if container.name.trim().is_empty() {
@@ -334,6 +346,10 @@ impl JsonSchema for SandboxPlacement {
         .message("container names must be unique")
 )]
 #[x_kube(
+    validation = Rule::new("!has(self.imagePullSecrets) || self.imagePullSecrets.all(s, self.imagePullSecrets.filter(other, other.name == s.name).size() == 1)")
+        .message("image pull secret names must be unique")
+)]
+#[x_kube(
     validation = Rule::new("!has(self.exposedPorts) || self.exposedPorts.all(p, self.containers.exists(c, c.name == p.container))")
         .message("every exposed port must name one declared container")
 )]
@@ -376,6 +392,13 @@ pub struct SandboxTemplateSpec {
     /// context, service accounts, and arbitrary Pod fields are not exposed.
     #[schemars(length(min = 1, max = 16))]
     pub containers: Vec<SandboxContainerSpec>,
+    /// Administrator-owned image-pull credentials in the SandboxPool's own
+    /// namespace. This is deliberately limited to `LocalObjectReference`s:
+    /// callers cannot select a secret, a namespace, a service account, or any
+    /// other Pod identity field.
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    #[schemars(length(max = 16))]
+    pub image_pull_secrets: Vec<SandboxImagePullSecret>,
     /// Ports that later access brokers may expose, each declared as one port
     /// or one contiguous range. Any undeclared port remains unauthorized.
     ///
@@ -417,6 +440,22 @@ pub struct SandboxTemplateSpec {
     #[serde(default, skip_serializing_if = "Option::is_none")]
     #[schemars(length(min = 1, max = 255), pattern(r"^/[A-Za-z0-9._/-]*$"))]
     pub runner_path: Option<String>,
+}
+
+/// A same-namespace Kubernetes Secret used only for pulling an image.
+///
+/// `SandboxPool` is an administrator-authored resource, and the controller
+/// projects this exact reference into `PodSpec.imagePullSecrets`. Keeping the
+/// namespace implicit prevents a pool from selecting credentials outside the
+/// namespace in which its controller-owned workload runs.
+#[derive(Debug, Clone, Serialize, Deserialize, JsonSchema, PartialEq, Eq)]
+#[serde(rename_all = "camelCase", deny_unknown_fields)]
+pub struct SandboxImagePullSecret {
+    #[schemars(
+        length(min = 1, max = 253),
+        pattern("^[a-z0-9]([-a-z0-9.]*[a-z0-9])?$")
+    )]
+    pub name: String,
 }
 
 impl SandboxTemplateSpec {
@@ -1452,6 +1491,10 @@ pub enum SandboxPoolValidationError {
     EmptyClusterPoolRef,
     #[error("template must contain at least one container")]
     NoContainers,
+    #[error("image pull secret name must not be empty")]
+    EmptyImagePullSecret,
+    #[error("duplicate image pull secret {0}")]
+    DuplicateImagePullSecret(String),
     #[error("container name must not be empty")]
     EmptyContainerName,
     #[error("duplicate container name {0}")]
@@ -1525,6 +1568,7 @@ mod tests {
                         },
                     },
                 }],
+                image_pull_secrets: vec![],
                 exposed_ports: vec![SandboxPortSpec {
                     name: "http".into(),
                     container: "agent".into(),
@@ -1722,6 +1766,22 @@ mod tests {
             spec.validate(),
             Err(SandboxPoolValidationError::UnknownDefaultContainer(
                 "missing".into()
+            ))
+        );
+
+        let mut spec = valid_pool_spec();
+        spec.template.image_pull_secrets = vec![
+            SandboxImagePullSecret {
+                name: "registry".into(),
+            },
+            SandboxImagePullSecret {
+                name: "registry".into(),
+            },
+        ];
+        assert_eq!(
+            spec.validate(),
+            Err(SandboxPoolValidationError::DuplicateImagePullSecret(
+                "registry".into()
             ))
         );
 

--- a/src/sandbox.rs
+++ b/src/sandbox.rs
@@ -13,8 +13,8 @@ use std::collections::BTreeMap;
 
 use chrono::{DateTime, SecondsFormat, Utc};
 use k8s_openapi::api::core::v1::{
-    Capabilities, Container, ContainerPort, PodSecurityContext, PodSpec, ResourceRequirements,
-    SeccompProfile, SecurityContext,
+    Capabilities, Container, ContainerPort, LocalObjectReference, PodSecurityContext, PodSpec,
+    ResourceRequirements, SeccompProfile, SecurityContext,
 };
 use k8s_openapi::apimachinery::pkg::api::resource::Quantity;
 use k8s_openapi::apimachinery::pkg::apis::meta::v1::OwnerReference;
@@ -279,6 +279,15 @@ pub fn build_sandbox_template(
         automount_service_account_token: Some(false),
         containers,
         enable_service_links: Some(false),
+        image_pull_secrets: (!pool.template.image_pull_secrets.is_empty()).then(|| {
+            pool.template
+                .image_pull_secrets
+                .iter()
+                .map(|secret| LocalObjectReference {
+                    name: secret.name.clone(),
+                })
+                .collect()
+        }),
         restart_policy: Some("Never".to_string()),
         runtime_class_name: pool.isolation.runtime_class_name().map(ToString::to_string),
         security_context: Some(PodSecurityContext {
@@ -1427,6 +1436,7 @@ mod tests {
                         limits: quantity("1", "1Gi", "2Gi"),
                     },
                 }],
+                image_pull_secrets: vec![],
                 exposed_ports: vec![SandboxPortSpec {
                     name: "http".into(),
                     container: "agent".into(),
@@ -1771,6 +1781,22 @@ mod tests {
             value["spec"]["podTemplate"]["spec"]
                 .get("volumes")
                 .is_none()
+        );
+    }
+
+    #[test]
+    fn template_projection_maps_only_administrator_selected_image_pull_secrets() {
+        let mut pool = pool();
+        pool.template.image_pull_secrets = vec![crate::crd::SandboxImagePullSecret {
+            name: "zondax-workspace-registry".into(),
+        }];
+
+        let object = build_sandbox_template("agents", "targets", &pool, Some(&owner())).unwrap();
+        let value = serde_json::to_value(object).unwrap();
+
+        assert_eq!(
+            value["spec"]["podTemplate"]["spec"]["imagePullSecrets"],
+            serde_json::json!([{ "name": "zondax-workspace-registry" }])
         );
     }
 


### PR DESCRIPTION
Sandbox pools can now reference administrator-owned, same-namespace image pull Secrets through `template.imagePullSecrets`. Kobe validates the bounded references and projects them into controller-owned Sandbox Pods, enabling private workspace images without exposing service-account or caller-controlled Pod configuration.\n\nValidation: `cargo fmt --check`, `cargo clippy --all-targets -- -D warnings`, and `cargo test sandbox --no-fail-fast`.