### PR TITLE
docs: document kobe-action for GitHub Actions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,29 @@ curl -X DELETE https://pool.kunobi.ninja/v1/leases/lease-a1b2c3d4e5f6 \
 
 > Prefer the CLI? `kobe login` → `kobe lease ci-small` → `kobe release <lease-id>`. See the [quick start](docs/kobe-docs/getting-started/quick-start.mdx).
 
+### In GitHub Actions
+
+[`kunobi-ninja/kobe-action`](https://github.com/kunobi-ninja/kobe-action) leases a cluster with the job's OIDC token and releases it when the job ends, including on failure or cancellation:
+
+```yaml
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+      - uses: kunobi-ninja/kobe-action@v2
+        id: cluster
+        with:
+          endpoint: https://kobe.example.com
+          pool: ci-small
+          wait-for-ready: true
+
+      - run: kubectl --kubeconfig ${{ steps.cluster.outputs.kubeconfig-path }} get nodes
+```
+
+The endpoint needs an `AccessPolicy` that trusts GitHub's OIDC issuer. See [GitHub Actions](docs/kobe-docs/getting-started/github-actions.mdx).
+
 ## How It Works
 
 Kobe runs as an operator in a host Kubernetes cluster. It maintains warm **pools** of clusters, each defined by a `ClusterPool` (a backend + cluster template with specific configuration, addons, and resource limits).

--- a/docs/kobe-docs/auth/oidc.mdx
+++ b/docs/kobe-docs/auth/oidc.mdx
@@ -40,7 +40,10 @@ spec:
       maxExtensions: 0
 ```
 
-In your GitHub Actions workflow, request the token and pass it to kobe:
+In your workflow, lease with [`kunobi-ninja/kobe-action`](https://github.com/kunobi-ninja/kobe-action).
+It requests the token and releases the lease when the job ends. Set its
+`audience` to a value the policy accepts; the action's default is
+`kobe-system`:
 
 ```yaml
 jobs:
@@ -48,16 +51,18 @@ jobs:
     permissions:
       id-token: write    # required to request the OIDC token
     steps:
-      - name: Claim cluster
-        run: |
-          TOKEN=$(curl -s -H "Authorization: bearer $ACTIONS_ID_TOKEN_REQUEST_TOKEN" \
-            "${ACTIONS_ID_TOKEN_REQUEST_URL}&audience=https://kobe.example.com" | jq -r .value)
-          LEASE=$(curl -s -X POST https://kobe.example.com/v1/leases \
-            -H "Authorization: Bearer $TOKEN" \
-            -d '{"pool": "ci-small", "ttl": "20m"}')
-          echo "LEASE_ID=$(echo $LEASE | jq -r .id)" >> $GITHUB_ENV
-          echo "$LEASE" | jq -r .kubeconfig > /tmp/kube.yaml
+      - uses: kunobi-ninja/kobe-action@v2
+        id: cluster
+        with:
+          endpoint: https://kobe.example.com
+          pool: ci-small
+          ttl: 20m
+          audience: https://kobe.example.com
+      - run: kubectl --kubeconfig ${{ steps.cluster.outputs.kubeconfig-path }} get nodes
 ```
+
+See [GitHub Actions](/docs/getting-started/github-actions) for a complete
+workflow.
 
 ## Clerk
 

--- a/docs/kobe-docs/getting-started/github-actions.mdx
+++ b/docs/kobe-docs/getting-started/github-actions.mdx
@@ -1,0 +1,103 @@
+---
+title: GitHub Actions
+description: Lease a cluster for a CI job with kobe-action and release it when the job ends.
+---
+
+# GitHub Actions
+
+[`kunobi-ninja/kobe-action`](https://github.com/kunobi-ninja/kobe-action)
+leases a cluster from a pool, writes its kubeconfig, and releases the lease
+when the job ends. It authenticates with the job's GitHub OIDC token, so the
+repository stores no kobe secret.
+
+## Allow the repository to lease
+
+Create an `AccessPolicy` that trusts GitHub's OIDC issuer. The action
+requests tokens for the audience `kobe-system` unless you set `audience`, so
+the policy must accept the same value:
+
+```yaml
+apiVersion: kobe.kunobi.ninja/v1alpha1
+kind: AccessPolicy
+metadata:
+  name: github-ci
+  namespace: kobe
+spec:
+  auth:
+    oidc:
+      issuer: https://token.actions.githubusercontent.com
+      audience: ["kobe-system"]
+  identity: "{repository}"
+  rules:
+    - match:
+        claim: repository
+        value: my-org/api-service
+      pools: ["ci-small"]
+      maxTtl: 30m
+      maxConcurrentLeases: 5
+      maxExtensions: 0
+```
+
+Each rule limits which pools the repository may use, for how long, and how
+many leases it may hold at once. See [OIDC](/docs/auth/oidc) for other claims
+you can match on.
+
+## Lease a cluster in a workflow
+
+```yaml
+name: e2e
+
+on: [pull_request]
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write    # lets the job request an OIDC token
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: kunobi-ninja/kobe-action@v2
+        id: cluster
+        with:
+          endpoint: https://kobe.example.com
+          pool: ci-small
+          ttl: 30m
+          wait-for-ready: true
+
+      - name: Run tests against the leased cluster
+        env:
+          KUBECONFIG: ${{ steps.cluster.outputs.kubeconfig-path }}
+        run: |
+          kubectl get nodes
+          make e2e
+```
+
+The job needs no release step. The action's post step releases the lease
+whether the job succeeds, fails, or is cancelled. If the job dies without
+running it, the lease still ends at its TTL.
+
+## Wait for nodes, not only the API
+
+A lease is `Bound` once the cluster's API server answers. Nodes can take
+longer to register, so tests that list nodes right away may find none. Set
+`wait-for-ready: true` to wait until nodes report Ready. For pools with
+separate workers, also set `min-ready-nodes: 1`.
+
+## Inputs and outputs
+
+| Input | Default | Purpose |
+|---|---|---|
+| `endpoint` | | kobe API URL (required) |
+| `pool` | | Pool to lease from (required) |
+| `ttl` | `1h` | Lease duration, capped by the policy's `maxTtl` |
+| `audience` | `kobe-system` | OIDC audience; must match the policy |
+| `timeout` | `5m` | How long to wait for the lease to become `Bound` |
+| `wait-for-ready` | `false` | Also wait for nodes to be Ready |
+| `min-ready-nodes` | `0` | Workers required when waiting for readiness |
+| `ready-timeout` | `2m` | How long to wait for readiness after `Bound` |
+
+Outputs: `kubeconfig-path`, `lease-id`, `cluster-name`, and
+`cluster-backend`. The [action's README](https://github.com/kunobi-ninja/kobe-action#readme)
+has the full reference.

--- a/docs/kobe-docs/getting-started/meta.json
+++ b/docs/kobe-docs/getting-started/meta.json
@@ -1,4 +1,4 @@
 {
   "title": "Getting Started",
-  "pages": ["installation", "quick-start", "configuration"]
+  "pages": ["installation", "quick-start", "github-actions", "configuration"]
 }


### PR DESCRIPTION
kobe already has a GitHub Action, [`kunobi-ninja/kobe-action`](https://github.com/kunobi-ninja/kobe-action), but nothing in this repo pointed to it.

- Add `getting-started/github-actions.mdx`: an `AccessPolicy` for GitHub OIDC, a complete workflow, readiness waiting, and the inputs and outputs.
- Link the action from the README quick start.
- Replace the curl example in the OIDC guide with the action. The old example requested audience `https://kobe.example.com` while the action defaults to `kobe-system`, so copying the policy and the action together failed authentication. The example now sets `audience` to match the policy.

Not in this PR: the action is not listed on the GitHub Marketplace yet. Listing it takes the "Publish this Action to the GitHub Marketplace" checkbox on a kobe-action release.
